### PR TITLE
fix(security): Batch 1 backend hardening — SSRF guard, busy_timeout, const-time compare, HITL sweep, requires_pip, subagent select

### DIFF
--- a/a2a_impl/auth.py
+++ b/a2a_impl/auth.py
@@ -238,7 +238,7 @@ class A2AAuthMiddleware(BaseHTTPMiddleware):
 
         # X-API-Key (legacy) — enforced only when configured.
         api_key = _API_KEY[0]
-        if api_key and request.headers.get("x-api-key") != api_key:
+        if api_key and not hmac.compare_digest(request.headers.get("x-api-key", "") or "", api_key):
             return _unauthorized("Unauthorized")
 
         # Bearer — enforced only when configured.

--- a/a2a_impl/stores.py
+++ b/a2a_impl/stores.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import httpx
-from sqlalchemy import bindparam, delete, select, text, update
+from sqlalchemy import bindparam, delete, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from a2a.server.context import ServerCallContext
@@ -298,7 +298,15 @@ async def sweep_expired_tasks(engine: AsyncEngine, *, ttl_s: int = _DEFAULT_TTL_
 
     session_maker = async_sessionmaker(engine, expire_on_commit=False)
     async with session_maker() as session:
-        result = await session.execute(delete(TaskModel).where(TaskModel.last_updated < cutoff))
+        # Preserve resumable HITL/auth pauses (their checkpoint outlives the TTL).
+        # A NULL/absent state is not a preserved pause, so still sweep it (the
+        # JSON-path is NULL for a stateless row, and ``NOT IN`` wouldn't match it).
+        state = TaskModel.status["state"].as_string()
+        result = await session.execute(
+            delete(TaskModel)
+            .where(TaskModel.last_updated < cutoff)
+            .where(or_(state.is_(None), state.notin_(_PRESERVED_STATES)))
+        )
         await session.commit()
         return result.rowcount or 0
 
@@ -342,6 +350,11 @@ async def sweep_orphaned_push_configs(task_engine: AsyncEngine, push_engine: Asy
 # those are HITL / auth *pauses* whose LangGraph checkpoint survives the restart
 # and can resume on the next message, so failing them would be wrong.
 _INTERRUPTED_STATES = ("TASK_STATE_SUBMITTED", "TASK_STATE_WORKING")
+
+# HITL / auth *pauses* whose LangGraph checkpoint survives a restart and resumes on
+# the next message — the TTL sweep must NOT delete them (initialize_a2a_stores'
+# docstring promises this; sweep_expired_tasks now actually enforces it).
+_PRESERVED_STATES = ("TASK_STATE_INPUT_REQUIRED", "TASK_STATE_AUTH_REQUIRED")
 
 
 def _interrupted_status_blob(now: datetime) -> dict:

--- a/docs/dev/launch-hardening-tasklist.md
+++ b/docs/dev/launch-hardening-tasklist.md
@@ -28,29 +28,29 @@ Status legend: `[ ]` todo · `[~]` in progress · `[x]` done · `[>]` deferred (
 
 Additive guards / one-liners; near-zero regression risk, high security ROI.
 
-- [ ] **Ingestion SSRF guard** — `High` · churn Low · LOE S — `ingestion/engine.py:334-398`.
+- [x] **Ingestion SSRF guard** — `High` · churn Low · LOE S — `ingestion/engine.py:334-398`.
   Route `extract_url`/`_http_fetch` through the existing `security.egress.check_url`
   (as `fetch_url` already does), set `follow_redirects=False` and re-check every hop.
   Closes internal/metadata-fetch-into-KB. *(Two finders flagged this; asymmetric with
   the already-guarded `fetch_url` tool.)*
-- [ ] **`KnowledgeStore` missing `busy_timeout`** — Med · Low · XS — `knowledge/store.py:273`.
+- [x] **`KnowledgeStore` missing `busy_timeout`** — Med · Low · XS — `knowledge/store.py:273`.
   `PRAGMA busy_timeout=5000` in `_connect` (concurrent writes silently lost today;
   error swallowed at `400-402`).
-- [ ] **Scheduler raw `database is locked`** — Low · Low · XS — `scheduler/local.py:245`.
+- [x] **Scheduler raw `database is locked`** — Low · Low · XS — `scheduler/local.py:245`.
   Same PRAGMA in `LocalScheduler._connect`.
-- [ ] **Non-constant-time credential compare** — Low · Low · XS — `a2a_impl/auth.py:218`,
+- [x] **Non-constant-time credential compare** — Low · Low · XS — `a2a_impl/auth.py:218`,
   `operator_api/console_handlers.py:389`. Use `hmac.compare_digest` for X-API-Key and
   the inbox token (bearer already does).
 - [ ] **`requestForm` double-body-read masks 401** — Med · Low · XS–S —
   `apps/web/src/lib/api.ts:345`. Read body once (`text()` then best-effort
   `JSON.parse`); restores the real error + the 401 AuthGate on uploads.
-- [ ] **Boot TTL sweep deletes HITL tasks** — Low · Low · XS–S —
+- [x] **Boot TTL sweep deletes HITL tasks** — Low · Low · XS–S —
   `a2a_impl/stores.py:291`. Exclude `INPUT_REQUIRED`/`AUTH_REQUIRED` from
   `sweep_expired_tasks` (mirror reconcile's preserved states).
-- [ ] **`requires_pip` arg injection** — Med · Low · S — `graph/plugins/installer.py:630`.
+- [x] **`requires_pip` arg injection** — Med · Low · S — `graph/plugins/installer.py:630`.
   Validate each entry as a plain PEP 508 requirement: reject leading `-`
   (`--index-url`/`-e`), reject VCS/URL/`@`/`file:` refs, pass `--` before specs.
-- [ ] **Subagent return-value mis-parse** — Low · Med · S — `graph/agent.py:278`.
+- [x] **Subagent return-value mis-parse** — Low · Med · S — `graph/agent.py:278`.
   Select the last `AIMessage` (not "any message with content"); drop the
   `startswith("Error")` heuristic — use the `SubagentError` path for failures.
 - [ ] **Palette deep-link dead-ends on workspace console** — Low · Low · S —

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -7,7 +7,7 @@ Uses langchain's create_agent() with AgentMiddleware for the DeerFlow pattern.
 from typing import Annotated, Any
 
 from langchain.agents import create_agent
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import AIMessage, ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph.prebuilt import InjectedState
 
@@ -275,13 +275,16 @@ async def _run_subagent(
 
         messages = result.get("messages", [])
 
+        # The delegation's answer is the subagent's last AIMessage with content —
+        # not "any message with content" (which could surface a raw tool dump) and
+        # not gated on a fragile startswith("Error") text sniff (which discarded a
+        # legitimate answer that opened with "Error"). Hard failures already raise
+        # SubagentError below, so they never reach here.
         body = None
         for msg in reversed(messages):
-            if hasattr(msg, "content") and msg.content:
-                content = msg.content if isinstance(msg.content, str) else str(msg.content)
-                if content and not content.startswith("Error"):
-                    body = content
-                    break
+            if isinstance(msg, AIMessage) and msg.content:
+                body = msg.content if isinstance(msg.content, str) else str(msg.content)
+                break
 
         if body is None:
             return f"[{subagent_type} completed: {description}] -- no output produced."

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -603,6 +603,29 @@ def uninstall(plugin_id: str, *, purge: bool = False) -> dict:
     return {"id": plugin_id, "removed": removed, "deps_left": deps_left, "purged": purge}
 
 
+def _validate_pip_specs(plugin_id: str, deps: list[str]) -> None:
+    """Reject ``requires_pip`` entries that aren't plain package requirements — a
+    pip option (``--index-url``/``-e``), a VCS/URL/direct reference, or junk — so a
+    plugin manifest can't inject pip flags (index hijack) or arbitrary build code
+    beyond the named packages an operator reviewed. ``--`` before the specs in the
+    pip argv is the belt to this suspenders."""
+    for d in deps:
+        s = str(d).strip()
+        low = s.lower()
+        if not s or s.startswith("-"):
+            raise InstallError(
+                f"plugin {plugin_id!r}: requires_pip entry {d!r} looks like a pip option, not a package."
+            )
+        if "://" in s or "@" in s or low.startswith(("git+", "hg+", "svn+", "bzr+", "file:")):
+            raise InstallError(
+                f"plugin {plugin_id!r}: requires_pip entry {d!r} is a VCS/URL/direct reference, which is not allowed."
+            )
+        if not _PKG_NAME_RE.match(s):
+            raise InstallError(
+                f"plugin {plugin_id!r}: requires_pip entry {d!r} is not a valid PEP 508 package requirement."
+            )
+
+
 def install_deps(plugin_id: str) -> list[str]:
     """Pip-install a plugin's declared ``requires_pip`` — the explicit code-exec
     step that ``install`` deliberately skips (ADR 0027 D4). Returns the deps."""
@@ -616,6 +639,7 @@ def install_deps(plugin_id: str) -> list[str]:
     deps = list(manifest.requires_pip)
     if not deps:
         return []
+    _validate_pip_specs(plugin_id, deps)
     # Frozen runtime (desktop): no pip. The deps must already be bundled — confirm
     # (nothing to install) or refuse with a clear message (ADR 0058 D2).
     if _frozen_like():
@@ -628,7 +652,7 @@ def install_deps(plugin_id: str) -> list[str]:
         log.info("[plugins] %s deps already in the runtime — nothing to install", plugin_id)
         return deps
     proc = subprocess.run(
-        [sys.executable, "-m", "pip", "install", *deps],
+        [sys.executable, "-m", "pip", "install", "--", *deps],
         capture_output=True,
         text=True,
     )

--- a/ingestion/engine.py
+++ b/ingestion/engine.py
@@ -23,6 +23,9 @@ _FETCH_UA = "protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)"
 # ffmpeg audio-extraction (video → audio) is bounded so a pathological file can't
 # wedge an ingest thread.
 _FFMPEG_TIMEOUT_S = 600.0
+# Cap redirect chains so a fetched URL can't bounce us toward an internal target
+# after the initial egress check — every hop is re-checked. See _http_fetch.
+_MAX_REDIRECTS = 5
 
 
 class IngestionError(Exception):
@@ -389,10 +392,28 @@ def _media_filename(url: str, url_ext: str, default_ext: str) -> str:
 def _http_fetch(url: str) -> tuple[bytes, str]:
     import httpx
 
-    with httpx.Client(follow_redirects=True, timeout=_FETCH_TIMEOUT_S, headers={"User-Agent": _FETCH_UA}) as client:
-        resp = client.get(url)
-        resp.raise_for_status()
-        content = resp.content
-        if len(content) > _MAX_FETCH_BYTES:
-            raise ExtractionError(f"document too large ({len(content)} bytes > {_MAX_FETCH_BYTES})")
-        return content, resp.headers.get("content-type", "")
+    from security import egress
+
+    # SSRF guard: ingestion fetches an operator/user-supplied URL server-side and
+    # persists the response, so it gets the same destination policy as the
+    # ``fetch_url`` tool — reject private/loopback/link-local/cloud-metadata hosts
+    # (unless egress-allowlisted), and re-check every redirect hop manually so a
+    # public URL can't 30x-bounce us onto an internal target.
+    err = egress.check_url(url)
+    if err:
+        raise UnsupportedSource(err)
+    with httpx.Client(follow_redirects=False, timeout=_FETCH_TIMEOUT_S, headers={"User-Agent": _FETCH_UA}) as client:
+        for _ in range(_MAX_REDIRECTS + 1):
+            resp = client.get(url)
+            if resp.is_redirect:
+                url = str(resp.url.join(resp.headers.get("location", "")))
+                err = egress.check_url(url)
+                if err:
+                    raise UnsupportedSource(err)
+                continue
+            resp.raise_for_status()
+            content = resp.content
+            if len(content) > _MAX_FETCH_BYTES:
+                raise ExtractionError(f"document too large ({len(content)} bytes > {_MAX_FETCH_BYTES})")
+            return content, resp.headers.get("content-type", "")
+    raise ExtractionError(f"too many redirects (> {_MAX_REDIRECTS}) fetching {url}")

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -273,6 +273,7 @@ class KnowledgeStore:
     def _connect(self) -> sqlite3.Connection:
         db = sqlite3.connect(str(self.path))
         db.row_factory = sqlite3.Row
+        db.execute("PRAGMA busy_timeout=5000")  # wait (don't error) on lock contention
         # WAL is best-effort — read-only sqlite files (e.g. immutable
         # mounts) reject the PRAGMA. The connection stays usable for
         # reads; only writes will fail later, and those go through

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -16,6 +16,7 @@ imported under the same alias names the bodies use, and the one captured local
 
 from __future__ import annotations
 
+import hmac
 import logging
 import os
 
@@ -386,7 +387,7 @@ def _inbox_authorized(token: str | None) -> bool:
     ).strip()
     if not active:
         return True
-    return (token or "") == active
+    return hmac.compare_digest(token or "", active)
 
 
 async def _fire_activity_from_inbox(item: dict) -> bool:

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -245,6 +245,7 @@ class LocalScheduler:
     def _connect(self) -> sqlite3.Connection:
         db = sqlite3.connect(str(self.path))
         db.row_factory = sqlite3.Row
+        db.execute("PRAGMA busy_timeout=5000")  # wait (don't error) on lock contention
         try:
             db.execute("PRAGMA journal_mode=WAL")
         except sqlite3.OperationalError as exc:

--- a/tests/test_a2a_stores.py
+++ b/tests/test_a2a_stores.py
@@ -132,6 +132,49 @@ async def test_task_ttl_sweep_evicts_old_rows(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_task_ttl_sweep_preserves_hitl_pauses(tmp_path):
+    """A resumable input_required/auth_required pause must NOT be TTL-swept even
+    when stale — its LangGraph checkpoint can still resume (a non-HITL stale task
+    on the same sweep is still evicted)."""
+    from datetime import UTC, datetime, timedelta
+
+    from a2a.server.models import TaskModel
+    from a2a.types import a2a_pb2
+    from sqlalchemy import select, update
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    ctx = _ctx()
+    engine = make_sqlite_engine(str(tmp_path / "a2a-tasks.db"))
+    store = DatabaseTaskStore(engine)
+    await store.initialize()
+    await store.save(a2a_pb2.Task(id="paused", context_id="c"), ctx)
+    await store.save(a2a_pb2.Task(id="dead", context_id="c"), ctx)
+
+    old = datetime.now(UTC) - timedelta(hours=48)
+    sm = async_sessionmaker(engine, expire_on_commit=False)
+    async with sm() as session:
+        await session.execute(
+            update(TaskModel)
+            .where(TaskModel.id == "paused")
+            .values(last_updated=old, status={"state": "TASK_STATE_INPUT_REQUIRED"})
+        )
+        await session.execute(
+            update(TaskModel)
+            .where(TaskModel.id == "dead")
+            .values(last_updated=old, status={"state": "TASK_STATE_WORKING"})
+        )
+        await session.commit()
+
+    deleted = await sweep_expired_tasks(engine)
+    assert deleted == 1  # only the non-HITL stale row
+    async with sm() as session:
+        remaining = {r[0] for r in (await session.execute(select(TaskModel.id))).all()}
+    assert "paused" in remaining  # resumable HITL pause survives the TTL
+    assert "dead" not in remaining
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_orphaned_push_config_sweep(tmp_path):
     """sweep_orphaned_push_configs drops push configs whose task is gone (ADR 0051),
     keeps configs for live tasks."""

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -204,6 +204,22 @@ def test_extract_url_empty_raises():
         extract_url("   ")
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",  # cloud-metadata (link-local)
+        "http://127.0.0.1:7870/api/config",  # loopback
+        "http://[::1]/x",  # loopback (v6)
+        "file:///etc/passwd",  # no host / non-http scheme
+    ],
+)
+def test_http_fetch_blocks_internal_ssrf(url):
+    """The real URL fetcher applies the egress SSRF guard before any network I/O —
+    internal / metadata / loopback targets are refused (literal IPs need no DNS)."""
+    with pytest.raises(UnsupportedSource):
+        engine._http_fetch(url)
+
+
 # ── audio / video (gateway STT, injected transcribe + ffmpeg) ─────────────────
 
 

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -180,7 +180,26 @@ def test_install_deps_runs_pip_with_declared_deps(env, monkeypatch):
     deps = installer.install_deps("demo_ext")
     assert deps == ["requests>=2", "rich"]
     assert calls and calls[0][1:4] == ["-m", "pip", "install"]
-    assert calls[0][4:] == ["requests>=2", "rich"]
+    # `--` ends pip option parsing so a manifest dep can't be read as a flag.
+    assert calls[0][4:] == ["--", "requests>=2", "rich"]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "--index-url=https://evil.example/simple",
+        "-e .",
+        "git+https://evil.example/pkg.git",
+        "foo @ https://evil.example/foo.whl",
+        "https://evil.example/foo.tar.gz",
+    ],
+)
+def test_install_deps_rejects_non_pep508_requires_pip(env, bad):
+    """A plugin manifest can't smuggle pip options / VCS+URL refs through requires_pip."""
+    repo = _make_plugin_repo(env, manifest_extra=f"requires_pip: ['{bad}']\n")
+    installer.install(str(repo))
+    with pytest.raises(installer.InstallError):
+        installer.install_deps("demo_ext")
 
 
 def test_uninstall_removes_enabled_ref_keeps_config(env):


### PR DESCRIPTION
**Batch 1 (backend)** of the launch-hardening plan (`docs/dev/launch-hardening-tasklist.md`) — additive, low-regression fixes from the 2026-06-28 antagonistic review. Frontend Batch 1 items (requestForm, palette, SSE) follow in a separate PR for clean web gating.

| Fix | Sev | What |
|---|---|---|
| **Ingestion SSRF guard** | **High** | `_http_fetch` now runs `security.egress.check_url` (same guard as `fetch_url`), disables auto-redirects, and re-checks every hop — closes server-side fetch of cloud-metadata/internal hosts into the KB. |
| `requires_pip` arg injection | Med | Validate each manifest dep as a plain PEP 508 requirement (reject `-`/`@`/`://`/VCS) + pass `--` before specs, so a manifest can't inject pip flags / VCS build code. |
| Preserve HITL pauses from TTL sweep | Low | `sweep_expired_tasks` deleted `input_required`/`auth_required` pauses the docstring promised to keep; now filtered (`state IS NULL OR state NOT IN preserved`). |
| Const-time credential compare | Low | `hmac.compare_digest` for X-API-Key + inbox token (bearer already did). |
| `busy_timeout` on KnowledgeStore + scheduler | Low/Med | Convention-align with sibling stores (default connect timeout already 5s — robustness, not a behavior change). |
| Subagent answer = last `AIMessage` | Low | Stop discarding a legit answer starting with "Error" / surfacing a raw tool dump; `SubagentError` already signals hard failures. |

## Gates (isolated worktree off `main`)
- `ruff check .` (0.15.10) ✓ · `lint-imports` 3/0 ✓ · `pytest tests/ -q` — **2567 passed** (+12 new: SSRF guard, HITL-preserve, requires_pip rejection).

No frontend changes. Each fix is its own commit. From the 2026-06-28 antagonistic review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)