### PR TITLE
fix(web): guard streaming against cross-context frames (#1394 follow-up)

### DIFF
--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -270,7 +270,11 @@ async function handleA2AStream(req, res, body) {
     .join("");
   const frames = buildFrames({
     rpcId: body.id ?? "1",
-    contextId: params.contextId || "e2e-ctx",
+    // Echo the contextId the console sent (it rides on the MESSAGE, like the real server,
+    // which mirrors message.context_id back onto every frame). The console now drops frames
+    // whose contextId != its sessionId (frameIsForeign, #1399); a mock that didn't echo the
+    // real contextId would have all its frames rejected and render nothing.
+    contextId: params.message?.contextId || params.contextId || "e2e-ctx",
     taskId: "task-e2e-1",
     prompt,
   });

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ApiError, apiUrl, drainSseBuffer, isColdStart, textFromParts, hitlFromParts } from "./api";
+import { ApiError, apiUrl, drainSseBuffer, frameIsForeign, isColdStart, textFromParts, hitlFromParts } from "./api";
 
 describe("cold-start detection (ApiError / isColdStart)", () => {
   it("ApiError carries the HTTP status", () => {
@@ -148,5 +148,44 @@ describe("apiUrl — fleet slug routing (ADR 0042)", () => {
     focus("m");
     expect(apiUrl("/api/fleet")).not.toContain("/agents/");
     expect(apiUrl("/api/archetypes")).not.toContain("/agents/");
+  });
+});
+
+describe("frameIsForeign — cross-context stream guard (subagent-stream-isolation #1394 follow-up)", () => {
+  // A console turn streams exactly one A2A context (its sessionId); the SDK stamps every frame
+  // with its originating contextId, so a frame from a DIFFERENT context is cross-talk to drop.
+  // A frame with no contextId is never foreign (back-compat / A2A 0.3 flat shape).
+  const SESSION = "sess-1";
+
+  it("drops an artifactUpdate stamped with a different contextId (e.g. a background job)", () => {
+    const frame = { result: { artifactUpdate: { taskId: "t9", contextId: "background:bg-7", artifact: { parts: [] } } } };
+    expect(frameIsForeign(frame, SESSION)).toBe(true);
+  });
+
+  it("keeps an artifactUpdate stamped with this turn's contextId", () => {
+    const frame = { result: { artifactUpdate: { taskId: "t1", contextId: SESSION, artifact: { parts: [] } } } };
+    expect(frameIsForeign(frame, SESSION)).toBe(false);
+  });
+
+  it("keeps an artifactUpdate with NO contextId (older server → guard is a no-op)", () => {
+    const frame = { result: { artifactUpdate: { taskId: "t1", artifact: { parts: [] } } } };
+    expect(frameIsForeign(frame, SESSION)).toBe(false);
+  });
+
+  it("drops foreign statusUpdate and task frames; keeps matching ones", () => {
+    expect(frameIsForeign({ result: { statusUpdate: { taskId: "t9", contextId: "other" } } }, SESSION)).toBe(true);
+    expect(frameIsForeign({ result: { task: { id: "t9", contextId: "other" } } }, SESSION)).toBe(true);
+    expect(frameIsForeign({ result: { statusUpdate: { taskId: "t1", contextId: SESSION } } }, SESSION)).toBe(false);
+    expect(frameIsForeign({ result: { task: { id: "t1", contextId: SESSION } } }, SESSION)).toBe(false);
+  });
+
+  it("handles the A2A 0.3 flat shape via result.contextId", () => {
+    expect(frameIsForeign({ result: { kind: "artifact-update", contextId: "other" } }, SESSION)).toBe(true);
+    expect(frameIsForeign({ result: { kind: "artifact-update", contextId: SESSION } }, SESSION)).toBe(false);
+  });
+
+  it("never treats an empty / resultless frame as foreign", () => {
+    expect(frameIsForeign({}, SESSION)).toBe(false);
+    expect(frameIsForeign({ result: {} }, SESSION)).toBe(false);
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -80,6 +80,7 @@ type A2AFrame = {
     };
     artifactUpdate?: {
       taskId?: string;
+      contextId?: string;
       artifact?: { parts?: A2APart[] };
       append?: boolean;
       lastChunk?: boolean;
@@ -100,6 +101,25 @@ type A2AFrame = {
     message?: string;
   };
 };
+
+/**
+ * Defense-in-depth for streaming (follow-up to the subagent-stream-isolation fix #1394).
+ *
+ * The a2a SDK stamps EVERY frame it emits — `task`, `statusUpdate`, `artifactUpdate` — with
+ * the originating `contextId`, and a single console turn streams exactly ONE context (the
+ * `sessionId` it sent as the message `contextId`; the server echoes it back unchanged). So a
+ * frame carrying a DIFFERENT contextId is cross-talk from a concurrent turn or a detached
+ * background job and must never be rendered into this turn's message. Returns true for such a
+ * foreign frame. A frame with no contextId (an older server / the A2A 0.3 flat shape that
+ * omits it) is never treated as foreign — the guard degrades to a no-op rather than dropping
+ * legitimate output.
+ */
+export function frameIsForeign(frame: A2AFrame, expectedContextId: string): boolean {
+  const r = frame.result;
+  if (!r) return false;
+  const cid = r.task?.contextId ?? r.statusUpdate?.contextId ?? r.artifactUpdate?.contextId ?? r.contextId;
+  return !!cid && cid !== expectedContextId;
+}
 
 function defaultApiBase() {
   if (typeof window === "undefined") return "";
@@ -1168,6 +1188,9 @@ export const api = {
       if (frame.error?.message) throw new Error(frame.error.message);
       const result = frame.result;
       if (!result) return;
+      // Drop any frame stamped with a different contextId than this turn's — cross-talk from
+      // a concurrent turn or background job can't leak into this message (see frameIsForeign).
+      if (frameIsForeign(frame, sessionId)) return;
       const task = result.task ?? (result.kind === "task" ? result : undefined);
       const statusUpdate = result.statusUpdate ?? (result.kind === "status-update" ? result : undefined);
       const artifactUpdate = result.artifactUpdate ?? (result.kind === "artifact-update" ? result : undefined);


### PR DESCRIPTION
## Why

Defense-in-depth on top of #1394. That PR stopped subagent tokens leaking into the lead stream *server-side*. This adds the *client-side* belt-and-suspenders so a stray frame from another A2A context can never render into the wrong chat message.

## The guarantee it leans on

The a2a SDK stamps **every** frame — `task`, `statusUpdate`, `artifactUpdate` — with its originating `contextId`. A console turn sends `contextId: sessionId` and the server echoes it back unchanged (verified: `RequestContext` uses `message.context_id` when present, so `context.context_id === sessionId`). So for a turn's own frames `contextId === sessionId`; anything else is cross-talk from a concurrent turn or a detached `background:<job_id>` job.

## Change (client-only — the SDK already emits contextId)

- `dispatchFrame` drops any frame whose `contextId` differs from this turn's `sessionId` (new exported `frameIsForeign`), guarding **every** channel (text/reasoning/tools/status), not just the answer artifact.
- Frames with **no** contextId pass through untouched → older servers and the A2A 0.3 flat shape are unaffected; the guard degrades to a no-op rather than ever dropping legitimate output.
- `artifactUpdate` type now reads the `contextId` the SDK was already putting on the wire (it was the only frame variant the client type omitted).

## Tests
- `apps/web/src/lib/api.test.ts` — `frameIsForeign` across `task` / `statusUpdate` / `artifactUpdate` / 0.3-flat shapes, the no-contextId no-op, and empty frames. `npm run test:unit` ✅ 28 passed; `tsc --noEmit` ✅.

## Notes
- **Draft / verify live** per the console local-test gate: send a normal message and confirm streaming still renders token-by-token (the guard must not drop your own frames — it won't, since they carry `contextId === sessionId`, but it's a 10-second sanity check given it sits on the hot streaming path).
- Pairs with #1394 and #1396; independent of both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)