### PR TITLE
fix(security): Batch 2 (1/2) — plugin public_paths auth-bypass, data-verifier eval sandbox, install off-loop

### DIFF
--- a/a2a_impl/auth.py
+++ b/a2a_impl/auth.py
@@ -29,6 +29,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import time
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -78,6 +79,13 @@ _PLUGIN_PUBLIC: list[str] = []
 # SSE token lifetime (seconds).
 _SSE_TOKEN_LIFETIME = 30
 
+# A plugin public-prefix must be a real SUBTREE of its own namespace —
+# ``/plugins/<id>/…`` or ``/api/plugins/<id>/…`` with a trailing slash after the
+# id segment — so a bare core route like ``/api/plugins/install`` can never be
+# prefix-matched into the exempt set (defence-in-depth behind the manifest
+# parser, which applies the same boundary).
+_PLUGIN_NS_RE = re.compile(r"^/(?:api/)?plugins/[^/]+/")
+
 
 def set_public_prefixes(prefixes) -> None:
     """Replace the plugin-declared public-prefix set (idempotent + reload-safe).
@@ -90,10 +98,12 @@ def set_public_prefixes(prefixes) -> None:
         s = str(p).strip()
         if not s:
             continue
-        if s.startswith("/plugins/") or s.startswith("/api/plugins/"):
+        if _PLUGIN_NS_RE.match(s):
             cleaned.append(s)
         else:
-            logger.warning("[a2a] ignoring plugin public prefix %r — must live under /plugins/<id>/", s)
+            logger.warning(
+                "[a2a] ignoring plugin public prefix %r — must be under /plugins/<id>/ or /api/plugins/<id>/", s
+            )
     _PLUGIN_PUBLIC[:] = cleaned
     if cleaned:
         logger.info("[a2a] %d plugin-declared auth-exempt path(s): %s", len(cleaned), ", ".join(cleaned))

--- a/docs/dev/launch-hardening-tasklist.md
+++ b/docs/dev/launch-hardening-tasklist.md
@@ -62,7 +62,7 @@ Additive guards / one-liners; near-zero regression risk, high security ROI.
 
 ## Batch 2 — Med churn × Low–Med LOE → contained, needs regression tests (one PR each)
 
-- [ ] **Plugin `public_paths` prefix-match auth bypass** — `High` · churn Med · LOE S–M —
+- [x] **Plugin `public_paths` prefix-match auth bypass** — `High` · churn Med · LOE S–M —
   `graph/plugins/manifest.py:141-146` + `a2a_impl/auth.py:88-100`. Boundary-less
   `startswith` lets a plugin with `id: install` + `public_paths:["/api/plugins/install"]`
   strip the bearer gate off the core install (RCE) route. Fix: require a trailing-slash
@@ -76,11 +76,11 @@ Additive guards / one-liners; near-zero regression risk, high security ROI.
   fallback cache (`139-153`) → make discovery signal failure distinctly; (c) MCP inline
   env/header secrets returned + stored unredacted (`386-391`) → route to `secrets.yaml`
   / mask.
-- [ ] **Plugin install/update/sync block the event loop** — `High` · Med · S–M —
+- [x] **Plugin install/update/sync block the event loop** — `High` · Med · S–M —
   `operator_api/plugin_routes.py:192,324,337,382` → `graph/plugins/installer.py`.
   `await asyncio.to_thread(installer.…)` in the handlers + bounded subprocess timeouts
   on clone/ls-remote. Self-DoS: one install freezes all chat/A2A/scheduler.
-- [ ] **`data` goal-verifier `eval()` escapable sandbox** — Low (adj) · Low–Med · S —
+- [x] **`data` goal-verifier `eval()` escapable sandbox** — Low (adj) · Low–Med · S —
   `graph/goals/verifiers.py:178-184`. Replace `eval()` with the AST-whitelist approach
   from `tools/lg_tools.py:_safe_eval` (reject `Attribute`/`Call`/comprehensions); fix the
   misleading "blocks exec/eval" comment. *(Low on its own — the sibling `command`

--- a/graph/goals/verifiers.py
+++ b/graph/goals/verifiers.py
@@ -20,6 +20,7 @@ operator action — only set goals from trusted input. See docs/guides/goal-mode
 
 from __future__ import annotations
 
+import ast
 import json
 import logging
 from dataclasses import dataclass
@@ -60,6 +61,27 @@ _SAFE_BUILTINS = {
         "filter",
     )
 }
+
+# Attribute access is the eval-sandbox escape (``().__class__.__bases__[0].
+# __subclasses__()`` and the ``"{0.__class__}".format`` / f-string variants), so
+# the `data` verifier's expr is AST-validated to reject it (and dunder names,
+# lambda, await/yield) BEFORE evaluation — subscripts, comparisons, boolean/
+# arithmetic ops, comprehensions and calls to the curated builtins still work.
+_DISALLOWED_EXPR_NODES = (ast.Attribute, ast.Lambda, ast.Await, ast.Yield, ast.YieldFrom)
+
+
+def _eval_data_expr(expr: str, data):
+    """Evaluate a `data` verifier expr with the escape vectors statically rejected
+    and only the curated read-only builtins available. Raises ``ValueError`` on a
+    disallowed construct, otherwise returns the expr's value."""
+    tree = ast.parse(expr, mode="eval")
+    for node in ast.walk(tree):
+        if isinstance(node, _DISALLOWED_EXPR_NODES):
+            raise ValueError(f"{type(node).__name__} is not allowed in a data expr")
+        if isinstance(node, ast.Name) and node.id.startswith("__"):
+            raise ValueError(f"dunder name {node.id!r} is not allowed in a data expr")
+    code = compile(tree, "<data-expr>", "eval")
+    return eval(code, {"__builtins__": _SAFE_BUILTINS}, {"data": data})  # noqa: S307 — AST-validated above
 
 
 @dataclass
@@ -175,9 +197,10 @@ async def _verify_data(spec: dict, ctx: VerifyContext) -> VerifyResult:
         except json.JSONDecodeError as exc:
             return VerifyResult(False, f"{path} is not valid JSON: {exc}", _tail(text))
         try:
-            # Restricted eval: only curated read-only builtins + the parsed
-            # document as `data`. Blocks __import__/open/exec/eval.
-            result = eval(expr, {"__builtins__": _SAFE_BUILTINS}, {"data": data})  # noqa: S307
+            # AST-validated restricted eval: curated read-only builtins + the
+            # parsed document as `data`, with attribute access / dunder names
+            # rejected so the expr can't escape the sandbox. See _eval_data_expr.
+            result = _eval_data_expr(expr, data)
         except Exception as exc:
             return VerifyResult(False, f"expr error: {type(exc).__name__}: {exc}", _tail(text))
         met = bool(result)

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -48,6 +48,10 @@ _ALLOWED_SCHEMES = ("https://", "http://", "git://", "ssh://", "git@", "file://"
 # (source_url, ref) so repeated polls don't ls-remote the same source every call.
 _LSREMOTE_TIMEOUT_S = 5.0
 _LSREMOTE_TTL_S = 300.0  # ~5 min
+# A git clone of a slow/large remote is bounded so it can't hang an install thread
+# indefinitely (the operator install/update routes offload to a thread, so this
+# caps the worst case rather than wedging a pool worker forever).
+_CLONE_TIMEOUT_S = 600.0
 _lsremote_cache: dict[tuple[str, str], tuple[float, str]] = {}
 
 
@@ -174,13 +178,13 @@ def _clone(url: str, ref: str | None, dest: Path) -> str:
     if ref and _SHA_RE.match(ref):
         # A specific commit: full clone (shallow can't reliably check out an
         # arbitrary SHA), then check it out.
-        _git("clone", "--no-recurse-submodules", url, str(dest))
+        _git("clone", "--no-recurse-submodules", url, str(dest), timeout=_CLONE_TIMEOUT_S)
         _git("checkout", ref, cwd=dest)
     elif ref:
         # A tag or branch: shallow clone of just that ref.
-        _git("clone", "--depth", "1", "--no-recurse-submodules", "--branch", ref, url, str(dest))
+        _git("clone", "--depth", "1", "--no-recurse-submodules", "--branch", ref, url, str(dest), timeout=_CLONE_TIMEOUT_S)
     else:
-        _git("clone", "--depth", "1", "--no-recurse-submodules", url, str(dest))
+        _git("clone", "--depth", "1", "--no-recurse-submodules", url, str(dest), timeout=_CLONE_TIMEOUT_S)
     return _git("rev-parse", "HEAD", cwd=dest)
 
 

--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -130,15 +130,25 @@ def _parse_views(views, plugin_id: str) -> list[dict]:
     return kept
 
 
+# A plugin id namespaces its routes (``/plugins/<id>/``, ``/api/plugins/<id>/``)
+# and its config section, so it must be a safe slug AND must not shadow a core
+# ``/api/plugins/<verb>`` management route — otherwise its ``public_paths`` could
+# prefix-match and exempt that core route (e.g. install = RCE) from the auth gate.
+_VALID_PLUGIN_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+_RESERVED_PLUGIN_IDS = frozenset({"install", "installed", "sync", "updates", "catalog", "enabled"})
+
+
 def _parse_public_paths(paths, plugin_id: str) -> list[str]:
-    """Keep auth-exempt paths that live under THIS plugin's namespace
+    """Keep auth-exempt paths that live under THIS plugin's namespace SUBTREE
     (``/plugins/<id>/…`` or ``/api/plugins/<id>/…``); drop + warn on anything else.
 
     Namespace-scoping is the security boundary: a plugin can exempt only its own
-    routes from the auth gate, never a core path like ``/api/config``."""
+    routes from the auth gate, never a core path like ``/api/config`` or the core
+    ``/api/plugins/<verb>`` routes. The trailing slash is load-bearing — without
+    it, id ``install`` would prefix-match the core ``/api/plugins/install`` route."""
     if not isinstance(paths, (list, tuple)):
         return []
-    roots = (f"/plugins/{plugin_id}", f"/api/plugins/{plugin_id}")
+    roots = (f"/plugins/{plugin_id}/", f"/api/plugins/{plugin_id}/")
     kept: list[str] = []
     for p in paths:
         s = str(p).strip()
@@ -205,6 +215,13 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
     name = str(data.get("name", "")).strip()
     if not pid or not name:
         log.warning("[plugins] %s: manifest missing required id/name — skipping", plugin_dir.name)
+        return None
+    if not _VALID_PLUGIN_ID.match(pid) or pid.lower() in _RESERVED_PLUGIN_IDS:
+        log.warning(
+            "[plugins] %s: invalid or reserved plugin id %r — must match %s and must not shadow a "
+            "core /api/plugins/ route; skipping",
+            plugin_dir.name, pid, _VALID_PLUGIN_ID.pattern,
+        )
         return None
 
     req = data.get("requires_env")

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -26,6 +26,7 @@ routes don't serve until a process restart, so both routes flag it.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 
@@ -189,12 +190,10 @@ def register_plugin_routes(app) -> None:
         ref = str(body.get("ref", "")).strip() or None
         force = bool(body.get("force"))
         try:
-            summary = installer.install(
-                url,
-                ref,
-                force=force,
-                by="console",
-                allow=_sources_allowlist(),
+            # git clone + dep work is blocking — offload so it can't stall the
+            # event loop (and with it every chat/A2A/scheduler request) (#DoS).
+            summary = await asyncio.to_thread(
+                installer.install, url, ref, force=force, by="console", allow=_sources_allowlist()
             )
         except installer.InstallError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -321,7 +320,7 @@ def register_plugin_routes(app) -> None:
         Pinned-to-SHA plugins skip the network; the rest ls-remote their ref
         (TTL-cached + timeout-bounded so the poll can't hang). Errors are
         non-fatal per entry — surfaced in each row's ``error``."""
-        return {"plugins": installer.check_updates()}
+        return {"plugins": await asyncio.to_thread(installer.check_updates)}
 
     @app.post("/api/plugins/sync")
     async def _sync():
@@ -334,7 +333,7 @@ def register_plugin_routes(app) -> None:
         (e.g. a restored data dir whose config still enables it), hot-reload so
         it comes up live — a previously-missing plugin has no mounted router, so
         the hot-mount path applies and no restart is needed."""
-        results = installer.sync(allow=_sources_allowlist())
+        results = await asyncio.to_thread(installer.sync, allow=_sources_allowlist())
         fetched = {r["id"] for r in results if r.get("status") == "installed"}
 
         reloaded = False
@@ -379,12 +378,8 @@ def register_plugin_routes(app) -> None:
             )
         ref = entry.get("requested_ref", "") or None
         try:
-            summary = installer.install(
-                source_url,
-                ref,
-                force=True,
-                by="console",
-                allow=_sources_allowlist(),
+            summary = await asyncio.to_thread(
+                installer.install, source_url, ref, force=True, by="console", allow=_sources_allowlist()
             )
         except installer.InstallError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/tests/test_a2a_auth.py
+++ b/tests/test_a2a_auth.py
@@ -215,6 +215,22 @@ def test_plugin_public_prefix_exempts_only_namespaced(monkeypatch):
         assert _client_multi().get("/plugins/example/status").status_code == 401
 
 
+def test_set_public_prefixes_rejects_core_route_prefix(monkeypatch):
+    """A plugin can't strip the gate off a core /api/plugins/<verb> route by
+    declaring it a public_path — the namespace boundary needs a trailing slash
+    after the <id> segment (defence-in-depth vs the id=='install' bypass)."""
+    monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    auth.configure(bearer_token="secret", api_key="", allowed_origins_raw="")
+    try:
+        auth.set_public_prefixes(["/api/plugins/install", "/api/plugins/", "/plugins/install"])
+        c = _client_multi()
+        assert c.post("/api/plugins/install").status_code == 401  # core route stays gated
+        auth.set_public_prefixes(["/api/plugins/myplugin/webhook"])
+        assert c.get("/api/plugins/myplugin/webhook").status_code != 401  # real subtree exempt
+    finally:
+        auth.set_public_prefixes([])
+
+
 # AC5: /app is public (SPA served without auth)
 def test_ac5_app_public(monkeypatch):
     monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)

--- a/tests/test_goal_verifiers.py
+++ b/tests/test_goal_verifiers.py
@@ -67,6 +67,22 @@ async def test_data_expr_no_builtins_blocked(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_data_expr_attribute_escape_blocked(tmp_path):
+    """The classic eval-sandbox escape via attribute traversal is statically
+    rejected (Attribute nodes disallowed) — not-met, never code execution."""
+    f = tmp_path / "out.json"
+    f.write_text("[]")
+    for expr in (
+        "().__class__.__bases__[0].__subclasses__()",
+        "data.__class__",
+        "'{0.__class__}'.format(data)",
+    ):
+        res = await run_verifier({"type": "data", "path": str(f), "expr": expr}, VerifyContext())
+        assert res.met is False, expr
+        assert "not allowed" in res.reason or "error" in res.reason.lower()
+
+
+@pytest.mark.asyncio
 async def test_data_missing_file(tmp_path):
     res = await run_verifier({"type": "data", "path": str(tmp_path / "nope.json"), "contains": "x"}, VerifyContext())
     assert res.met is False

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -74,6 +74,35 @@ def test_public_paths_namespace_scoped(tmp_path) -> None:
     assert m.public_paths == ["/plugins/wh/webhook", "/api/plugins/wh/data"]
 
 
+def test_public_paths_reject_core_route_prefix(tmp_path) -> None:
+    # The historical bypass: a plugin id that prefix-matches a core /api/plugins/<verb>
+    # route (e.g. "install") could exempt that RCE route from the auth gate. Such an
+    # id is now refused at load, and the path boundary requires a trailing slash after
+    # the id so it can't prefix-match the bare core route either.
+    from graph.plugins.manifest import _parse_public_paths
+
+    _make_plugin(tmp_path, "install", enabled=True, manifest_extra="public_paths:\n  - /api/plugins/install\n")
+    assert load_manifest(tmp_path / "install") is None  # reserved id → skipped entirely
+
+    assert _parse_public_paths(["/api/plugins/install"], "install") == []  # no trailing slash → not a subtree
+    assert _parse_public_paths(["/api/plugins/demo/webhook"], "demo") == ["/api/plugins/demo/webhook"]
+
+
+def test_invalid_plugin_id_rejected(tmp_path) -> None:
+    from graph.plugins.manifest import _VALID_PLUGIN_ID
+
+    _make_plugin(tmp_path, "ok-id_1", enabled=True)
+    assert load_manifest(tmp_path / "ok-id_1") is not None  # ordinary slug is fine
+
+    assert not _VALID_PLUGIN_ID.match("../etc")  # path traversal
+    assert not _VALID_PLUGIN_ID.match("a/b")  # slash
+    for reserved in ("sync", "Updates", "catalog"):
+        d = tmp_path / f"x_{reserved}"
+        d.mkdir()
+        (d / "protoagent.plugin.yaml").write_text(f"id: {reserved}\nname: x\nversion: 0.1.0\n", encoding="utf-8")
+        assert load_manifest(d) is None, reserved
+
+
 def test_discover_live_overrides_bundle(tmp_path, monkeypatch) -> None:
     bundle = tmp_path / "bundle"
     live = tmp_path / "live"


### PR DESCRIPTION
**Batch 2 (part 1)** of the launch-hardening plan (`docs/dev/launch-hardening-tasklist.md`). Three independent backend fixes from the 2026-06-28 antagonistic review. (The secret-redaction trio is part 2, a separate PR.)

### 1. Plugin `public_paths` auth-bypass → **High**
`_parse_public_paths` used a boundary-less `startswith`, and `plugin_id` was unvalidated — so a plugin with `id: install` + `public_paths: ["/api/plugins/install"]` could strip the bearer gate off the **core install (=RCE) route**, surviving token rotation. Fix:
- trailing-slash namespace subtree (`/plugins/<id>/`, `/api/plugins/<id>/`) in the manifest parser;
- validate `plugin_id` (`^[A-Za-z0-9][A-Za-z0-9_-]*$` + reserved-name denylist `install`/`installed`/`sync`/`updates`/`catalog`/`enabled`);
- same boundary re-checked in `set_public_prefixes` (defence-in-depth).

### 2. `data` goal-verifier `eval()` sandbox escape → Low (defence-in-depth)
The `data` verifier `eval()`'d an expr with curated builtins but no AST guard, so the classic attribute-traversal escape (`().__class__.__bases__[0].__subclasses__()`) was reachable. Now AST-validated: `ast.Attribute` / dunder names / lambda / await are rejected before eval; subscripts, comparisons, comprehensions, and safe-builtin calls still work.

### 3. Plugin install/update/sync block the event loop → **High** (availability)
`git clone` + dep work ran synchronously on the asyncio loop, so one operator install froze **all** chat/A2A/scheduler requests. Wrapped the four installer calls in `asyncio.to_thread` + bounded `git clone` with a timeout.

## Gates (isolated worktree off `main`)
- `ruff check .` (0.15.10) ✓ · `lint-imports` 3/0 ✓ · `pytest tests/ -q` — **2574 passed** (+7 new: public_paths bypass + id validation, attribute-escape blocked, set_public_prefixes boundary).

Each fix is its own commit. From the 2026-06-28 antagonistic review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)