### PR TITLE
feat(web): live tool-card feed for background jobs (ADR 0050 Phase 3)

### DIFF
--- a/apps/web/src/app/BackgroundJobs.test.ts
+++ b/apps/web/src/app/BackgroundJobs.test.ts
@@ -59,4 +59,14 @@ describe("applyProgress", () => {
     for (let i = 0; i < 20; i++) p = applyProgress(p, { phase: "tool_start", tool_call_id: `t${i}` });
     expect(p.length).toBe(8);
   });
+
+  it("captures the tool output on tool_end (for the expandable feed) and preserves it", () => {
+    let p = applyProgress([], { phase: "tool_start", tool: "web_search", tool_call_id: "tc1" });
+    expect(p[0].output).toBeUndefined(); // no output while running
+    p = applyProgress(p, { phase: "tool_end", tool: "web_search", tool_call_id: "tc1", output: "found 3 results" });
+    expect(p[0]).toMatchObject({ id: "tc1", done: true, output: "found 3 results" });
+    // a later frame without output for the same tool keeps the captured value
+    p = applyProgress(p, { phase: "tool_end", tool: "web_search", tool_call_id: "tc1" });
+    expect(p[0].output).toBe("found 3 results");
+  });
 });

--- a/apps/web/src/app/BackgroundJobs.tsx
+++ b/apps/web/src/app/BackgroundJobs.tsx
@@ -1,4 +1,5 @@
 import { Dialog, Tooltip } from "@protolabsai/ui/overlays";
+import { ToolCard, ToolCardList, ToolSection } from "@protolabsai/ui/tool-card";
 import { Bot, CheckCircle2, Loader2, Square, Trash2, XCircle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -98,6 +99,7 @@ export function BackgroundJobs() {
           tool: d.tool ? String(d.tool) : undefined,
           tool_call_id: d.tool_call_id ? String(d.tool_call_id) : undefined,
           error: !!d.error,
+          output: d.output ? String(d.output) : undefined,
         }),
       }));
     });
@@ -249,6 +251,11 @@ function BgJobRow({
   );
   const elapsed = fmtElapsed(job.created_at, running ? undefined : job.completed_at);
   const hasResult = !running && !!job.result;
+  const hasTools = tools.length > 0;
+  // Expandable when there's a result to read OR a live/historical tool feed to watch —
+  // so a RUNNING job can now be opened to follow its tool-by-tool activity (ADR 0050
+  // Phase 3's deferred "rich live subagent card"), not just finished jobs.
+  const canExpand = hasResult || hasTools;
   const recentTools = tools.slice(-3);
   return (
     <li className="bg-jobs-row">
@@ -256,9 +263,9 @@ function BgJobRow({
         <button
           type="button"
           className="bg-jobs-rowmain"
-          onClick={() => hasResult && setExpanded((v) => !v)}
-          aria-expanded={hasResult ? expanded : undefined}
-          disabled={!hasResult}
+          onClick={() => canExpand && setExpanded((v) => !v)}
+          aria-expanded={canExpand ? expanded : undefined}
+          disabled={!canExpand}
         >
           <span className="bg-jobs-icon">{icon}</span>
           <span className="bg-jobs-meta">
@@ -268,7 +275,7 @@ function BgJobRow({
             <span className="bg-jobs-sub">
               {job.status}
               {elapsed ? ` · ${elapsed}` : ""}
-              {hasResult ? (expanded ? " · hide result" : " · show result") : ""}
+              {canExpand ? (expanded ? " · hide details" : hasResult ? " · show result" : " · show activity") : ""}
             </span>
             {running && recentTools.length > 0 ? (
               <span className="bg-jobs-tools">
@@ -303,9 +310,26 @@ function BgJobRow({
           </button>
         )}
       </div>
-      {hasResult && expanded ? (
-        <div className="bg-jobs-result">
-          <Markdown>{job.result || ""}</Markdown>
+      {expanded && canExpand ? (
+        <div className="bg-jobs-detail">
+          {hasTools ? (
+            <ToolCardList className="bg-jobs-feed">
+              {tools.map((t) => (
+                <ToolCard
+                  key={t.id}
+                  name={t.tool}
+                  status={t.error ? "error" : t.done ? "done" : "running"}
+                >
+                  {t.output ? <ToolSection label="output">{t.output}</ToolSection> : null}
+                </ToolCard>
+              ))}
+            </ToolCardList>
+          ) : null}
+          {hasResult ? (
+            <div className="bg-jobs-result">
+              <Markdown>{job.result || ""}</Markdown>
+            </div>
+          ) : null}
         </div>
       ) : null}
     </li>

--- a/apps/web/src/app/background-jobs.ts
+++ b/apps/web/src/app/background-jobs.ts
@@ -22,14 +22,16 @@ export function fmtElapsed(startIso?: string, endIso?: string): string {
 }
 
 // A background turn's tool, as surfaced by the `background.progress` channel (ADR 0051).
-export type ProgressTool = { id: string; tool: string; done: boolean; error: boolean };
+// `output` is the (server-truncated) tool result that rides the tool_end frame — shown in
+// the expandable per-tool card; absent while the tool is still running.
+export type ProgressTool = { id: string; tool: string; done: boolean; error: boolean; output?: string };
 
 /** Merge a `background.progress` frame into a job's tool list, keyed by tool_call_id
- *  (tool_start → running, tool_end → done/error). Capped so a chatty job can't grow
- *  unbounded. Pure → unit-testable. */
+ *  (tool_start → running, tool_end → done/error, carrying the truncated output). Capped so a
+ *  chatty job can't grow unbounded. Pure → unit-testable. */
 export function applyProgress(
   prev: ProgressTool[],
-  frame: { phase?: string; tool?: string; tool_call_id?: string; error?: boolean },
+  frame: { phase?: string; tool?: string; tool_call_id?: string; error?: boolean; output?: string },
 ): ProgressTool[] {
   const id = String(frame.tool_call_id || frame.tool || "");
   if (!id) return prev;
@@ -40,6 +42,8 @@ export function applyProgress(
     tool: String(frame.tool || (i >= 0 ? next[i].tool : "tool")),
     done: frame.phase === "tool_end",
     error: !!frame.error,
+    // tool_end carries the output; keep any earlier value if a later frame omits it.
+    output: frame.output != null ? String(frame.output) : i >= 0 ? next[i].output : undefined,
   };
   if (i >= 0) next[i] = entry;
   else next.push(entry);

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -295,6 +295,26 @@
   overscroll-behavior: contain;
 }
 
+/* Expanded row body: a live tool-by-tool feed (DS ToolCard) and/or the result. The wrapper
+   owns the single top separator; the nested result drops its own to avoid a double rule. */
+.bg-jobs-detail {
+  border-top: 1px solid var(--border, #2a2a31);
+}
+.bg-jobs-detail .bg-jobs-result {
+  border-top: none;
+}
+.bg-jobs-feed {
+  padding: 8px 12px 8px 33px;
+  /* A chatty job (many tools) scrolls within the row rather than growing the dialog. */
+  max-height: 40vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+/* Divider when a result is shown beneath the tool feed. */
+.bg-jobs-feed + .bg-jobs-result {
+  border-top: 1px solid var(--border, #2a2a31);
+}
+
 .topbar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What

Realizes ADR 0050 Phase 3's deferred **"rich live subagent card."** A running background job (`task(run_in_background=True)` / `task_batch(run_in_background=True)`) can now be **expanded in the Background-agents dialog to follow its tool-by-tool activity live** — each tool as a DS `ToolCard` (name · status glyph · output), instead of only the last-3 collapsed pills. Finished jobs still expand to their result; the compact pills stay on the running row as the at-a-glance summary.

## Why it's small

The `background.progress` bus channel (ADR 0051) was **already fully wired** and `BackgroundJobs.tsx` was already subscribed — the data was on the bus, just under-rendered. So this is mostly a rendering upgrade:

- `ProgressTool` + `applyProgress` now **capture the per-tool `output`** the `tool_end` frame already carries (and preserve it across later frames).
- The expanded row renders the tool list via **`@protolabsai/ui/tool-card`** — the exact kit the chat transcript uses. **Checked DS-first per the contribute-back rule: `ToolCard`/`ToolCardList`/`ToolSection` fit the need precisely (props `name`/`status`/`children`), so no upstream DS change was needed.**
- Running rows became expandable (`canExpand = hasResult || hasTools`); the result-only path is unchanged for jobs hydrated from `/api/background` without live progress (e.g. after a reload).

## Tests
- `BackgroundJobs.test.ts`: `applyProgress` captures `output` on `tool_end` and preserves it. `npm run test:unit` ✅ 8 passed; `tsc --noEmit` ✅; `vite build` ✅.

## Notes
- **Draft / verify visually** per the console local-test gate (CI can't judge UX). To exercise it: spin up a couple of background agents (e.g. `task_batch(run_in_background=True)` from #1396), open the **Background agents** pill, and expand a running job to watch its tool feed grow.
- Stacks naturally with #1396 (background batch) — more jobs to watch — but is independent of it and of #1394/#1399.
- Output shown is the server-truncated (≤500 char) preview the bus already emits; the full result still renders on completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)