### PR TITLE
fix(security): Batch 2 (2/2) — fail-safe plugin secret redaction (discovery-failure != empty)

### DIFF
--- a/docs/dev/launch-hardening-tasklist.md
+++ b/docs/dev/launch-hardening-tasklist.md
@@ -69,13 +69,14 @@ Additive guards / one-liners; near-zero regression risk, high security ROI.
   boundary (`/api/plugins/{id}/`), validate `plugin_id` against `^[a-z0-9][a-z0-9_-]*$`,
   reserved-name denylist (`install`,`installed`,`sync`,`updates`,`catalog`,`enabled`).
   Test that legit plugin public pages still pass.
-- [ ] **Secret-redaction fail-open trio** — Med×2/Low · Med · S–M — `graph/config_io.py`.
-  Root cause: discovery-empty is indistinguishable from discovery-failure. Fix all three:
-  (a) `GET /api/config` echoes plugin secrets when schema discovery returns empty
-  (`423-438`) → redact the whole section when no schema; (b) dead `secret_paths()` `#877`
-  fallback cache (`139-153`) → make discovery signal failure distinctly; (c) MCP inline
-  env/header secrets returned + stored unredacted (`386-391`) → route to `secrets.yaml`
-  / mask.
+- [x] **Secret-redaction fail-open (a)+(b)** — Med×2 · Med · S–M — `graph/config_io.py` +
+  `graph/plugins/pconfig.py`. Root cause: discovery-empty was indistinguishable from
+  discovery-failure. Added `strict=True` discovery that PROPAGATES errors: (a) `GET
+  /api/config` now blanks the whole plugin section on discovery failure (fail-safe);
+  (b) `secret_paths()` `#877` cache fallback actually triggers now (was dead).
+  - [>] **(c) MCP inline env/header secrets** unredacted in `config_to_dict` (`386-391`) —
+    deferred (Low; live YAML is gitignored, and masking needs save-roundtrip / blank-means-
+    unchanged handling so a re-save doesn't clobber the stored value).
 - [x] **Plugin install/update/sync block the event loop** — `High` · Med · S–M —
   `operator_api/plugin_routes.py:192,324,337,382` → `graph/plugins/installer.py`.
   `await asyncio.to_thread(installer.…)` in the handlers + bounded subprocess timeouts

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -140,7 +140,7 @@ def secret_paths() -> tuple[tuple[str, str], ...]:
     try:
         from graph.plugins.pconfig import installed_plugin_config_schemas
 
-        extra = tuple((sch.section, key) for sch in installed_plugin_config_schemas() for key in sch.secrets)
+        extra = tuple((sch.section, key) for sch in installed_plugin_config_schemas(strict=True) for key in sch.secrets)
         _PLUGIN_SECRET_PATHS_CACHE = extra  # remember the good set for next time
     except Exception as e:  # noqa: BLE001 — discovery is best-effort; fail SAFE, not empty
         extra = _PLUGIN_SECRET_PATHS_CACHE
@@ -422,15 +422,23 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
     # (blank-means-unchanged, like api_key). A default config has none.
     plugin_cfg = getattr(config, "plugin_config", {}) or {}
     if plugin_cfg:
+        discovery_ok = True
         try:
             # ALL installed plugins (not just enabled) — so a disabled plugin's stored
             # secret is redacted from the API response too, never echoed back in the clear.
             from graph.plugins.pconfig import installed_plugin_config_schemas
 
-            secrets_by_section = {s.section: set(s.secrets) for s in installed_plugin_config_schemas()}
-        except Exception:  # noqa: BLE001
+            secrets_by_section = {s.section: set(s.secrets) for s in installed_plugin_config_schemas(strict=True)}
+        except Exception:  # noqa: BLE001 — discovery FAILED (vs genuinely-empty): we no longer know which keys are secret
+            discovery_ok = False
             secrets_by_section = {}
         for section, vals in plugin_cfg.items():
+            if not discovery_ok:
+                # Fail SAFE: with no schema we can't tell a secret from a non-secret
+                # value, so blank the WHOLE section rather than risk echoing a plugin
+                # secret in the clear (blank-means-unchanged on save, like api_key).
+                d[section] = {k: "" for k in vals}
+                continue
             redacted = dict(vals)
             for skey in secrets_by_section.get(section, set()):
                 if skey in redacted:

--- a/graph/plugins/pconfig.py
+++ b/graph/plugins/pconfig.py
@@ -61,14 +61,17 @@ class PluginConfigSchema:
     guide_url: str = ""  # optional setup-guide link rendered next to the group (ADR 0059)
 
 
-def discover_plugin_config(roots, enabled_ids, disabled_ids=None) -> list[PluginConfigSchema]:
+def discover_plugin_config(roots, enabled_ids, disabled_ids=None, *, strict: bool = False) -> list[PluginConfigSchema]:
     """Config schemas of **active** plugins that declare config/secrets/settings.
 
     ``roots`` are plugin directories (bundle + live); ``enabled_ids`` the operator's
     ``plugins.enabled`` set (a manifest ``enabled: true`` also counts);
     ``disabled_ids`` (``plugins.disabled``) turns one off regardless. A section
-    colliding with a built-in (or a second plugin) is dropped (logged). Never
-    raises — bad discovery yields no plugin config, not a broken boot.
+    colliding with a built-in (or a second plugin) is dropped (logged). Never raises
+    by default — bad discovery yields no plugin config, not a broken boot. With
+    ``strict=True`` a discovery ERROR propagates instead of returning ``[]``, so a
+    caller (secret routing / config redaction) can tell a real failure from a
+    genuinely-empty result and fail SAFE rather than open.
     """
     try:
         from graph.plugins.loader import discover_plugins
@@ -106,6 +109,8 @@ def discover_plugin_config(roots, enabled_ids, disabled_ids=None) -> list[Plugin
         return out
     except Exception:  # noqa: BLE001 — discovery is best-effort
         log.exception("[plugins] config-schema discovery failed")
+        if strict:
+            raise
         return []
 
 
@@ -136,12 +141,16 @@ def live_plugin_config_schemas() -> list[PluginConfigSchema]:
         return []
 
 
-def installed_plugin_config_schemas() -> list[PluginConfigSchema]:
+def installed_plugin_config_schemas(*, strict: bool = False) -> list[PluginConfigSchema]:
     """Like ``live_plugin_config_schemas`` but for EVERY installed plugin — enabled or
     not. The SECRET-ROUTING + config-redaction paths use this so a secret saved for a
     currently-DISABLED plugin is still pulled into ``secrets.yaml`` (never left in
     plaintext in the live config) and never echoed back to the API. The settings UI
-    keeps the enabled-only view (you don't configure a plugin that's off)."""
+    keeps the enabled-only view (you don't configure a plugin that's off).
+
+    ``strict=True`` propagates a discovery error (vs returning ``[]``) so the
+    secret-routing / redaction callers can fail SAFE instead of treating a transient
+    failure as "no secrets"."""
     try:
         from graph.config_io import _live_config_dir, load_yaml_doc
         from graph.plugins.loader import discover_plugins
@@ -149,7 +158,9 @@ def installed_plugin_config_schemas() -> list[PluginConfigSchema]:
         data = load_yaml_doc() or {}
         roots = plugin_roots_from(_live_config_dir(), str((data.get("plugins") or {}).get("dir") or ""))
         all_ids = {m.id for m in discover_plugins(roots)}
-        return discover_plugin_config(roots, all_ids, set())  # every installed plugin, on or off
+        return discover_plugin_config(roots, all_ids, set(), strict=strict)  # every installed plugin, on or off
     except Exception:  # noqa: BLE001
         log.exception("[plugins] installed config-schema discovery failed")
+        if strict:
+            raise
         return []

--- a/tests/test_config_secrets.py
+++ b/tests/test_config_secrets.py
@@ -152,12 +152,12 @@ def test_secret_paths_falls_back_to_cache_on_discovery_failure(monkeypatch, capl
 
     # 1) a good discovery populates the cache (the plugin secret is recognized).
     monkeypatch.setattr(config_io, "_PLUGIN_SECRET_PATHS_CACHE", ())
-    monkeypatch.setattr("graph.plugins.pconfig.installed_plugin_config_schemas", lambda: [_Schema()])
+    monkeypatch.setattr("graph.plugins.pconfig.installed_plugin_config_schemas", lambda **kw: [_Schema()])
     assert pair in config_io.secret_paths()
 
     # 2) discovery now FAILS — the plugin secret must still be recognized (cached),
     #    and the failure is logged (no silent downgrade).
-    def _boom():
+    def _boom(**kw):
         raise RuntimeError("manifest parse blew up")
 
     monkeypatch.setattr("graph.plugins.pconfig.installed_plugin_config_schemas", _boom)
@@ -177,14 +177,42 @@ def test_a_plugin_secret_is_stripped_from_the_doc_even_if_rediscovery_fails(monk
         secrets = ["api_key"]
 
     monkeypatch.setattr(config_io, "_PLUGIN_SECRET_PATHS_CACHE", ())
-    monkeypatch.setattr("graph.plugins.pconfig.installed_plugin_config_schemas", lambda: [_Schema()])
+    monkeypatch.setattr("graph.plugins.pconfig.installed_plugin_config_schemas", lambda **kw: [_Schema()])
     config_io.secret_paths()  # prime the cache
 
     monkeypatch.setattr(
         "graph.plugins.pconfig.installed_plugin_config_schemas",
-        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        lambda **kw: (_ for _ in ()).throw(RuntimeError("boom")),
     )
     doc = {"myplugin": {"api_key": "sk-should-be-stripped", "host": "ok-to-keep"}}
     config_io.strip_secrets_from_doc(doc)
     assert "api_key" not in doc["myplugin"]  # the secret never reaches the main YAML
     assert doc["myplugin"]["host"] == "ok-to-keep"  # non-secret kept
+
+
+def test_config_to_dict_blanks_plugin_section_on_discovery_failure(monkeypatch):
+    """GET /api/config must fail SAFE: if plugin-schema discovery raises, config_to_dict
+    can't tell a secret from a non-secret value, so it blanks the WHOLE plugin section
+    rather than echoing a plugin secret in the clear."""
+    from graph import config_io
+    from graph.config import LangGraphConfig
+
+    cfg = LangGraphConfig(plugin_config={"discord": {"bot_token": "sek-ret", "guild": "123"}})
+
+    class _S:
+        section = "discord"
+        secrets = ["bot_token"]
+
+    # discovery OK → only the declared secret is blanked, non-secret config preserved.
+    monkeypatch.setattr("graph.plugins.pconfig.installed_plugin_config_schemas", lambda **kw: [_S()])
+    d = config_io.config_to_dict(cfg)
+    assert d["discord"]["bot_token"] == ""
+    assert d["discord"]["guild"] == "123"
+
+    # discovery FAILS → blank the whole section (no plugin secret echoed in the clear).
+    monkeypatch.setattr(
+        "graph.plugins.pconfig.installed_plugin_config_schemas",
+        lambda **kw: (_ for _ in ()).throw(RuntimeError("discovery boom")),
+    )
+    d2 = config_io.config_to_dict(cfg)
+    assert d2["discord"] == {"bot_token": "", "guild": ""}


### PR DESCRIPTION
**Batch 2 (part 2)** of the launch-hardening plan. Closes the plugin secret-redaction fail-open from the 2026-06-28 antagonistic review.

**Root cause:** `discover_plugin_config` / `installed_plugin_config_schemas` swallowed errors and returned `[]` — indistinguishable from "no plugins / no secrets." So on a transient discovery failure:
- **(a)** `GET /api/config` echoed plugin secrets **in the clear** (no schema → nothing redacted);
- **(b)** `secret_paths()`'s `#877` cache fallback was **dead** (the empty return clobbered the cache rather than raising), so a plugin secret could be written into the exportable main YAML in plaintext.

**Fix:** added `strict=True` to the discovery functions so a real failure **propagates** (vs returning `[]`):
- `secret_paths()` calls it strict → a failure now hits the existing `except` and **keeps the cached** secret paths;
- `config_to_dict()` fails **safe** — when discovery raises it blanks the **whole** plugin section instead of echoing values it can't classify. On success, normal per-key redaction (non-secret config still shows).

**Deferred:** (c) MCP inline `env`/header secret masking — Low severity (the live YAML is gitignored), and masking needs save-roundtrip / blank-means-unchanged handling so a re-save doesn't clobber the stored value. Tracked in the tasklist.

## Gates (isolated worktree off `main`)
- `ruff` ✓ · `lint-imports` 3/0 ✓ · `pytest tests/ -q` — **2571 passed** (+1 new fail-safe test; updated the `#877` mocks to the new `strict` signature so they exercise the now-live path).

From the 2026-06-28 antagonistic review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret handling so plugin-related settings are redacted more safely when discovery fails.
  * Sensitive values in affected plugin sections are now fully blanked instead of potentially left visible.
  * Cached secret-path results are preserved even if a later discovery attempt fails, helping avoid unexpected leakage.
  * Existing config documents continue to strip known secrets while keeping non-sensitive fields intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->