### PR TITLE
fix(web): requestForm reads the error body once (restores 401 prompt on uploads)

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -343,12 +343,15 @@ async function requestForm<T>(path: string, form: FormData, opts: { host?: boole
     body: form,
   });
   if (!response.ok) {
+    // Read the body ONCE (a Response stream can't be read twice — calling
+    // .json() then .text() throws "body stream already read", which masked the
+    // real HTTP detail and skipped the 401 AuthGate). Mirror `request`.
+    const raw = await response.text().catch(() => "");
     let detail = `${response.status} ${response.statusText}`;
     try {
-      const payload = (await response.json()) as { detail?: string };
-      detail = payload.detail || detail;
+      detail = (JSON.parse(raw) as { detail?: string }).detail || raw || detail;
     } catch {
-      detail = await response.text();
+      detail = raw || detail;
     }
     if (response.status === 401) notifyAuthRequired();
     throw new ApiError(response.status, detail || "request failed");

--- a/docs/dev/launch-hardening-tasklist.md
+++ b/docs/dev/launch-hardening-tasklist.md
@@ -41,7 +41,7 @@ Additive guards / one-liners; near-zero regression risk, high security ROI.
 - [x] **Non-constant-time credential compare** — Low · Low · XS — `a2a_impl/auth.py:218`,
   `operator_api/console_handlers.py:389`. Use `hmac.compare_digest` for X-API-Key and
   the inbox token (bearer already does).
-- [ ] **`requestForm` double-body-read masks 401** — Med · Low · XS–S —
+- [x] **`requestForm` double-body-read masks 401** — Med · Low · XS–S —
   `apps/web/src/lib/api.ts:345`. Read body once (`text()` then best-effort
   `JSON.parse`); restores the real error + the 401 AuthGate on uploads.
 - [x] **Boot TTL sweep deletes HITL tasks** — Low · Low · XS–S —
@@ -53,9 +53,10 @@ Additive guards / one-liners; near-zero regression risk, high security ROI.
 - [x] **Subagent return-value mis-parse** — Low · Med · S — `graph/agent.py:278`.
   Select the last `AIMessage` (not "any message with content"); drop the
   `startswith("Error")` heuristic — use the `SubagentError` path for failures.
-- [ ] **Palette deep-link dead-ends on workspace console** — Low · Low · S —
-  `apps/web/src/app/usePaletteRegistry.ts:142`. Gate `box:fleet`/`box:telemetry`
-  registrations behind `isHostConsole()`. *(Surfaced on the settings-IA branch.)*
+- [>] **Palette deep-link dead-ends on workspace console** — Low · Low · S —
+  `apps/web/src/app/usePaletteRegistry.ts`. *(Deferred: `_link` registers at module-import,
+  so an `isHostConsole()` gate there is timing-fragile; the clean fix is a run-time guard in
+  `SettingsSurface`. Cosmetic — low priority.)*
 - [ ] **SSE token in URL** — Low · Low · XS — `apps/web/src/lib/events.ts:70`. Scrub
   `token` from server access logs (cookie-bound SSE token is a bigger change; defer).
   Already mitigated by 30s HMAC TTL + `/api/events`-only scope.
@@ -102,16 +103,25 @@ Additive guards / one-liners; near-zero regression risk, high security ROI.
   **Breaks servers that relied on an implicitly-inherited secret env var** — they set
   `inherit_env: true` or a per-server `env:`. *(Authorized for launch; shipped on this
   branch.)*
-- [ ] **"Operator-only" goal trust gate** — `High` · High · M — `server/chat.py:692,1036`
+- [>] **"Operator-only" goal trust gate** — `High` · High · M — `server/chat.py:692,1036`
   → `graph/goals/controller.py:98`. Thread `trusted: bool` from the calling surface into
   `parse_control`; refuse `command`/`test`/`ci`/`data` verifiers on the A2A and `/v1`
   paths (route through `set_goal_safe`'s allowlist). Today a shared-token A2A peer gets
   `bash -c` on the host. Pairs with the Batch 2 `eval` fix.
-- [ ] **ACP runtime eviction race** — Med · Med–High · M — `server/chat.py:102-141`,
+  **DEFERRED — needs a decision (surfaced to the user):** the console's *streaming* chat
+  goes through `/a2a` with the operator bearer (ADR 0045), i.e. the SAME path + SAME token
+  a federated peer uses — so console-vs-peer is indistinguishable by code-path or token. A
+  clean gate would break the operator's own console `/goal command`, and the `/a2a`
+  federation vector (the main one) can't be gated without a **separate operator-vs-federation
+  token** model. (`data`'s eval escape is already closed in Batch 2, so `data` is no longer
+  an RCE sink — only `command`/`test`/`ci` remain.)
+- [>] **ACP runtime eviction race** — Med · Med–High · M — `server/chat.py:102-141`,
   `runtime/acp_runtime.py:216`. LRU/idle eviction closes an in-flight runtime mid-turn;
   registry dicts mutated lock-free. Add a per-thread busy flag/refcount (never evict
   busy) + `asyncio.Lock`; `pop(tid, None)` to tolerate concurrent eviction. ACP opt-in
-  bounds blast radius.
+  bounds blast radius. *(Deferred this pass: the never-evict-busy half needs a ~65-line
+  reindent of the ACP turn body in the streaming generator — high-churn, near the Batch 4
+  area; narrow/opt-in so low priority.)*
 
 ## Batch 4 — High churn × Med–High LOE → design-first, isolate (own initiative)
 


### PR DESCRIPTION
Completes **Batch 1** of the launch-hardening plan (the frontend leftover).

`requestForm` (the multipart upload sibling of `request`) called `await response.json()` then `await response.text()` on the **same** `Response` in its error path. The second read throws `"body stream already read"` (TypeError) — which **masked the real HTTP detail** (e.g. "file too large") and, on a token-gated deployment, **skipped the 401 AuthGate** (#873) so uploads never prompted for the token. Fix: read the body once via `text()` then best-effort `JSON.parse`, mirroring `request()`.

## Gates (worktree off `main`, full `npm ci`)
- `npm run build` (tsc + bundle) ✓ · `npm run test:unit` — **169 passed**. (Backend untouched.)

## Also in this PR (docs)
Updated `docs/dev/launch-hardening-tasklist.md`: checked off requestForm, and **deferred three items with reasons**:
- **Goal trust-gate (High)** — needs a decision: the console's streaming chat uses `/a2a` with the operator bearer (same path + token as a federated peer), so a clean gate would break the operator's own `/goal command`; the `/a2a` federation vector needs a separate operator-vs-federation token model. *(Surfaced for the user.)*
- **ACP eviction race (Med, opt-in)** — the never-evict-busy fix needs a ~65-line reindent of the ACP turn body in the streaming generator (high-churn, near the Batch 4 area).
- **Palette dead-end (Low, cosmetic)** — `_link` registers at module-import, so an `isHostConsole()` gate there is timing-fragile; clean fix is a run-time guard in `SettingsSurface`.

From the 2026-06-28 antagonistic review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed form requests so server responses are read safely and error messages are preserved more reliably.
  * Kept authentication-required handling and API error behavior unchanged.

* **Documentation**
  * Updated the launch hardening task list to reflect completed work and revised status for several deferred items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->