### PR TITLE
feat(web): Tools view — group MCP tools by server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Tools view — MCP tools grouped by server** (#1404) — MCP tools (namespaced
+- **Tools view — MCP tools grouped by server** (#1405) — MCP tools (namespaced
   `<server>__<tool>`) now group under the server that serves them, mirroring the plugin
   grouping, instead of one flat "MCP" bucket; the group sorts after core + plugin groups
   with an `mcp` source chip on its header.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Tools view — MCP tools grouped by server** (#1404) — MCP tools (namespaced
+  `<server>__<tool>`) now group under the server that serves them, mirroring the plugin
+  grouping, instead of one flat "MCP" bucket; the group sorts after core + plugin groups
+  with an `mcp` source chip on its header.
 - **Settings IA — domain-first (ADR 0048)** (#1393) — the settings dialog is reorganized by what a
   setting *does*: an **Agent** group (Identity · Operator & access · Model · Behavior · Knowledge ·
   Integrations), a **Capabilities** group (Tools · MCP · Skills · Subagents · Delegates), a host-only

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -125,7 +125,7 @@ function handleApiGet(pathname, fleet = FLEET) {
         tools: [
           { name: "web_search", description: "Search the web.", source: "core", category: "General" },
           { name: "memory_recall", description: "Search long-term memory.", source: "core", category: "Memory" },
-          { name: "echo__ping", description: "Echo ping.", source: "mcp", category: "MCP" },
+          { name: "echo__ping", description: "Echo ping.", source: "mcp", category: "echo" },
         ],
         count: 3,
       };

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -159,13 +159,21 @@ _TOOL_CATEGORY = {
 }
 
 
-def _tool_category(name: str, source: str, plugin_owner: str | None = None) -> str:
+def _tool_category(
+    name: str, source: str, plugin_owner: str | None = None, mcp_servers: list[str] | None = None
+) -> str:
     # Plugin tools group by the plugin that contributed them (its display name), so the
     # console organizes by plugin instead of one flat "Plugin" dump.
     if source == "plugin":
         return plugin_owner or "Plugin"
     if source == "mcp":
-        return "MCP"
+        # MCP tools are namespaced "<server>__<tool>" (tool_name_prefix=True), so group by
+        # the originating server — match the known server names first (handles a name that
+        # itself contains "__"), else fall back to the prefix before the first "__".
+        for s in mcp_servers or []:
+            if name.startswith(f"{s}__"):
+                return s
+        return name.split("__", 1)[0] if "__" in name else "MCP"
     # Core tools group by subsystem; the long tail falls back to "General".
     return _TOOL_CATEGORY.get(name, "General")
 
@@ -188,6 +196,9 @@ def _operator_tools_list():
     mcp_names = {getattr(t, "name", None) for t in (getattr(STATE, "mcp_tools", None) or [])}
     # tool name -> owning plugin display name (Tools tab grouping), stamped by the loader.
     plugin_owner = getattr(STATE, "plugin_tool_owner", None) or {}
+    # Configured MCP server names (mcp_meta = [{name, transport, tool_count}]) → group MCP
+    # tools by the server that serves them, mirroring the plugin grouping.
+    mcp_servers = [m.get("name") for m in (getattr(STATE, "mcp_meta", None) or []) if m.get("name")]
 
     def add(tool, source=None):
         name = getattr(tool, "name", None)
@@ -201,7 +212,7 @@ def _operator_tools_list():
                 "name": name,
                 "description": desc,
                 "source": src,
-                "category": _tool_category(name, src, plugin_owner.get(name)),
+                "category": _tool_category(name, src, plugin_owner.get(name), mcp_servers),
             }
         )
 

--- a/tests/test_tools_inventory_single_source.py
+++ b/tests/test_tools_inventory_single_source.py
@@ -83,7 +83,19 @@ def test_plugin_tools_group_by_owning_plugin():
     assert _tool_category("github_create_pr", "plugin", "GitHub") == "GitHub"
     # No owner recorded → the generic fallback.
     assert _tool_category("mystery", "plugin", None) == "Plugin"
-    assert _tool_category("echo__ping", "mcp") == "MCP"
+
+
+def test_mcp_tools_group_by_server():
+    """MCP tools (namespaced <server>__<tool>) group by the originating server."""
+    from operator_api.console_handlers import _tool_category
+
+    # Matched against the known server list (handles a server name containing "__").
+    assert _tool_category("echo__ping", "mcp", None, ["echo"]) == "echo"
+    assert _tool_category("we__ird__t", "mcp", None, ["we__ird"]) == "we__ird"
+    # No server list → fall back to the prefix before the first "__".
+    assert _tool_category("echo__ping", "mcp", None, []) == "echo"
+    # A bare (un-namespaced) name with no match → the generic MCP bucket.
+    assert _tool_category("loner", "mcp", None, []) == "MCP"
 
 
 def test_inventory_uses_plugin_owner_map(monkeypatch):


### PR DESCRIPTION
Follow-up to #1397: MCP tools (namespaced `<server>__<tool>`) now group under the **server** that serves them, mirroring the plugin grouping — instead of one flat "MCP" bucket.

- Backend: `/api/tools` derives the server from `STATE.mcp_meta` (match known server names; else the prefix before the first `__`). No signature changes.
- Frontend: none needed — ToolsPanel already orders core → plugin → MCP and shows an `mcp` source chip per group.
- Tests + `[Unreleased]` changelog entry included.

Gates (worktree off main): ruff · pytest 7 · tsc · vitest 169 · build · changelog check — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)