### PR TITLE
feat(web): split Settings ▸ Knowledge into sub-sections + open first accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Settings ▸ Knowledge split into sub-sections** (#1408) — the 22-field Knowledge panel is
+  organized into **Recall · Ingestion · History** accordion groups instead of one wall, and
+  every settings panel now opens its first group by default (no more landing on a fully
+  collapsed panel).
 - **Tools view — MCP tools grouped by server** (#1405) — MCP tools (namespaced
   `<server>__<tool>`) now group under the server that serves them, mirroring the plugin
   grouping, instead of one flat "MCP" bucket; the group sorts after core + plugin groups

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -329,11 +329,14 @@ export function SettingsCategory({
           </div>
         ) : (
           <Accordion className="settings-groups">
-            {groups.map((group) => {
+            {groups.map((group, i) => {
               const groupDirty = group.fields.filter(isVisible).reduce((n, f) => n + (f.key in dirty ? 1 : 0), 0);
               return (
                 <AccordionItem
                   key={group.section}
+                  // Open the first group by default so a panel never lands fully collapsed
+                  // (the operator sees content immediately; the rest expand on demand).
+                  defaultOpen={i === 0}
                   title={
                     <span className="settings-group-head">
                       {group.section}

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -667,6 +667,42 @@ FIELDS: list[Field] = [
     ),
 ]
 
+# Knowledge domain sub-sections (console grouping). The Knowledge fields are declared with
+# section "Knowledge" above for locality; here we split that one 22-field wall into three
+# scannable accordion groups — Recall (retrieval), Ingestion (import/chunking), History
+# (checkpoints) — all still under the Knowledge domain (see _SECTION_CATEGORY). One map, so
+# the split is reviewable in one place instead of scattered across 22 field definitions.
+_KNOWLEDGE_SUBSECTION = {
+    # Recall — what the agent retrieves into context, and how.
+    "knowledge.top_k": "Recall",
+    "knowledge.scope": "Recall",
+    "knowledge.embeddings": "Recall",
+    "knowledge.embed_model": "Recall",
+    "knowledge.recall_preview_chars": "Recall",
+    "knowledge.vector_k": "Recall",
+    "knowledge.rrf_k": "Recall",
+    "knowledge.min_score": "Recall",
+    "skills.top_k": "Recall",  # skills surfaced into context — a recall-count sibling
+    # Ingestion — bringing documents in (extraction, chunking, enrichment).
+    "knowledge.transcribe_model": "Ingestion",
+    "knowledge.image_describe_model": "Ingestion",
+    "knowledge.chunk_max_chars": "Ingestion",
+    "knowledge.chunk_overlap_chars": "Ingestion",
+    "knowledge.contextual_enrichment": "Ingestion",
+    "knowledge.attach_inline_budget": "Ingestion",
+    "knowledge.facts": "Ingestion",
+    # History — conversation checkpoints + retention/harvest.
+    "checkpoint.db_path": "History",
+    "checkpoint.keep_per_thread": "History",
+    "checkpoint.max_age_days": "History",
+    "checkpoint.prune_interval_hours": "History",
+    "checkpoint.harvest_enabled": "History",
+    "checkpoint.vacuum": "History",
+}
+for _f in FIELDS:
+    if _f.key in _KNOWLEDGE_SUBSECTION:
+        _f.section = _KNOWLEDGE_SUBSECTION[_f.key]
+
 _BY_KEY = {f.key: f for f in FIELDS}
 _SECRET_KEYS = {f.key for f in FIELDS if f.type == "secret"}
 _HOST_KEYS = {f.key for f in FIELDS if getattr(f, "scope", "agent") == "host"}
@@ -741,8 +777,10 @@ _SECTION_CATEGORY = {
     # Tools/MCP/Skills/Subagents/Delegates managers are bespoke console panels).
     "Skills": "Capabilities",
     "MCP": "Capabilities",
-    # Knowledge — recall / RAG config.
-    "Knowledge": "Knowledge",
+    # Knowledge — recall / RAG config, split into sub-sections (see _KNOWLEDGE_SUBSECTION).
+    "Recall": "Knowledge",
+    "Ingestion": "Knowledge",
+    "History": "Knowledge",
     # Box — box-wide operational config (host console only): the telemetry store + the
     # host box-runtime knobs (network / discovery / keep-warm, ADR 0047 D8). Host-scoped;
     # a workspace-leaf override of these is a silent no-op (consumed by the host process).

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -72,10 +72,25 @@ def test_groups_carry_category_in_taxonomy_order():
     assert seen == [c for c in _CATEGORY_ORDER if c in seen]
     # Known domain mappings hold (ADR 0048).
     by_section = {g["section"]: g["category"] for g in groups}
-    assert by_section["Knowledge"] == "Knowledge"
     assert by_section["Middleware"] == "Behavior"
     assert by_section["Model"] == "Model"
     assert by_section["Telemetry"] == "Box"
+    # Knowledge is split into Recall/Ingestion/History, all under the Knowledge domain.
+    assert by_section["Recall"] == "Knowledge"
+    assert by_section["Ingestion"] == "Knowledge"
+    assert by_section["History"] == "Knowledge"
+    assert "Knowledge" not in by_section  # the single 22-field wall is gone
+
+
+def test_knowledge_split_into_subsections():
+    """The Knowledge domain renders as Recall → Ingestion → History (not one wall)."""
+    groups = build_schema(LangGraphConfig())
+    kn = [g["section"] for g in groups if g["category"] == "Knowledge"]
+    assert kn == ["Recall", "Ingestion", "History"]
+    keys = {g["section"]: [f["key"] for f in g["fields"]] for g in groups if g["category"] == "Knowledge"}
+    assert "knowledge.top_k" in keys["Recall"]
+    assert "knowledge.transcribe_model" in keys["Ingestion"]
+    assert "checkpoint.db_path" in keys["History"]
 
 
 def test_secrets_are_redacted_with_is_set():


### PR DESCRIPTION
Two console settings tweaks:
- **Knowledge** — the 22-field panel is split into **Recall · Ingestion · History** accordion groups (backend `_KNOWLEDGE_SUBSECTION`; still one Knowledge domain). No more single wall.
- **First accordion open by default** in every settings panel (`defaultOpen` on the first group) — a panel never lands fully collapsed.

Gates (worktree off main): ruff · pytest 37 (schema split + roundtrip) · tsc · vitest 176 · build · changelog check — all green. `[Unreleased]` entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)