### PR TITLE
fix(chat/a2a): Batch 4 finalization quick-wins — no answer truncation; A2A artifact replace-on-divergence

### DIFF
--- a/a2a_impl/executor.py
+++ b/a2a_impl/executor.py
@@ -310,8 +310,16 @@ class ProtoAgentExecutor(AgentExecutor):
             the text was streamed (delta frames), append ONLY the meta parts so
             concat-based consumers don't double the answer; otherwise emit the full
             text once (the non-streaming path: workflow/subagent short-circuits)."""
-            # text="" yields a dataparts-only list (the text part is conditional).
-            body = "" if _answer_started else final_text
+            # If text streamed but the canonical final_text DIVERGES from what
+            # streamed (a goal-outcome note appended, a kicker / multi-iteration retry,
+            # or extract_output reshaping it), REPLACE the artifact (append=False) with
+            # the full final_text so the durable task + any tasks/get re-fetch carry the
+            # real answer, not the raw streamed deltas. When it matches (the common case)
+            # append meta-only so concat-based consumers don't double the answer.
+            diverged = _answer_started and (final_text or "").strip() != accumulated.strip()
+            replace = (not _answer_started) or diverged
+            # body="" yields a dataparts-only list (the text part is conditional).
+            body = final_text if replace else ""
             # Compaction context (#1372): the live prompt size + the configured trigger /
             # token threshold, merged into one context-v1 DataPart. Provider failures
             # degrade to "size only" — never break the turn's finalization.
@@ -340,7 +348,7 @@ class ProtoAgentExecutor(AgentExecutor):
                 await updater.add_artifact(
                     parts,
                     artifact_id=answer_aid,
-                    append=_answer_started,
+                    append=not replace,
                     last_chunk=True,
                 )
 

--- a/graph/output_format.py
+++ b/graph/output_format.py
@@ -102,9 +102,14 @@ Optionally, after `</output>`, you may self-report confidence:
 # (truncating the answer). The real tags are never backtick-wrapped.
 _OUTPUT_RE = re.compile(r"(?<!`)<output>([\s\S]*?)(?<!`)</output>", re.IGNORECASE)
 _SCRATCH_RE = re.compile(r"<scratch_pad>[\s\S]*?</scratch_pad>", re.IGNORECASE)
-_ORPHAN_SCRATCH_OPEN_RE = re.compile(r"<scratch_pad>[\s\S]*$", re.IGNORECASE)
+# Orphan eat-to-end (truncation recovery). Backtick-guarded like _OUTPUT_RE: a
+# plain answer that *mentions* the protocol in inline code (e.g. ``I reason in
+# `<scratch_pad>` then write `<output>` ``) must not be eaten to end-of-text on
+# the no-<output>-wrapper fallback tiers. A real (un-backticked) orphan tag — a
+# genuinely truncated/leaked reasoning block — still gets stripped.
+_ORPHAN_SCRATCH_OPEN_RE = re.compile(r"(?<!`)<scratch_pad>[\s\S]*$", re.IGNORECASE)
 _THINK_RE = re.compile(r"<think>[\s\S]*?</think>", re.IGNORECASE)
-_ORPHAN_THINK_OPEN_RE = re.compile(r"<think>[\s\S]*$", re.IGNORECASE)
+_ORPHAN_THINK_OPEN_RE = re.compile(r"(?<!`)<think>[\s\S]*$", re.IGNORECASE)
 _ORPHAN_THINK_CLOSE_RE = re.compile(r"</think>\s*", re.IGNORECASE)
 _CONFIDENCE_BLOCK_RE = re.compile(r"<confidence>[\s\S]*?</confidence>", re.IGNORECASE)
 _CONFIDENCE_EXPL_BLOCK_RE = re.compile(

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -170,6 +170,20 @@ def test_extract_output_keeps_literal_scratch_pad_mention():
     assert "<scratch_pad>" in out  # the literal mention survives
 
 
+def test_extract_output_keeps_backticked_tag_mention_without_output_wrapper():
+    """Regression (Batch-4): the same literal-protocol-mention answer but with NO
+    <output> wrapper falls to the orphan-strip fallback tiers. The eat-to-EOT orphan
+    openers are backtick-guarded too, so a backticked `<scratch_pad>` / `<think>`
+    mention no longer truncates the stored/A2A/Discord copy at that token — while a
+    genuine (un-backticked) orphan is still recovered (eat-to-EOT)."""
+    text = (
+        "Here's how I work: I reason in `<scratch_pad>` and `<think>` blocks, then "
+        "write the final answer. No protocol wrapper on this reply."
+    )
+    assert extract_output(text) == text  # whole answer survives the fallback tier
+    assert extract_output("real answer <scratch_pad>leaked unfinished") == "real answer"
+
+
 def test_extract_output_ignores_backticked_open_tag_in_scratch():
     """Regression: the model commonly explains the protocol *in its scratch_pad*
     ("answer in `<output>` format"). The matcher must open on the real


### PR DESCRIPTION
**Batch 4, PR-A** — the two self-contained, low-churn finalization fixes (re-verified against current `main` after the bg-jobs/#1394 work, which touched neither file).

### 1. `extract_output` truncation (`graph/output_format.py`) — was Med, now narrowed to XS
The `<output>`-wrapper path was already backtick-guarded (#302/#304). The residual gap: the **orphan eat-to-EOT** fallback openers (`_ORPHAN_SCRATCH_OPEN_RE` / `_ORPHAN_THINK_OPEN_RE`, used by `_strip_reasoning` + the public storage guardrail) were **not**. So an answer with *no* `<output>` wrapper that mentions the protocol in inline code (`` I reason in `<scratch_pad>` ``) was truncated at that token in the stored / A2A / Discord copy. Added the `(?<!`)` guard (mirroring `_OUTPUT_RE`); a genuine un-backticked orphan (real truncated/leaked reasoning) is still eaten to EOT.
> Note: deliberately **not** the original review's "balanced-only strategy-3" — that would re-leak genuinely truncated reasoning and break the pinned orphan-recovery test. The backtick guard is the correct minimal form.

### 2. A2A artifact append-vs-replace divergence (`a2a_impl/executor.py`)
`_finalize` appended only the meta DataParts (`body=""`) whenever text had streamed, so the **durable** A2A task artifact kept the raw streamed deltas and **dropped a divergent canonical answer** (a goal-outcome note, a kicker/multi-iteration retry, or an `extract_output` reshaping). The docstring already promised replace-semantics. Now: when text streamed **and** `final_text` differs from the streamed `accumulated`, **replace** the artifact (`append=False`) with the full `final_text`; the common (matching) case still appends meta-only. `tasks/get` re-fetch + a delegating agent now get the real final answer.

## Gates (worktree off current `main`)
- `ruff` ✓ · `lint-imports` 3/0 ✓ · `pytest tests/ -q` — **2589 passed** (+1 new: strategy-3 backtick-mention preserved / un-backticked orphan still stripped).

PR-B (streaming empty-turn fallback + per-`context_id` lock, both in `server/chat.py`) follows. From the Batch-4 re-check against `c3240dfd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed responses so the final answer is now replaced correctly when the completed text differs from what was streamed.
  * Preserved full answers when protocol tag names are mentioned literally in backticks, avoiding unintended stripping in those cases.

* **Tests**
  * Added regression coverage for backticked protocol-tag mentions and orphan tag recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->