### PR TITLE
docs(security): document the console localStorage bearer; recommend env-var config

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -4,6 +4,15 @@
 // prompts for the operator bearer. Pure module so it's unit-testable and usable
 // from non-React code (api.ts).
 
+// SECURITY — the bearer is cached here in localStorage, an ACCEPTED residual: a
+// console-origin XSS could read it. The credential's real home is the server env
+// (`A2A_AUTH_TOKEN`); this is just the browser's copy so it can authenticate. We do NOT
+// try to "harden" it in place — an httpOnly cookie can't auth the cross-origin desktop
+// webview, and hashing/encrypting at rest is no defense against same-origin XSS (a script
+// in the page can read the key and reuse this very send path). Bounded by the
+// localhost-default + default-deny bearer-gate posture; the real lever beyond localhost is
+// a CSP connect-src egress limit. See docs/guides/deploy-docker.md → "Where the operator
+// token lives".
 const TOKEN_KEY = "protoagent.authToken";
 
 let needed = false;

--- a/docs/dev/launch-hardening-tasklist.md
+++ b/docs/dev/launch-hardening-tasklist.md
@@ -145,13 +145,26 @@ touches the same chat/subagent streaming surface.
 - [>] **chat-store cross-tab clobber** — Med · Med–High · M —
   `apps/web/src/chat/chat-store.ts:141`. `storage`-event merge (union by id, newest
   `updatedAt` wins) or a `BroadcastChannel` single-writer.
-- [>] **`localStorage` bearer (XSS-exfiltratable)** — Low · High · L —
-  `apps/web/src/lib/auth.ts:42`. Move to an httpOnly SameSite cookie, or accept-risk +
-  guarantee no raw-HTML/JS render sink (none found today — DS markdown only). Interim:
-  document as a known sink.
+- [x] **`localStorage` bearer (XSS-exfiltratable)** — Low · High · L — **ACCEPTED + documented**
+  (2026-06-29). `apps/web/src/lib/auth.ts`. An httpOnly cookie was evaluated and rejected: it
+  can't authenticate the cross-origin **desktop** webview (`SameSite` isn't sent cross-origin;
+  `SameSite=None` needs the HTTPS the localhost sidecar lacks), so it would protect only the
+  browser while adding a dual auth path. Hashing/encrypting at rest is no defense against
+  same-origin XSS (a script in the page reads the key + reuses the send path). Bounded by
+  localhost-default + default-deny bearer-gate + sanitized-markdown-only render (no raw-HTML
+  sink). Recommended credential home = the server env (`A2A_AUTH_TOKEN`); operator note in
+  `docs/guides/deploy-docker.md` → "Where the operator token lives". The real lever if exposed
+  beyond localhost = a CSP `connect-src` egress allowlist (tracked below).
 
 ## Doc-only / optional
 
+- [ ] **CSP `connect-src` egress allowlist** — Low · Med · M — the effective XSS-exfil lever
+  (replaces the rejected httpOnly-cookie move for the `localStorage` bearer above; works for
+  both the browser console AND the cross-origin desktop). Enumerate the console's legitimate
+  egress (same-origin `/api` + `/a2a`, the desktop sidecar origin, the hub proxy, any gateway),
+  then serve a `Content-Security-Policy` with a `connect-src` allowlist so an injected script
+  can't `fetch`/beacon the token off-origin. Test deeply against SSE, plugin iframes, fleet,
+  and the desktop. Only worth it before exposing the console beyond localhost.
 - [ ] **Plugin iframe `allow-scripts`+`allow-same-origin`** — Low · Low · XS —
   `apps/web/src/app/PluginView.tsx:266` (+ `App.tsx:529`, `Launcher.tsx:67`). No
   functional change (plugins are trusted code, given the bearer by design); document the

--- a/docs/guides/deploy-docker.md
+++ b/docs/guides/deploy-docker.md
@@ -48,6 +48,30 @@ protoAgent refuses to bind `0.0.0.0` with an **open** operator API (`/api/*`, `/
 - bind `127.0.0.1` (single-host);
 - or, only behind a trusted network boundary, `PROTOAGENT_ALLOW_OPEN=1`.
 
+### Where the operator token lives
+
+Configure the token in the **server's environment** — `A2A_AUTH_TOKEN` (or `auth.token` in
+`langgraph-config.yaml`). That's the credential's home: it never lives in a browser, and
+rotating it instantly invalidates every client.
+
+The **browser console** has to authenticate too, so when you paste the token into its
+sign-in prompt it's cached in that browser's `localStorage`. Know the trade-off:
+
+- A script injected into the console's origin (XSS) could read that cached token and
+  exfiltrate it. The exposure is bounded by the default posture — the console binds
+  `127.0.0.1` and the whole API is default-deny bearer-gated — and the console renders
+  agent/model output only through sanitized markdown (no raw-HTML sink). Treat the cached
+  token like any browser-stored credential: don't expose the console beyond localhost
+  without a fronting auth proxy, and rotate `A2A_AUTH_TOKEN` if a workstation is compromised.
+- It stays in `localStorage` deliberately. An httpOnly cookie can't authenticate the
+  **desktop app** — its Tauri webview and the local HTTP sidecar are different origins, so a
+  `SameSite` cookie isn't sent cross-origin and `SameSite=None` needs the HTTPS the localhost
+  sidecar doesn't have — so a cookie would protect only the browser. And hashing/encrypting
+  the value at rest doesn't defend against same-origin XSS: a script in the page can read the
+  key and reuse the same code path the console uses to send the token. The effective lever,
+  if the console is ever exposed beyond localhost, is an egress limit (a CSP `connect-src`
+  allowlist) that blocks exfiltration for both the browser and the desktop.
+
 ## Day-2
 
 | Want to… | Do |


### PR DESCRIPTION
Closes the last launch-hardening Batch 4 item — the operator bearer in the browser console's `localStorage` (XSS-exfiltratable). After implementing and then **reverting** an httpOnly-cookie migration, we **accept the residual** and document it, because the alternatives don't fit this app:

- **httpOnly cookie** — can't authenticate the **desktop** app: the Tauri webview (`tauri://localhost`) and the local HTTP sidecar (`http://localhost:<port>`) are different origins, so a `SameSite` cookie isn't sent cross-origin and `SameSite=None` needs the HTTPS the localhost sidecar lacks. It would protect only the browser path while adding a dual auth path.
- **hashing/encrypting at rest** — no defense against same-origin XSS: injected JS runs with the app's privileges, so it reads the key and reuses the same send path the console uses. *Anything the client can authenticate with, an XSS can too.*

The residual is bounded by the posture: localhost-default bind, default-deny bearer-gate, and sanitized-markdown-only rendering (no raw-HTML sink). The **recommended credential home is the server env (`A2A_AUTH_TOKEN`)**, now documented for operators.

### Changes (docs + one code comment, no logic)
- `docs/guides/deploy-docker.md` — new **"Where the operator token lives"**: env-var is the home; the localStorage trade-off + why a cookie / at-rest hashing don't help; rotate on compromise; don't expose beyond localhost without a fronting proxy.
- `apps/web/src/lib/auth.ts` — comment recording the accepted residual + a pointer to the doc.
- `docs/dev/launch-hardening-tasklist.md` — close the item as **ACCEPTED**, and add a tracked follow-up: a **CSP `connect-src` egress allowlist** (the real lever — covers browser *and* desktop) for if the console is ever exposed beyond localhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified where the operator authentication token is stored and how the browser session uses a cached copy.
  * Added security guidance on the trade-offs of browser-cached credentials, including residual XSS risk and recommended protective controls.
  * Updated launch-hardening notes to reflect the accepted risk posture and added an egress allowlist task for stronger script-exfiltration protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->