### PR TITLE
chore: release v0.73.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.73.0] - 2026-06-29
+
 ### Added
 - **Background batch delegation** (#1396) — `task_batch(run_in_background=True)` fans a whole batch
   of subagents out detached, returning job ids immediately while you keep working, with each

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.72.0"
+version = "0.73.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,32 @@
 [
   {
+    "version": "v0.73.0",
+    "date": "2026-06-29",
+    "changes": [
+      "Background batch delegation",
+      "Live tool-card feed for background agents",
+      "Settings ▸ Knowledge split into sub-sections",
+      "Tools view — MCP tools grouped by server",
+      "Settings IA — domain-first",
+      "Tools view — grouped by plugin + subsystem",
+      "Built-in subagents answer natively",
+      "CI off the deprecated Node 20 action runtime",
+      "Structured-output parser retired",
+      "Concurrent same-conversation turns no longer corrupt chat history",
+      "Chat answers no longer truncated; A2A tasks return the real final answer",
+      "Subagent token streams isolated from the live chat",
+      "Cross-tab chat no longer clobbers itself",
+      "ACP coding-agent eviction race closed",
+      "Cross-context streaming guard",
+      "File uploads restore the token prompt on auth failure",
+      "Secure defaults for metrics and MCP secrets",
+      "Backend launch-hardening — ingestion SSRF guard + credential hardening",
+      "Plugin auth-bypass and event-loop hardening",
+      "Fail-safe plugin secret redaction",
+      "Operator-token storage guidance"
+    ]
+  },
+  {
     "version": "v0.72.0",
     "date": "2026-06-28",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.73.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.73.0 -m 'Release v0.73.0' && git push origin v0.73.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to **0.73.0**.
  * Added the latest release notes entry with highlights for this version.
* **New Features**
  * Introduced background batch delegation and a live tool-card feed.
  * Updated the UI with improved settings grouping.
* **Bug Fixes**
  * Included fixes for chat streaming, history, and cross-context behavior.
  * Added multiple security and stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->