### PR TITLE
feat(tools): bypass-permissions mode — per-tab auto-approve for run_command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Bypass-permissions mode** (#1418) — a per-tab toggle that auto-approves `run_command` so the
+  agent runs shell commands without the HITL approval prompt: `/bypass on|off`, a DS warning badge
+  in the composer while it's on, and an **"Approve & don't ask again"** button in the approval
+  dialog. Every bypassed command is audit-logged, and a host can forbid bypass entirely via
+  `filesystem.bypass_allowed: false`.
+
+### Changed
+- **`run_command` runs shell operators** (#1419) — the fenced `run_command` tool executes via
+  `/bin/sh -c`, so `&&`, `|`, `>`, and `$(…)` work instead of being literalized by argv-splitting.
+  No new capability (the agent could already nest `bash -c "…"`); still cwd-fenced and
+  approval/bypass-gated, and a timed-out command now kills its whole process group.
+
+### Fixed
+- **Slash-command notices render as system notes** (#1420) — local in-thread notices (e.g. the
+  `/effort` and `/bypass` confirmations) are now tone-aware `role:"system"` notes instead of fake
+  assistant messages, so they no longer carry the answer action row (copy/fork/regenerate).
+
 ## [0.73.0] - 2026-06-29
 
 ### Added

--- a/apps/web/e2e/commands.spec.ts
+++ b/apps/web/e2e/commands.spec.ts
@@ -6,7 +6,7 @@ import { SLASH_COMMANDS } from "./fixtures.mjs";
 // (GET /api/chat/commands) and autocompletes them as you type "/name".
 
 // Deterministic client-side commands (ADR 0057) surface FIRST, then the server skills.
-const CLIENT_SLASH = ["/new", "/clear", "/effort"];
+const CLIENT_SLASH = ["/new", "/clear", "/effort", "/bypass"];
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1032,7 +1032,9 @@ function ChatSessionSlot({
         images: opts.images,
         model: session.model,
         reasoningEffort: effectiveReasoningEffort(session),
-        bypassPermissions: session.bypassPermissions,
+        // Read live (not the render-closure session) so an "Approve & don't ask again" that
+        // flips bypass on right before this resume turn is carried by it.
+        bypassPermissions: chatStore.getSnapshot().sessions.find((s) => s.id === session.id)?.bypassPermissions,
       });
       chatStore.setSessionStatus(session.id, "idle");
       setStatusMessage("idle");
@@ -1125,6 +1127,14 @@ function ChatSessionSlot({
           busy={status === "streaming"}
           onSubmit={resumeHitl}
           onCancel={() => setHitl(null)}
+          onApproveAlways={
+            hitl.kind === "approval" && session
+              ? () => {
+                  chatStore.setSessionBypassPermissions(session.id, true); // turn bypass on for this tab
+                  void resumeHitl("approved"); // …and approve the pending command
+                }
+              : undefined
+          }
         />
       )}
 

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1028,7 +1028,12 @@ function ChatSessionSlot({
             }),
           );
         },
-      }, { images: opts.images, model: session.model, reasoningEffort: effectiveReasoningEffort(session) });
+      }, {
+        images: opts.images,
+        model: session.model,
+        reasoningEffort: effectiveReasoningEffort(session),
+        bypassPermissions: session.bypassPermissions,
+      });
       chatStore.setSessionStatus(session.id, "idle");
       setStatusMessage("idle");
       void reconcileSteer();
@@ -1210,6 +1215,16 @@ function ChatSessionSlot({
                 </Button>
               ))}
               <ComposerModelSelect />
+              {session?.bypassPermissions ? (
+                <button
+                  type="button"
+                  className="composer-bypass-chip"
+                  title="Bypass permissions is ON for this tab — run_command runs WITHOUT approval. Click to turn it off."
+                  onClick={() => chatStore.setSessionBypassPermissions(session.id, false)}
+                >
+                  ⚠ bypass on
+                </button>
+              ) : null}
             </>
           }
           attachments={attachments.map((a) => ({

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1,5 +1,5 @@
 import "./chat.css";
-import { Button, Empty } from "@protolabsai/ui/primitives";
+import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { Switch } from "@protolabsai/ui/forms";
 import { Conversation, Message, PromptInput } from "@protolabsai/ui/ai";
 import { TabBar } from "@protolabsai/ui/navigation";
@@ -1228,11 +1228,11 @@ function ChatSessionSlot({
               {session?.bypassPermissions ? (
                 <button
                   type="button"
-                  className="composer-bypass-chip"
+                  className="composer-bypass-toggle"
                   title="Bypass permissions is ON for this tab — run_command runs WITHOUT approval. Click to turn it off."
                   onClick={() => chatStore.setSessionBypassPermissions(session.id, false)}
                 >
-                  ⚠ bypass on
+                  <Badge status="warning">bypass on</Badge>
                 </button>
               ) : null}
             </>

--- a/apps/web/src/chat/HitlForm.tsx
+++ b/apps/web/src/chat/HitlForm.tsx
@@ -94,11 +94,15 @@ export function HitlForm({
   busy,
   onSubmit,
   onCancel,
+  onApproveAlways,
 }: {
   payload: HitlPayload;
   busy?: boolean;
   onSubmit: (response: Record<string, unknown> | string) => void;
   onCancel: () => void;
+  // Approval gates only: "Approve & don't ask again" — approve this action AND turn on
+  // bypass-permissions for the tab (skip future approvals). Omitted ⇒ the button is hidden.
+  onApproveAlways?: () => void;
 }) {
   const isForm = payload.kind === "form" && (payload.steps?.length ?? 0) > 0;
   const isApproval = payload.kind === "approval";
@@ -116,6 +120,18 @@ export function HitlForm({
           <Button type="button" variant="ghost" onClick={() => onSubmit("denied")} disabled={busy}>
             Deny
           </Button>
+          {onApproveAlways && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="hitl-approve-always"
+              title="Approve this — and skip approval for the rest of this tab's commands (bypass mode). Turn off with /bypass off."
+              onClick={onApproveAlways}
+              disabled={busy}
+            >
+              Approve &amp; don&apos;t ask again
+            </Button>
+          )}
           <Button type="button" variant="primary" onClick={() => onSubmit("approved")} disabled={busy}>
             Approve
           </Button>

--- a/apps/web/src/chat/chat-store.ts
+++ b/apps/web/src/chat/chat-store.ts
@@ -18,6 +18,10 @@ export type ChatSession = {
   // (DEFAULT_REASONING_EFFORT, auto-enabled); "off" → no reasoning this tab;
   // else low|medium|high|max. Sent each turn so the tab reasons at its own level.
   reasoningEffort?: string;
+  // Per-tab "bypass permissions" mode (the /bypass command): when true, each turn carries
+  // metadata.bypass_permissions so the server auto-approves run_command (no HITL gate). A
+  // deliberately dangerous escape hatch — default OFF; the composer shows a loud chip while on.
+  bypassPermissions?: boolean;
 };
 
 // Reasoning is ON by default in the console (auto-enable) — a fresh tab thinks at
@@ -474,6 +478,17 @@ export const chatStore = {
       ...current,
       sessions: current.sessions.map((session) =>
         session.id === sessionId ? { ...session, reasoningEffort: effort || undefined } : session,
+      ),
+    }));
+  },
+
+  // Per-tab bypass-permissions toggle (the /bypass command). Dangerous — auto-approves
+  // run_command for this tab's turns until turned off.
+  setSessionBypassPermissions(sessionId: string, on: boolean) {
+    setState((current) => ({
+      ...current,
+      sessions: current.sessions.map((session) =>
+        session.id === sessionId ? { ...session, bypassPermissions: on || undefined } : session,
       ),
     }));
   },

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -153,25 +153,15 @@
   color: var(--pl-color-danger, #e5484d);
 }
 
-/* Bypass-permissions warning chip in the composer toolbar — loud, so the dangerous mode is
-   never silently on. Clicking it turns bypass off (same as `/bypass off`). */
-.composer-bypass-chip {
+/* Bypass-permissions indicator in the composer toolbar — a DS warning Badge (outline tone) in a
+   bare button so clicking it turns bypass off (same as `/bypass off`). The Badge owns the styling. */
+.composer-bypass-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 2px 8px;
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  color: #fff;
-  background: var(--pl-color-danger, #e5484d);
+  padding: 0;
   border: none;
-  border-radius: 999px;
+  background: none;
   cursor: pointer;
-}
-.composer-bypass-chip:hover {
-  filter: brightness(1.08);
 }
 .chat-tabbar-wrap--del .pl-tabbar__close:hover svg {
   display: none;

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -152,6 +152,27 @@
 .chat-tabbar-wrap--del .pl-tabbar__close:hover {
   color: var(--pl-color-danger, #e5484d);
 }
+
+/* Bypass-permissions warning chip in the composer toolbar — loud, so the dangerous mode is
+   never silently on. Clicking it turns bypass off (same as `/bypass off`). */
+.composer-bypass-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: #fff;
+  background: var(--pl-color-danger, #e5484d);
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+}
+.composer-bypass-chip:hover {
+  filter: brightness(1.08);
+}
 .chat-tabbar-wrap--del .pl-tabbar__close:hover svg {
   display: none;
 }

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -68,8 +68,9 @@ registerSlashCommand({
     chatStore.setSessionBypassPermissions(ctx.sessionId, next);
     ctx.noteToThread(
       next
-        ? "⚠️ **Bypass permissions ON** for this tab — `run_command` runs **without approval** until you turn it off with `/bypass off`. (A host can forbid this entirely via `filesystem.bypass_allowed: false`.)"
+        ? "**Bypass permissions ON** for this tab — `run_command` runs **without approval** until you turn it off with `/bypass off`. (A host can forbid this entirely via `filesystem.bypass_allowed: false`.)"
         : "Bypass permissions **off** — tool approvals will prompt again.",
+      { tone: next ? "warning" : "info" },
     );
     ctx.focusComposer();
     return true;

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -54,3 +54,24 @@ registerSlashCommand({
     return true;
   },
 });
+
+registerSlashCommand({
+  name: "bypass",
+  description: "DANGER: auto-approve tool permissions (run_command) for this tab",
+  usage: "/bypass on|off",
+  run: (ctx) => {
+    if (!ctx.sessionId) return false;
+    const arg = ctx.rest.trim().toLowerCase();
+    const session = chatStore.getSnapshot().sessions.find((s) => s.id === ctx.sessionId);
+    const cur = !!session?.bypassPermissions;
+    const next = arg === "on" ? true : arg === "off" ? false : !cur; // bare /bypass toggles
+    chatStore.setSessionBypassPermissions(ctx.sessionId, next);
+    ctx.noteToThread(
+      next
+        ? "⚠️ **Bypass permissions ON** for this tab — `run_command` runs **without approval** until you turn it off with `/bypass off`. (A host can forbid this entirely via `filesystem.bypass_allowed: false`.)"
+        : "Bypass permissions **off** — tool approvals will prompt again.",
+    );
+    ctx.focusComposer();
+    return true;
+  },
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1156,7 +1156,12 @@ export const api = {
       onFailed?: (message: string) => void;
       onDone?: () => void;
     } = {},
-    opts: { images?: { b64: string; mime: string; name: string }[]; model?: string; reasoningEffort?: string } = {},
+    opts: {
+      images?: { b64: string; mime: string; name: string }[];
+      model?: string;
+      reasoningEffort?: string;
+      bypassPermissions?: boolean;
+    } = {},
   ) {
     // One A2A SendStreamingMessage body + one frame dispatcher, shared by the desktop
     // (Tauri-relayed) and browser (fetch SSE) paths so both decode turns identically.
@@ -1176,11 +1181,12 @@ export const api = {
           contextId: sessionId,
           // Per-turn overrides ride the A2A message metadata (server/chat.py reads them):
           // the tab's chosen model + the /effort reasoning level.
-          ...((opts.model || opts.reasoningEffort)
+          ...((opts.model || opts.reasoningEffort || opts.bypassPermissions)
             ? {
                 metadata: {
                   ...(opts.model ? { model: opts.model } : {}),
                   ...(opts.reasoningEffort ? { reasoning_effort: opts.reasoningEffort } : {}),
+                  ...(opts.bypassPermissions ? { bypass_permissions: true } : {}),
                 },
               }
             : {}),

--- a/graph/config.py
+++ b/graph/config.py
@@ -666,6 +666,12 @@ class LangGraphConfig:
     filesystem_enabled: bool = True
     filesystem_allow_run: bool = True
     filesystem_run_requires_approval: bool = True
+    # Escape hatch (off by default per-turn): when True (default), an operator may toggle
+    # bypass-permissions mode per-turn via A2A ``message.metadata.bypass_permissions`` to
+    # auto-approve ``run_command`` — for trusted-autonomous / container runs. Set False to
+    # FORBID bypass entirely regardless of caller metadata (locked-down hosts); the approval
+    # gate is then always enforced.
+    filesystem_bypass_allowed: bool = True
     filesystem_projects: list[dict] = field(default_factory=list)
 
     # Egress allowlist (ADR 0008) — deny-by-default outbound-host allowlist
@@ -931,6 +937,9 @@ class LangGraphConfig:
             filesystem_allow_run=data.get("filesystem", {}).get("allow_run", cls.filesystem_allow_run),
             filesystem_run_requires_approval=data.get("filesystem", {}).get(
                 "run_requires_approval", cls.filesystem_run_requires_approval
+            ),
+            filesystem_bypass_allowed=data.get("filesystem", {}).get(
+                "bypass_allowed", cls.filesystem_bypass_allowed
             ),
             filesystem_projects=list(data.get("filesystem", {}).get("projects", []) or []),
             egress_allowed_hosts=list(data.get("egress", {}).get("allowed_hosts", []) or []),

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -83,6 +83,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "enforcement_enabled": False,
     "enforcement_rate_limits": {},
     "filesystem_allow_run": True,
+    "filesystem_bypass_allowed": True,
     "filesystem_enabled": True,
     "filesystem_projects": [],
     "filesystem_run_requires_approval": True,

--- a/tests/test_fs_tools.py
+++ b/tests/test_fs_tools.py
@@ -15,6 +15,7 @@ class _Cfg:
     filesystem_enabled: bool = True
     filesystem_allow_run: bool = False
     filesystem_run_requires_approval: bool = True
+    filesystem_bypass_allowed: bool = True
     filesystem_projects: list = field(default_factory=list)
 
 
@@ -169,6 +170,50 @@ def test_run_command_declined_raises(workspace, monkeypatch):
     )
     with pytest.raises(ToolException):
         asyncio.run(t["run_command"].ainvoke({"project": "a", "command": "ls"}))
+
+
+def test_run_command_bypass_skips_approval(workspace, monkeypatch):
+    """Bypass-permissions mode (per-turn metadata + host allows): run_command runs WITHOUT the
+    approval gate. interrupt() is stubbed to DENY, so if the gate were reached the command would
+    raise — a clean run proves it was skipped."""
+    import langgraph.types
+    from graph.middleware.request_context import request_metadata_scope
+
+    _, a, _ = workspace
+    monkeypatch.setattr(langgraph.types, "interrupt", lambda payload: "denied")
+    t = _tools(
+        _Cfg(
+            filesystem_projects=[{"name": "a", "path": str(a)}],
+            filesystem_allow_run=True,
+            filesystem_run_requires_approval=True,
+            filesystem_bypass_allowed=True,
+        )
+    )
+    with request_metadata_scope({"bypass_permissions": True}):
+        out = asyncio.run(t["run_command"].ainvoke({"project": "a", "command": "ls"}))
+    assert "README.md" in out
+
+
+def test_run_command_bypass_forbidden_by_host_still_gates(workspace, monkeypatch):
+    """When the host forbids bypass (filesystem_bypass_allowed=False), caller bypass metadata is
+    IGNORED and the approval gate still fires (here stubbed to deny → raises)."""
+    import langgraph.types
+    from langchain_core.tools import ToolException
+    from graph.middleware.request_context import request_metadata_scope
+
+    _, a, _ = workspace
+    monkeypatch.setattr(langgraph.types, "interrupt", lambda payload: "denied")
+    t = _tools(
+        _Cfg(
+            filesystem_projects=[{"name": "a", "path": str(a)}],
+            filesystem_allow_run=True,
+            filesystem_run_requires_approval=True,
+            filesystem_bypass_allowed=False,
+        )
+    )
+    with request_metadata_scope({"bypass_permissions": True}):
+        with pytest.raises(ToolException):
+            asyncio.run(t["run_command"].ainvoke({"project": "a", "command": "ls"}))
 
 
 # ── config round-trip ──────────────────────────────────────────────────────────

--- a/tools/fs_tools.py
+++ b/tools/fs_tools.py
@@ -109,6 +109,16 @@ def _registry_from_config(config) -> ProjectRegistry:
     return ProjectRegistry(projects)
 
 
+def _bypass_requested() -> bool:
+    """True when the in-flight turn carries the per-turn ``bypass_permissions`` flag — the
+    operator's explicit /bypass toggle, sent in the A2A request metadata (read live, so it's
+    per-turn, not captured at tool-build time). Gated additionally by ``filesystem_bypass_allowed``
+    at the call site, so a host can forbid bypass regardless of caller-supplied metadata."""
+    from graph.middleware.request_context import current_request_metadata
+
+    return bool(current_request_metadata().get("bypass_permissions"))
+
+
 def build_fs_tools(config) -> list:
     """Build the fenced filesystem tools from config. Empty list when no valid
     projects are registered (so the primitive is inert by default)."""
@@ -122,6 +132,9 @@ def build_fs_tools(config) -> list:
     # the command + approves/denies). Forks can disable the gate (e.g. inside a
     # hardened container, or for a trusted autonomous deploy).
     run_requires_approval = bool(getattr(config, "filesystem_run_requires_approval", True))
+    # Whether this HOST permits bypass-permissions mode at all (default True). When False, the
+    # approval gate is enforced regardless of any caller-supplied bypass metadata.
+    bypass_allowed = bool(getattr(config, "filesystem_bypass_allowed", True))
 
     @tool
     def list_projects() -> str:
@@ -263,7 +276,7 @@ def build_fs_tools(config) -> list:
             # the command before it runs. interrupt() re-runs this fn from the
             # top on resume (the validation above is idempotent) and returns the
             # operator's decision. Denied → don't run.
-            if run_requires_approval:
+            if run_requires_approval and not (bypass_allowed and _bypass_requested()):
                 from langgraph.types import interrupt
 
                 decision = interrupt(
@@ -279,6 +292,10 @@ def build_fs_tools(config) -> list:
                     # status="error": the chat card then renders the declined action
                     # as a failure (red X) instead of a green "done" with decline text.
                     raise ToolException(f"Command declined by the operator — not run: {command!r}")
+            elif run_requires_approval:
+                # Bypass-permissions mode (the operator's explicit per-turn /bypass toggle): the
+                # approval gate is skipped. AUDIT every command that runs without confirmation.
+                log.warning("[fs] run_command ran under bypass-permissions (no approval): %s", command)
             res = await _shell_run(["/bin/sh", "-c", command], cwd=str(root), timeout=timeout)
             if res.error:
                 raise ToolException(res.error)


### PR DESCRIPTION
## What
**Bypass-permissions mode** — a per-tab toggle that auto-approves `run_command` so the agent runs shell commands without the HITL approval prompt.

- `/bypass on|off` (bare `/bypass` toggles) — a client slash command
- a DS **warning Badge** in the composer while it's on (click to turn off)
- **"Approve & don't ask again"** in the `run_command` approval dialog — approves the pending command AND turns bypass on for the tab
- per-turn `metadata.bypass_permissions` rides the request-context contextvar (ADR 0032, same channel as model/effort)
- backend gate in `run_command`: skips the approval interrupt when bypass is requested **and** the host allows it — every bypassed command is **AUDIT-logged**
- master switch `filesystem.bypass_allowed` (default **ON**; a host sets `false` to forbid bypass entirely)

## Tests
+2 `fs_tools` tests (bypass skips approval; host-forbidden still gates). build (tsc) + web unit clean.

## Related (split out of this PR for clean review)
- **#1419** — `run_command` via `/bin/sh -c` (general tool fix)
- **#1420** — reusable tone-aware system-note type (general chat infra)

Once **#1420** lands, `/bypass` will post its confirmation as a `warning`-toned system note (1-line follow-up); today it posts a plain note.
