### PR TITLE
feat(tools): run_command via /bin/sh -c so shell operators work

### DIFF
--- a/tests/test_fs_tools.py
+++ b/tests/test_fs_tools.py
@@ -146,7 +146,9 @@ def test_run_command_runs_via_shell(workspace):
         )
     )
     out = asyncio.run(t["run_command"].ainvoke({"project": "a", "command": "echo one && echo two"}))
-    assert "one" in out and "two" in out
+    # Exact lines (not substrings): the old argv path would print the literal "one && echo two",
+    # so this assertion specifically fails unless the && actually chained two commands.
+    assert out.splitlines() == ["one", "two"]
 
 
 def test_run_command_declined_raises(workspace, monkeypatch):

--- a/tests/test_fs_tools.py
+++ b/tests/test_fs_tools.py
@@ -135,6 +135,20 @@ def test_run_command_executes_in_project_cwd(workspace):
     assert "README.md" in out
 
 
+def test_run_command_runs_via_shell(workspace):
+    """run_command goes through /bin/sh -c, so shell operators (&&, |, >, $()) work."""
+    _, a, _ = workspace
+    t = _tools(
+        _Cfg(
+            filesystem_projects=[{"name": "a", "path": str(a)}],
+            filesystem_allow_run=True,
+            filesystem_run_requires_approval=False,
+        )
+    )
+    out = asyncio.run(t["run_command"].ainvoke({"project": "a", "command": "echo one && echo two"}))
+    assert "one" in out and "two" in out
+
+
 def test_run_command_declined_raises(workspace, monkeypatch):
     """A declined approval RAISES (ToolException) rather than returning a string —
     so the ToolNode stamps status="error" and the chat card shows the X, not a green

--- a/tools/fs_tools.py
+++ b/tools/fs_tools.py
@@ -21,7 +21,6 @@ Security (ADR 0007 §4):
 from __future__ import annotations
 
 import logging
-import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -251,17 +250,14 @@ def build_fs_tools(config) -> list:
 
             Powerful + dual-use (like execute_code) — use it for read-only
             inspection (`git status`, `gh pr list`, `br list`) and only mutate in
-            read-write projects. argv is shell-split; no shell metacharacters.
+            read-write projects. Runs via ``/bin/sh -c``, so shell operators
+            (``&&``, ``|``, ``>``, ``$(…)``) work.
             """
             try:
                 root = registry.resolve(project, ".")
             except ValueError as exc:
                 return f"Error: {exc}"
-            try:
-                argv = shlex.split(command)
-            except ValueError as exc:
-                return f"Error: cannot parse command: {exc}"
-            if not argv:
+            if not command.strip():
                 return "Error: empty command."
             # HITL approval gate (Sprint A): pause for the operator to approve
             # the command before it runs. interrupt() re-runs this fn from the
@@ -283,7 +279,7 @@ def build_fs_tools(config) -> list:
                     # status="error": the chat card then renders the declined action
                     # as a failure (red X) instead of a green "done" with decline text.
                     raise ToolException(f"Command declined by the operator — not run: {command!r}")
-            res = await _shell_run(argv, cwd=str(root), timeout=timeout)
+            res = await _shell_run(["/bin/sh", "-c", command], cwd=str(root), timeout=timeout)
             if res.error:
                 raise ToolException(res.error)
             body = res.stdout or "(no output)"

--- a/tools/shell.py
+++ b/tools/shell.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import signal
 from dataclasses import dataclass
 
 
@@ -62,6 +63,9 @@ async def run_command(
             stderr=asyncio.subprocess.PIPE,
             env=merged_env,
             cwd=cwd,
+            # Own process group so a timeout can kill the whole tree — a shell command
+            # (run_command goes through /bin/sh -c) may spawn children via |, &, $(…).
+            start_new_session=True,
         )
     except FileNotFoundError:
         binary = argv[0] if argv else "?"
@@ -75,7 +79,12 @@ async def run_command(
             timeout=timeout,
         )
     except asyncio.TimeoutError:
-        proc.kill()
+        # Kill the whole process group, not just the immediate child: a shell command can
+        # spawn children (pipes, &, $(…)) that would otherwise be orphaned on timeout.
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            proc.kill()
         try:
             await proc.communicate()
         except Exception:  # noqa: BLE001 — process already killed; draining is best-effort


### PR DESCRIPTION
## What
`run_command` now executes via `/bin/sh -c <command>` instead of `shlex.split` + direct argv exec. Shell operators — `&&`, `|`, `>`, `$(…)` — now work.

## Why
Argv-split literalized every shell metacharacter, so `echo "a" && date` ran `echo` with `a && date` as literal args. For a tool called "run command," operators should work (reported in dogfooding).

## Security
No new capability: the agent could already get a real shell by nesting `bash -c "…"` as a single argv, so this only makes the obvious case work. Still cwd-fenced + HITL-approval-gated (and honours the bypass-permissions toggle in the sibling PR).

## Test
+`test_run_command_runs_via_shell` (asserts `echo one && echo two` chains). Full `test_fs_tools.py`: 18 passed locally.

Split out of the bypass-permissions PR — a general `run_command` improvement, not bypass-specific.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Command execution now supports shell syntax like `&&`, pipes, redirects, and command substitution.
* **Bug Fixes**
  * Fixed command handling so multi-part shell commands run as expected instead of being split into separate arguments.
* **Tests**
  * Added coverage to confirm shell-based command execution works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->