### PR TITLE
feat(chat): reusable tone-aware system-note type for in-thread notices

### DIFF
--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -43,7 +43,17 @@ export function ChatMessageView({
   // Per-turn token/cost footer is an opt-out display pref (Settings ▸ Chat, #1372).
   const showChatUsage = useUI((s) => s.showChatUsage);
   return (
-    <Message role={message.role} streaming={streaming} className={message.report ? "chat-report" : undefined}>
+    <Message
+      role={message.role}
+      streaming={streaming}
+      className={
+        message.report
+          ? "chat-report"
+          : message.noteTone
+            ? `chat-note chat-note--${message.noteTone}`
+            : undefined
+      }
+    >
       {message.reasoning && !(message.parts && message.parts.length) ? (
         // History-loaded turns have no ordered parts — fall back to the flat collapsed
         // reasoning card. Live turns render reasoning inline via parts.

--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -49,8 +49,10 @@ export function ChatMessageView({
       className={
         message.report
           ? "chat-report"
-          : message.noteTone
-            ? `chat-note chat-note--${message.noteTone}`
+          : // Any non-report system message is a local note → compact .chat-note card; the
+            // tone modifier is appended only when set, so neutral notes still get the styling.
+            message.role === "system"
+            ? `chat-note${message.noteTone ? ` chat-note--${message.noteTone}` : ""}`
             : undefined
       }
     >

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -14,7 +14,7 @@ import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { runtimeStatusQuery } from "../lib/queries";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
-import type { ChatMessage, ChatPart, HitlPayload, SlashCommand, ToolCall } from "../lib/types";
+import type { ChatMessage, ChatPart, HitlPayload, SlashCommand, SystemNoteTone, ToolCall } from "../lib/types";
 import { HitlForm } from "./HitlForm";
 import { notifyIfHidden } from "../lib/notify";
 import {
@@ -409,14 +409,17 @@ function ChatSessionSlot({
   const slashActive = slashMatches.length > 0;
   const slashSel = slashActive ? Math.min(slashIndex, slashMatches.length - 1) : 0;
 
-  // A local-only system note in the thread (e.g. /effort confirmation) — never sent
-  // to the agent, just shown so the operator sees the command took effect.
-  function noteToThread(text: string) {
+  // Post a local SYSTEM NOTE to the thread (e.g. a /effort confirmation, a status line, a
+  // warning) — never sent to the agent, just shown so the operator sees a local action took
+  // effect. role "system" so it renders distinctly and never gets the answer action row
+  // (copy/fork/regenerate). `tone` colours it (info/warning/danger/success). This is the reusable
+  // seam for any non-agent in-thread notice — exposed to forks via the slash/composer registries.
+  function noteToThread(text: string, opts?: { tone?: SystemNoteTone }) {
     if (!session) return;
     const base = chatStore.getSnapshot().sessions.find((s) => s.id === session.id)?.messages ?? [];
     chatStore.updateMessages(session.id, [
       ...base,
-      { id: messageId(), role: "assistant", content: text, createdAt: Date.now(), status: "done" },
+      { id: messageId(), role: "system", content: text, noteTone: opts?.tone, createdAt: Date.now(), status: "done" },
     ]);
   }
 

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -206,6 +206,21 @@
 .chat-session-slot .pl-message--system .pl-message__content .markdown > :first-child { margin-top: 0; }
 .chat-session-slot .pl-message--system .pl-message__content .markdown > :last-child { margin-bottom: 0; }
 
+/* Local SYSTEM NOTE (noteToThread) — a slash-command confirmation / status / warning. Same
+   inset system card as a report, but compact and with a tone-coloured left accent driven by
+   the message's `noteTone` (info/warning/danger/success). System notes never carry the answer
+   action row (that's role-"assistant"-only). Add a tone: one rule here + the SystemNoteTone
+   union in lib/types.ts. The `.chat-note--*` class sits ON `.pl-message--system`, so these
+   (4 classes) outrank the base system rule above (3 classes). */
+.chat-session-slot .pl-message--system.chat-note .pl-message__content {
+  font-size: 0.85rem;
+  padding: 8px 12px;
+}
+.chat-session-slot .pl-message--system.chat-note--info .pl-message__content { border-left-color: var(--pl-color-info, #3b82f6); }
+.chat-session-slot .pl-message--system.chat-note--success .pl-message__content { border-left-color: var(--pl-color-success, #30a46c); }
+.chat-session-slot .pl-message--system.chat-note--warning .pl-message__content { border-left-color: var(--pl-color-warning, #d98324); }
+.chat-session-slot .pl-message--system.chat-note--danger .pl-message__content { border-left-color: var(--pl-color-danger, #e5484d); }
+
 /* No "loading side-bar" on streaming answer text. The DS pulses a 2px accent left-border +
    10px inset on a streaming message body (ai.css) — but the streaming text itself is the cue,
    and it should read FULL WIDTH, not inset behind an animated rail. Drop it (higher specificity

--- a/apps/web/src/ext/composerRegistry.ts
+++ b/apps/web/src/ext/composerRegistry.ts
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import type { SystemNoteTone } from "../lib/types";
+
 // Build-time fork seam for COMPOSER ACTIONS (ADR 0061, extends ADR 0038 D3). A fork drops
 // a `src/ext/<name>.tsx` that calls `registerComposerAction()` to add a control to the chat
 // composer's actions slot (beside the model picker) — WITHOUT editing `ChatSurface.tsx`, so
@@ -17,8 +19,9 @@ export type ComposerActionContext = {
   setDraft: (text: string) => void;
   /** Return focus to the composer textarea. */
   focusComposer: () => void;
-  /** Drop a LOCAL system note into the thread (shown to the operator, never sent). */
-  noteToThread: (markdown: string) => void;
+  /** Drop a LOCAL system note into the thread (shown to the operator, never sent). `tone`
+   *  colours it (info/warning/danger/success); omit for a neutral note. */
+  noteToThread: (markdown: string, opts?: { tone?: SystemNoteTone }) => void;
 };
 
 export type ComposerAction = {

--- a/apps/web/src/ext/slashRegistry.ts
+++ b/apps/web/src/ext/slashRegistry.ts
@@ -12,6 +12,8 @@
 // Core itself registers `/new`, `/clear`, `/effort` through this seam (see
 // `chat/coreSlashCommands.ts`) — the seam is the only path, not a special case.
 
+import type { SystemNoteTone } from "../lib/types";
+
 /** What a client slash command's handler receives. The host (ChatSurface) builds this
  *  from its local state + the chat store when the command fires. */
 export type SlashContext = {
@@ -19,8 +21,9 @@ export type SlashContext = {
   rest: string;
   /** The active chat session id, or null if none. */
   sessionId: string | null;
-  /** Drop a LOCAL system note into the thread (shown to the operator, never sent). */
-  noteToThread: (markdown: string) => void;
+  /** Drop a LOCAL system note into the thread (shown to the operator, never sent). `tone`
+   *  colours it (info/warning/danger/success); omit for a neutral note. */
+  noteToThread: (markdown: string, opts?: { tone?: SystemNoteTone }) => void;
   /** Replace the composer draft text. */
   setDraft: (text: string) => void;
   /** Return focus to the composer textarea. */

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -462,6 +462,13 @@ export type ContextWindow = {
   enabled?: boolean;
 };
 
+/** Emphasis tone for a local SYSTEM NOTE (a role-"system" message without a `report`) —
+ *  e.g. a slash-command confirmation, a status line, or a warning. The reusable seam for
+ *  posting non-agent, in-thread notices is `ChatSurface.noteToThread(text, { tone })`,
+ *  exposed to forks via the slash + composer registries. Add a tone here + a matching
+ *  `.chat-note--<tone>` rule in chat.css; nothing else needs to change. */
+export type SystemNoteTone = "info" | "warning" | "danger" | "success";
+
 export type ChatMessage = {
   id?: string;
   role: "user" | "assistant" | "system";
@@ -490,6 +497,11 @@ export type ChatMessage = {
   /** This turn's context-window fill + compaction threshold (terminal context-v1 DataPart).
    *  Drives the meter in the same footer; absent on user turns / pre-ship history. */
   contextWindow?: ContextWindow;
+  /** Set on a local SYSTEM NOTE (role "system", no `report`) to tone its rendering — a
+   *  reusable, non-agent in-thread notice (slash-command confirmation, status, warning).
+   *  Posted via `noteToThread(text, { tone })`; system notes never carry the answer
+   *  action row (copy/fork/regenerate) — those are answer-only. */
+  noteTone?: SystemNoteTone;
 };
 
 // HITL (human-in-the-loop) request surfaced when a turn pauses as input-required


### PR DESCRIPTION
## What
Local in-thread notices (slash-command confirmations, status lines, warnings) are now a first-class **system note** type instead of fake assistant messages. `noteToThread(text, { tone })` posts a `role:"system"` message with an optional `SystemNoteTone` (`info | warning | danger | success`), rendered as a compact, tone-accented system card.

## Why
`noteToThread` posted `role:"assistant"`, so a `/effort` confirmation looked like an agent answer and got the **copy / fork / regenerate** action row — nonsensical for a note the model never produced.

## Extensible by design
- tone = the `SystemNoteTone` union (`lib/types.ts`) + a `.chat-note--<tone>` CSS rule — adding one is two lines
- carried through the `noteToThread` seam exposed on **both** the slash- and composer-command registries, so forks get toned notices for free
- system notes never carry the answer action row (role-`assistant`-gated)

## Test
build (tsc) clean; web unit **185 passed**.

Split out of the bypass-permissions PR — a general chat improvement. (The `/bypass` command there opts into `{ tone: "warning" }` once this lands.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for color-coded system notes in chat, with tones like info, success, warning, and danger.
  * System notes can now be inserted with an optional tone, and they render with matching visual styling.
* **Bug Fixes**
  * Updated chat message rendering so note messages display consistently with their tone-specific styling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->