### PR TITLE
chore: release v0.74.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.74.0] - 2026-06-29
+
 ### Added
 - **Bypass-permissions mode** (#1418) — a per-tab toggle that auto-approves `run_command` so the
   agent runs shell commands without the HITL approval prompt: `/bypass on|off`, a DS warning badge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.73.0"
+version = "0.74.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.74.0",
+    "date": "2026-06-29",
+    "changes": [
+      "Bypass-permissions mode",
+      "run_command runs shell operators",
+      "Slash-command notices render as system notes"
+    ]
+  },
+  {
     "version": "v0.73.0",
     "date": "2026-06-29",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.74.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.74.0 -m 'Release v0.74.0' && git push origin v0.74.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).