### PR TITLE
fix: custom api_base gateway not blocked + plugin config appears without restart

### DIFF
--- a/apps/web/src/plugins/InstallPluginDialog.tsx
+++ b/apps/web/src/plugins/InstallPluginDialog.tsx
@@ -28,6 +28,10 @@ export function InstallPluginDialog({ open, onClose }: { open: boolean; onClose:
       // gates Uninstall.
       qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
       qc.invalidateQueries({ queryKey: queryKeys.installedPlugins });
+      // Install auto-enables the plugin, so its declared Settings fields (ADR 0019) are
+      // now in the schema — refetch it or the plugin's config section won't appear until
+      // a restart clears the 5-min-stale cache (#1423).
+      qc.invalidateQueries({ queryKey: queryKeys.settings });
       setUrl("");
       setRef("");
       // Clean install (auto-enabled, nothing to flag) → close; the new row shows in the

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -167,12 +167,19 @@ function LocalTab() {
     qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
     qc.invalidateQueries({ queryKey: queryKeys.installedPlugins });
     qc.invalidateQueries({ queryKey: queryKeys.pluginUpdates });
+    // The active plugin set changed, so the settings schema (which carries each enabled
+    // plugin's declared config fields, ADR 0019) is stale — refetch it (#1423).
+    qc.invalidateQueries({ queryKey: queryKeys.settings });
   };
 
   const toggle = useMutation({
     mutationFn: (p: Plugin) => api.setPluginEnabled(p.id, !p.enabled),
     onSuccess: (res, p) => {
       qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+      // Enable/disable changes which plugins contribute Settings fields (ADR 0019), so
+      // refetch the schema — else a just-enabled plugin's config section won't appear
+      // until a restart clears the 5-min-stale cache (#1423).
+      qc.invalidateQueries({ queryKey: queryKeys.settings });
       // Enable hot-mounts the plugin's router (#822). Only DISABLE leaves a stale
       // route/surface behind (FastAPI can't unmount) → restart_recommended on OFF.
       setHint(
@@ -191,6 +198,8 @@ function LocalTab() {
     onSuccess: (res, p) => {
       qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
       qc.invalidateQueries({ queryKey: queryKeys.pluginUpdates });
+      // A new version may declare new/changed config fields — refetch the schema (#1423).
+      qc.invalidateQueries({ queryKey: queryKeys.settings });
       setHint(
         res.restart_recommended
           ? `${p.name} updated${res.version ? ` to v${res.version}` : ""} — restart to fully load its console view or background surface.`

--- a/docs/adr/0047-layered-settings-cascade.md
+++ b/docs/adr/0047-layered-settings-cascade.md
@@ -139,6 +139,7 @@ the corresponding items in §7.
    | `prompt_cache.enabled/ttl/warm.enabled/warm.interval_seconds` | cache tier is gateway/deployment-dependent |
    | `telemetry.enabled`, `telemetry.retention_days` | observability is machine-wide |
    | `identity.org` | white-label org branding is deployment-wide (`identity.name`/`operator` stay per-agent) |
+   | `egress.allowed_hosts` | box-wide outbound network policy (ADR 0008); sits at the Host layer beside the inbound `network.bind` (D8) |
 
    Everything else is `agent`: `identity.name/operator`, `model.temperature/max_tokens/max_iterations`,
    `agent_runtime` (each agent picks **native or `acp:*`** independently), `operator_mcp.tools`,

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -254,7 +254,7 @@ filesystem:
 
 ## `egress`
 
-Deny-by-default outbound-host allowlist ([ADR 0008](../adr/0008-sandboxing-and-openshell.md)) enforced in `fetch_url` — the tool where the model picks an arbitrary host (the in-process exfiltration / SSRF vector). Also the single source of truth the OpenShell network policy is generated from (`scripts/gen_openshell_policy.py`).
+Deny-by-default outbound-host allowlist ([ADR 0008](../adr/0008-sandboxing-and-openshell.md)) enforced in `fetch_url` — the tool where the model picks an arbitrary host (the in-process exfiltration / SSRF vector). Also the single source of truth the OpenShell network policy is generated from (`scripts/gen_openshell_policy.py`). Editable in the console at **Settings ▸ Box ▸ Network** (host-scoped, hot-reloads).
 
 ```yaml
 egress:
@@ -265,9 +265,9 @@ egress:
 
 | Key | Default | What |
 |---|---|---|
-| `allowed_hosts` | `[]` | Hosts `fetch_url` may reach. **Empty = permissive** (off). When set, any other host is denied. `*.host` matches subdomains + apex; case-insensitive, port-agnostic. Hot-reloads. |
+| `allowed_hosts` | `[]` | Hosts `fetch_url` may reach. **Empty = permissive** (off, with a built-in SSRF guard still blocking private / loopback / cloud-metadata addresses). When set, any other host is denied. `*.host` matches subdomains + apex; case-insensitive, port-agnostic. Hot-reloads. |
 
-Covers `fetch_url` only; `execute_code`/`run_command` process-level egress is fenced by running under OpenShell (see [Sandboxing & egress](../guides/sandboxing.md)).
+When the allowlist **is** set, your configured model gateway (`model.api_base`) host is permitted **automatically** — you don't have to list it, and the connection-test / "Get models" probes for a custom base URL won't be blocked. (With an empty allowlist this auto-add is a no-op; adding one host there would flip the guard into deny-by-default for every other host.) Covers `fetch_url` only; `execute_code`/`run_command` process-level egress is fenced by running under OpenShell (see [Sandboxing & egress](../guides/sandboxing.md)).
 
 ## `security`
 

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -711,12 +711,18 @@ def list_gateway_models(
 
     key = api_key or os.environ.get("OPENAI_API_KEY", "")
     url = api_base.rstrip("/") + "/models"
-    # SSRF guard (#871): an operator-supplied api_base must not steer this probe at an
-    # internal service or cloud-metadata (169.254.169.254). Blocked unless explicitly
-    # allowlisted via egress.allowed_hosts.
+    # SSRF guard (#871): an operator-supplied api_base must not steer this probe at
+    # cloud-metadata (169.254.169.254) or another link-local/reserved address. But a
+    # custom api_base is an OPERATOR-configured gateway — overwhelmingly localhost
+    # (Ollama / LM Studio / local vLLM / LiteLLM) or a LAN/tailnet host — so allow_private
+    # (same as the fleet-remote probe in graph/fleet/supervisor.py) while STILL blocking
+    # link-local/metadata/multicast/reserved. An unresolvable host isn't itself an SSRF
+    # target — let the real httpx connection error surface instead of a misleading block.
+    # If an egress allowlist IS set, it still enforces (the host must be allowlisted, which
+    # it also needs for actual gateway egress / the OpenShell policy anyway).
     from security import egress
 
-    if egress.check_url(url):
+    if egress.check_url(url, allow_private=True, block_unresolvable=False):
         return [], "api_base host is blocked by the egress guard (set egress.allowed_hosts to permit it)"
     headers = {}
     if key:
@@ -783,10 +789,12 @@ def validate_model_connection(
 
     key = api_key or os.environ.get("OPENAI_API_KEY", "")
     url = api_base.rstrip("/") + "/chat/completions"
-    # SSRF guard (#871) — same as list_gateway_models.
+    # SSRF guard (#871) — same as list_gateway_models: allow_private so a localhost /
+    # LAN / tailnet operator gateway works, link-local/metadata stays blocked, and an
+    # allowlist (when set) still enforces.
     from security import egress
 
-    if egress.check_url(url):
+    if egress.check_url(url, allow_private=True, block_unresolvable=False):
         return False, "api_base host is blocked by the egress guard (set egress.allowed_hosts to permit it)"
     headers = {"Content-Type": "application/json"}
     if key:

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -598,6 +598,23 @@ FIELDS: list[Field] = [
         restart=True,
         scope="host",
     ),
+    # Outbound counterpart to the inbound bind interface (ADR 0008). Host-scoped +
+    # hot-reloaded (egress.set_allowed_hosts runs on save). string_list → the generic
+    # one-per-line editor; no bespoke console code.
+    Field(
+        "egress.allowed_hosts",
+        "egress_allowed_hosts",
+        "Outbound host allowlist",
+        "string_list",
+        "Network",
+        "Hosts the agent's fetch_url tool may reach — one per line; a leading `*.` matches "
+        "subdomains (e.g. `*.github.com`). Empty = off: any public host is reachable, with a "
+        "built-in SSRF guard still blocking private / loopback / cloud-metadata addresses. When "
+        "set it's deny-by-default (only these hosts) — your configured model gateway (Model ▸ API "
+        "base URL) is always permitted automatically, so you needn't list it. Also the source of "
+        "truth for the OpenShell sandbox network policy.",
+        scope="host",
+    ),
     Field(
         "fleet.port_base",
         "fleet_port_base",

--- a/security/egress.py
+++ b/security/egress.py
@@ -27,10 +27,26 @@ from urllib.parse import urlparse
 _allowed: list[str] = []  # lowercased host patterns; empty = permissive (off)
 
 
-def set_allowed_hosts(hosts) -> None:
-    """Set the allowlist (called once at startup from config). Empty = off."""
+def set_allowed_hosts(hosts, *, also_allow_url: str = "") -> None:
+    """Set the allowlist (called at startup / live-reload from config). Empty = off.
+
+    ``also_allow_url`` — when an allowlist IS configured, the host of this URL (the
+    operator-configured model gateway / ``api_base``) is always included, so a deny-by-default
+    allowlist never blocks the operator's own deliberately-set gateway. Mirrors
+    ``scripts/gen_openshell_policy.py``, which already auto-adds the api_base host to the
+    process-level network policy. Ignored when ``hosts`` is empty — permissive mode must stay
+    permissive (adding one host would flip the guard into deny-by-default for everything else).
+    """
     global _allowed
-    _allowed = [str(h).strip().lower() for h in (hosts or []) if h and str(h).strip()]
+    cleaned = [str(h).strip().lower() for h in (hosts or []) if h and str(h).strip()]
+    if cleaned and also_allow_url:
+        try:
+            host = (urlparse(also_allow_url).hostname or "").lower()
+        except ValueError:
+            host = ""
+        if host and host not in cleaned:
+            cleaned.append(host)
+    _allowed = cleaned
 
 
 def allowed_hosts() -> list[str]:

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -110,7 +110,9 @@ def _init_langgraph_agent(headless_setup: bool = False):
     # Egress allowlist (ADR 0008): deny-by-default outbound hosts for fetch_url.
     from security import egress
 
-    egress.set_allowed_hosts(STATE.graph_config.egress_allowed_hosts)
+    egress.set_allowed_hosts(
+        STATE.graph_config.egress_allowed_hosts, also_allow_url=STATE.graph_config.api_base
+    )
     # Opt-in CIDR allowlist for outbound A2A destinations — callbacks + delegate_to a2a delegates (#572).
     from security import policy
 
@@ -1366,7 +1368,9 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
         from security import egress
         from security import policy
 
-        egress.set_allowed_hosts(new_config.egress_allowed_hosts)  # live-reload (ADR 0008)
+        egress.set_allowed_hosts(
+            new_config.egress_allowed_hosts, also_allow_url=new_config.api_base
+        )  # live-reload (ADR 0008)
         policy.set_callback_allowlist(new_config.security_callback_allowlist)  # live-reload (#572)
     except Exception:  # noqa: BLE001 — never block a reload on the egress update
         pass

--- a/tests/test_config_drift_guard.py
+++ b/tests/test_config_drift_guard.py
@@ -254,6 +254,9 @@ HOST_SCOPED_KEYS = {
     "commons.path",
     # Box runtime (ADR 0047 D8) — env/CLI knobs promoted into the Host layer.
     "network.bind",
+    # Egress allowlist (ADR 0008) — a box-wide outbound security policy, so it lives
+    # at the Host layer alongside the inbound bind interface.
+    "egress.allowed_hosts",
     "fleet.port_base",
     "fleet.discovery.port_min",
     "fleet.discovery.port_max",

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -153,6 +153,8 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
         # Box runtime (Host layer, ADR 0047 D8).
         "network",
         "fleet",
+        # Egress allowlist (ADR 0008) — surfaced in Settings ▸ Box ▸ Network.
+        "egress",
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature
@@ -494,6 +496,47 @@ def test_list_gateway_models_blocks_internal_api_base(monkeypatch):
     models, err = config_io.list_gateway_models("http://169.254.169.254/latest/v1")
     assert models == [] and "blocked" in err
     assert called["n"] == 0  # never hit the network
+
+
+def test_list_gateway_models_allows_localhost_api_base(monkeypatch):
+    """A custom api_base is an operator-configured gateway — most commonly localhost
+    (Ollama / LM Studio / local vLLM / LiteLLM). allow_private (mirroring the fleet-remote
+    probe) lets it through the SSRF guard while link-local/metadata stays blocked. Regression
+    for "connection failed — api_base host is blocked by the egress guard" on a local gateway."""
+    from graph import config_io
+
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = {"data": [{"id": "llama3"}]}
+
+    fake_client = MagicMock()
+    fake_client.__enter__ = lambda self: fake_client
+    fake_client.__exit__ = lambda *args: None
+    fake_client.get.return_value = fake_response
+    monkeypatch.setattr("httpx.Client", lambda **kw: fake_client)
+
+    models, err = config_io.list_gateway_models("http://127.0.0.1:11434/v1")
+    assert err == ""  # not blocked — the probe reached the (mocked) gateway
+    assert models == ["llama3"]
+    assert fake_client.get.call_args[0][0] == "http://127.0.0.1:11434/v1/models"
+
+
+def test_validate_model_connection_allows_localhost_api_base(monkeypatch):
+    """Same fix on the completion probe: a localhost gateway is not blocked by egress."""
+    from graph import config_io
+
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+
+    fake_client = MagicMock()
+    fake_client.__enter__ = lambda self: fake_client
+    fake_client.__exit__ = lambda *args: None
+    fake_client.post.return_value = fake_response
+    monkeypatch.setattr("httpx.Client", lambda **kw: fake_client)
+
+    ok, err = config_io.validate_model_connection("http://127.0.0.1:11434/v1", model="llama3")
+    assert ok is True and err == ""
+    assert fake_client.post.call_args[0][0] == "http://127.0.0.1:11434/v1/chat/completions"
 
 
 # ── list_available_tools ─────────────────────────────────────────────────────

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -211,6 +211,9 @@ CONFIG_TO_DICT_GOLDEN = {
         "model": "",
         "trigger": "fraction:0.8",
     },
+    "egress": {
+        "allowed_hosts": [],
+    },
     "fleet": {
         "port_base": 7870,
         "discovery": {

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -73,6 +73,31 @@ def test_set_filters_blanks():
     assert egress.allowed_hosts() == ["good.com"]
 
 
+def test_also_allow_url_includes_gateway_host_when_allowlist_set():
+    # When an allowlist IS configured, the operator-configured gateway (api_base) host is
+    # always reachable — so the deny-by-default allowlist never blocks the user's own gateway
+    # they explicitly pointed the agent at (the "custom baseURL → blocked by egress" report).
+    egress.set_allowed_hosts(["api.proto-labs.ai"], also_allow_url="https://my-gateway.internal:4000/v1")
+    assert "my-gateway.internal" in egress.allowed_hosts()
+    assert egress.check_url("https://my-gateway.internal:4000/v1/models") is None
+    # The explicitly-listed host still works; an unrelated host is still denied.
+    assert egress.check_url("https://api.proto-labs.ai/v1") is None
+    assert egress.check_url("https://evil.example/") is not None
+
+
+def test_also_allow_url_ignored_when_no_allowlist():
+    # Empty allowlist = permissive mode (default SSRF denylist only). Auto-adding the api_base
+    # host here would flip the guard into deny-by-default for EVERY other host — so it must not.
+    egress.set_allowed_hosts([], also_allow_url="https://my-gateway.internal/v1")
+    assert egress.is_enabled() is False
+    assert egress.allowed_hosts() == []
+
+
+def test_also_allow_url_not_duplicated():
+    egress.set_allowed_hosts(["gw.example"], also_allow_url="https://gw.example/v1")
+    assert egress.allowed_hosts() == ["gw.example"]
+
+
 # ── config round-trip ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -82,6 +82,22 @@ def test_groups_carry_category_in_taxonomy_order():
     assert "Knowledge" not in by_section  # the single 22-field wall is gone
 
 
+def test_egress_allowlist_surfaced_in_box_network():
+    """The egress allowlist (ADR 0008) is editable in Settings ▸ Box ▸ Network —
+    a host-scoped, hot-reloaded string_list (so it renders in the generic list editor)."""
+    groups = build_schema(LangGraphConfig())
+    by_key = {f["key"]: f for g in groups for f in g["fields"]}
+    e = by_key.get("egress.allowed_hosts")
+    assert e is not None, "egress.allowed_hosts must be rendered in the settings UI"
+    assert e["type"] == "string_list"
+    assert e["section"] == "Network"
+    assert e["scope"] == "host"  # box-wide default (ADR 0047)
+    assert e["restart"] is False  # set_allowed_hosts runs on live-reload
+    assert e["default"] == []
+    section_cat = {g["section"]: g["category"] for g in groups}
+    assert section_cat["Network"] == "Box"
+
+
 def test_knowledge_split_into_subsections():
     """The Knowledge domain renders as Recall → Ingestion → History (not one wall)."""
     groups = build_schema(LangGraphConfig())


### PR DESCRIPTION
Two related operator-console fixes, bundled to release together.

---

## 1. Custom api_base gateway blocked by the egress guard

Adding a **custom model base URL** (Settings ▸ Model ▸ *API base URL*) failed with:

> connection failed — api_base host is blocked by the egress guard (set egress.allowed_hosts to permit it)

A custom base URL is overwhelmingly a **local gateway** — Ollama / LM Studio / local vLLM / LiteLLM on `localhost`, or a LAN/tailnet host. The two operator-facing connection probes (`list_gateway_models` → `/models`, `validate_model_connection` → `/chat/completions`) ran the URL through the strict egress SSRF guard, which exists to stop the *model* from `fetch_url`-ing internal hosts. But the api_base is **operator-configured**, and **actual model inference never goes through the guard** (`create_llm` → `ChatOpenAI` directly) — so the probe was a pure false-negative.

**Fix**
- `graph/config_io.py` — both probes use `egress.check_url(url, allow_private=True, block_unresolvable=False)`, the same posture as the fleet-remote probe (`graph/fleet/supervisor.py`). localhost / LAN / tailnet pass; **link-local / cloud-metadata (`169.254.169.254`) / multicast / reserved stay blocked**.
- `security/egress.py` — `set_allowed_hosts` gains `also_allow_url=`. When an allowlist **is** configured, the gateway host (`model.api_base`) is auto-included (mirrors `scripts/gen_openshell_policy.py`). **No-op when the allowlist is empty** (never flips permissive → deny-by-default). Wired into the startup + live-reload sites in `server/agent_init.py`.
- **Operator UI** — new `egress.allowed_hosts` field in **Settings ▸ Box ▸ Network** (host-scoped, hot-reloads), the outbound counterpart to the inbound *Bind interface*. Previously YAML-only; renders via the generic `string_list` editor — no bespoke frontend.
- Docs: `configuration.md` egress section + ADR 0047 §2.1 host-field table.

**Security note:** this relaxes a *probe*, not the runtime egress fence. The genuinely dangerous SSRF targets remain blocked in every path, and the allowlist auto-include only ever adds the operator's own gateway, only when an allowlist is already active.

---

## 2. Plugin config not available until restart — Fixes #1423

A newly added plugin's config section didn't appear in Settings until the app was restarted.

**Cause:** the settings schema query (`queryKeys.settings` — includes each enabled plugin's declared config fields, ADR 0019) has a 5-min `staleTime` and was only invalidated after a settings *save*. The plugin mutations (install, enable/disable, uninstall, sync, update) refreshed `runtimeStatus` / `installedPlugins` / `pluginUpdates` but **never the settings schema** — so it stayed cached until a restart cleared React Query's cache. The backend already serves it fresh (`live_plugin_config_schemas()` re-reads the YAML on every `/api/settings/schema` call after the enable persists + hot-reloads); the only gap was the client not refetching.

**Fix:** invalidate `queryKeys.settings` wherever the active plugin set changes — `InstallPluginDialog` (install auto-enables), `PluginsSurface.refreshAll()` (uninstall, sync), and the enable/disable + update mutations.

---

## Tests
- **Python:** localhost api_base passes both probes (existing `169.254.169.254`-blocked test still green); allowlist auto-includes the gateway; empty allowlist stays permissive; `egress.allowed_hosts` renders in Box ▸ Network as a host-scoped `string_list`; updated the `config_to_dict` key-set, the round-trip golden, and the ADR-0047 scope drift-guard for the new top-level `egress` key. **Full suite green: 2351 passed.** `ruff check .` clean, `lint-imports` 3/3.
- **Web:** `tsc --noEmit` clean; unit suite green (185 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)