### PR TITLE
chore: release v0.75.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.75.0] - 2026-06-29
+
 ### Added
 - **Egress allowlist in Settings** (#1422) — the outbound-host allowlist (`egress.allowed_hosts`,
   ADR 0008) is now editable in **Settings ▸ Box ▸ Network**, the outbound counterpart to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.74.0"
+version = "0.75.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.75.0",
+    "date": "2026-06-29",
+    "changes": [
+      "Egress allowlist in Settings",
+      "Custom model gateway no longer blocked on the connection test",
+      "Plugin config appears without a restart"
+    ]
+  },
+  {
     "version": "v0.74.0",
     "date": "2026-06-29",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.75.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.75.0 -m 'Release v0.75.0' && git push origin v0.75.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for egress allowlists in Settings.
  * Custom model gateway connection tests now complete without being blocked.
  * Plugin configuration is now visible without requiring a restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->