### PR TITLE
feat(web): add "Manage plugins…" to the rail context menus

### DIFF
--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -169,6 +169,25 @@ test("the Hidden views menu restores onto the rail it was opened on", async ({ p
   await expect(leftRail.getByRole("button", { name: "Board", exact: true })).toHaveCount(0);
 });
 
+test("right-click the empty rail → 'Manage plugins…' opens Settings ▸ Integrations", async ({ page }) => {
+  // The rail-background menu also carries a rail-wide action (not tied to one surface) that opens
+  // the plugin manager — Settings ▸ Integrations — via openGlobalSettings("plugins").
+  await page.goto("/app/", { waitUntil: "load" });
+  const rail = page.getByRole("complementary", { name: "Left surfaces" });
+  await expect(rail.getByRole("button", { name: "Board", exact: true })).toBeVisible();
+
+  // Right-click empty rail space (below the icons) → the menu offers "Manage plugins…".
+  const box = await rail.boundingBox();
+  if (!box) throw new Error("left rail has no bounding box");
+  await rail.click({ button: "right", position: { x: box.width / 2, y: box.height - 8 } });
+  await page.locator(".pl-menu").getByText("Manage plugins", { exact: false }).click();
+
+  // The one settings dialog opens, deep-linked to the Integrations (plugins) section.
+  const overlay = page.locator(".settings-overlay");
+  await expect(overlay).toBeVisible();
+  await expect(overlay.locator(".pl-sidenav__item--active")).toHaveText(/Integrations/);
+});
+
 test("right-click a plugin view → Configure opens that plugin's settings dialog", async ({ page }) => {
   // ADR 0036/0059 — a plugin view's rail menu offers "Configure…", which opens the owning
   // plugin's per-plugin settings dialog (titled with the plugin's display name, "Boardy").

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -197,6 +197,17 @@ test("right-click a plugin view → Configure opens that plugin's settings dialo
   await expect(page.getByRole("dialog", { name: "Boardy" })).toBeVisible();
 });
 
+test("right-click a rail icon → 'Manage plugins…' opens Settings ▸ Integrations", async ({ page }) => {
+  // The per-icon rail menu also carries the rail-wide "Manage plugins…" action (the all-plugins
+  // counterpart to the per-plugin "Configure…"), opening Settings ▸ Integrations.
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".pl-rail").getByRole("button", { name: "Board", exact: true }).click({ button: "right" });
+  await page.locator(".pl-menu").getByText("Manage plugins", { exact: false }).click();
+  const overlay = page.locator(".settings-overlay");
+  await expect(overlay).toBeVisible();
+  await expect(overlay.locator(".pl-sidenav__item--active")).toHaveText(/Integrations/);
+});
+
 test("right-click a plugin's util-bar widget → Configure opens its settings dialog", async ({ page }) => {
   // ADR 0036/0059 — the util-bar widget context menu mirrors the rail-icon Configure.
   await page.goto("/app/", { waitUntil: "load" });

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftRight, ChevronDown, ChevronUp, Eye, EyeOff, Pencil, Plus, SlidersHorizontal, X } from "lucide-react";
+import { ArrowLeftRight, ChevronDown, ChevronUp, Eye, EyeOff, Pencil, Plus, Puzzle, SlidersHorizontal, X } from "lucide-react";
 
 import { openView } from "../app/usePaletteRegistry";
 import { useUI } from "../state/uiStore";
@@ -91,34 +91,44 @@ registerContextMenu({
   },
 });
 
-// Right-click the EMPTY rail background (not an icon) → the "Hidden views" menu: one entry per
-// hidden surface (railOrder.hidden), each restored onto the dock whose background was clicked
-// (`ctx.side`) and then opened. The App-side trigger resolves each hidden id's label (core/plugin/
-// ext metadata lives there) + the clicked side into `ctx`. When nothing is hidden, a disabled hint
-// shows so the menu still confirms the feature. The discoverable counterpart to ⌘K (ADR 0035/0036).
+// Right-click the EMPTY rail background (not an icon) → the rail menu: one "Show hidden view" entry
+// per hidden surface (railOrder.hidden), each restored onto the dock whose background was clicked
+// (`ctx.side`) and then opened, plus a rail-wide "Manage plugins…" action that opens Settings ▸
+// Integrations. The App-side trigger resolves each hidden id's label (core/plugin/ext metadata lives
+// there) + the clicked side into `ctx`. When nothing is hidden, a disabled hint shows so that part
+// still confirms the feature. The discoverable counterpart to ⌘K (ADR 0035/0036).
 registerContextMenu({
   type: "rail-background",
   items: (ctx: { side?: "left" | "right" | "bottom"; hidden?: { id: string; label: string }[] }): MenuEntry[] => {
     const hidden = ctx?.hidden ?? [];
-    if (!hidden.length) {
-      return [{ id: "none", label: "No hidden views", disabled: true, run: () => {} }];
-    }
-    return [
-      { id: "hidden-header", label: "Show hidden view", disabled: true, run: () => {} },
-      { id: "hidden-div", divider: true },
-      ...hidden.map(
-        (h): MenuEntry => ({
-          id: `show-${h.id}`,
-          label: h.label,
-          icon: <Eye size={14} />,
-          // Restore to the dock the menu was opened on, then open it there.
-          run: () => {
-            useUI.getState().showSurface(h.id, ctx?.side);
-            openView(h.id);
-          },
-        }),
-      ),
-    ];
+    const out: MenuEntry[] = hidden.length
+      ? [
+          { id: "hidden-header", label: "Show hidden view", disabled: true, run: () => {} },
+          { id: "hidden-div", divider: true },
+          ...hidden.map(
+            (h): MenuEntry => ({
+              id: `show-${h.id}`,
+              label: h.label,
+              icon: <Eye size={14} />,
+              // Restore to the dock the menu was opened on, then open it there.
+              run: () => {
+                useUI.getState().showSurface(h.id, ctx?.side);
+                openView(h.id);
+              },
+            }),
+          ),
+        ]
+      : [{ id: "none", label: "No hidden views", disabled: true, run: () => {} }];
+    // A rail-wide action (not tied to one surface): open the plugin manager — Settings ▸
+    // Integrations — to install, enable/disable, configure, or update plugins.
+    out.push({ id: "manage-div", divider: true });
+    out.push({
+      id: "manage-plugins",
+      label: "Manage plugins…",
+      icon: <Puzzle size={14} />,
+      run: () => useUI.getState().openGlobalSettings("plugins"),
+    });
+    return out;
   },
 });
 

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -37,10 +37,10 @@ registerContextMenu({
       { side: "right", label: "Move to right rail" },
       { side: "bottom", label: "Move to bottom dock" },
     ];
-    // Management actions, gathered so the divider only shows when at least one applies:
-    // Configure (plugin views only) opens the owning plugin's settings dialog; Hide moves the
-    // surface to railOrder.hidden (restore from ⌘K or "Move to …"). Chat is never hidden — it
-    // mounts unconditionally on its dock, so a hidden chat would render with no rail icon.
+    // Management actions. "Manage plugins…" (open the all-plugins manager, Settings ▸ Integrations)
+    // is always present; Configure (plugin views only) opens the owning plugin's settings dialog;
+    // Hide moves the surface to railOrder.hidden (restore from ⌘K or "Move to …"). Chat is never
+    // hidden — it mounts unconditionally on its dock, so a hidden chat would render with no rail icon.
     const manage: MenuEntry[] = [];
     if (ctx.pluginId) {
       const pid = ctx.pluginId;
@@ -52,6 +52,14 @@ registerContextMenu({
         run: () => useUI.getState().openPluginConfig(pid, pname),
       });
     }
+    // A rail-wide escape hatch on every icon: the all-plugins counterpart to the per-plugin
+    // "Configure…" above — opens Settings ▸ Integrations.
+    manage.push({
+      id: "manage-plugins",
+      label: "Manage plugins…",
+      icon: <Puzzle size={14} />,
+      run: () => useUI.getState().openGlobalSettings("plugins"),
+    });
     if (ctx.id !== "chat") {
       manage.push({
         id: "hide",


### PR DESCRIPTION
## What

Adds a rail-wide **"Manage plugins…"** action to **both** rail context menus, opening the plugin manager — the one Settings dialog deep-linked to **Integrations** — via `openGlobalSettings("plugins")`:

- **Empty rail space** (`rail-background` menu — already lists hidden views, ADR 0035/0036): "Manage plugins…" sits below the hidden-views list, separated by a divider; shown whether or not any views are hidden.
- **Per icon** (`rail-surface` menu): always present in the manage section, as the all-plugins counterpart to the per-plugin **Configure…** (which opens *that* plugin's dialog).

## Test plan

- `apps/web/e2e/plugin-views.spec.ts` — two new regressions: right-click empty rail / a rail icon → "Manage plugins…" → settings overlay opens with **Integrations** as the active section.
- Local: right-click empty rail space, or any rail icon → **Manage plugins…** → Settings opens at Integrations.

## Verification

- `tsc` typecheck — clean
- `vite build` — clean
- e2e (`plugin-views` 16/16, incl. both new tests; `settings` 9/9 unchanged)
- vitest unit — 185/185

🤖 Generated with [Claude Code](https://claude.com/claude-code)