### PR TITLE
fix(web): retire the two residual /api/config writers (identity name + fleet delegates)

### DIFF
--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -91,11 +91,11 @@ test("topbar switcher navigates to an agent by slug", async ({ page }) => {
 
 test("host without delegates: add → 404 → Enable delegates → retried add succeeds (#797)", async ({ page }) => {
   // The focused agent (host) doesn't serve /api/delegates until the plugin is enabled;
-  // enabling appends plugins.enabled via /api/config and the reload hot-mounts the routes,
-  // so the retry lands without a restart.
+  // enabling goes through the dedicated /api/plugins/{id}/enabled endpoint and the reload
+  // hot-mounts the routes, so the retry lands without a restart.
   let enabled = false;
   let delegatePosts = 0;
-  let configPosts = 0;
+  let enablePosts = 0;
   await page.route("**/api/fleet", async (route) => {
     const response = await route.fetch();
     const json = await response.json();
@@ -108,11 +108,11 @@ test("host without delegates: add → 404 → Enable delegates → retried add s
     if (!enabled) return route.fulfill({ status: 404, json: { detail: "Not Found" } });
     return route.fulfill({ json: { ok: true } });
   });
-  await page.route("**/api/config", async (route) => {
+  await page.route("**/api/plugins/*/enabled", async (route) => {
     if (route.request().method() !== "POST") return route.fallback();
-    configPosts += 1;
+    enablePosts += 1;
     enabled = true;
-    return route.fulfill({ json: { ok: true, messages: ["config saved", "reloaded"] } });
+    return route.fulfill({ json: { ok: true, enabled: true, reloaded: true, restart_recommended: false } });
   });
 
   await openAgents(page);
@@ -125,7 +125,7 @@ test("host without delegates: add → 404 → Enable delegates → retried add s
   await expect(error).toContainText("can't hold delegates");
   await page.getByTestId("enable-delegates").click();
 
-  await expect.poll(() => configPosts).toBe(1); // plugins.enabled += delegates applied
+  await expect.poll(() => enablePosts).toBe(1); // delegates enabled via the dedicated endpoint
   await expect.poll(() => delegatePosts).toBe(2); // the 404'd attempt + the post-enable retry
   await expect(error).toHaveCount(0); // retry succeeded -> error cleared
 });

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -185,3 +185,29 @@ test("per-agent (fleet member) settings show ADR 0047 inheritance badges + reset
   await expect(page.locator(".pl-toast", { hasText: /inherited/i })).toBeVisible();
   await expect(page.locator('.setting-row[data-key="routing.fallback_models"] .setting-inheritance')).toHaveCount(0);
 });
+
+test("Identity: a name change saves via /api/settings, not /api/config (no operator clobber)", async ({ page }) => {
+  // The Identity panel routes the name through the canonical settings cascade; SOUL (unchanged
+  // here) is what goes via /api/config. The old code ALWAYS POSTed /api/config echoing a cached
+  // operator, which could clobber a fresh Operator & access edit — assert that's gone: a name-only
+  // save POSTs /api/settings with identity.name and never touches /api/config.
+  await openSettings(page);
+  await section(page, "Identity");
+  const nameInput = page.getByTestId("identity-name");
+  await expect(nameInput).toBeVisible();
+
+  let configPosted = false;
+  page.on("request", (r) => {
+    if (r.method() === "POST" && new URL(r.url()).pathname.endsWith("/api/config")) configPosted = true;
+  });
+
+  await nameInput.fill("renamed-agent");
+  const settingsReq = page.waitForRequest(
+    (r) => r.method() === "POST" && new URL(r.url()).pathname.endsWith("/api/settings"),
+  );
+  await page.getByTestId("identity-save").click();
+  const req = await settingsReq;
+  expect(req.postDataJSON()?.updates?.["identity.name"]).toBe("renamed-agent");
+  await expect(page.locator(".pl-toast", { hasText: /Identity saved/i })).toBeVisible();
+  expect(configPosted).toBe(false);
+});

--- a/apps/web/src/agent/IdentityPanel.tsx
+++ b/apps/web/src/agent/IdentityPanel.tsx
@@ -2,6 +2,7 @@ import "./identity.css";
 
 import { Input, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
+import { useToast } from "@protolabsai/ui/overlays";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useEffect, useState } from "react";
@@ -13,11 +14,15 @@ import { api } from "../lib/api";
 import { queryKeys } from "../lib/queries";
 
 // Agent → Identity: who this agent is. The SOUL.md (persona) renders as Markdown by default and
-// fills the panel; "Edit" flips it to a raw textarea. Saving merges the name into config, writes
-// SOUL.md, and hot-reloads the graph (POST /api/config).
+// fills the panel; "Edit" flips it to a raw textarea. Saving routes the name through the canonical
+// settings cascade (POST /api/settings — the same path every other field uses; `identity.name` is
+// ui_hidden in the schema so this panel stays its single editor) and writes SOUL.md via POST
+// /api/config, then hot-reloads. It does NOT touch `identity.operator` — that's owned solely by the
+// Operator & access panel; echoing a cached copy here used to clobber fresh edits made there.
 
 export function IdentityPanel() {
   const qc = useQueryClient();
+  const toast = useToast();
   const { data, isLoading } = useQuery({ queryKey: ["config"], queryFn: () => api.config() });
 
   const [name, setName] = useState("");
@@ -38,15 +43,19 @@ export function IdentityPanel() {
   const dirty = seeded && (name !== baseName || soul !== baseSoul);
 
   const save = useMutation({
-    mutationFn: () =>
-      api.applyConfig(
-        { identity: { name: name.trim(), operator: data?.config?.identity?.operator ?? "" } },
-        soul,
-      ),
+    mutationFn: async () => {
+      // Name → the canonical schema cascade; SOUL (not a schema field) → /api/config with a null
+      // config so nothing else in the config doc is touched. Only write what actually changed.
+      if (name.trim() !== baseName) await api.saveSettings({ "identity.name": name.trim() });
+      if (soul !== baseSoul) await api.applyConfig(null, soul);
+    },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["config"] });
       qc.invalidateQueries({ queryKey: queryKeys.runtime });
+      qc.invalidateQueries({ queryKey: queryKeys.settings });
+      toast({ tone: "success", title: "Identity saved", message: "Agent reloaded." });
     },
+    onError: () => toast({ tone: "error", title: "Save failed", message: "Check the server log." }),
   });
 
   return (
@@ -75,12 +84,11 @@ export function IdentityPanel() {
               <span>Agent name</span>
               <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="my-agent" data-testid="identity-name" />
             </label>
-            {/* Save feedback + what saving does — ABOVE the editor (near the Save button), so the
-                SOUL.md editor runs to the panel bottom instead of being trailed by helper text. */}
-            {save.isError ? <p className="error-strip" role="alert">Save failed — check the server log.</p> : null}
-            {save.isSuccess && !dirty ? <p className="muted">Saved — agent reloaded.</p> : null}
+            {/* What saving does — kept ABOVE the editor so the SOUL.md editor runs to the panel
+                bottom. Save success/failure is reported via toast, not an inline strip. */}
             <p className="muted soul-hint">
-              Saving writes SOUL.md + config and hot-reloads the agent. The name updates the A2A card and console.
+              Saving updates the name (settings cascade) and writes SOUL.md, then hot-reloads the agent.
+              The name updates the A2A card and console.
             </p>
             <div className="field soul-field">
               <div className="soul-head">

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -69,8 +69,8 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
   // When an add 404s (the focused agent doesn't serve /api/delegates), we keep the attempted
   // entry so "Enable delegates" can retry it after enabling the plugin. Fleet agents ship with
   // delegates enabled at create (ADR 0042); the HOST carries no plugins by default — enabling
-  // appends to plugins.enabled via applyConfig, and the reload hot-mounts the routes (#797),
-  // so the retry succeeds without a restart.
+  // goes through the dedicated /api/plugins/{id}/enabled endpoint, and the reload hot-mounts the
+  // routes (#797), so the retry succeeds without a restart.
   const [needsEnable, setNeedsEnable] = useState<{ name: string; url: string } | null>(null);
   const addDelegate = useMutation({
     mutationFn: (entry: { name: string; url: string }) =>
@@ -96,7 +96,10 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
       const { config } = await api.config(); // the FOCUSED agent's live config (slug-scoped)
       const enabled = config.plugins?.enabled ?? [];
       if (!enabled.includes("delegates")) {
-        await api.applyConfig({ plugins: { enabled: [...enabled, "delegates"] } }, null);
+        // Use the dedicated endpoint, not a raw plugins.enabled patch: it reconciles the
+        // enabled/disabled lists, refuses builtins, and runs the install/surface logic a
+        // hand-written `applyConfig({plugins:{enabled:[…]}})` would skip.
+        await api.setPluginEnabled("delegates", true);
       }
       return entry;
     },

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -533,10 +533,12 @@ FIELDS: list[Field] = [
         scope="host",
     ),
     # ── Identity / operator ──────────────────────────────────────────────────
-    # `identity.name` stays in FIELDS so it round-trips through the YAML writer, but
-    # it's ui_hidden: the dedicated Identity panel (Workspace ▸ Identity, POST
-    # /api/config) owns the agent name alongside its persona (SOUL.md). Surfacing it
-    # here too made the same field editable from two places with two write paths (#1076).
+    # `identity.name` stays in FIELDS so it round-trips through the YAML writer AND so it
+    # validates/cascades on save, but it's ui_hidden: the dedicated Identity panel (Agent ▸
+    # Identity) is its single editor, alongside the persona (SOUL.md). Surfacing it here too
+    # would make the same field editable from two places (#1076). The panel saves the name
+    # through the canonical /api/settings cascade (a ui_hidden key still saves fine — only
+    # build_schema rendering is gated); only SOUL goes via /api/config.
     Field("identity.name", "identity_name", "Agent name", "string", "Identity", ui_hidden=True),
     Field("identity.operator", "identity_operator", "Operator", "string", "Identity"),
     Field("identity.org", "identity_org", "Organization", "string", "Identity", scope="host"),


### PR DESCRIPTION
**Phase 1 of the settings/views/config true-up** (audit → unify onto one system → contribute upstream to the DS). The schema-cascade `/api/settings` path is canonical and broadly adopted; this retires the last two callers that still wrote agent config through the raw `/api/config` door.

## Changes

**1. Identity (`IdentityPanel`) — fixes a real bug + unifies the name save path.**
- 🐞 It echoed a **cached** `identity.operator` on every name/SOUL save (`applyConfig({identity:{name, operator}})`), so a name save with a stale config cache could **clobber a fresh edit** made in the *Operator & access* panel. Gone — operator is owned solely by that panel now.
- The **name** now saves through the canonical `/api/settings` cascade (`saveSettings({"identity.name": …})`). `identity.name` stays `ui_hidden` in the schema, so IdentityPanel remains its single editor — the *save path* is unified without double-rendering the field.
- **SOUL** (not a schema field) saves via `/api/config` with a **null config**, touching nothing else. Only what changed is written.
- Inline status strips → DS `useToast` (toast convention).

**2. Fleet (`FleetManagerPanel.enableDelegates`) — use the dedicated endpoint.**
- It hand-patched `plugins.enabled` via `applyConfig({plugins:{enabled:[…]}})`, skipping the `/api/plugins/{id}/enabled` endpoint's enabled/disabled reconciliation + builtin guard. Now calls `api.setPluginEnabled("delegates", true)`.

## Test plan
- **New e2e** (`settings.spec.ts`): a name-only save POSTs `/api/settings` with `identity.name` and **never** POSTs `/api/config` — directly proving the operator-clobber path is gone.
- Local: Settings ▸ Identity → rename → Save → success toast; Operator & access edits no longer get stomped by a later name save.

## Verification
- `tsc` clean · `vite build` clean
- e2e settings 11/11 (incl. new test), navigation + quick-settings green
- vitest 185/185

Decision context (per the true-up audit): `identity.name` end-state = unify save path, keep single editor; SetupWizard + SOUL stay first-run bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Identity settings save flow to persist only changed identity fields, reducing the risk of overwriting unrelated identity data.
  * Added success and error toast notifications for Identity settings saves.
  * Updated delegate setup to use a dedicated plugin enablement endpoint for more reliable retries after missing-component errors.
* **Tests**
  * Added an end-to-end test covering the Settings → Identity panel name change persistence.
  * Updated fleet end-to-end mocking/assertions to align with the new delegate enablement flow.
* **Documentation**
  * Refreshed inline documentation for how `identity.name` is handled in Settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->