### PR TITLE
fix(web): Skills surface self-reports errors via toast (no silent swallow)

### DIFF
--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -118,3 +118,17 @@ test("deleting a playbook confirms first, then removes it", async ({ page }) => 
   await dialog.getByRole("button", { name: "Delete", exact: true }).click();
   await expect(surface.getByText("pr-triage-flow")).toBeHidden();
 });
+
+test("a failed skills load surfaces a toast (errors are no longer swallowed)", async ({ page }) => {
+  // PlaybooksSurface is embedded in Settings ▸ Skills with no error host; it used to delegate
+  // failures to a no-op onError prop and swallow them. It now self-reports via toast.
+  await page.route("**/api/playbooks", (route) =>
+    route.request().method() === "GET"
+      ? route.fulfill({ status: 500, json: { detail: "boom" } })
+      : route.fallback(),
+  );
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("settings-widget").click();
+  await page.locator(".pl-sidenav").getByRole("tab", { name: "Skills", exact: true }).click();
+  await expect(page.locator(".pl-toast", { hasText: /Skills/i })).toBeVisible();
+});

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -4,7 +4,7 @@ import { ArrowDownFromLine, ArrowUpToLine, Library, Pencil, Pin, Plus, Share2, S
 
 import { useEffect, useMemo, useState } from "react";
 
-import { ConfirmDialog, Dialog } from "@protolabsai/ui/overlays";
+import { ConfirmDialog, Dialog, useToast } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { RefreshButton } from "../app/ui-kit";
 import { api } from "../lib/api";
@@ -165,7 +165,14 @@ function SourceBadge({ p }: { p: Playbook }) {
   );
 }
 
-export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: string) => void }) {
+export function PlaybooksSurface() {
+  // Self-reports failures via toast. This surface only ever renders inside Settings ▸ Skills, where
+  // the old `onError` callback prop defaulted to a no-op and silently swallowed every failure. A
+  // blank message is a clear-no-op (toasts auto-dismiss on their own).
+  const toast = useToast();
+  const onError = (message: string) => {
+    if (message) toast({ tone: "error", title: "Skills", message });
+  };
   const [playbooks, setPlaybooks] = useState<Playbook[]>([]);
   const [enabled, setEnabled] = useState(true);
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
**Phase 1 (T4)** of the settings/views/config true-up.

`PlaybooksSurface` only ever renders inside **Settings ▸ Skills**, where its `onError` callback prop defaulted to a **no-op** — so every load/save/promote/unshare/delete failure was **silently swallowed**. It now owns a `useToast` and reports failures itself; the prop is removed (no caller passed it).

KnowledgeStore is *not* in this PR: it routes errors to App's shared error host (`onError={setError}`), so it surfaces failures today — its migration to toast is a Phase 2 toast-convention item, not a silent-failure bug.

## Test plan
- New e2e (`playbooks.spec.ts`): a 500 on the skills list now raises a `.pl-toast` (previously nothing).

## Verification
- tsc clean · vite build clean · full e2e 158/158 (+ new test) · vitest 185/185

Ref ADR 0048 §6.2 (T4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)