### PR TITLE
refactor(web): toast-convention sweep — MCP · Plugins · Knowledge (Phase 2 / T5)

### DIFF
--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -16,7 +16,7 @@ test("MCP tab lists servers and adds one inline", async ({ page }) => {
   await page.getByPlaceholder("name (e.g. echo)").fill("mathy");
   await page.getByPlaceholder("command (e.g. python)").fill("python");
   await page.getByRole("button", { name: "Connect", exact: true }).click();
-  await expect(page.locator(".pl-toast")).toContainText("Connected mathy");
+  await expect(page.locator(".pl-toast", { hasText: "Connected mathy" })).toBeVisible();
 });
 
 test("MCP tab imports servers from pasted JSON", async ({ page }) => {
@@ -30,7 +30,7 @@ test("MCP tab imports servers from pasted JSON", async ({ page }) => {
     '{"mcpServers": {"filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]}, "weather": {"url": "https://x/mcp"}}}',
   );
   await page.getByRole("button", { name: "Import", exact: true }).click();
-  await expect(page.locator(".pl-toast")).toContainText("Imported 2 servers: filesystem, weather");
+  await expect(page.locator(".pl-toast", { hasText: "Imported 2 servers: filesystem, weather" })).toBeVisible();
 });
 
 test("MCP catalog quick-adds a common server that needs an input", async ({ page }) => {
@@ -51,7 +51,7 @@ test("MCP catalog quick-adds a common server that needs an input", async ({ page
 
   // A successful add closes the dialog, hints, and the server joins the list.
   await expect(page.getByLabel("search MCP servers")).toHaveCount(0);
-  await expect(page.locator(".pl-toast")).toContainText("Connected filesystem");
+  await expect(page.locator(".pl-toast", { hasText: "Connected filesystem" })).toBeVisible();
   await expect(page.getByText("filesystem · stdio")).toBeVisible();
 });
 
@@ -67,7 +67,7 @@ test("MCP catalog adds a no-input server in one click", async ({ page }) => {
   // Memory needs no config → one click adds it and closes the dialog.
   await dialog.locator(".mcp-catalog-card", { hasText: "Memory" }).getByRole("button", { name: "Add" }).click();
   await expect(page.getByLabel("search MCP servers")).toHaveCount(0);
-  await expect(page.locator(".pl-toast")).toContainText("Connected memory");
+  await expect(page.locator(".pl-toast", { hasText: "Connected memory" })).toBeVisible();
   await expect(page.getByText("memory · stdio")).toBeVisible();
 });
 

--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -16,7 +16,7 @@ test("MCP tab lists servers and adds one inline", async ({ page }) => {
   await page.getByPlaceholder("name (e.g. echo)").fill("mathy");
   await page.getByPlaceholder("command (e.g. python)").fill("python");
   await page.getByRole("button", { name: "Connect", exact: true }).click();
-  await expect(page.locator(".plugin-hint")).toContainText("Connected mathy");
+  await expect(page.locator(".pl-toast")).toContainText("Connected mathy");
 });
 
 test("MCP tab imports servers from pasted JSON", async ({ page }) => {
@@ -30,7 +30,7 @@ test("MCP tab imports servers from pasted JSON", async ({ page }) => {
     '{"mcpServers": {"filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]}, "weather": {"url": "https://x/mcp"}}}',
   );
   await page.getByRole("button", { name: "Import", exact: true }).click();
-  await expect(page.locator(".plugin-hint")).toContainText("Imported 2 servers: filesystem, weather");
+  await expect(page.locator(".pl-toast")).toContainText("Imported 2 servers: filesystem, weather");
 });
 
 test("MCP catalog quick-adds a common server that needs an input", async ({ page }) => {
@@ -51,7 +51,7 @@ test("MCP catalog quick-adds a common server that needs an input", async ({ page
 
   // A successful add closes the dialog, hints, and the server joins the list.
   await expect(page.getByLabel("search MCP servers")).toHaveCount(0);
-  await expect(page.locator(".plugin-hint")).toContainText("Connected filesystem");
+  await expect(page.locator(".pl-toast")).toContainText("Connected filesystem");
   await expect(page.getByText("filesystem · stdio")).toBeVisible();
 });
 
@@ -67,7 +67,7 @@ test("MCP catalog adds a no-input server in one click", async ({ page }) => {
   // Memory needs no config → one click adds it and closes the dialog.
   await dialog.locator(".mcp-catalog-card", { hasText: "Memory" }).getByRole("button", { name: "Add" }).click();
   await expect(page.getByLabel("search MCP servers")).toHaveCount(0);
-  await expect(page.locator(".plugin-hint")).toContainText("Connected memory");
+  await expect(page.locator(".pl-toast")).toContainText("Connected memory");
   await expect(page.getByText("memory · stdio")).toBeVisible();
 });
 

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -87,7 +87,7 @@ test("plugins section: Installed / Discover (config + advanced install folded in
   await expect(page.getByText("Zzz Disabled", { exact: false })).toBeVisible();
   await page.locator(".subagent-row", { hasText: "Zzz Disabled" })
     .getByRole("button", { name: "Enable" }).click();
-  await expect(page.locator(".pl-toast")).toContainText("Zzz Disabled");
+  await expect(page.locator(".pl-toast", { hasText: "Zzz Disabled" })).toBeVisible();
 
   // Configure opens a per-plugin settings DIALOG now (2026-06) — not an inline row expander.
   // The (icon-only) Configure button is labelled "Configure <name>"; the dialog is

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -87,7 +87,7 @@ test("plugins section: Installed / Discover (config + advanced install folded in
   await expect(page.getByText("Zzz Disabled", { exact: false })).toBeVisible();
   await page.locator(".subagent-row", { hasText: "Zzz Disabled" })
     .getByRole("button", { name: "Enable" }).click();
-  await expect(page.locator(".plugin-hint")).toContainText("Zzz Disabled enabled");
+  await expect(page.locator(".pl-toast")).toContainText("Zzz Disabled");
 
   // Configure opens a per-plugin settings DIALOG now (2026-06) — not an inline row expander.
   // The (icon-only) Configure button is labelled "Configure <name>"; the dialog is

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -573,7 +573,7 @@ export function App() {
       // Knowledge is the searchable Store; its Memory settings folded into
       // Settings ▸ Workspace ▸ Memory (ADR 0048 S-C).
       case "knowledge":
-        return <KnowledgeStore onError={setError} />;
+        return <KnowledgeStore />;
       // Settings is no longer a rail surface (2026-06 consolidation) — it's a utility-bar
       // pill opening the settings dialog (SettingsOverlay). Notes is the first-party `notes`
       // plugin (ADR 0034 S4) — rendered via the default

--- a/apps/web/src/app/McpCatalogDialog.tsx
+++ b/apps/web/src/app/McpCatalogDialog.tsx
@@ -1,5 +1,5 @@
 import { Input } from "@protolabsai/ui/forms";
-import { Dialog } from "@protolabsai/ui/overlays";
+import { Dialog, useToast } from "@protolabsai/ui/overlays";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, ExternalLink, Loader2, Plus, Search } from "lucide-react";
@@ -40,13 +40,12 @@ function fillTemplate(
 export function McpCatalogDialog({
   open,
   onClose,
-  onAdded,
 }: {
   open: boolean;
   onClose: () => void;
-  onAdded: (msg: string) => void;
 }) {
   const qc = useQueryClient();
+  const toast = useToast();
   const catalog = useQuery({
     queryKey: MCP_CATALOG_KEY,
     queryFn: () => api.mcpCatalog(),
@@ -57,7 +56,6 @@ export function McpCatalogDialog({
   const [cat, setCat] = useState("All");
   const [selected, setSelected] = useState<McpCatalogEntry | null>(null);
   const [values, setValues] = useState<Record<string, string>>({});
-  const [err, setErr] = useState<string | null>(null);
 
   const servers = catalog.data?.servers ?? [];
   const categories = useMemo(
@@ -78,16 +76,15 @@ export function McpCatalogDialog({
     onSuccess: (res) => {
       qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
       qc.invalidateQueries({ queryKey: MCP_CATALOG_KEY });
-      onAdded(`Connected ${res.name} — its tools are live.`);
+      toast({ tone: "success", title: "MCP server", message: `Connected ${res.name} — its tools are live.` });
       close();
     },
-    onError: (e: unknown) => setErr(errMsg(e)),
+    onError: (e: unknown) => toast({ tone: "error", title: "Couldn't add server", message: errMsg(e) }),
   });
 
   function back() {
     setSelected(null);
     setValues({});
-    setErr(null);
   }
   function close() {
     back();
@@ -96,7 +93,6 @@ export function McpCatalogDialog({
     onClose();
   }
   function pick(entry: McpCatalogEntry) {
-    setErr(null);
     if (entry.inputs?.length) {
       setSelected(entry);
       setValues(Object.fromEntries(entry.inputs.map((i) => [i.key, ""])));
@@ -142,7 +138,6 @@ export function McpCatalogDialog({
               />
             </label>
           ))}
-          {err ? <p className="plugin-hint">{err}</p> : null}
           <div className="mcp-add-actions">
             <Button
               type="button"
@@ -182,7 +177,6 @@ export function McpCatalogDialog({
               ))}
             </div>
           </div>
-          {err ? <p className="plugin-hint">{err}</p> : null}
           {catalog.isError ? (
             <p className="plugin-hint">Couldn't load the server directory.</p>
           ) : !shown.length ? (

--- a/apps/web/src/app/McpPanel.tsx
+++ b/apps/web/src/app/McpPanel.tsx
@@ -1,6 +1,6 @@
 import { DropdownSelect, Input, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
-import { ConfirmDialog } from "@protolabsai/ui/overlays";
+import { ConfirmDialog, useToast } from "@protolabsai/ui/overlays";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { ArrowDownFromLine, ArrowUpToLine, Boxes, Library, Loader2, Plus, Share2, Trash2 } from "lucide-react";
@@ -22,8 +22,9 @@ type McpServer = { name: string; transport: string; tool_count: number; tier?: "
 
 type Transport = "stdio" | "http" | "sse";
 
-function AddServerForm({ onDone }: { onDone: (msg: string) => void }) {
+function AddServerForm() {
   const qc = useQueryClient();
+  const toast = useToast();
   const [open, setOpen] = useState(false);
   const [mode, setMode] = useState<"form" | "json">("form");
   const [name, setName] = useState("");
@@ -40,18 +41,18 @@ function AddServerForm({ onDone }: { onDone: (msg: string) => void }) {
     qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
     reset();
     setOpen(false);
-    onDone(msg);
+    toast({ tone: "success", title: "MCP server", message: msg });
   };
   const add = useMutation({
     mutationFn: () =>
       api.addMcpServer(transport === "stdio" ? { name, transport, command, args } : { name, transport, url }),
     onSuccess: (res) => onSuccess(`Connected ${res.name} — its tools are live.`),
-    onError: (err: unknown) => onDone(`Couldn't add server: ${errMsg(err)}`),
+    onError: (err: unknown) => toast({ tone: "error", title: "Couldn't add server", message: errMsg(err) }),
   });
   const importJson = useMutation({
     mutationFn: () => api.importMcpServers(json),
     onSuccess: (res) => onSuccess(`Imported ${res.added.length} server${res.added.length === 1 ? "" : "s"}: ${res.added.join(", ")}.`),
-    onError: (err: unknown) => onDone(`Import failed: ${errMsg(err)}`),
+    onError: (err: unknown) => toast({ tone: "error", title: "Import failed", message: errMsg(err) }),
   });
 
   const formValid = name.trim() && (transport === "stdio" ? command.trim() : url.trim());
@@ -133,7 +134,7 @@ function AddServerForm({ onDone }: { onDone: (msg: string) => void }) {
 function McpBody() {
   const { data: runtime } = useSuspenseQuery(runtimeStatusQuery());
   const qc = useQueryClient();
-  const [hint, setHint] = useState<string | null>(null);
+  const toast = useToast();
   const [catalogOpen, setCatalogOpen] = useState(false);
   const [forgetPending, setForgetPending] = useState<McpServer | null>(null);
   const servers = (runtime.mcp?.servers ?? []) as McpServer[];
@@ -146,9 +147,9 @@ function McpBody() {
     mutationFn: (n: string) => api.removeMcpServer(n),
     onSuccess: (_res, n) => {
       qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
-      setHint(`Removed ${n}.`);
+      toast({ tone: "success", title: "Server removed", message: `${n} is no longer wired in.` });
     },
-    onError: (err: unknown, n) => setHint(`Couldn't remove ${n}: ${errMsg(err)}`),
+    onError: (err: unknown, n) => toast({ tone: "error", title: "Couldn't remove server", message: `${n}: ${errMsg(err)}` }),
   });
   const removingName = remove.isPending ? remove.variables : undefined;
 
@@ -156,17 +157,17 @@ function McpBody() {
     mutationFn: (n: string) => api.promoteMcpServer(n),
     onSuccess: (_res, n) => {
       qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
-      setHint(`Shared ${n} to the box commons — every layered agent on this box now runs it.`);
+      toast({ tone: "success", title: "Shared to the box commons", message: `Every layered agent on this box now runs ${n}.` });
     },
-    onError: (err: unknown, n) => setHint(`Couldn't share ${n}: ${errMsg(err)}`),
+    onError: (err: unknown, n) => toast({ tone: "error", title: "Couldn't share server", message: `${n}: ${errMsg(err)}` }),
   });
   const forget = useMutation({
     mutationFn: (n: string) => api.forgetMcpServer(n),
     onSuccess: (_res, n) => {
       qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
-      setHint(`Unshared ${n} — it's private to this agent again.`);
+      toast({ tone: "success", title: "Unshared", message: `${n} is private to this agent again.` });
     },
-    onError: (err: unknown, n) => setHint(`Couldn't unshare ${n}: ${errMsg(err)}`),
+    onError: (err: unknown, n) => toast({ tone: "error", title: "Couldn't unshare server", message: `${n}: ${errMsg(err)}` }),
   });
   const busyName = promote.isPending ? promote.variables : forget.isPending ? forget.variables : undefined;
 
@@ -177,15 +178,14 @@ function McpBody() {
         kicker={`${servers.length} server${servers.length === 1 ? "" : "s"} · ${total} tool${total === 1 ? "" : "s"}`}
       />
       <div className="stage-body">
-        {hint ? <p className="plugin-hint">{hint}</p> : null}
         <div className="mcp-browse-row">
           <Button type="button" variant="ghost" onClick={() => setCatalogOpen(true)} title="Add a common MCP server from a curated list">
             <Boxes size={14} /> Browse common servers
           </Button>
           <QuickSetting keys={["mcp.scope"]} title="MCP server sharing" label="MCP server sharing" icon={<Share2 size={16} />} />
         </div>
-        <AddServerForm onDone={setHint} />
-        <McpCatalogDialog open={catalogOpen} onClose={() => setCatalogOpen(false)} onAdded={setHint} />
+        <AddServerForm />
+        <McpCatalogDialog open={catalogOpen} onClose={() => setCatalogOpen(false)} />
         <div className="table-list">
           {servers.length ? (
             servers.map((server) => (
@@ -206,7 +206,7 @@ function McpBody() {
                   <StatusPill label={`${server.tool_count} tool${server.tool_count === 1 ? "" : "s"}`} tone="success" />
                   {layered && server.tier === "private" ? (
                     <Button type="button" variant="ghost" disabled={busyName === server.name}
-                      onClick={() => { setHint(null); promote.mutate(server.name); }}
+                      onClick={() => promote.mutate(server.name)}
                       title={`Share ${server.name} to the box commons`} aria-label={`share ${server.name}`}
                     >
                       <ArrowUpToLine size={14} className={busyName === server.name ? "spin" : ""} />
@@ -214,7 +214,7 @@ function McpBody() {
                   ) : null}
                   {layered && server.tier === "commons" ? (
                     <Button type="button" variant="ghost" disabled={busyName === server.name}
-                      onClick={() => { setHint(null); setForgetPending(server); }}
+                      onClick={() => setForgetPending(server)}
                       title={`Unshare ${server.name} from the box commons`} aria-label={`unshare ${server.name}`}
                     >
                       <ArrowDownFromLine size={14} />
@@ -223,7 +223,7 @@ function McpBody() {
                   <Button type="button"
                     variant="ghost"
                     disabled={removingName === server.name}
-                    onClick={() => { setHint(null); remove.mutate(server.name); }}
+                    onClick={() => remove.mutate(server.name)}
                     title={`Remove ${server.name}`}
                   >
                     {removingName === server.name ? <Loader2 size={14} className="spin" /> : <Trash2 size={14} />}

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -1,5 +1,5 @@
 import { Input, Textarea } from "@protolabsai/ui/forms";
-import { ConfirmDialog } from "@protolabsai/ui/overlays";
+import { ConfirmDialog, useToast } from "@protolabsai/ui/overlays";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { ArrowDownFromLine, ArrowUpToLine, Database, FileUp, Library, Pencil, Plus, Trash2 } from "lucide-react";
 
@@ -196,7 +196,13 @@ function IngestForm({
   );
 }
 
-export function KnowledgeStore({ onError }: { onError: (message: string) => void }) {
+export function KnowledgeStore() {
+  // Self-reports failures via toast. This surface used to route errors up to App's shared error
+  // strip through an `onError` prop; it now owns its feedback. A blank message is a clear-no-op.
+  const toast = useToast();
+  const onError = (message: string) => {
+    if (message) toast({ tone: "error", title: "Knowledge", message });
+  };
   const [results, setResults] = useState<KnowledgeChunk[]>([]);
   const [stats, setStats] = useState<Record<string, number>>({});
   const [enabled, setEnabled] = useState(true);

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -2,6 +2,7 @@ import "../settings/plugins.css";
 
 import { Button } from "@protolabsai/ui/primitives";
 import { Alert } from "@protolabsai/ui/data";
+import { useToast } from "@protolabsai/ui/overlays";
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 
 import { useState, type JSX } from "react";
@@ -160,7 +161,7 @@ function LocalTab() {
   // in-tree built-ins are not) + which are locked-but-missing on disk.
   const installed = useQuery(installedPluginsQuery());
   const qc = useQueryClient();
-  const [hint, setHint] = useState<string | null>(null);
+  const toast = useToast();
   const [installOpen, setInstallOpen] = useState(false);
 
   const refreshAll = () => {
@@ -182,15 +183,15 @@ function LocalTab() {
       qc.invalidateQueries({ queryKey: queryKeys.settings });
       // Enable hot-mounts the plugin's router (#822). Only DISABLE leaves a stale
       // route/surface behind (FastAPI can't unmount) → restart_recommended on OFF.
-      setHint(
+      toast(
         res.restart_recommended
-          ? `${p.name} disabled — restart to fully remove its console view or background surface.`
-          : `${p.name} ${res.enabled ? "enabled" : "disabled"}.`,
+          ? { tone: "info", title: "Plugin disabled", message: `${p.name} — restart to fully remove its console view or background surface.` }
+          : { tone: "success", title: `Plugin ${res.enabled ? "enabled" : "disabled"}`, message: `${p.name} is ${res.enabled ? "live" : "off"}.` },
       );
     },
-    onError: (err: unknown, p) => setHint(`Couldn't toggle ${p.name}: ${errMsg(err)}`),
+    onError: (err: unknown, p) => toast({ tone: "error", title: "Couldn't toggle plugin", message: `${p.name}: ${errMsg(err)}` }),
   });
-  const onToggle = (p: Plugin) => { setHint(null); toggle.mutate(p); };
+  const onToggle = (p: Plugin) => toggle.mutate(p);
   const pendingId = toggle.isPending ? toggle.variables?.id : undefined;
 
   const update = useMutation({
@@ -200,15 +201,15 @@ function LocalTab() {
       qc.invalidateQueries({ queryKey: queryKeys.pluginUpdates });
       // A new version may declare new/changed config fields — refetch the schema (#1423).
       qc.invalidateQueries({ queryKey: queryKeys.settings });
-      setHint(
+      toast(
         res.restart_recommended
-          ? `${p.name} updated${res.version ? ` to v${res.version}` : ""} — restart to fully load its console view or background surface.`
-          : `${p.name} updated${res.version ? ` to v${res.version}` : ""}${res.reloaded ? " (hot-reloaded)" : ""}.`,
+          ? { tone: "info", title: "Plugin updated", message: `${p.name}${res.version ? ` to v${res.version}` : ""} — restart to fully load its console view or background surface.` }
+          : { tone: "success", title: "Plugin updated", message: `${p.name}${res.version ? ` to v${res.version}` : ""}${res.reloaded ? " (hot-reloaded)" : ""}.` },
       );
     },
-    onError: (err: unknown, p) => setHint(`Couldn't update ${p.name}: ${errMsg(err)}`),
+    onError: (err: unknown, p) => toast({ tone: "error", title: "Couldn't update plugin", message: `${p.name}: ${errMsg(err)}` }),
   });
-  const onUpdate = (p: Plugin) => { setHint(null); update.mutate(p); };
+  const onUpdate = (p: Plugin) => update.mutate(p);
   const updatingId = update.isPending ? update.variables?.id : undefined;
   const updateById = new Map((updates.data?.plugins ?? []).map((u) => [u.id, u]));
 
@@ -217,12 +218,11 @@ function LocalTab() {
   // lock-backed inventory.
   const remove = useMutation({
     mutationFn: (p: Plugin) => api.uninstallPlugin(p.id),
-    onSuccess: (_res, p) => { refreshAll(); setHint(`${p.name} uninstalled.`); },
-    onError: (err: unknown, p) => setHint(`Couldn't uninstall ${p.name}: ${errMsg(err)}`),
+    onSuccess: (_res, p) => { refreshAll(); toast({ tone: "success", title: "Plugin uninstalled", message: `${p.name} removed.` }); },
+    onError: (err: unknown, p) => toast({ tone: "error", title: "Couldn't uninstall plugin", message: `${p.name}: ${errMsg(err)}` }),
   });
   const onRemove = (p: Plugin) => {
     if (window.confirm(`Uninstall ${p.name}? This deletes its code from disk and removes it from plugins.lock. (To keep it installed, Disable it instead.)`)) {
-      setHint(null);
       remove.mutate(p);
     }
   };
@@ -234,22 +234,20 @@ function LocalTab() {
     onSuccess: (res) => {
       const fetched = res.plugins.filter((r) => r.status === "installed").map((r) => r.id);
       const failed = res.plugins.filter((r) => r.status === "failed");
-      setHint(
+      toast(
         failed.length
-          ? `Sync: ${failed.map((f) => `${f.id} (${f.error ?? "failed"})`).join(", ")}${fetched.length ? ` — fetched ${fetched.join(", ")}` : ""}`
-          : fetched.length
-            ? `Fetched ${fetched.join(", ")}${res.reloaded ? " — enabled plugins are live" : ""}.`
-            : "Nothing to sync — all locked plugins present.",
+          ? { tone: "error", title: "Sync had problems", message: `${failed.map((f) => `${f.id} (${f.error ?? "failed"})`).join(", ")}${fetched.length ? ` — fetched ${fetched.join(", ")}` : ""}` }
+          : { tone: "success", title: "Plugins synced", message: fetched.length ? `Fetched ${fetched.join(", ")}${res.reloaded ? " — enabled plugins are live" : ""}.` : "All locked plugins present." },
       );
       refreshAll();
     },
-    onError: (err: unknown) => setHint(`Couldn't sync: ${errMsg(err)}`),
+    onError: (err: unknown) => toast({ tone: "error", title: "Couldn't sync", message: errMsg(err) }),
   });
 
   const restart = useMutation({
     mutationFn: () => api.restart(),
-    onSuccess: () => setHint("Restarting server… the console will reconnect when it's back."),
-    onError: (err: unknown) => setHint(`Couldn't restart: ${errMsg(err)}`),
+    onSuccess: () => toast({ tone: "info", title: "Restarting server", message: "The console will reconnect when it's back." }),
+    onError: (err: unknown) => toast({ tone: "error", title: "Couldn't restart", message: errMsg(err) }),
   });
 
   // Which plugins have settings to fold in (ADR 0059) — the schema's plugin-tagged groups.
@@ -293,13 +291,12 @@ function LocalTab() {
             <Download size={14} /> Install from URL
           </Button>
         </div>
-        {hint ? <p className="plugin-hint">{hint}</p> : null}
 
         {missing.length ? (
           <Alert
             status="warning"
             action={
-              <Button type="button" variant="default" size="sm" disabled={sync.isPending} onClick={() => { setHint(null); sync.mutate(); }} title="Re-clone every locked plugin at its pinned commit">
+              <Button type="button" variant="default" size="sm" disabled={sync.isPending} onClick={() => sync.mutate()} title="Re-clone every locked plugin at its pinned commit">
                 {sync.isPending ? <Loader2 size={13} className="spin" /> : <DownloadCloud size={13} />} Sync plugins
               </Button>
             }
@@ -347,7 +344,6 @@ function LocalTab() {
             disabled={restart.isPending}
             onClick={() => {
               if (window.confirm("Restart the server now? In-flight work finishes, then the console reconnects automatically.")) {
-                setHint("Restarting server…");
                 restart.mutate();
               }
             }}
@@ -370,16 +366,16 @@ function DiscoverTab() {
   const catalog = useQuery({ queryKey: ["plugin-catalog"], queryFn: () => api.pluginCatalog(), retry: false });
   const [q, setQ] = useState("");
   const [cat, setCat] = useState("All");
-  const [hint, setHint] = useState<string | null>(null);
+  const toast = useToast();
 
   const install = useMutation({
     mutationFn: (p: CatalogPlugin) => api.installPlugin(p.repo),
     onSuccess: (res, p) => {
       qc.invalidateQueries({ queryKey: ["plugin-catalog"] });
       qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
-      setHint(`${p.name} installed${res.reloaded ? " + enabled" : ""}.`);
+      toast({ tone: "success", title: "Plugin installed", message: `${p.name}${res.reloaded ? " — enabled and live" : ""}.` });
     },
-    onError: (err: unknown, p) => setHint(`Couldn't install ${p.name}: ${errMsg(err)}`),
+    onError: (err: unknown, p) => toast({ tone: "error", title: "Couldn't install plugin", message: `${p.name}: ${errMsg(err)}` }),
   });
   const installingRepo = install.isPending ? install.variables?.repo : undefined;
 
@@ -391,7 +387,6 @@ function DiscoverTab() {
     <>
       <PanelHeader title="Discover" kicker={`${plugins.length} official plugins`} />
       <div className="stage-body">
-        {hint ? <p className="plugin-hint">{hint}</p> : null}
         <div className="plugin-discover-controls">
           <div className="plugin-search">
             <Search size={14} />
@@ -422,7 +417,7 @@ function DiscoverTab() {
                 ) : p.installed ? (
                   <StatusPill label={p.enabled ? "installed · on" : "installed"} tone="success" />
                 ) : (
-                  <Button type="button" disabled={install.isPending} onClick={() => { setHint(null); install.mutate(p); }}>
+                  <Button type="button" disabled={install.isPending} onClick={() => install.mutate(p)}>
                     {installingRepo === p.repo ? <Loader2 size={14} className="spin" /> : <Download size={14} />} Install
                   </Button>
                 )}


### PR DESCRIPTION
**Phase 2 (T5) — the toast-convention sweep.** Transient action results that were inline `.plugin-hint`/status lines now fire DS toasts; structural status stays inline.

## Swept → toasts
- **McpPanel + McpCatalogDialog** — add / import / remove / share / unshare / catalog-add. The threaded `onDone`/`onAdded` callbacks + `hint`/`err` state are deleted.
- **PluginsSurface** (Installed + Discover) — enable / disable / update / uninstall / sync / restart / install. The `hint` state is gone.
- **KnowledgeStore** — mirrors PlaybooksSurface (#1430): owns a `useToast`, drops the `onError` prop that routed errors up to App's shared error strip; App stops wiring `setError` into it.

## Deliberately kept inline (per the convention)
- **InstallPluginDialog** — its status is a *persistent actionable note* (dialog stays open: "auto-enable failed; enable it from the list" + a manual-deps list). A transient toast would lose it.
- Structural directory/empty/loading states ("Loading…", "No servers match", "Couldn't load the catalog/directory").

## Out of scope (other slices)
- `window.confirm` (uninstall, restart) → `ConfirmDialog` and the catalog's raw `<input>`/chip `<button>`s → **T7 DS-adoption**.

## Verification
- tsc clean · build clean · full e2e **159/159** · vitest **185/185**
- e2e updated: `mcp.spec` + `navigation.spec` assert `.pl-toast` instead of `.plugin-hint`.

Ref ADR 0048 §6.2 (T5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)