### PR TITLE
refactor(web): plugin uninstall/restart use ConfirmDialog, not window.confirm (T7)

### DIFF
--- a/apps/web/e2e/plugin-install.spec.ts
+++ b/apps/web/e2e/plugin-install.spec.ts
@@ -26,9 +26,11 @@ test("install a plugin from a git URL, then uninstall it from its row", async ({
   const row = page.locator(".plugin-row-wrap", { hasText: "protoagent-plugin-widgets" });
   await expect(row).toBeVisible();
 
-  // Uninstall from the row — a window.confirm guards it; accept and the row disappears.
-  page.once("dialog", (d) => d.accept());
+  // Uninstall from the row — a DS ConfirmDialog guards it; confirm and the row disappears.
   await row.getByRole("button", { name: /uninstall/i }).click();
+  const confirm = page.getByRole("dialog", { name: "Uninstall plugin?" });
+  await expect(confirm).toBeVisible();
+  await confirm.getByRole("button", { name: "Uninstall", exact: true }).click();
   await expect(page.locator(".plugin-row-wrap", { hasText: "protoagent-plugin-widgets" })).toHaveCount(0);
 });
 

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -2,7 +2,7 @@ import "../settings/plugins.css";
 
 import { Button } from "@protolabsai/ui/primitives";
 import { Alert } from "@protolabsai/ui/data";
-import { useToast } from "@protolabsai/ui/overlays";
+import { ConfirmDialog, useToast } from "@protolabsai/ui/overlays";
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 
 import { useState, type JSX } from "react";
@@ -163,6 +163,8 @@ function LocalTab() {
   const qc = useQueryClient();
   const toast = useToast();
   const [installOpen, setInstallOpen] = useState(false);
+  const [uninstallPending, setUninstallPending] = useState<Plugin | null>(null);
+  const [restartPending, setRestartPending] = useState(false);
 
   const refreshAll = () => {
     qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
@@ -221,11 +223,7 @@ function LocalTab() {
     onSuccess: (_res, p) => { refreshAll(); toast({ tone: "success", title: "Plugin uninstalled", message: `${p.name} removed.` }); },
     onError: (err: unknown, p) => toast({ tone: "error", title: "Couldn't uninstall plugin", message: `${p.name}: ${errMsg(err)}` }),
   });
-  const onRemove = (p: Plugin) => {
-    if (window.confirm(`Uninstall ${p.name}? This deletes its code from disk and removes it from plugins.lock. (To keep it installed, Disable it instead.)`)) {
-      remove.mutate(p);
-    }
-  };
+  const onRemove = (p: Plugin) => setUninstallPending(p);
   const removingId = remove.isPending ? remove.variables?.id : undefined;
 
   // Re-clone locked-but-missing plugins (fresh clone / restored data dir).
@@ -342,11 +340,7 @@ function LocalTab() {
             variant="default"
             size="sm"
             disabled={restart.isPending}
-            onClick={() => {
-              if (window.confirm("Restart the server now? In-flight work finishes, then the console reconnects automatically.")) {
-                restart.mutate();
-              }
-            }}
+            onClick={() => setRestartPending(true)}
             title="Gracefully restart the server process"
           >
             {restart.isPending ? <Loader2 size={13} className="spin" /> : <RefreshCw size={13} />} Restart server
@@ -354,6 +348,27 @@ function LocalTab() {
         </div>
       </div>
       <InstallPluginDialog open={installOpen} onClose={() => setInstallOpen(false)} />
+      <ConfirmDialog
+        open={uninstallPending !== null}
+        title="Uninstall plugin?"
+        confirmLabel="Uninstall"
+        destructive
+        onConfirm={() => { if (uninstallPending) remove.mutate(uninstallPending); setUninstallPending(null); }}
+        onClose={() => setUninstallPending(null)}
+      >
+        {uninstallPending
+          ? `"${uninstallPending.name}" — this deletes its code from disk and removes it from plugins.lock. To keep it installed, Disable it instead.`
+          : undefined}
+      </ConfirmDialog>
+      <ConfirmDialog
+        open={restartPending}
+        title="Restart the server?"
+        confirmLabel="Restart"
+        onConfirm={() => { restart.mutate(); setRestartPending(false); }}
+        onClose={() => setRestartPending(false)}
+      >
+        In-flight work finishes, then the console reconnects automatically.
+      </ConfirmDialog>
     </>
   );
 }


### PR DESCRIPTION
**Phase 2 (T7) DS-adoption.** The two remaining native `window.confirm()` prompts in PluginsSurface — **uninstall a plugin** and **restart the server** — become DS `ConfirmDialog`s, consistent with every other destructive action in the console (MCP unshare, Fleet remove, Skills/Knowledge delete) and themeable, unlike the browser-chrome native dialog.

## Test plan
- `plugin-install.spec.ts`: the uninstall flow now clicks the `ConfirmDialog`'s "Uninstall" button instead of `page.once("dialog")` accepting a native confirm.

## Verification
- tsc clean · build clean · full e2e 159/159 · vitest 185/185

Ref ADR 0048 §6.2 (T7). Remaining T7: raw `<input>`/chips → DS (McpCatalogDialog + Discover), `HelpLink`→`TextLink`, raw `<kbd>`→`Kbd` — separate slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated plugin uninstall and restart confirmations to use an in-app dialog flow.
  * Added a clearer confirmation experience that shows plugin details before uninstalling.

* **Bug Fixes**
  * Replaced browser confirmation prompts with consistent modal dialogs for plugin actions.
  * Aligned end-to-end test coverage with the new confirmation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->