### PR TITLE
refactor(web): adopt DS TextLink + Kbd (T7)

### DIFF
--- a/apps/web/src/app/ui-kit.tsx
+++ b/apps/web/src/app/ui-kit.tsx
@@ -1,7 +1,7 @@
 // Small shared UI leaves — the button/link idioms repeated verbatim across the
 // surface panels. Pure presentation, no state.
 
-import { Button } from "@protolabsai/ui/primitives";
+import { Button, TextLink } from "@protolabsai/ui/primitives";
 import { ExternalLink, Loader2, RefreshCw, ShieldCheck } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -53,8 +53,8 @@ export function TestConnectionButton({
 /** External help link with a trailing ExternalLink glyph (and safe `rel`). */
 export function HelpLink({ href, children }: { href: string; children: ReactNode }) {
   return (
-    <a className="settings-help-link" href={href} target="_blank" rel="noreferrer">
+    <TextLink className="settings-help-link" href={href} external>
       {children} <ExternalLink size={13} />
-    </a>
+    </TextLink>
   );
 }

--- a/apps/web/src/settings/KeybindingsPanel.tsx
+++ b/apps/web/src/settings/KeybindingsPanel.tsx
@@ -1,6 +1,6 @@
 import "./keybindings.css";
 
-import { Button } from "@protolabsai/ui/primitives";
+import { Button, Kbd } from "@protolabsai/ui/primitives";
 import { useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 
@@ -68,7 +68,7 @@ export function KeybindingsPanel() {
     <div className="kb-panel">
       <div className="kb-panel__head">
         <p className="muted kb-panel__hint">
-          Click a shortcut to rebind it. Note: <kbd>⌘T</kbd>, <kbd>⌘1–9</kbd> and <kbd>⌃Tab</kbd> are
+          Click a shortcut to rebind it. Note: <Kbd>⌘T</Kbd>, <Kbd>⌘1–9</Kbd> and <Kbd>⌃Tab</Kbd> are
           reserved by the browser — they work in the desktop app; in a browser, rebind to a free combo.
         </p>
         <Button variant="ghost" size="sm" onClick={resetAll} disabled={overrideCount === 0}>


### PR DESCRIPTION
**Phase 2 (T7) DS-adoption.** Two hand-rolled primitives → their DS equivalents (both already in `@protolabsai/ui` 0.48.1):
- `HelpLink` (ui-kit) now wraps DS **`TextLink`** with the `external` prop (owns `target=_blank` + safe `rel`) instead of a raw `<a>`. Keeps the trailing glyph + `.settings-help-link` class.
- KeybindingsPanel's reserved-keys hint uses DS **`Kbd`** instead of raw `<kbd>`.

## Verification
- tsc clean · build clean · full e2e 159/159 · vitest 185/185

Ref ADR 0048 §6.2 (T7). Remaining T7: raw `<input>`/category chips → DS (McpCatalogDialog + Plugins Discover) — a separate slice (needs a DS search-input/segmented choice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated help and keyboard shortcut hints to use shared UI components for a more consistent look and behavior.
  * Preserved the same external help link behavior and shortcut labels while improving how they are rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->