### PR TITLE
refactor(web): adopt DS ToastProvider `position`; drop the toast-stack CSS hack

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.48.3",
+    "@protolabsai/ui": "^0.49.1",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -688,15 +688,8 @@ select:disabled {
   padding: var(--pl-space-6, 24px);
 }
 
-/* Toasts anchor TOP-right, not the DS default bottom-right — they read as app-level
-   notifications and shouldn't collide with the bottom utility bar / composer. `column-reverse`
-   keeps the NEWEST toast nearest the top-right corner (mirrors the DS's newest-nearest-the-anchor
-   behavior). Loads after the DS overlays.css, so equal specificity wins. */
-.pl-toast-stack {
-  top: var(--pl-space-4, 16px);
-  bottom: auto;
-  flex-direction: column-reverse;
-}
+/* Toast top-right anchoring now comes from the DS prop (`<ToastProvider position="top-right">`,
+   @protolabsai/ui ≥ 0.49) — the `.pl-toast-stack` override that used to live here is retired. */
 
 /* MCP catalog quick-add (McpCatalogDialog) — a curated directory of common servers,
    self-contained styles so the dialog doesn't depend on the Plugins surface CSS. */

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -38,7 +38,10 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         the providers themselves is caught too. */}
     <ErrorBoundary fallback={({ error }) => <AppCrash error={error} />}>
       <QueryClientProvider client={queryClient}>
-        <ToastProvider>{launcher ? <Launcher /> : <App />}</ToastProvider>
+        {/* Toasts anchor TOP-right (app-level notifications; clear of the bottom utility
+            bar / composer) via the DS prop — no `.pl-toast-stack` CSS override needed
+            since @protolabsai/ui 0.49 (ToastProvider `position`). */}
+        <ToastProvider position="top-right">{launcher ? <Launcher /> : <App />}</ToastProvider>
       </QueryClientProvider>
     </ErrorBoundary>
   </React.StrictMode>,

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.48.3",
+        "@protolabsai/ui": "^0.49.1",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -64,6 +64,46 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.5.1.tgz",
       "integrity": "sha512-vffDv6H527tZXyfie41OM1nxIr3AoyCuvL8r+YxTIWczPjaI0EVHbJTE63IASoTsstAyBIETZeMQsTnhvYM9Qg==",
+      "license": "MIT",
+      "bin": {
+        "protolabs-sync-assets": "bin/sync-assets.mjs"
+      }
+    },
+    "apps/web/node_modules/@protolabsai/ui": {
+      "version": "0.49.1",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.49.1.tgz",
+      "integrity": "sha512-v2/L9p4ROGYynJ5h6TlEOFQW/cO5EkMwHsSAxxrMF3VFfbpLCrshOxEYfCB7x79IzTVOu/LiStdF2CbKcSP3xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@protolabsai/design": "0.7.0",
+        "@radix-ui/react-dropdown-menu": "^2.1.17",
+        "@radix-ui/react-popover": "^1.1.16",
+        "@radix-ui/react-tooltip": "^1.2.10",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "culori": "^4.0.2",
+        "framer-motion": "^11.18.0",
+        "rehype-katex": "^7.0.1",
+        "remark-math": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "streamdown": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "streamdown": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@protolabsai/ui/node_modules/@protolabsai/design": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.7.0.tgz",
+      "integrity": "sha512-QF/SShqPhP9SFPFiBnJkjOyp8/bbP07xi6dVtqZDkPb4U8QwnUtL1ld88xEZMa3SvY6GX2R53fa+JCgSiz3HGw==",
       "license": "MIT",
       "bin": {
         "protolabs-sync-assets": "bin/sync-assets.mjs"
@@ -1677,46 +1717,6 @@
       "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.3.0.tgz",
       "integrity": "sha512-vitFVJ9c7L66idoskukAyd48uCTHXy0Y3oQKmcm9osmwZmfogFSPqrGEB1Ot7ZblWDFgsOBr7aRf6iBJMU+k2g==",
       "dev": true,
-      "license": "MIT",
-      "bin": {
-        "protolabs-sync-assets": "bin/sync-assets.mjs"
-      }
-    },
-    "node_modules/@protolabsai/ui": {
-      "version": "0.48.3",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.48.3.tgz",
-      "integrity": "sha512-6sJ8Tcm1Ko+AJMjJxVW0fWOBQs/+hsF8D5g6Sn2P3g13qJ64afYchofQw3dnv5U/Qq9PLj56COKbTZATQ9JmxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/sortable": "^10.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
-        "@protolabsai/design": "0.7.0",
-        "@radix-ui/react-dropdown-menu": "^2.1.17",
-        "@radix-ui/react-popover": "^1.1.16",
-        "@radix-ui/react-tooltip": "^1.2.10",
-        "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0",
-        "culori": "^4.0.2",
-        "framer-motion": "^11.18.0",
-        "rehype-katex": "^7.0.1",
-        "remark-math": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "streamdown": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "streamdown": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@protolabsai/ui/node_modules/@protolabsai/design": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.7.0.tgz",
-      "integrity": "sha512-QF/SShqPhP9SFPFiBnJkjOyp8/bbP07xi6dVtqZDkPb4U8QwnUtL1ld88xEZMa3SvY6GX2R53fa+JCgSiz3HGw==",
       "license": "MIT",
       "bin": {
         "protolabs-sync-assets": "bin/sync-assets.mjs"


### PR DESCRIPTION
## What

Settings true-up **Phase 4 (DS extraction), item 1 of 5** — the cheapest item, proving the *adopt* half of the contribute-back loop.

`@protolabsai/ui` 0.49 added a `position` prop to `ToastProvider` (protoContent #348): the toast stack renders `data-position` and the DS owns corner anchoring + newest-nearest-the-anchor ordering. This adopts it:

- `<ToastProvider position="top-right">` in `main.tsx`
- deletes the app's `.pl-toast-stack` override in `theme.css`

The DS rule `.pl-toast-stack[data-position="top-right"]` sets the **same** `top` / `right` / `column-reverse` the app override did, so toasts stay exactly where they were — top-right, newest nearest the corner — now DS-owned instead of an app CSS hack. **Visually net-zero.**

Bumps `@protolabsai/ui` `^0.48.3` → `^0.49.1` (0.49.0 = the position prop; 0.49.1 = marketing-prose CSS the operator console doesn't use). The 0.48.1→0.49.1 span is otherwise benign for the console (Eyebrow/Stats/`.pl-prose` are marketing-only).

## Note on the lockfile

`@protolabsai/ui` resolves into `apps/web/node_modules` (npm's deterministic placement for 0.49.1; only `apps/web` depends on it). Build + full e2e were run against this exact tree.

## Gates (all green locally, isolated worktree w/ real 0.49.1 install)

- `tsc --noEmit` ✅ · `vite build` ✅ · `vitest run` — 185 ✅ · `npx playwright test` (full) — **159 passed** ✅

## Next (Phase 4 remaining)

`Button loading` prop → `SegmentedControl`/`ChipGroup` + icon-`Input` → context-menu kit (protoContent #341 in flight) → `FieldControl`/`PropertyRow`/`SecretInput`. Those need DS *builds* first (publish → bump → adopt).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App notifications now appear in the top-right corner by default for a more consistent toast experience.
* **Bug Fixes**
  * Removed conflicting in-app styling so notification stacking behaves correctly with the updated UI library.
* **Chores**
  * Updated the web app to a newer version of the shared UI package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->