### PR TITLE
refactor(web): adopt DS `Button loading`; retire the app `.spin` keyframe

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.49.1",
+    "@protolabsai/ui": "^0.50.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -11,7 +11,6 @@ import {
   Gauge,
   Inbox,
   LayoutDashboard,
-  Loader2,
   MessageSquare,
   PanelBottom,
   PanelLeft,

--- a/apps/web/src/app/BackgroundJobs.tsx
+++ b/apps/web/src/app/BackgroundJobs.tsx
@@ -1,6 +1,7 @@
 import { Dialog, Tooltip } from "@protolabsai/ui/overlays";
 import { ToolCard, ToolCardList, ToolSection } from "@protolabsai/ui/tool-card";
-import { Bot, CheckCircle2, Loader2, Square, Trash2, XCircle } from "lucide-react";
+import { Spinner } from "@protolabsai/ui/data";
+import { Bot, CheckCircle2, Square, Trash2, XCircle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Markdown } from "../chat/LazyMarkdown";
@@ -198,7 +199,7 @@ export function BackgroundJobs() {
           aria-label={`Background agents${running ? ` — ${running} running` : ""}`}
           data-testid="background-jobs-pill"
         >
-          {running > 0 ? <Loader2 size={13} className="spin" /> : <Bot size={13} />}
+          {running > 0 ? <Spinner size={13} /> : <Bot size={13} />}
           {running > 0 ? <span>{running}</span> : null}
           {unread > 0 ? <span className="bg-jobs-unread" aria-label={`${unread} finished`} /> : null}
         </button>
@@ -243,7 +244,7 @@ function BgJobRow({
   const [expanded, setExpanded] = useState(false);
   const running = job.status === "running";
   const icon = running ? (
-    <Loader2 size={14} className="spin" />
+    <Spinner size={14} />
   ) : job.status === "failed" ? (
     <XCircle size={14} className="bg-jobs-fail" />
   ) : (
@@ -281,7 +282,7 @@ function BgJobRow({
               <span className="bg-jobs-tools">
                 {recentTools.map((t) => (
                   <span key={t.id} className={`bg-jobs-tool ${t.error ? "is-err" : t.done ? "is-done" : "is-run"}`}>
-                    {t.error ? <XCircle size={11} /> : t.done ? <CheckCircle2 size={11} /> : <Loader2 size={11} className="spin" />} {t.tool}
+                    {t.error ? <XCircle size={11} /> : t.done ? <CheckCircle2 size={11} /> : <Spinner size={11} />} {t.tool}
                   </span>
                 ))}
               </span>

--- a/apps/web/src/app/McpCatalogDialog.tsx
+++ b/apps/web/src/app/McpCatalogDialog.tsx
@@ -2,7 +2,7 @@ import { Input } from "@protolabsai/ui/forms";
 import { Dialog, useToast } from "@protolabsai/ui/overlays";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, ExternalLink, Loader2, Plus, Search } from "lucide-react";
+import { ArrowLeft, ExternalLink, Plus, Search } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { api } from "../lib/api";
@@ -142,10 +142,11 @@ export function McpCatalogDialog({
             <Button
               type="button"
               variant="primary"
-              disabled={missing || add.isPending}
+              loading={add.isPending}
+              disabled={missing}
               onClick={() => add.mutate(selected)}
             >
-              {add.isPending ? <Loader2 size={14} className="spin" /> : <Plus size={14} />} Add server
+              {add.isPending ? null : <Plus size={14} />} Add server
             </Button>
             <Button type="button" variant="ghost" onClick={back}>
               Cancel

--- a/apps/web/src/app/McpPanel.tsx
+++ b/apps/web/src/app/McpPanel.tsx
@@ -3,7 +3,7 @@ import { Badge, Button } from "@protolabsai/ui/primitives";
 import { ConfirmDialog, useToast } from "@protolabsai/ui/overlays";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useState } from "react";
-import { ArrowDownFromLine, ArrowUpToLine, Boxes, Library, Loader2, Plus, Share2, Trash2 } from "lucide-react";
+import { ArrowDownFromLine, ArrowUpToLine, Boxes, Library, Plus, Share2, Trash2 } from "lucide-react";
 
 import { PanelHeader, Tabs } from "@protolabsai/ui/navigation";
 import { runtimeStatusQuery } from "../lib/queries";
@@ -122,8 +122,8 @@ function AddServerForm() {
       )}
 
       <div className="mcp-add-actions">
-        <Button type="submit" variant="ghost" disabled={busy || (mode === "json" ? !json.trim() : !formValid)}>
-          {busy ? <Loader2 size={14} className="spin" /> : mode === "json" ? "Import" : "Connect"}
+        <Button type="submit" variant="ghost" loading={busy} disabled={mode === "json" ? !json.trim() : !formValid}>
+          {mode === "json" ? "Import" : "Connect"}
         </Button>
         <Button type="button" variant="ghost" onClick={() => { reset(); setOpen(false); }}>Cancel</Button>
       </div>
@@ -205,11 +205,11 @@ function McpBody() {
                 <div className="plugin-row-actions">
                   <StatusPill label={`${server.tool_count} tool${server.tool_count === 1 ? "" : "s"}`} tone="success" />
                   {layered && server.tier === "private" ? (
-                    <Button type="button" variant="ghost" disabled={busyName === server.name}
+                    <Button type="button" variant="ghost" loading={busyName === server.name}
                       onClick={() => promote.mutate(server.name)}
                       title={`Share ${server.name} to the box commons`} aria-label={`share ${server.name}`}
                     >
-                      <ArrowUpToLine size={14} className={busyName === server.name ? "spin" : ""} />
+                      {busyName === server.name ? null : <ArrowUpToLine size={14} />}
                     </Button>
                   ) : null}
                   {layered && server.tier === "commons" ? (
@@ -222,11 +222,11 @@ function McpBody() {
                   ) : null}
                   <Button type="button"
                     variant="ghost"
-                    disabled={removingName === server.name}
+                    loading={removingName === server.name}
                     onClick={() => remove.mutate(server.name)}
                     title={`Remove ${server.name}`}
                   >
-                    {removingName === server.name ? <Loader2 size={14} className="spin" /> : <Trash2 size={14} />}
+                    {removingName === server.name ? null : <Trash2 size={14} />}
                   </Button>
                 </div>
               </div>

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -1,4 +1,5 @@
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { Spinner } from "@protolabsai/ui/data";
+import { AlertTriangle } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { apiUrl, authToken } from "../lib/api";
@@ -246,7 +247,7 @@ export function PluginView({ view }: { view: PluginViewType }) {
           <>
             {!loaded ? (
               <div className="plugin-view-state">
-                <Loader2 className="spin" size={18} />
+                <Spinner size={18} />
                 <span>Loading {view.label}…</span>
               </div>
             ) : null}

--- a/apps/web/src/app/TasksPanel.tsx
+++ b/apps/web/src/app/TasksPanel.tsx
@@ -13,7 +13,6 @@ import {
   ChevronDown,
   ChevronRight,
   CircleAlert,
-  Loader2,
   Play,
   Plus,
   Trash2,
@@ -91,11 +90,12 @@ function TaskCreateDialog({
           <Button
             type="button"
             variant="primary"
+            loading={busy}
             disabled={!canSubmit}
             data-testid="task-create-submit"
             onClick={() => onCreate(draft)}
           >
-            {busy ? <Loader2 className="spin" size={16} /> : <Plus size={16} />} Create task
+            {busy ? null : <Plus size={16} />} Create task
           </Button>
         </>
       }

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1670,15 +1670,8 @@ textarea {
   border-top: 1px solid var(--border);
 }
 
-.spin {
-  animation: spin 1000ms linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
+/* The app `.spin` keyframe is retired — busy spinners now come from the DS
+   (`<Button loading>` and `<Spinner>`, @protolabsai/ui ≥ 0.50). */
 
 /* Below this width there isn't room for the rail + chat + side panel, so drop
    to two columns and hide the panel (reachable again by widening / the toggle).

--- a/apps/web/src/app/ui-kit.tsx
+++ b/apps/web/src/app/ui-kit.tsx
@@ -2,12 +2,12 @@
 // surface panels. Pure presentation, no state.
 
 import { Button, TextLink } from "@protolabsai/ui/primitives";
-import { ExternalLink, Loader2, RefreshCw, ShieldCheck } from "lucide-react";
+import { ExternalLink, RefreshCw, ShieldCheck } from "lucide-react";
 import type { ReactNode } from "react";
 
 /**
- * Ghost icon-button whose glyph spins while `busy`. The header "Refresh" in
- * Activity / Inbox / Schedule / Telemetry / Knowledge / Playbooks / Commons.
+ * Ghost icon-button that shows a spinner while `busy` (DS `Button loading`). The
+ * header "Refresh" in Activity / Inbox / Schedule / Telemetry / Knowledge / Playbooks.
  */
 export function RefreshButton({
   onClick,
@@ -21,15 +21,15 @@ export function RefreshButton({
   size?: number;
 }) {
   return (
-    <Button icon variant="ghost" type="button" onClick={onClick} disabled={busy} title={title} aria-label={title}>
-      <RefreshCw size={size} className={busy ? "spin" : undefined} />
+    <Button icon variant="ghost" type="button" onClick={onClick} loading={busy} title={title} aria-label={title}>
+      <RefreshCw size={size} />
     </Button>
   );
 }
 
 /**
  * "Test connection" button — a ShieldCheck that swaps to a spinner while
- * `pending`. `disabled` is OR-ed with `pending` (a pending test is also disabled).
+ * `pending` (DS `Button loading`). `disabled` still disables it independently.
  */
 export function TestConnectionButton({
   onClick,
@@ -43,8 +43,8 @@ export function TestConnectionButton({
   children?: ReactNode;
 }) {
   return (
-    <Button type="button" onClick={onClick} disabled={disabled || pending}>
-      {pending ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
+    <Button type="button" onClick={onClick} loading={pending} disabled={disabled}>
+      {pending ? null : <ShieldCheck size={15} />}
       {children}
     </Button>
   );

--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -1,7 +1,8 @@
 import { Button } from "@protolabsai/ui/primitives";
 import { Message, MessageAction, MessageActions } from "@protolabsai/ui/ai";
 import { Tooltip } from "@protolabsai/ui/overlays";
-import { ArrowDownToLine, Check, Clock, Coins, Copy, GitBranch, Gauge, Loader2, Maximize2, RotateCcw } from "lucide-react";
+import { Spinner } from "@protolabsai/ui/data";
+import { ArrowDownToLine, Check, Clock, Coins, Copy, GitBranch, Gauge, Maximize2, RotateCcw } from "lucide-react";
 
 import { openDocument } from "../docviewer";
 import { api } from "../lib/api";
@@ -132,7 +133,7 @@ export function ChatMessageView({
       !(message.toolCalls && message.toolCalls.length) &&
       !(message.components && message.components.length) &&
       !message.reasoning ? (
-        <Loader2 className="spin" size={15} />
+        <Spinner size={15} />
       ) : null}
       {/* History fallback: a message persisted before component-parts existed renders its
           components here (after the answer). Live turns render them inline via ordered parts

--- a/apps/web/src/docviewer/DocumentViewer.tsx
+++ b/apps/web/src/docviewer/DocumentViewer.tsx
@@ -1,7 +1,7 @@
 import "./docviewer.css";
 
 import { Dialog } from "@protolabsai/ui/overlays";
-import { Loader2 } from "lucide-react";
+import { Spinner } from "@protolabsai/ui/data";
 import { useEffect, useState } from "react";
 
 import { Markdown } from "../chat/LazyMarkdown";
@@ -67,7 +67,7 @@ export function DocumentViewer() {
           doc.render()
         ) : loading ? (
           <div className="doc-viewer__status">
-            <Loader2 className="spin" size={16} /> Loading…
+            <Spinner size={16} /> Loading…
           </div>
         ) : error ? (
           <div className="doc-viewer__status" role="alert">

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -427,10 +427,10 @@ export function KnowledgeStore() {
                             type="button"
                             title="Share to the commons (every agent on this box can then recall it)"
                             onClick={() => promote.mutate(c)}
-                            disabled={promotingId === c.id}
+                            loading={promotingId === c.id}
                             aria-label={`share entry ${c.id}`}
                           >
-                            <ArrowUpToLine size={14} className={promotingId === c.id ? "spin" : ""} />
+                            <ArrowUpToLine size={14} />
                           </Button>
                         ) : null}
                         {c.tier === "commons" ? (

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -414,10 +414,10 @@ function PlaybooksBody() {
                           variant="ghost"
                           title="Promote to the shared commons (every agent on this box can then reuse it)"
                           onClick={() => promote.mutate(p)}
-                          disabled={promotingId === p.id}
+                          loading={promotingId === p.id}
                           data-testid={`playbook-promote-${p.id}`}
                         >
-                          <ArrowUpToLine size={14} className={promotingId === p.id ? "spin" : ""} />
+                          <ArrowUpToLine size={14} />
                         </Button>
                       ) : null}
                       {isEditable(p) ? (

--- a/apps/web/src/plugins/InstallPluginDialog.tsx
+++ b/apps/web/src/plugins/InstallPluginDialog.tsx
@@ -2,7 +2,7 @@ import { Button } from "@protolabsai/ui/primitives";
 import { Input } from "@protolabsai/ui/forms";
 import { Dialog } from "@protolabsai/ui/overlays";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Loader2, Plus } from "lucide-react";
+import { Plus } from "lucide-react";
 import { useState } from "react";
 
 import { api } from "../lib/api";
@@ -79,10 +79,11 @@ export function InstallPluginDialog({ open, onClose }: { open: boolean; onClose:
         />
         <Button
           variant="primary"
-          disabled={!url.trim() || install.isPending}
+          loading={install.isPending}
+          disabled={!url.trim()}
           onClick={() => { setStatus(""); install.mutate(); }}
         >
-          {install.isPending ? <Loader2 className="spin" size={15} /> : <Plus size={15} />} Install
+          {install.isPending ? null : <Plus size={15} />} Install
         </Button>
       </div>
       {status ? <p className="plugin-install-status" role="status">{status}</p> : null}

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -6,7 +6,7 @@ import { ConfirmDialog, useToast } from "@protolabsai/ui/overlays";
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 
 import { useState, type JSX } from "react";
-import { Download, DownloadCloud, ExternalLink, Github, Loader2, RefreshCw, Search, Settings2, Store, Trash2 } from "lucide-react";
+import { Download, DownloadCloud, ExternalLink, Github, RefreshCw, Search, Settings2, Store, Trash2 } from "lucide-react";
 
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { installedPluginsQuery, pluginUpdatesQuery, queryKeys, runtimeStatusQuery, settingsSchemaQuery } from "../lib/queries";
@@ -84,12 +84,12 @@ function PluginRow({
               type="button"
               icon
               variant="ghost"
-              disabled={updating}
+              loading={updating}
               onClick={() => onUpdate(p)}
               title={`Update ${p.name} to the latest commit`}
               aria-label={`Update ${p.name}`}
             >
-              {updating ? <Loader2 size={15} className="spin" /> : <RefreshCw size={15} />}
+              <RefreshCw size={15} />
             </Button>
           ) : null}
           {/* Configure opens a per-plugin settings dialog (ADR 0059) rather than expanding
@@ -110,11 +110,11 @@ function PluginRow({
             type="button"
             variant="ghost"
             size="sm"
-            disabled={busy}
+            loading={busy}
             onClick={() => onToggle(p)}
             title={on ? `Disable ${p.name}` : `Enable ${p.name}`}
           >
-            {busy ? <Loader2 size={14} className="spin" /> : on ? "Disable" : "Enable"}
+            {on ? "Disable" : "Enable"}
           </Button>
           {/* Uninstall — only plugins in the writable plugins dir (git-installed / local
               copies) are removable; in-tree built-ins are refused server-side, so they
@@ -125,12 +125,12 @@ function PluginRow({
               icon
               variant="ghost"
               className="plugin-row-danger"
-              disabled={removing}
+              loading={removing}
               onClick={() => onRemove(p)}
               title={`Uninstall ${p.name}`}
               aria-label={`uninstall ${p.id}`}
             >
-              {removing ? <Loader2 size={15} className="spin" /> : <Trash2 size={15} />}
+              <Trash2 size={15} />
             </Button>
           ) : null}
         </div>
@@ -294,8 +294,8 @@ function LocalTab() {
           <Alert
             status="warning"
             action={
-              <Button type="button" variant="default" size="sm" disabled={sync.isPending} onClick={() => sync.mutate()} title="Re-clone every locked plugin at its pinned commit">
-                {sync.isPending ? <Loader2 size={13} className="spin" /> : <DownloadCloud size={13} />} Sync plugins
+              <Button type="button" variant="default" size="sm" loading={sync.isPending} onClick={() => sync.mutate()} title="Re-clone every locked plugin at its pinned commit">
+                {sync.isPending ? null : <DownloadCloud size={13} />} Sync plugins
               </Button>
             }
           >
@@ -339,11 +339,11 @@ function LocalTab() {
             type="button"
             variant="default"
             size="sm"
-            disabled={restart.isPending}
+            loading={restart.isPending}
             onClick={() => setRestartPending(true)}
             title="Gracefully restart the server process"
           >
-            {restart.isPending ? <Loader2 size={13} className="spin" /> : <RefreshCw size={13} />} Restart server
+            {restart.isPending ? null : <RefreshCw size={13} />} Restart server
           </Button>
         </div>
       </div>
@@ -432,8 +432,8 @@ function DiscoverTab() {
                 ) : p.installed ? (
                   <StatusPill label={p.enabled ? "installed · on" : "installed"} tone="success" />
                 ) : (
-                  <Button type="button" disabled={install.isPending} onClick={() => install.mutate(p)}>
-                    {installingRepo === p.repo ? <Loader2 size={14} className="spin" /> : <Download size={14} />} Install
+                  <Button type="button" loading={installingRepo === p.repo} disabled={install.isPending} onClick={() => install.mutate(p)}>
+                    {installingRepo === p.repo ? null : <Download size={14} />} Install
                   </Button>
                 )}
               </div>

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -10,7 +10,7 @@ import { StatusDot } from "@protolabsai/ui/data";
 import { StatusPill } from "../app/StatusPill";
 import { HelpLink } from "../app/ui-kit";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2, Pencil, Plug, Plus, ShieldCheck, Trash2 } from "lucide-react";
+import { Pencil, Plug, Plus, ShieldCheck, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { api } from "../lib/api";
@@ -136,8 +136,8 @@ export function DelegatesSection() {
                 <span>{p ? probeLine(p) : d.description || d.error || ""}</span>
               </div>
               <div className="issue-actions">
-                <Button icon variant="ghost" title="Test" onClick={() => testRow.mutate(d)} disabled={testRow.isPending}>
-                  {testRow.isPending && testRow.variables?.name === d.name ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
+                <Button icon variant="ghost" title="Test" onClick={() => testRow.mutate(d)} loading={testRow.isPending && testRow.variables?.name === d.name} disabled={testRow.isPending}>
+                  <ShieldCheck size={15} />
                 </Button>
                 <Button icon variant="ghost" title="Edit" onClick={() => { setEditing(d); setAdding(false); }}>
                   <Pencil size={15} />
@@ -289,12 +289,12 @@ function DelegateForm({
       {err ? <p className="settings-status">{err}</p> : null}
 
       <div className="settings-group-actions">
-        <Button type="button" onClick={() => test.mutate()} disabled={test.isPending}>
-          {test.isPending ? <Loader2 className="spin" size={15} /> : <Plug size={15} />} Test
+        <Button type="button" onClick={() => test.mutate()} loading={test.isPending}>
+          {test.isPending ? null : <Plug size={15} />} Test
         </Button>
         <Button type="button" onClick={onClose}>Cancel</Button>
-        <Button variant="primary" type="button" onClick={() => save.mutate()} disabled={save.isPending || !name.trim()}>
-          {save.isPending ? <Loader2 className="spin" size={15} /> : null} Save
+        <Button variant="primary" type="button" onClick={() => save.mutate()} loading={save.isPending} disabled={!name.trim()}>
+          Save
         </Button>
       </div>
     </div>

--- a/apps/web/src/settings/QuickSetting.tsx
+++ b/apps/web/src/settings/QuickSetting.tsx
@@ -4,7 +4,7 @@ import { Badge, Button } from "@protolabsai/ui/primitives";
 import { Dialog, useToast } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ExternalLink, Loader2, Save, Settings2 } from "lucide-react";
+import { ExternalLink, Save, Settings2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
@@ -130,8 +130,8 @@ function QuickSettingDialog({
             </Button>
           ) : null}
           <Button type="button" onClick={onClose} disabled={save.isPending}>Cancel</Button>
-          <Button variant="primary" type="button" onClick={() => save.mutate()} disabled={save.isPending || !dirtyKeys.length}>
-            {save.isPending ? <Loader2 className="spin" size={15} /> : <Save size={15} />} Save
+          <Button variant="primary" type="button" onClick={() => save.mutate()} loading={save.isPending} disabled={!dirtyKeys.length}>
+            {save.isPending ? null : <Save size={15} />} Save
           </Button>
         </>
       }

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -4,7 +4,7 @@ import { Alert } from "@protolabsai/ui/data";
 import { Combobox, DropdownSelect, Input, Switch, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { Boxes, Loader2, RotateCcw, Save } from "lucide-react";
+import { Boxes, RotateCcw, Save } from "lucide-react";
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
@@ -260,8 +260,8 @@ export function SettingsCategory({
               <>
                 {/* #1386 — pull the form gateway's model list into the Primary model dropdown, so
                     switching provider/key isn't a dead-end (the saved list is stale). */}
-                <Button type="button" onClick={() => getModels.mutate()} disabled={getModels.isPending || save.isPending}>
-                  {getModels.isPending ? <Loader2 className="spin" size={15} /> : <Boxes size={15} />} Get models
+                <Button type="button" onClick={() => getModels.mutate()} loading={getModels.isPending} disabled={save.isPending}>
+                  {getModels.isPending ? null : <Boxes size={15} />} Get models
                 </Button>
                 <TestConnectionButton onClick={() => testConn.mutate()} pending={testConn.isPending} disabled={save.isPending} />
               </>
@@ -389,8 +389,8 @@ function SettingRow({
           <p className="setting-inheritance">
             <Badge status={inherit.status}>{inherit.label}</Badge>
             {inherit.overridden && onReset ? (
-              <Button variant="ghost" size="sm" type="button" onClick={onReset} disabled={resetting}>
-                {resetting ? <Loader2 className="spin" size={13} /> : <RotateCcw size={13} />}
+              <Button variant="ghost" size="sm" type="button" onClick={onReset} loading={resetting}>
+                {resetting ? null : <RotateCcw size={13} />}
                 Reset to inherited
               </Button>
             ) : null}

--- a/apps/web/src/workflows/WorkflowBuilder.tsx
+++ b/apps/web/src/workflows/WorkflowBuilder.tsx
@@ -1,6 +1,6 @@
 import { Checkbox, DropdownSelect, Input, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
-import { Loader2, Plus, Save, Trash2, X } from "lucide-react";
+import { Plus, Save, Trash2, X } from "lucide-react";
 
 import { useState } from "react";
 
@@ -200,8 +200,8 @@ export function WorkflowBuilder({
         <Button variant="ghost" type="button" onClick={onCancel} disabled={saving}>
           Cancel
         </Button>
-        <Button variant="primary" type="button" onClick={() => void save()} disabled={!valid || saving}>
-          {saving ? <Loader2 className="spin" size={16} /> : <Save size={16} />}
+        <Button variant="primary" type="button" onClick={() => void save()} loading={saving} disabled={!valid}>
+          {saving ? null : <Save size={16} />}
           Save workflow
         </Button>
       </div>

--- a/apps/web/src/workflows/WorkflowsSurface.tsx
+++ b/apps/web/src/workflows/WorkflowsSurface.tsx
@@ -7,7 +7,7 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { Loader2, Play, Plus, RefreshCw, Trash2, Workflow } from "lucide-react";
+import { Play, Plus, RefreshCw, Trash2, Workflow } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { StagePanel } from "../app/ErrorBoundary";
@@ -168,10 +168,11 @@ function WorkflowsBody() {
                     variant="primary"
                     type="button"
                     onClick={doRun}
-                    disabled={run.isPending || missingRequired.length > 0}
+                    loading={run.isPending}
+                    disabled={missingRequired.length > 0}
                     title={missingRequired.length ? `missing: ${missingRequired.join(", ")}` : "Run workflow"}
                   >
-                    {run.isPending ? <Loader2 className="spin" size={16} /> : <Play size={16} />}
+                    {run.isPending ? null : <Play size={16} />}
                     Run
                   </Button>
                   <Button

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.49.1",
+        "@protolabsai/ui": "^0.50.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -70,9 +70,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.49.1.tgz",
-      "integrity": "sha512-v2/L9p4ROGYynJ5h6TlEOFQW/cO5EkMwHsSAxxrMF3VFfbpLCrshOxEYfCB7x79IzTVOu/LiStdF2CbKcSP3xQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.50.0.tgz",
+      "integrity": "sha512-WBwURECHrZVeUZvd1OMqyhZ/xHkG62HVZLGh9u2+5VjQPfpQVsU8E5QTtW3dY1ydc2pcFXA1HqOOaBPJJJZm1A==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## What

Settings true-up **Phase 4 (DS extraction), item 2 — the app half.** The DS `loading` prop shipped in protoContent #363 / `@protolabsai/ui` **0.50.0**; this adopts it everywhere the console hand-rolled a busy spinner.

- ~20 `{busy ? <Loader2 className="spin"/> : <Icon/>}` swaps inside buttons → `<Button loading={busy}>` (the `disabled` state folds in).
- The `RefreshButton` / `TestConnectionButton` wrappers (`ui-kit.tsx`) use it.
- The few **standalone** (non-button) spinners move to the DS `<Spinner>` (BackgroundJobs, ChatMessageView, PluginView, DocumentViewer).
- Deletes the app `.spin` keyframe + class from `theme.css` — DS-owned now.

Drops every `Loader2` import (14 files) and the duplicate spin animation. Bumps `@protolabsai/ui` `^0.49.1` → `^0.50.0` (surgical lock change: the version/range/integrity only).

## 👀 Visual deltas to eyeball (why this isn't auto-merged)

Most sites were already a ring spinner (`Loader2`), so they're visually unchanged. Two cases change the *look* (not behavior):

- **RefreshButton** (Activity/Inbox/Schedule/Telemetry/Knowledge/Playbooks headers) previously spun the **refresh arrow** itself; it now shows the DS ring spinner while busy.
- The **promote / share** icon buttons (MCP, Skills, Knowledge) previously spun an **up-arrow**; they now show the DS ring spinner.

Both are functionally identical (spinner + disabled during the in-flight action). Flagging per the UI-local-test gate — please glance at a refresh + a promote before merge.

## Gates (all green locally, isolated worktree @ 0.50.0)

- `tsc --noEmit` ✅ · `vite build` ✅ · `vitest run` — 185 ✅ · `npx playwright test` (full) — **159 passed** ✅

## Phase 4 remaining

item 3 SegmentedControl/ChipGroup + icon-`Input` · item 4 context-menu kit (protoContent #341 in flight) · item 5 FieldControl/PropertyRow/SecretInput.