### PR TITLE
refactor(web): MCP catalog & plugin Discover use DS Input icon + segmented Tabs

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.50.0",
+    "@protolabsai/ui": "^0.51.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/McpCatalogDialog.tsx
+++ b/apps/web/src/app/McpCatalogDialog.tsx
@@ -1,4 +1,5 @@
 import { Input } from "@protolabsai/ui/forms";
+import { Tabs } from "@protolabsai/ui/navigation";
 import { Dialog, useToast } from "@protolabsai/ui/overlays";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -156,27 +157,23 @@ export function McpCatalogDialog({
       ) : (
         <>
           <div className="mcp-catalog-controls">
-            <div className="mcp-catalog-search">
-              <Search size={14} />
-              <input
-                placeholder="Search servers"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                aria-label="search MCP servers"
-              />
-            </div>
-            <div className="mcp-catalog-cats">
-              {categories.map((c) => (
-                <button
-                  key={c}
-                  type="button"
-                  className={`mcp-catalog-cat${c === cat ? " on" : ""}`}
-                  onClick={() => setCat(c)}
-                >
-                  {c}
-                </button>
-              ))}
-            </div>
+            <Input
+              className="mcp-catalog-search"
+              icon={<Search size={14} />}
+              type="search"
+              placeholder="Search servers"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="search MCP servers"
+            />
+            <Tabs
+              variant="segmented"
+              responsive
+              ariaLabel="filter servers by category"
+              items={categories.map((c) => ({ id: c, label: c }))}
+              active={cat}
+              onSelect={setCat}
+            />
           </div>
           {catalog.isError ? (
             <p className="plugin-hint">Couldn't load the server directory.</p>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -722,52 +722,11 @@ select:disabled {
   flex-wrap: wrap;
   margin: 2px 0 12px;
 }
+/* The search box (DS Input + `icon`) and category filter (DS segmented Tabs)
+   own their own styling now; the controls row just sizes the search to fill. */
 .mcp-catalog-search {
-  display: flex;
-  align-items: center;
-  gap: 6px;
   flex: 1;
   min-width: 200px;
-  padding: 6px 10px;
-  background: var(--bg-raised);
-  border: 1px solid var(--border);
-  border-radius: 7px;
-}
-.mcp-catalog-search > svg {
-  color: var(--fg-muted);
-  flex-shrink: 0;
-}
-.mcp-catalog-search input {
-  flex: 1;
-  min-width: 0;
-  border: 0;
-  background: transparent;
-  color: var(--fg);
-  font-size: 13px;
-  outline: none;
-}
-.mcp-catalog-cats {
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-.mcp-catalog-cat {
-  padding: 4px 10px;
-  font-size: 12px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-  background: transparent;
-  color: var(--fg-secondary);
-  cursor: pointer;
-  transition: border-color 0.15s, color 0.15s;
-}
-.mcp-catalog-cat:hover {
-  border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 45%, transparent);
-}
-.mcp-catalog-cat.on {
-  background: color-mix(in srgb, var(--pl-color-brand-lavender) 18%, transparent);
-  border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 55%, transparent);
-  color: var(--fg);
 }
 .mcp-catalog-grid {
   display: grid;

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -8,7 +8,8 @@ import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tansta
 import { useState, type JSX } from "react";
 import { Download, DownloadCloud, ExternalLink, Github, RefreshCw, Search, Settings2, Store, Trash2 } from "lucide-react";
 
-import { PanelHeader } from "@protolabsai/ui/navigation";
+import { Input } from "@protolabsai/ui/forms";
+import { PanelHeader, Tabs } from "@protolabsai/ui/navigation";
 import { installedPluginsQuery, pluginUpdatesQuery, queryKeys, runtimeStatusQuery, settingsSchemaQuery } from "../lib/queries";
 import { StagePanel } from "../app/ErrorBoundary";
 import { errMsg } from "../lib/format";
@@ -403,15 +404,23 @@ function DiscoverTab() {
       <PanelHeader title="Discover" kicker={`${plugins.length} official plugins`} />
       <div className="stage-body">
         <div className="plugin-discover-controls">
-          <div className="plugin-search">
-            <Search size={14} />
-            <input placeholder="Search plugins…" value={q} onChange={(e) => setQ(e.target.value)} aria-label="Search plugins" />
-          </div>
-          <div className="plugin-cats">
-            {categories.map((c) => (
-              <button key={c} type="button" className={c === cat ? "plugin-cat on" : "plugin-cat"} onClick={() => setCat(c)}>{c}</button>
-            ))}
-          </div>
+          <Input
+            className="plugin-search"
+            icon={<Search size={14} />}
+            type="search"
+            placeholder="Search plugins…"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            aria-label="Search plugins"
+          />
+          <Tabs
+            variant="segmented"
+            responsive
+            ariaLabel="filter plugins by category"
+            items={categories.map((c) => ({ id: c, label: c }))}
+            active={cat}
+            onSelect={setCat}
+          />
         </div>
         {catalog.isLoading ? <p className="muted">Loading directory…</p> : null}
         {catalog.isError ? <p className="plugin-hint">Couldn't load the catalog: {errMsg(catalog.error)}</p> : null}

--- a/apps/web/src/settings/plugins.css
+++ b/apps/web/src/settings/plugins.css
@@ -57,13 +57,9 @@
 /* Discover (ADR 0059) — the in-app official-plugin directory: search + category
    filter over a grid of installable cards. */
 .plugin-discover-controls { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin: 6px 0 12px; }
-.plugin-search { display: flex; align-items: center; gap: 6px; flex: 1; min-width: 200px; padding: 6px 10px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 7px; }
-.plugin-search > svg { color: var(--fg-muted); flex-shrink: 0; }
-.plugin-search input { flex: 1; min-width: 0; border: 0; background: transparent; color: var(--fg); font-size: 13px; outline: none; }
-.plugin-cats { display: flex; gap: 6px; flex-wrap: wrap; }
-.plugin-cat { padding: 4px 10px; font-size: 12px; border-radius: 999px; border: 1px solid var(--border); background: transparent; color: var(--fg-secondary); cursor: pointer; transition: border-color 0.15s, color 0.15s; }
-.plugin-cat:hover { border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 45%, transparent); }
-.plugin-cat.on { background: color-mix(in srgb, var(--pl-color-brand-lavender) 18%, transparent); border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 55%, transparent); color: var(--fg); }
+/* Search (DS Input + `icon`) and category filter (DS segmented Tabs) own their
+   styling now; the controls row just sizes the search to fill. */
+.plugin-search { flex: 1; min-width: 200px; }
 .plugin-card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 10px; }
 .plugin-card { display: flex; flex-direction: column; gap: 6px; padding: 12px; border: 1px solid var(--border); border-radius: 9px; background: var(--bg-raised); }
 .plugin-card-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.50.0",
+        "@protolabsai/ui": "^0.51.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -70,9 +70,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.50.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.50.0.tgz",
-      "integrity": "sha512-WBwURECHrZVeUZvd1OMqyhZ/xHkG62HVZLGh9u2+5VjQPfpQVsU8E5QTtW3dY1ydc2pcFXA1HqOOaBPJJJZm1A==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.51.0.tgz",
+      "integrity": "sha512-xcNirwwPeu2G5bIox0wwcjMC+S5CfuQiLKHW3cW3SDNMrYxeP9nZUgvmxLg6mJQeHz8DNgp5hIE9udc3BBaz5Q==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## What

Settings true-up **Phase 4 (DS extraction), item 3 — the app half.**

The MCP "add a common server" dialog and the plugin **Discover** tab each hand-rolled the *same* two controls. Both are DS now:

| Control | Before | After |
|---------|--------|-------|
| Search box | `<Search/>` icon + bare `<input>` in a bordered `<div>` | `<Input icon={<Search/>} type="search">` — the new `icon` prop (`@protolabsai/ui` **0.51.0**) |
| Category filter | a row of pill `<button>`s (`.mcp-catalog-cat` / `.plugin-cat`, one `.on`) | `<Tabs variant="segmented" responsive>` — single-select pills, collapses to a `<select>` when the row is narrow |

Drops **~70 lines of duplicated CSS** (`.mcp-catalog-search/-cats/-cat` + `.plugin-search/-cats/-cat`) — the DS owns the box, icon, focus ring, and the active-pill treatment. Bumps `@protolabsai/ui` `^0.50.0` → `^0.51.0`.

## 👀 Visual deltas

Both controls keep the same layout and behavior; the styling becomes DS-standard:
- **Search**: DS input border/focus-ring + the leading icon sits in the field's left padding (was a custom bordered wrapper).
- **Category filter**: the DS **segmented** pill group (connected pills) replaces the separate lavender-outline pills, and now collapses to a dropdown on a narrow dialog. Same single-select semantics; the active category reads as `aria-pressed`.

The `icon` prop landed upstream in protoContent #366 (its only adopters are these two surfaces).

## Gates (local, isolated worktree @ 0.51.0)

- `tsc --noEmit` ✅ · `vite build` ✅ · `vitest run` — 185 ✅ · `npx playwright test` — **158 passed**; the lone fail is `nesting.spec.ts` (known full-suite load flake — passes in isolation at 1.2s, unrelated to these surfaces).

## Phase 4 status

item 1 (toast) ✅ · item 2 (Button loading) ✅ · **item 3 (this)** · item 4 (context-menu) = protoContent #341 in flight · item 5 (FieldControl/PropertyRow/SecretInput) next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved browsing and filtering controls in the plugin and catalog views with a cleaner search field and tab-based category switching.
  * Updated the app to use a newer UI library version, bringing the latest interface enhancements.

* **Style**
  * Refined spacing and layout for search/filter areas to better match the updated component design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->