### PR TITLE
refactor(web): secret fields use DS SecretInput (password + reveal toggle)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.51.0",
+    "@protolabsai/ui": "^0.52.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/AuthGate.tsx
+++ b/apps/web/src/app/AuthGate.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@protolabsai/ui/primitives";
-import { Input } from "@protolabsai/ui/forms";
+import { SecretInput } from "@protolabsai/ui/forms";
 import { Dialog } from "@protolabsai/ui/overlays";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState, useSyncExternalStore } from "react";
@@ -55,8 +55,7 @@ export function AuthGate() {
           This instance is token-gated. Paste the operator token (the server's{" "}
           <code>A2A_AUTH_TOKEN</code>) to connect — it's kept in this browser only.
         </p>
-        <Input
-          type="password"
+        <SecretInput
           autoFocus
           placeholder="operator token"
           aria-label="Operator token"

--- a/apps/web/src/app/McpCatalogDialog.tsx
+++ b/apps/web/src/app/McpCatalogDialog.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@protolabsai/ui/forms";
+import { Input, SecretInput } from "@protolabsai/ui/forms";
 import { Tabs } from "@protolabsai/ui/navigation";
 import { Dialog, useToast } from "@protolabsai/ui/overlays";
 import { Badge, Button } from "@protolabsai/ui/primitives";
@@ -130,13 +130,22 @@ export function McpCatalogDialog({
                 {inp.label}
                 {inp.required ? " *" : ""}
               </span>
-              <Input
-                type={inp.secret ? "password" : "text"}
-                placeholder={inp.placeholder}
-                value={values[inp.key] ?? ""}
-                onChange={(e) => setValues((v) => ({ ...v, [inp.key]: e.target.value }))}
-                aria-label={inp.label}
-              />
+              {inp.secret ? (
+                <SecretInput
+                  placeholder={inp.placeholder}
+                  value={values[inp.key] ?? ""}
+                  onChange={(e) => setValues((v) => ({ ...v, [inp.key]: e.target.value }))}
+                  aria-label={inp.label}
+                />
+              ) : (
+                <Input
+                  type="text"
+                  placeholder={inp.placeholder}
+                  value={values[inp.key] ?? ""}
+                  onChange={(e) => setValues((v) => ({ ...v, [inp.key]: e.target.value }))}
+                  aria-label={inp.label}
+                />
+              )}
             </label>
           ))}
           <div className="mcp-add-actions">

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -1,7 +1,7 @@
 import "./settings.css";
 import "./delegates.css";
 
-import { DropdownSelect, Input, RadioCard, RadioCardGroup, Textarea } from "@protolabsai/ui/forms";
+import { DropdownSelect, Input, RadioCard, RadioCardGroup, SecretInput, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 import { Dialog, useToast } from "@protolabsai/ui/overlays";
 
@@ -327,8 +327,7 @@ function DelegateField({
     control = <Textarea rows={3} placeholder={field.placeholder} {...common} />;
   } else if (field.kind === "secret") {
     control = (
-      <Input
-        type="password"
+      <SecretInput
         autoComplete="new-password"
         placeholder={hasStoredSecret ? "•••••••• (set — leave blank to keep)" : field.placeholder || "unset"}
         {...common}

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -1,7 +1,7 @@
 import "./settings.css";
 
 import { Alert } from "@protolabsai/ui/data";
-import { Combobox, DropdownSelect, Input, Switch, Textarea } from "@protolabsai/ui/forms";
+import { Combobox, DropdownSelect, Input, SecretInput, Switch, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Boxes, RotateCcw, Save } from "lucide-react";
@@ -537,10 +537,9 @@ export function SettingInput({ field, value, onChange }: { field: SettingsField;
   }
   if (field.type === "secret") {
     return (
-      <Input
+      <SecretInput
         id={id}
         className="setting-input"
-        type="password"
         autoComplete="new-password"
         value={typeof value === "string" ? value : ""}
         placeholder={field.is_set ? "•••••••• (set — leave blank to keep)" : "unset"}

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { DropdownSelect, Field, FormField, Input, RadioCard, RadioCardGroup, Textarea } from "@protolabsai/ui/forms";
+import { DropdownSelect, Field, FormField, Input, RadioCard, RadioCardGroup, SecretInput, Textarea } from "@protolabsai/ui/forms";
 import { Button, Callout } from "@protolabsai/ui/primitives";
 import { Alert, Spinner } from "@protolabsai/ui/data";
 import {
@@ -514,8 +514,7 @@ export function SetupWizard({
                   <div className="setup-grid two">
                     <Field label="API base" value={state.apiBase} onValueChange={(value) => update({ apiBase: value })} />
                     <FormField label="API key">
-                      <Input
-                        type="password"
+                      <SecretInput
                         value={state.apiKey}
                         onChange={(event) => update({ apiKey: event.target.value })}
                         autoComplete="off"

--- a/docs/adr/0048-settings-ia-two-scope-homes.md
+++ b/docs/adr/0048-settings-ia-two-scope-homes.md
@@ -298,12 +298,29 @@ each a genuine DS gap with app-agnostic reuse:
 Delivered as the full contribute-back loop (build in `protoContent` → PR → DS release → bump
 `@protolabsai/ui` → adopt in-app), leading with P0 (smallest DS change, largest app reduction).
 
+**Delivered (2026-06-29 — the full loop, autonomous):**
+
+| Item | DS | App adopt |
+|---|---|---|
+| `ToastProvider position` | shipped (0.49.0) | #1438 |
+| `Button loading` (spinner + disabled + `aria-busy`) | protoContent #363 → **0.50.0** | #1439 |
+| `Input` `icon` + reuse segmented `Tabs` for the filter chips | protoContent #366 → **0.51.0** | #1441 |
+| `SecretInput` (password + reveal toggle) | protoContent #369 → **0.52.0** | #1442 |
+
+Reclassified during delivery: the "SegmentedControl/ChipGroup" need is met by the **existing**
+`Tabs variant="segmented"` (no new component). `FieldControl`/`PropertyRow` proved **redundant with
+the existing `FormField`**, and the `SettingInput` type→control switch is domain logic that stays
+app-side — so `SecretInput` is the one reusable primitive extracted from that surface. The headless
+**context-menu kit** is tracked separately in protoContent #341 (in flight); `TabBar
+onTabContextMenu` / `KeyRecorder` remain future DS gaps.
+
 ### 6.4 Slice plan (true-up)
 
 - **Phase 0** — this section (record + ledger).
 - **Phase 1 (correctness, auto-merge on green):** T1–T3 (#1428, done) · T4. Identity (T1/T2) folded in.
 - **Phase 2 (conventions, DRAFT under the UI local-test gate):** T5–T7 + delete the dead `hostLayer` path.
-- **Phase 4:** the §6.3 DS extraction wave.
+- **Phase 4:** the §6.3 DS extraction wave. — ✅ **DONE 2026-06-29** (DS 0.50.0–0.52.0; app
+  #1438/#1439/#1441/#1442). Context-menu kit (protoContent #341) tracked separately.
 
 ## 7. History — superseded 2026-06-10 proposal ("two scope-based homes")
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.51.0",
+        "@protolabsai/ui": "^0.52.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -70,9 +70,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.51.0.tgz",
-      "integrity": "sha512-xcNirwwPeu2G5bIox0wwcjMC+S5CfuQiLKHW3cW3SDNMrYxeP9nZUgvmxLg6mJQeHz8DNgp5hIE9udc3BBaz5Q==",
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.52.0.tgz",
+      "integrity": "sha512-Rqc5dVXUhdJKTMQTd/CQtFqQ7OgBx2OZjWbyYXRwOEZuXZ6ZTuSTEO2ponSsDkEMj7911ZKpj9Mt/7ThHKmtuA==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## What

Settings true-up **Phase 4 (DS extraction), item 5 — the app half.**

Every `type="password"` input in the console was masked with no way to verify what was typed or pasted. Adopt the DS **`SecretInput`** (`@protolabsai/ui` **0.52.0**, protoContent #369) — a password field with a reveal toggle — at all five sites:

| Site | Field |
|------|-------|
| `SettingsCategory` | settings `secret` fields |
| `DelegatesSection` | delegate auth tokens |
| `AuthGate` | the operator-token gate |
| `McpCatalogDialog` | MCP catalog secret inputs (secret branch only) |
| `SetupWizard` | the API key |

Same value / placeholder / onChange behavior — the only change is the trailing eye button (and `type` is now managed by the component). Bumps `@protolabsai/ui` `^0.51.0` → `^0.52.0`.

## Scope note

The original plan listed `FieldControl` / `PropertyRow` / `SecretInput` for item 5. In practice `FieldControl`/`PropertyRow` are redundant with the existing DS `FormField`, and the app's `SettingInput` type-switch is business logic (it knows the settings schema) that stays app-side — so `SecretInput` is the one genuinely reusable primitive in that surface.

## Gates (local, isolated worktree @ 0.52.0)

- `tsc --noEmit` ✅ · `vite build` ✅ · `vitest run` — 185 ✅ · `npx playwright test` — **159 passed** ✅ (incl. the AuthGate / setup flows that exercise these fields)

## Phase 4 — complete

item 1 toast ✅ · item 2 Button loading ✅ · item 3 Input icon + segmented Tabs ✅ · item 4 context-menu = protoContent #341 (separate, in flight) · **item 5 SecretInput ✅**