### PR TITLE
chore: release v0.76.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.76.0] - 2026-06-30
+
 ### Added
 - **"Manage plugins…" in the rail context menus** (#1426) — right-clicking empty rail space or any
   rail icon now offers **Manage plugins…**, which opens the plugin manager (Settings ▸

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.75.0"
+version = "0.76.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "v0.76.0",
+    "date": "2026-06-30",
+    "changes": [
+      "\"Manage plugins…\" in the rail context menus",
+      "Reveal toggle on secret fields",
+      "Settings true-up — one canonical config system",
+      "Settings surfaces no longer swallow load/save errors",
+      "Identity name and fleet delegates save through the canonical settings cascade"
+    ]
+  },
+  {
     "version": "v0.75.0",
     "date": "2026-06-29",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.76.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.76.0 -m 'Release v0.76.0' && git push origin v0.76.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the release notes with the latest product improvements.
  * Added UI enhancements for rails/plugins and secret-field visibility toggles.

* **Bug Fixes**
  * Improved settings handling to better normalize values and surface errors.
  * Refined save behavior for identity and fleet delegate settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->