### PR TITLE
feat(graph): stall guard — break a no-progress tool loop (#1446)

### DIFF
--- a/graph/agent.py
+++ b/graph/agent.py
@@ -41,6 +41,13 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
 
     middleware.append(WaitYieldMiddleware())
 
+    # Break a no-progress tool loop (#1446) — the same tool + args returning the
+    # same result over and over. Nudge once, then end the turn instead of spinning
+    # to the recursion limit. No-op on any healthy/varied history.
+    from graph.middleware.stall_guard import StallGuardMiddleware
+
+    middleware.append(StallGuardMiddleware())
+
     # Mid-turn user steering (spike) — fold queued user input into the running
     # turn at the next model call, so a user can redirect ongoing work without
     # stopping the stream. No-op when nothing was injected this turn.

--- a/graph/middleware/stall_guard.py
+++ b/graph/middleware/stall_guard.py
@@ -1,0 +1,165 @@
+"""Break a no-progress tool loop.
+
+An agent that re-issues the *same* tool call with the *same* arguments and gets
+the *same* result, over and over, is stuck. It is NOT a dropped-stream bug — the
+ToolMessages are right there in the history and the model received them (see the
+`checkpoints.db` decode in #1446); the model simply isn't changing strategy. Left
+alone it spins until the recursion limit, burning the whole turn budget.
+
+This middleware watches the trailing run of identical ``(tool, args, result)``
+round-trips at ``before_model``:
+
+- at ``nudge_at`` it injects ONE guidance note — change approach or stop — and
+  returns to the model (the recovery path);
+- if the loop continues to ``stop_at`` it ends the turn with a short explanation
+  instead of looping to the recursion limit.
+
+It is a **no-op on any healthy / varied history**: the run only extends while the
+*exact same* calls keep getting the *exact same* answers, contiguously, right at
+the tail. A real user message (mid-turn steering) breaks the run, as it should;
+the middleware's own nudge does not (it carries a marker the scan skips).
+
+Distinct from :class:`ToolCallRepairMiddleware`, which heals the *opposite* case —
+an orphaned, *unanswered* tool_call. Here every call IS answered, identically.
+"""
+
+from __future__ import annotations
+
+import json
+
+from langchain.agents.middleware import AgentMiddleware, hook_config
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+# Consecutive identical round-trips before we act. Generous on purpose: identical
+# tool + args + result N times running is a strong "stuck" signal, but we leave
+# headroom so a legitimate short repeat is never touched.
+NUDGE_AT = 3
+STOP_AT = 6
+
+# Leading tag on our injected note — visible to the model (informative) and the
+# sentinel the scan uses so the note doesn't break the round-trip run it measures.
+NUDGE_MARK = "[stall-guard]"
+
+
+def _tc_id(tc):
+    return tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+
+
+def _tc_name(tc):
+    return tc.get("name") if isinstance(tc, dict) else getattr(tc, "name", None)
+
+
+def _tc_args(tc):
+    return tc.get("args") if isinstance(tc, dict) else getattr(tc, "args", None)
+
+
+def _content(m) -> str:
+    return m.content if isinstance(m.content, str) else str(m.content)
+
+
+def _is_nudge(m) -> bool:
+    return isinstance(m, HumanMessage) and isinstance(m.content, str) and m.content.startswith(NUDGE_MARK)
+
+
+def _signature(msg, results: dict):
+    """A hashable fingerprint of one assistant tool-call message + its answers:
+    the sorted ``(tool, args_json)`` calls and the sorted result contents. Two
+    units with equal signatures made the same calls and got the same results."""
+    calls = tuple(
+        sorted(
+            (str(_tc_name(tc)), json.dumps(_tc_args(tc), sort_keys=True, default=str))
+            for tc in (msg.tool_calls or [])
+        )
+    )
+    answers = tuple(sorted((results.get(_tc_id(tc)) or "") for tc in (msg.tool_calls or [])))
+    return calls, answers
+
+
+def trailing_repeat(messages) -> tuple[int, str, str]:
+    """Length of the trailing run of identical tool round-trips, plus the tool
+    name and a result snippet for the message. ``0`` when the tail is not an
+    active repeated-tool loop (e.g. a fresh user turn, a varied tail, or no tools).
+    """
+    msgs = messages or []
+    results = {
+        m.tool_call_id: _content(m)
+        for m in msgs
+        if isinstance(m, ToolMessage) and getattr(m, "tool_call_id", None)
+    }
+
+    i = len(msgs) - 1
+    while i >= 0 and _is_nudge(msgs[i]):  # tolerate a trailing nudge (shouldn't happen)
+        i -= 1
+    # An active loop means we just ran tools — the tail is a ToolMessage block.
+    if i < 0 or not isinstance(msgs[i], ToolMessage):
+        return 0, "", ""
+
+    units: list = []
+    while i >= 0:
+        if _is_nudge(msgs[i]):  # our own note never breaks the run it measures
+            i -= 1
+            continue
+        if not isinstance(msgs[i], ToolMessage):
+            break  # a real boundary (user message / plain answer) ends the loop
+        j = i
+        while j >= 0 and isinstance(msgs[j], ToolMessage):
+            j -= 1  # peel the contiguous ToolMessage block
+        if j < 0 or not getattr(msgs[j], "tool_calls", None):
+            break  # results with no answering assistant tool_calls — give up scanning
+        units.append(_signature(msgs[j], results))
+        i = j - 1
+
+    if not units or not units[0][0]:
+        return 0, "", ""
+    last = units[0]
+    n = 0
+    for sig in units:
+        if sig == last:
+            n += 1
+        else:
+            break
+    tool = last[0][0][0]
+    snippet = (last[1][0] if last[1] else "")[:200]
+    return n, tool, snippet
+
+
+class StallGuardMiddleware(AgentMiddleware):
+    """Interrupt a no-progress loop — same tool + args + result, repeated. Nudges
+    once at ``nudge_at``, ends the turn at ``stop_at``. No-op on healthy histories.
+    """
+
+    def __init__(self, *, nudge_at: int = NUDGE_AT, stop_at: int = STOP_AT):
+        super().__init__()
+        self.nudge_at = nudge_at
+        self.stop_at = stop_at
+
+    def _intervene(self, state):
+        n, tool, snippet = trailing_repeat(state.get("messages") or [])
+        if n >= self.stop_at:
+            seen = f" (it keeps returning: {snippet!r})" if snippet else ""
+            text = (
+                f"I'm stopping because I'm stuck in a loop: I called `{tool}` {n} times in a "
+                f"row with the same arguments and got the same result each time{seen}, so I'm "
+                "not making progress. Rather than keep spinning, I'll pause here — could you "
+                "point me at the right target or approach, or run it somewhere it works?"
+            )
+            return {"jump_to": "end", "messages": [AIMessage(content=text)]}
+        if n == self.nudge_at:
+            seen = f" ({snippet!r})" if snippet else ""
+            note = (
+                f"{NUDGE_MARK} You have called `{tool}` {n} times in a row with identical "
+                f"arguments and received the same result each time{seen}. Repeating it will "
+                "not help. Change your approach — different arguments, a different tool, or "
+                "fix the underlying problem — or, if you cannot make progress, stop and tell "
+                "the user what is blocking you and what you need. Do not issue that same call again."
+            )
+            return {"messages": [HumanMessage(content=note)]}
+        return None
+
+    @hook_config(can_jump_to=["end"])
+    def before_model(self, state, runtime):  # type: ignore[override]
+        return self._intervene(state)
+
+    @hook_config(can_jump_to=["end"])
+    async def abefore_model(self, state, runtime):  # type: ignore[override]
+        return self._intervene(state)

--- a/tests/test_stall_guard.py
+++ b/tests/test_stall_guard.py
@@ -1,0 +1,119 @@
+"""StallGuardMiddleware — breaks a no-progress tool loop (#1446)."""
+
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from graph.middleware.stall_guard import NUDGE_MARK, StallGuardMiddleware, trailing_repeat
+
+_DEFAULT_ARGS = {"project": "workspace", "command": "gh repo view"}
+
+
+def _roundtrip(i: int, *, args=None, result="no default repo", tool="run_command"):
+    cid = f"call_{i}"
+    ai = AIMessage(
+        content="",
+        tool_calls=[{"name": tool, "args": args or _DEFAULT_ARGS, "id": cid, "type": "tool_call"}],
+    )
+    return [ai, ToolMessage(content=result, tool_call_id=cid)]
+
+
+def _history(n: int, **kw):
+    msgs = [HumanMessage(content="file the issue")]
+    for i in range(n):
+        msgs += _roundtrip(i, **kw)
+    return msgs
+
+
+def _mw():
+    return StallGuardMiddleware(nudge_at=3, stop_at=6)
+
+
+# ── nudge / stop thresholds ──────────────────────────────────────────────────
+
+
+def test_below_threshold_is_noop():
+    assert _mw().before_model({"messages": _history(2)}, None) is None
+
+
+def test_nudge_fires_once_at_threshold():
+    out = _mw().before_model({"messages": _history(3)}, None)
+    assert out is not None and "jump_to" not in out
+    assert out["messages"][0].content.startswith(NUDGE_MARK)
+
+
+def test_nudge_does_not_refire_above_threshold():
+    # 4 identical round-trips with no intervening note → past the nudge point,
+    # not yet the stop point → no-op (the nudge already fired at 3).
+    assert _mw().before_model({"messages": _history(4)}, None) is None
+
+
+def test_stop_ends_the_turn_at_threshold():
+    out = _mw().before_model({"messages": _history(6)}, None)
+    assert out is not None and out.get("jump_to") == "end"
+    assert isinstance(out["messages"][0], AIMessage)
+    assert "loop" in out["messages"][0].content.lower()
+
+
+# ── the nudge marker must not break the run it measures ──────────────────────
+
+
+def test_injected_nudge_does_not_reset_the_count():
+    # 3 round-trips, our nudge, then 3 more identical round-trips → a true run of 6.
+    msgs = _history(3) + [HumanMessage(content=f"{NUDGE_MARK} change approach")]
+    for i in range(3, 6):
+        msgs += _roundtrip(i)
+    out = _mw().before_model({"messages": msgs}, None)
+    assert out is not None and out.get("jump_to") == "end"
+
+
+def test_real_user_message_breaks_the_run():
+    # A genuine user message mid-loop resets the run: only the 3 after it count.
+    msgs = _history(3) + [HumanMessage(content="actually, try the other repo")]
+    for i in range(3, 6):
+        msgs += _roundtrip(i)
+    out = _mw().before_model({"messages": msgs}, None)
+    assert out is not None and out.get("jump_to") is None  # nudge, not stop
+    assert out["messages"][0].content.startswith(NUDGE_MARK)
+
+
+# ── only fires on a genuine stall ────────────────────────────────────────────
+
+
+def test_varied_results_are_not_a_stall():
+    msgs = [HumanMessage(content="go")]
+    for i in range(6):
+        msgs += _roundtrip(i, result=f"different result {i}")
+    assert _mw().before_model({"messages": msgs}, None) is None
+
+
+def test_varied_args_are_not_a_stall():
+    msgs = [HumanMessage(content="go")]
+    for i in range(6):
+        msgs += _roundtrip(i, args={"project": "workspace", "command": f"ls dir{i}"})
+    assert _mw().before_model({"messages": msgs}, None) is None
+
+
+def test_fresh_user_turn_after_loop_is_noop():
+    # Tail is a new HumanMessage (not a tool block) → no active loop.
+    msgs = _history(6) + [HumanMessage(content="new question")]
+    assert _mw().before_model({"messages": msgs}, None) is None
+
+
+def test_empty_history_is_noop():
+    assert _mw().before_model({"messages": []}, None) is None
+    assert trailing_repeat([]) == (0, "", "")
+
+
+def test_trailing_repeat_reports_tool_and_snippet():
+    n, tool, snippet = trailing_repeat(_history(4))
+    assert n == 4 and tool == "run_command" and snippet == "no default repo"
+
+
+# ── async path mirrors sync ──────────────────────────────────────────────────
+
+
+async def test_async_before_model_matches_sync():
+    mw = _mw()
+    out = await mw.abefore_model({"messages": _history(6)}, None)
+    assert out is not None and out.get("jump_to") == "end"


### PR DESCRIPTION
Closes #1446.

## Problem

An agent that re-issues the **same** tool call with the **same** args and gets the **same** result, over and over, spun until the recursion limit. The live trace (decoded from `checkpoints.db`) showed ~15 identical `run_command → "no default repo"` round-trips.

Crucially this is **not** a dropped-stream bug — every `tool_call` was cleanly answered in the state the model reads; it just wasn't changing strategy. Nothing caught it: `ToolCallRepairMiddleware` only heals the *opposite* case (an orphaned, **unanswered** call).

## Fix

`StallGuardMiddleware` watches the trailing run of identical `(tool, args, result)` round-trips at `before_model`:

- at **`nudge_at` (3)** → injects one guidance note ("you've run this N× with the same result — change approach or stop");
- at **`stop_at` (6)** → ends the turn (`jump_to: end` + a short AIMessage) instead of spinning to the recursion limit.

Modeled on `WaitYieldMiddleware` (`@hook_config(can_jump_to=["end"])`) and registered unconditionally like `ToolCallRepairMiddleware` — a safety net with no config flag.

### Why it won't false-fire

- **No-op on healthy/varied history.** The run only extends while the *exact same* calls keep getting the *exact same* results, **contiguously, at the tail**. Different args or different results reset it.
- **A real user message breaks the run** (so mid-turn steering resets it), but the guard's **own marked note does not** — otherwise the nudge would reset the very count it measures and the stop could never be reached. The scan skips messages tagged `[stall-guard]`.
- 6 identical answered round-trips is itself pathological; legitimate work doesn't repeat the same call with the same result 6× in a row.

## Behavior-change callout

This can **end a turn early** (the `stop_at` path). Thresholds are conservative; tune `nudge_at`/`stop_at` if they feel off. Flagging for an eyeball since it touches the core loop.

## Scope note

The issue's "`run_command` legibility" half was premised on a stale checkout — current `main` runs `run_command` via `/bin/sh -c`, so shell constructs already work and the exit-0 masking is the model's own `|| echo`. So the PR is the stall guard only ([correction on the issue](https://github.com/protoLabsAI/protoAgent/issues/1446#issuecomment-4840515386)).

## Tests

`tests/test_stall_guard.py` (12) — thresholds, the marker-skip (nudge doesn't reset the count), varied args/results, fresh-turn no-op, async parity. Neighboring middleware tests stay green (198 passed locally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection for repeated, no-progress tool-use loops.
  * The app now gives a gentle nudge when the same tool call keeps producing the same result, and can stop the turn if the loop continues.

* **Bug Fixes**
  * Prevents the assistant from getting stuck in endless repetitive tool-call cycles.
  * Loop handling now correctly resets when the conversation changes or results differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->