### PR TITLE
fix(desktop): open plugin-iframe external links in the system browser

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -546,13 +546,30 @@ pub fn run() {
             let init = format!(
                 "window.__PROTOAGENT_API_BASE__ = \"http://127.0.0.1:{port}\";"
             );
+            // A `target="_blank"` / `window.open` from a (sandboxed) plugin iframe asks
+            // the host to spawn a child window. We don't host child windows, so without
+            // a handler WKWebView silently drops the request and the click does nothing
+            // — e.g. the GitHub plugin's PR/issue links were dead in the desktop app.
+            // Open external http(s) links in the system browser (shell:allow-open) and
+            // deny the in-app window. (Browsers handle this implicitly via allow-popups;
+            // the desktop shell has to do it explicitly.)
+            let link_opener = app.handle().clone();
             let mut win = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
                 .title("protoAgent")
                 .inner_size(1280.0, 820.0)
                 .min_inner_size(980.0, 640.0)
                 .resizable(true)
                 .center()
-                .initialization_script(&init);
+                .initialization_script(&init)
+                .on_new_window(move |url, _features| {
+                    let target = url.as_str();
+                    if target.starts_with("http://") || target.starts_with("https://") {
+                        if let Err(e) = link_opener.shell().open(target, None) {
+                            log::error!("desktop: failed to open external link {target}: {e}");
+                        }
+                    }
+                    tauri::webview::NewWindowResponse::Deny
+                });
             // Invisible title bar (macOS): no opaque chrome — content fills the
             // frame and the native traffic lights float top-left. The web shell
             // restores window-dragging + insets its topbar for the lights


### PR DESCRIPTION
**Bug:** in the desktop app, clicking a GitHub-plugin PR/issue link does nothing. (Reported: "I can't click the links to the PRs and issues. I used to be able to.")

**Cause:** the plugin renders those as `<a target="_blank">`. In a browser that opens a new tab implicitly (the `PluginView` sandbox has `allow-popups`). In the desktop shell (Tauri 2.11 / WKWebView), a `target="_blank"` / `window.open` asks the host to spawn a child window — and the shell had **no new-window handler**, so WKWebView silently dropped the request. Nothing happened.

**Fix:** add an `on_new_window` handler to the main `WebviewWindowBuilder` that opens external `http(s)` URLs in the system browser via the shell opener (`shell:allow-open`, already granted) and returns `NewWindowResponse::Deny` for the in-app window. Covers links from **every** plugin iframe, not just GitHub.

**Validation:** `cargo check` ✅ (against an identical `origin/main` desktop tree). Cross-platform compile is the desktop-build matrix on this PR. Runtime behavior validates on a desktop build.

**Note:** `shell::open` is deprecated in favor of `tauri-plugin-opener`; migrating the desktop shell off the shell plugin's opener is a follow-up (the existing `shell:allow-open` path works and is already permitted).

Reaches users on the **next desktop build/update** (this is the Tauri shell, not the web bundle).