### PR TITLE
feat(coder): P3 — wire the fusion rung (ADR 0064)

### DIFF
--- a/docs/guides/coder.md
+++ b/docs/guides/coder.md
@@ -28,8 +28,13 @@ Each rung fires **only when the cheaper one fails its tests**:
 1. greedy        1-shot                                   cheap; solves most
 2. best-of-k     k candidates → run tests → select         headroom recovery
 3. tree-search   refine on the *failing* tests, bounded     grounded fix loop
-4. fusion        richer candidates → execute-select         hardest (roadmap)
+4. fusion        richer candidates → execute-select         hardest (opt-in)
 ```
+
+Rung 4 is opt-in: set `coder.fusion_delegate` to a richer generator (e.g.
+`protolabs/fusion`, an `openai` delegate). It fires **only** after the cheaper rungs
+fail their tests and only while budget remains, so it pays fusion's ~3× cost solely
+on genuinely hard, verifiable problems — "fusion proposes, the tests dispose."
 
 The gate is **test pass/fail**, never an LLM judge. With **no tests**, `coder`
 degrades to a single un-verified candidate and says so — it shines on verifiable
@@ -61,6 +66,8 @@ coder:
   tree_depth: 2                 # refine-on-failing-tests rounds (rung 3)
   test_timeout: 60.0            # per-candidate pytest timeout (seconds)
   solution_name: solution       # module candidates are written to; tests import it
+  # fusion_delegate: fusion     # optional rung 4 — a richer generator (declare it in delegates)
+  # fusion_k: 2                 # fusion candidates per attempt at the top rung
 ```
 
 ## Worked example

--- a/plugins/coder/__init__.py
+++ b/plugins/coder/__init__.py
@@ -39,6 +39,10 @@ def _build_coder_solve_tool(cfg: dict):
     k = int(cfg.get("k", 3))
     tree_depth = int(cfg.get("tree_depth", 2))
     test_timeout = float(cfg.get("test_timeout", 60.0))
+    # Optional rung 4 (ADR 0064): a richer generator (e.g. protolabs/fusion, an openai
+    # delegate) tried only after the cheaper rungs fail their tests. Off unless set.
+    fusion_delegate = str(cfg.get("fusion_delegate") or "").strip()
+    fusion_k = int(cfg.get("fusion_k", 2))
 
     description = (
         "Solve a VERIFIABLE coding task and return a TEST-VERIFIED solution. Pass `task` "
@@ -61,6 +65,10 @@ def _build_coder_solve_tool(cfg: dict):
         if not (task and task.strip()):
             return "coder_solve: `task` is required."
         gen = make_delegate_generator(delegate_name, solution_name=solution_name)
+        # Rung 4 fires only when a fusion delegate is configured; otherwise the ladder
+        # stops at tree-search. The fusion rung is also test-gated AND budget-gated in
+        # solve(), so it pays fusion's ~3× cost only on genuinely hard problems.
+        fusion_gen = make_delegate_generator(fusion_delegate, solution_name=solution_name) if fusion_delegate else None
         verify = None
         if tests and tests.strip():
             async def verify(code: str):
@@ -74,6 +82,8 @@ def _build_coder_solve_tool(cfg: dict):
                 budget=Budget(budget_total),
                 k=k,
                 tree_depth=tree_depth,
+                fusion_generate=fusion_gen,
+                fusion_k=fusion_k,
             )
         except Exception as exc:  # noqa: BLE001 — surface as a tool result, not a crash
             log.exception("[coder] solve failed")

--- a/plugins/coder/protoagent.plugin.yaml
+++ b/plugins/coder/protoagent.plugin.yaml
@@ -33,6 +33,8 @@ config:
   tree_depth: 2       # refine-on-failing-tests depth (rung 3)
   test_timeout: 60.0  # per-candidate pytest timeout (seconds)
   solution_name: "solution"  # module name candidates are written to / tests import
+  fusion_delegate: ""  # optional rung 4: a richer generator (e.g. protolabs/fusion); off when blank
+  fusion_k: 2          # fusion candidates per attempt at the top rung
 settings:
   - { key: delegate, label: "Coder delegate", type: string, group: "Coder", description: "Declared delegate name to generate candidates against — an openai model endpoint, or an acp coder. Required." }
   - { key: budget, label: "Generation budget", type: number, group: "Coder", description: "Hard cap on total generations across the ladder. The fusion rung is budget-gated on top of being test-gated." }
@@ -40,3 +42,5 @@ settings:
   - { key: tree_depth, label: "Tree-search depth", type: number, group: "Coder", description: "How many refine-on-failing-tests rounds rung 3 runs." }
   - { key: test_timeout, label: "Test timeout (s)", type: number, group: "Coder", description: "Hard timeout per candidate's pytest run before it's killed." }
   - { key: solution_name, label: "Solution module name", type: string, group: "Coder", description: "Module candidates are written to; caller tests import from it (e.g. `from solution import add`)." }
+  - { key: fusion_delegate, label: "Fusion delegate (rung 4)", type: string, group: "Coder", description: "Optional: a declared delegate (e.g. protolabs/fusion) used as the top rung — tried only after greedy/best-of-k/tree-search fail their tests. Blank disables rung 4." }
+  - { key: fusion_k, label: "Fusion candidates", type: number, group: "Coder", description: "How many fusion candidates to generate + execution-select at the top rung." }

--- a/tests/test_coder_plugin.py
+++ b/tests/test_coder_plugin.py
@@ -70,6 +70,46 @@ async def test_tree_search_uses_failing_feedback():
     assert "failing" in calls["feedbacks"][-1]
 
 
+async def test_fusion_rung_fires_only_after_cheaper_rungs_fail():
+    # greedy + best-of-k + tree-search all "bad"; the fusion generator returns "good".
+    # Fusion must fire last and solve. Budget large enough to reach it.
+    gen, gcalls = _gen_sequence(["bad"])  # everything from the base generator fails
+
+    fcalls = {"n": 0}
+
+    async def fusion_gen(task, *, feedback=None):
+        fcalls["n"] += 1
+        return "good"
+
+    res = await solve(
+        "t",
+        generate=gen,
+        verify=_verify_passes_on("good"),
+        budget=Budget(12),
+        k=3,
+        tree_depth=2,
+        fusion_generate=fusion_gen,
+        fusion_k=2,
+    )
+    assert res.passed is True
+    assert res.rung == "fusion"
+    assert fcalls["n"] >= 1  # fusion was actually invoked
+    assert gcalls["n"] >= 1  # cheaper rungs ran first
+
+
+async def test_fusion_not_invoked_when_cheaper_rung_solves():
+    gen, _ = _gen_sequence(["good"])  # greedy solves immediately
+    fcalls = {"n": 0}
+
+    async def fusion_gen(task, *, feedback=None):
+        fcalls["n"] += 1
+        return "good"
+
+    res = await solve("t", generate=gen, verify=_verify_passes_on("good"), budget=Budget(12), fusion_generate=fusion_gen)
+    assert res.rung == "greedy"
+    assert fcalls["n"] == 0  # fusion never paid for
+
+
 async def test_no_oracle_degrades_to_greedy():
     gen, calls = _gen_sequence(["whatever"])
     res = await solve("t", generate=gen, verify=None, budget=Budget(6))


### PR DESCRIPTION
P3 of ADR 0064 (after #1449 P1 + #1451 fixes). `solve()` already had the `fusion_generate`/`fusion_k` hook; this exposes it through the `coder_solve` tool + config.

Set `coder.fusion_delegate` to a richer generator (e.g. `protolabs/fusion`, an `openai` delegate) and it becomes **rung 4** — tried only after greedy/best-of-k/tree-search fail their tests **and** while budget remains, so fusion's ~3× cost is paid only on genuinely hard, verifiable problems ("fusion proposes, the tests dispose"). Off when `fusion_delegate` is blank (ladder stops at tree-search).

- `__init__.py` — build a fusion generator when configured, pass it to `solve()`.
- manifest — `fusion_delegate` + `fusion_k` config + Settings.
- guide — ladder/config updated.
- +2 tests (fusion fires only after cheaper rungs fail; never paid when a cheaper rung solves). 15 total, ruff clean.

Refs #1440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)