### PR TITLE
feat(plugins): ship the artifact plugin on by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Artifact is now a bundled core plugin** (#1443) — the generative-UI surface (`show_artifact` —
-  charts, diagrams, Mermaid, Markdown, or live React rendered into a sandboxed panel; ADR 0038) is
-  vendored in-tree under `plugins/artifact/` and ships with the agent, **off by default**. Opt in
-  with `plugins.enabled: [artifact]` (or flip the manifest's `enabled: true`). Folds in a
-  pointer-lock fix so game/canvas artifacts can capture the pointer.
+- **Artifact is now a bundled core plugin, on by default** (#1443) — the generative-UI surface
+  (`show_artifact` — charts, diagrams, Mermaid, Markdown, or live React rendered into a sandboxed
+  panel; ADR 0038) is vendored in-tree under `plugins/artifact/` and ships with the agent enabled,
+  a first-party surface like notes/docs (turn off per-instance via `plugins.disabled: [artifact]`).
+  Folds in a pointer-lock fix so game/canvas artifacts can capture the pointer.
 
 ## [0.76.0] - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -140,15 +140,15 @@ python -m server plugin uninstall your-plugin --purge                # removes c
 
 **Browse the directory → [agent.protolabs.studio/plugins](https://agent.protolabs.studio/plugins)**
 
-First-party plugins ship in `plugins/` — `delegates` is a built-in, `notes` and `docs`
-are on by default, and the rest are opt-in (enable via `plugins.enabled`):
+First-party plugins ship in `plugins/` — `delegates` is a built-in, `notes`, `docs`, and
+`artifact` are on by default, and the rest are opt-in (enable via `plugins.enabled`):
 
 | Plugin | Adds | What it does |
 | --- | --- | --- |
 | [`delegates`](./plugins/delegates/) | tool · settings | **Built-in** — `delegate_to` over a2a / openai / acp, managed in Workspace ▸ Delegates |
 | [`notes`](./plugins/notes/) | tools · view | **On by default** — one shared markdown note the agent and operator both read/write |
 | [`docs`](./plugins/docs/) | tools · view · skill | **On by default** — offline search over protoAgent's own docs |
-| [`artifact`](./plugins/artifact/) | tools · view · skill | Generative UI — `show_artifact` renders charts, diagrams, Mermaid, Markdown, or live React into a sandboxed panel ([ADR 0038](./docs/adr/0038-generative-ui-artifacts-two-mode.md)) |
+| [`artifact`](./plugins/artifact/) | tools · view · skill | **On by default** — generative UI; `show_artifact` renders charts, diagrams, Mermaid, Markdown, or live React into a sandboxed panel ([ADR 0038](./docs/adr/0038-generative-ui-artifacts-two-mode.md)) |
 | [`plugin-devkit`](./plugins/plugin-devkit/) | tool · subagent · skill · workflow · view | The authoring kit + reference plugin — the agent can scaffold and build its own plugins |
 | [`workflows`](./plugins/workflows/) | tools | Declarative multi-step subagent workflows (DAG recipes) |
 | [`telegram`](./plugins/telegram/) | surface | Run the agent as a Telegram bot — the reference [communication plugin](./docs/guides/communication-plugins.md) |

--- a/docs/adr/0038-generative-ui-artifacts-two-mode.md
+++ b/docs/adr/0038-generative-ui-artifacts-two-mode.md
@@ -4,8 +4,9 @@
 
 **Update (2026-06-30, #1443):** the artifact plugin — first shipped as a standalone repo — is now
 **bundled into core** under `plugins/artifact/`, vendored back in-tree so the generative-UI surface
-ships with the agent and iterates in the monorepo. It stays lean-core **off by default**
-(`enabled: false`; opt in via `plugins.enabled: [artifact]`). The sandbox model (D1) is unchanged.
+ships with the agent and iterates in the monorepo. It ships **on by default** (`enabled: true`),
+a first-party surface like notes/docs; turn it off per-instance via `plugins.disabled: [artifact]`.
+The sandbox model (D1) is unchanged.
 
 ## Context
 

--- a/plugins/artifact/protoagent.plugin.yaml
+++ b/plugins/artifact/protoagent.plugin.yaml
@@ -11,10 +11,10 @@ description: >-
   WebUI do it. React artifacts can import a curated offline set (d3, chart.js, lucide) and the
   protoLabs design-system @pl/ui wrappers. The shell page is served by this plugin and iframed;
   the agent's generated code renders in a nested sandbox with no access to the console.
-# Bundled into core (protoAgent #1443) but lean-core OFF by default — opt in with
-# `plugins: { enabled: [artifact] }` in config (or flip this to `true`). Pulled in-tree
-# so the generative-UI surface ships with the agent and iterates in the monorepo.
-enabled: false
+# Bundled into core (protoAgent #1443) and ON by default — a first-party generative-UI
+# surface (like notes/docs). Turn it off per-instance with `plugins: { disabled: [artifact] }`.
+# Pulled in-tree so it ships with the agent and iterates in the monorepo.
+enabled: true
 capabilities:
   # Truly no network: the server makes no outbound calls, and the react/mermaid libs
   # are VENDORED + served same-origin, so artifacts render fully offline (no cdnjs).


### PR DESCRIPTION
Follow-up to #1454 (artifact → core). Flips `plugins/artifact` to **`enabled: true`**, so the generative-UI surface ships **on by default** — joining `notes` and `docs` as the on-by-default first-party trio. Turn off per-instance with `plugins.disabled: [artifact]`.

Docs updated to match: README plugin table (+ the on-by-default intro line), ADR 0038 update note, CHANGELOG.

Validated: loader discovery reports `artifact enabled: True`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The artifact plugin is now bundled with core and enabled by default.
  * Instances can still turn it off using the disabled plugins setting.

* **Documentation**
  * Updated guidance to reflect the new default availability and configuration options.
  * Clarified that the sandbox model remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->