### PR TITLE
fix(settings): surface when agent config shadows a host-scoped field (#1459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a first-party surface like notes/docs (turn off per-instance via `plugins.disabled: [artifact]`).
   Folds in a pointer-lock fix so game/canvas artifacts can capture the pointer.
 
+### Fixed
+- **Settings surfaces when the agent config shadows a host-scoped field** (#1459) — when a
+  `scope="host"` field (e.g. `model.api_base`) is set in both `host-config.yaml` and the agent
+  leaf (`langgraph-config.yaml`), the agent value wins at runtime (ADR 0047) but the host console
+  used to badge it a plain "box default", hiding the override. It now shows an **"overridden by
+  agent config"** warning with Reset-to-inherited (which removes the agent override so the box
+  default applies), and config load logs a warning naming each shadowed key.
+
 ## [0.76.0] - 2026-06-30
 
 ### Added

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -150,6 +150,11 @@ test("host-scoped fields show the 'box default' badge inline in Model", async ({
   );
   // An agent-scoped field (no host layer) carries no inheritance badge on the host.
   await expect(page.locator('.setting-row[data-key="routing.fallback_models"] .setting-inheritance')).toHaveCount(0);
+  // A host-scoped field the agent leaf ALSO sets (model.temperature, source=agent) is shadowed:
+  // the host console warns instead of mislabelling it "box default", and offers reset (issue #1459).
+  const temp = page.locator('.setting-row[data-key="model.temperature"]');
+  await expect(temp.locator(".setting-inheritance")).toContainText("overridden by agent config");
+  await expect(temp.getByRole("button", { name: /Reset to inherited/ })).toBeVisible();
 });
 
 // On the host these same host-scoped edits save to the host layer (ADR 0047): the mock echoes

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -343,7 +343,12 @@ function inheritance(field: SettingsField, onHost: boolean): { label: string; st
   if (onHost) {
     // On the host console you ARE the box: a host-scoped field is the shared default every
     // agent inherits (not "inherited from" anything); agent-scoped fields are the host's own.
-    if (field.scope === "host") return { label: "box default", status: "info", overridden: false };
+    // But if the agent leaf ALSO sets it (source=="agent"), the leaf WINS at runtime (ADR 0047)
+    // and silently shadows the box default — surface that as a warning + reset (issue #1459).
+    if (field.scope === "host")
+      return field.source === "agent"
+        ? { label: "overridden by agent config", status: "warning", overridden: true }
+        : { label: "box default", status: "info", overridden: false };
     return null;
   }
   // A fleet member (non-host): the ADR 0047 inheritance view.
@@ -400,6 +405,14 @@ function SettingRow({
             per-agent leaf override (not the box default) — make that effect explicit. */}
         {showInheritance && !onHost && dirty && field.scope === "host" && field.source !== "agent" ? (
           <p className="setting-override-note">Saving overrides the box default for this agent only.</p>
+        ) : null}
+        {/* Host console: this box default is shadowed by the agent leaf — the shown value is the
+            effective (agent) value that wins, so editing the box default here has no runtime effect
+            until the agent override is removed via Reset to inherited (issue #1459). */}
+        {showInheritance && onHost && field.scope === "host" && field.source === "agent" ? (
+          <p className="setting-override-note">
+            The agent config overrides this box default — the agent value shown is what runs. Reset to use the box default.
+          </p>
         ) : null}
       </div>
       <div className="setting-control">

--- a/graph/config.py
+++ b/graph/config.py
@@ -146,18 +146,22 @@ def _env_default(name: str, default, cast=str):
         return default
 
 
+def _host_scoped_fields():
+    """The host-scoped (ADR 0047 ``scope=="host"``) settings fields — the single
+    source for both the host-layer filter and the shadow check, so they can't drift."""
+    from graph.settings_schema import FIELDS
+
+    return [f for f in FIELDS if getattr(f, "scope", "agent") == "host"]
+
+
 def _filter_to_host_keys(raw: dict) -> dict:
     """Keep only the host-scoped FIELDS keys present in a raw host-config doc.
 
     The Host file can set box-shared defaults but **cannot inject agent-only
     settings** (ADR 0047 D1/D4) — anything outside the ``scope=="host"`` set is
     dropped here before the merge."""
-    from graph.settings_schema import FIELDS
-
     out: dict = {}
-    for f in FIELDS:
-        if getattr(f, "scope", "agent") != "host":
-            continue
+    for f in _host_scoped_fields():
         found, val = _get_dotted(raw, f.key)
         if found:
             _set_dotted(out, f.key, val)
@@ -170,11 +174,7 @@ def _warn_shadowed_host_keys(host_layer: dict, agent_data: dict) -> None:
     ``host-config.yaml`` is silently *shadowed* — otherwise invisible until you read
     the merge (issue #1459). Best-effort: a provenance warning must never break boot."""
     try:
-        from graph.settings_schema import FIELDS
-
-        for f in FIELDS:
-            if getattr(f, "scope", "agent") != "host":
-                continue
+        for f in _host_scoped_fields():
             h_found, h_val = _get_dotted(host_layer, f.key)
             a_found, a_val = _get_dotted(agent_data, f.key)
             if h_found and a_found and a_val not in (None, "") and a_val != h_val:

--- a/graph/config.py
+++ b/graph/config.py
@@ -164,6 +164,33 @@ def _filter_to_host_keys(raw: dict) -> dict:
     return out
 
 
+def _warn_shadowed_host_keys(host_layer: dict, agent_data: dict) -> None:
+    """Warn when the agent leaf overrides a host-scoped (box-shared) key with a
+    different, non-empty value. The agent wins (ADR 0047), so the box default in
+    ``host-config.yaml`` is silently *shadowed* — otherwise invisible until you read
+    the merge (issue #1459). Best-effort: a provenance warning must never break boot."""
+    try:
+        from graph.settings_schema import FIELDS
+
+        for f in FIELDS:
+            if getattr(f, "scope", "agent") != "host":
+                continue
+            h_found, h_val = _get_dotted(host_layer, f.key)
+            a_found, a_val = _get_dotted(agent_data, f.key)
+            if h_found and a_found and a_val not in (None, "") and a_val != h_val:
+                log.warning(
+                    "config: agent leaf overrides host-scoped %r — the box default %r is "
+                    "shadowed by the agent value %r, which wins. Remove %r from the agent "
+                    "config (langgraph-config.yaml) to use the box default.",
+                    f.key,
+                    h_val,
+                    a_val,
+                    f.key,
+                )
+    except Exception:  # noqa: BLE001 — never let a provenance warning break config load
+        pass
+
+
 def _load_host_layer() -> dict:
     """The Host layer (ADR 0047): ``host-config.yaml`` filtered to host-scoped keys.
 
@@ -733,6 +760,9 @@ class LangGraphConfig:
 
         # Host is the base; the agent leaf overlays it (agent wins). No host layer ⇒
         # merged is exactly the agent doc — the pre-cascade input, unchanged.
+        if host_layer:
+            # Surface silent shadowing of a box default by the agent leaf (issue #1459).
+            _warn_shadowed_host_keys(host_layer, agent_data)
         merged = _deep_merge_dicts(copy.deepcopy(host_layer), agent_data) if host_layer else agent_data
 
         secrets = _load_secrets_doc(p.parent)

--- a/tests/test_settings_cascade.py
+++ b/tests/test_settings_cascade.py
@@ -10,6 +10,7 @@ PROTOAGENT_HOST_CONFIG is defaulted to an absent path by conftest, so tests star
 with NO host layer and opt in by pointing it at a temp file.
 """
 
+import logging
 import textwrap
 from pathlib import Path
 
@@ -64,6 +65,37 @@ def test_host_cannot_inject_agent_scoped_key(tmp_path, monkeypatch):
     cfg = LangGraphConfig.from_yaml(path)
     assert cfg.goal_enabled is True  # host's agent-scoped goal.enabled IGNORED (default)
     assert cfg.model_name == "host-model"  # host's host-scoped key DID apply
+
+
+def test_agent_shadowing_host_key_warns(tmp_path, monkeypatch, caplog):
+    """A host-scoped key set in BOTH layers with differing values logs a shadow warning
+    (issue #1459): the agent wins, so the box default is silently overridden — surface it."""
+    _host_yaml(tmp_path, "model:\n  api_base: http://host-gw/v1\n", monkeypatch)
+    path = _agent_yaml(tmp_path, "model:\n  api_base: http://agent-gw/v1\n")
+    with caplog.at_level(logging.WARNING, logger="protoagent.config"):
+        cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.api_base == "http://agent-gw/v1"  # agent wins (unchanged behavior)
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("shadow" in m.lower() and "model.api_base" in m for m in msgs), msgs
+
+
+def test_no_shadow_warning_when_values_match(tmp_path, monkeypatch, caplog):
+    """No noise when the agent leaf merely repeats the host value — nothing is shadowed."""
+    _host_yaml(tmp_path, "model:\n  api_base: http://same-gw/v1\n", monkeypatch)
+    path = _agent_yaml(tmp_path, "model:\n  api_base: http://same-gw/v1\n")
+    with caplog.at_level(logging.WARNING, logger="protoagent.config"):
+        LangGraphConfig.from_yaml(path)
+    assert not any("shadow" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_no_shadow_warning_when_agent_silent(tmp_path, monkeypatch, caplog):
+    """A host default the agent never sets is plain inheritance, not a shadow — no warning."""
+    _host_yaml(tmp_path, "model:\n  api_base: http://host-gw/v1\n", monkeypatch)
+    path = _agent_yaml(tmp_path, "goal:\n  enabled: true\n")
+    with caplog.at_level(logging.WARNING, logger="protoagent.config"):
+        cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.api_base == "http://host-gw/v1"  # inherited
+    assert not any("shadow" in r.getMessage().lower() for r in caplog.records)
 
 
 def test_host_cannot_set_a_secret(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #1459.

## Problem
When a `scope="host"` field (e.g. `model.api_base`) is set in **both** `host-config.yaml` and the agent leaf `langgraph-config.yaml`, the agent value wins at runtime (`_deep_merge_dicts`, ADR 0047). But the host console badged it a plain **"box default"**, implying the host value was active. Editing the box default there had no runtime effect, with no indication why — the only way to discover the shadow was to read `graph/config.py`. Concrete failure: a user sets `model.api_base` to a working gateway, the template's `http://gateway:4000/v1` leaf silently wins, and the agent fails with `No route to host`.

## Fix
- **Host console badge** (`SettingsCategory.tsx`): a host-scoped field whose live value comes from the agent leaf (`source==="agent"`) is now badged **"overridden by agent config"** (warning) with **Reset to inherited** — the existing reset pops the key from the agent leaf, so the box default takes effect. A note clarifies the shown value is the effective (agent) value that wins.
- **Config-load warning** (`graph/config.py` `from_yaml`): logs a warning naming each host-scoped key the agent leaf overrides with a differing non-empty value — surfaces the shadow in headless/debug where there's no console.

No behavior change to the cascade itself (agent still wins); this is purely making the existing precedence visible.

## Tests
- `tests/test_settings_cascade.py`: warns on a real shadow; stays quiet when the agent merely repeats the host value or is silent.
- `apps/web/e2e/settings.spec.ts`: host console shows the "overridden by agent config" badge + Reset for `model.temperature` (the mock's `scope:host / source:agent` field).

## Gates (local)
ruff ✓ · pytest `tests/test_settings_cascade.py` (32) ✓ · tsc clean ✓ · vitest (193) ✓ · playwright `settings.spec.ts` (14) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings now clearly show when a host-level value is being overridden by agent configuration.
  * A **Reset to inherited** control is now visible for affected fields.

* **Bug Fixes**
  * Improved inheritance messaging so host settings accurately reflect when a lower-level override is taking effect.
  * Added a warning when a host-scoped setting is shadowed by agent config, helping surface unexpected configuration conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->