### PR TITLE
docs: phone/LAN/tailnet access guide + tunnel section

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -135,6 +135,7 @@ export default defineConfig({
           items: [
             { text: "Operator console (React/Tauri)", link: "/guides/react-tauri-ui" },
             { text: "Command palette (⌘K)", link: "/guides/command-palette" },
+            { text: "Access from your phone (LAN / Tailscale)", link: "/guides/phone-access" },
             { text: "Run headless (API + A2A)", link: "/guides/headless" },
           ],
         },

--- a/docs/guides/deploy-docker.md
+++ b/docs/guides/deploy-docker.md
@@ -72,6 +72,45 @@ sign-in prompt it's cached in that browser's `localStorage`. Know the trade-off:
   if the console is ever exposed beyond localhost, is an egress limit (a CSP `connect-src`
   allowlist) that blocks exfiltration for both the browser and the desktop.
 
+## Expose it with a tunnel (ngrok / Cloudflare)
+
+To reach the agent on a **public hostname** without opening a router port, front it with a
+tunnel. The tunnel terminates TLS and forwards to the container's published port; protoAgent
+itself can stay bound to `127.0.0.1`. Two non-negotiables when you do this:
+
+- **Keep `A2A_AUTH_TOKEN` set.** A tunnel makes the *whole* operator API
+  (`/api/*` plugin-install + config rewrite, `/v1/*`, `/a2a`) internet-reachable — the bearer
+  gate is the only thing fencing it. (For LAN/tailnet-only access, prefer
+  [Tailscale](/guides/phone-access#tailscale-reach-it-from-anywhere) — no public surface at all.)
+- **Set [`A2A_PUBLIC_URL`](/reference/environment-variables#a2a-agent-card-endpoint)** to the
+  tunnel hostname, so the agent card advertises the address peers actually use (not the bound
+  loopback port).
+
+**ngrok** — ephemeral hostname, good for a quick share or a phone demo:
+
+```bash
+ngrok http 7870
+# → Forwarding https://abc123.ngrok-free.app -> http://localhost:7870
+export A2A_PUBLIC_URL=https://abc123.ngrok-free.app
+```
+
+**Cloudflare Tunnel** (`cloudflared`) — a stable hostname mapped to your domain, no inbound
+ports:
+
+```bash
+# quick, throwaway URL:
+cloudflared tunnel --url http://localhost:7870
+# or a named tunnel routed to agent.example.com, then:
+export A2A_PUBLIC_URL=https://agent.example.com
+```
+
+Because the console authenticates over the tunnel too, add the tunnel origin to
+[`A2A_ALLOWED_ORIGINS`](/reference/environment-variables#streaming-origin-verification) if
+you've enabled origin verification — otherwise the SSE/WebSocket streams it relies on get a
+`403`. For a second factor in front of the bearer token, layer the tunnel's own access
+control (Cloudflare Access, an ngrok OAuth policy, or a fronting auth proxy) — the
+`localStorage`-cached token above is *all* the app-level auth there is.
+
 ## Day-2
 
 | Want to… | Do |

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -74,6 +74,7 @@ Surface the agent to people — the operator console, or no UI at all.
 |---|---|
 | [Operator console (React/Tauri)](/guides/react-tauri-ui) | You want the multi-chat React console and to package it for desktop |
 | [Command palette (⌘K)](/guides/command-palette) | You want the fast keyboard path to jump between surfaces + inline chat |
+| [Access from your phone (LAN / Tailscale)](/guides/phone-access) | You want to drive the agent from your phone — installable PWA over your LAN or tailnet, add-to-home-screen |
 | [Run headless (API + A2A)](/guides/headless) | You want the agent as a service — REST + A2A — with no UI |
 
 ## Operate & deploy

--- a/docs/guides/phone-access.md
+++ b/docs/guides/phone-access.md
@@ -1,0 +1,92 @@
+# Access from your phone (LAN / Tailscale)
+
+The console is an **installable PWA**, so you can drive your agent from your phone — on
+your home Wi-Fi, or from anywhere over **Tailscale** — and pin it to the home screen so it
+opens like an app (standalone, no browser chrome, recolored to the agent's accent). No app
+store, and **no offline mode** — the install is convenience, not a cached copy (see
+[the note below](#no-offline-mode)).
+
+It's three steps: bind the server to the network behind a token, open it on the phone, add
+it to the home screen.
+
+## 1. Bind to the network + set a token
+
+By default protoAgent binds **loopback only** (`127.0.0.1`) so a desktop run isn't exposed.
+To reach it from a phone you bind a routable interface — and the boot gate **refuses a
+non-loopback bind without an auth token** (the operator API includes plugin-install + config
+rewrite). So set both at once:
+
+```bash
+A2A_AUTH_TOKEN=$(openssl rand -hex 24) python -m server --host 0.0.0.0 --port 7870
+```
+
+Note the token — you'll paste it into the phone once. (You can also put it in
+`config/secrets.yaml` under `auth.token`; env wins.) See
+[`A2A_AUTH_TOKEN`](/reference/environment-variables#authentication-a2a-bearer-token) and
+[`PROTOAGENT_HOST`](/reference/environment-variables#deployment-ui-tier-adr-0010).
+
+## 2. Reach it from the phone
+
+Open the console at **`http://<host>:7870/app`** in the phone's browser. On the first
+request it prompts *"Authentication required"* — paste the token; it's cached in that
+browser's `localStorage`, so you do it once per device.
+
+What `<host>` is depends on how the phone gets to the machine:
+
+| From | `<host>` | Notes |
+|---|---|---|
+| **Same Wi-Fi (LAN)** | the machine's LAN IP — `192.168.x.x` / `10.x.x.x` | `ipconfig getifaddr en0` (macOS) or `hostname -I` (Linux). Only works while both are on that network. |
+| **Anywhere (Tailscale)** | the machine's tailnet IP (`100.x.x.x`) or its MagicDNS name | **Recommended for off-LAN.** Encrypted mesh, no port-forwarding, nothing exposed to the public internet. |
+
+### Tailscale (reach it from anywhere)
+
+Install [Tailscale](https://tailscale.com) on **both** the host and the phone and sign both
+into the same tailnet. Then the host is reachable at its stable `100.x.x.x` address (or
+`http://<host>.<tailnet>.ts.net:7870/app` with MagicDNS) from the phone over LTE/5G — no
+ports opened on your router, no public surface. The bearer token is still your auth; the
+tailnet is the network boundary.
+
+> Discover (Settings → Agents → **Discover**) already finds other protoAgents on your
+> tailnet via the Tailscale CLI — see [Fleet](/guides/fleet#remote-fleet-members-the-agent-there-the-ui-here)
+> for operating a remote agent's console through the hub.
+
+## 3. Add to Home Screen
+
+Once the console loads, install it so it launches full-screen:
+
+- **iOS Safari** — Share → **Add to Home Screen**. Works over plain `http` on your LAN /
+  tailnet. Uses the apple-touch-icon and opens standalone.
+- **Android Chrome** — ⋮ → **Add to Home screen**. (Chrome's *automatic* install banner
+  needs HTTPS **and** a service worker, which the console deliberately omits — so add it
+  from the menu instead.) The manifest's `display: standalone` still applies.
+
+The launched app is scoped to `/app/` and follows the agent's theme — favicon and mobile
+browser chrome recolor to the agent's accent.
+
+## No offline mode
+
+The console is a **manifest-only** PWA — there is **deliberately no service worker**. A SW
+would cache console assets (going stale the moment the agent updates — a real hazard on a
+version-coherent fleet) and would sit in front of the `/a2a` SSE stream the live chat rides
+on. So "install to home screen" gives you an app-like launcher, **not** an offline copy: the
+agent has to be reachable (LAN or tailnet) for the console to work. That's the intended
+trade-off — zero stale-asset risk over offline support.
+
+## Going further: a public URL
+
+Tailscale covers "just me, from my phone." If you want a **real hostname** — to share with
+others, or reach the agent without Tailscale on the client — put it behind a tunnel or
+reverse proxy and set
+[`A2A_PUBLIC_URL`](/reference/environment-variables#a2a-agent-card-endpoint) so the agent
+card advertises the right address. See
+[Deploy in Docker → Expose it with a tunnel](/guides/deploy-docker#expose-it-with-a-tunnel-ngrok-cloudflare).
+Keep the token set — once it's internet-reachable, the bearer gate is the only thing
+between the open operator API and the world.
+
+## See also
+
+- [Run headless (API + A2A)](/guides/headless) — the no-UI server you're binding here
+- [Deploy in Docker](/guides/deploy-docker) — binding, auth, and the tunnel section
+- [Fleet](/guides/fleet) — operate a remote agent's console from one hub
+- [Environment variables](/reference/environment-variables) — `A2A_AUTH_TOKEN`,
+  `PROTOAGENT_HOST`, `A2A_PUBLIC_URL`

--- a/plugins/docs/nav.json
+++ b/plugins/docs/nav.json
@@ -167,6 +167,10 @@
           "title": "Command palette (⌘K)"
         },
         {
+          "path": "guides/phone-access.md",
+          "title": "Access from your phone (LAN / Tailscale)"
+        },
+        {
           "path": "guides/headless.md",
           "title": "Run headless (API + A2A)"
         }


### PR DESCRIPTION
## What

Answers a recurring question — *"how do I get to my agent from my phone?"* — by stitching the already-shipped pieces (loopback-default bind, `A2A_AUTH_TOKEN`, the manifest-only PWA, tailnet discovery) into one how-to, and documenting the public-hostname escape hatch.

### New guide — `docs/guides/phone-access.md`
**Access from your phone (LAN / Tailscale).** Three steps:
1. Bind a routable interface behind `A2A_AUTH_TOKEN` (the boot gate refuses a non-loopback bind without a token).
2. Reach the console over the **LAN** (`192.168.x.x`) or, recommended for off-LAN, **Tailscale** (`100.x.x.x` / MagicDNS — encrypted, no port-forwarding, no public surface).
3. **Add to Home Screen** (iOS Safari / Android Chrome), with the deliberate **no-service-worker / no-offline** trade-off called out (a SW would cache stale assets + sit in front of the `/a2a` SSE stream).

### New section — `docs/guides/deploy-docker.md`
**Expose it with a tunnel (ngrok / Cloudflare).** For a *public hostname* when Tailscale-on-the-client isn't an option: keep the bearer token, set `A2A_PUBLIC_URL`, mind `A2A_ALLOWED_ORIGINS`, and layer the tunnel's own access control. Explicitly framed as the "going further" path — **Tailscale is the recommended default** for personal phone access; the tunnel is only for sharing a real URL.

### Wiring
- Added to the guides index (`docs/guides/index.md`, Console & UI group) + VitePress sidebar.
- Regenerated `plugins/docs/nav.json` (`scripts/gen_docs_nav.py`; `test_docs_plugin` asserts sync — `--check` passes).

## Notes
Docs-only. All cross-reference anchors match slugs already used elsewhere in the docs. No `ngrok`/`cloudflare` docs existed before; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)