### PR TITLE
feat(paths): two-tier InstancePaths resolver (box/instance) — config foundation

### DIFF
--- a/infra/paths.py
+++ b/infra/paths.py
@@ -20,6 +20,7 @@ import hashlib
 import os
 import re
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 _TRUTHY = {"1", "true", "yes", "on"}
@@ -407,3 +408,231 @@ def colocation_warning() -> str | None:
         "They can clobber each other's chat history, knowledge and stores — give each "
         "instance its own PROTOAGENT_INSTANCE id (or stop the extra one)."
     )
+
+
+# ── Two-tier instance paths (box / instance) ─────────────────────────────────
+# One resolution model that replaces the import-time path constants + the
+# scope_leaf/_config_scope double-scoping. Resolved ONCE from the environment into
+# an injectable, frozen object. Three tiers mirror the ADR-0047 cascade:
+#
+#   App      app_root/config        read-only bundle seed (example yaml, SOUL, presets)
+#   Box      box_root               machine-shared: host-config.yaml (Host layer),
+#                                    commons, heartbeats, data-version, cache
+#   Instance instance_root          per-agent: config leaf, plugins, every store
+#
+# Resolution (two orthogonal knobs — PROTOAGENT_HOME moves only the instance tier):
+#   box_root      = PROTOAGENT_BOX_ROOT  else  data_home()        # shared, never scoped
+#   instance_root = PROTOAGENT_HOME                               # terminal: the dir IS the root
+#                 | box_root / PROTOAGENT_INSTANCE                # named instance under the box
+#                 | box_root / "default"                         # neither → "default"
+#
+# instance_root IS the scoped leaf — scope_leaf is never applied to it, which is
+# what deletes the whole double-scope bug class.
+
+
+def _app_root() -> Path:
+    """Read-only bundle root: ``_MEIPASS`` when PyInstaller-frozen, else the repo
+    root (two levels up from this module)."""
+    import sys
+
+    if getattr(sys, "frozen", False):  # PyInstaller onefile — bundle at _MEIPASS (#894)
+        return Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parents[1]))
+    return Path(__file__).resolve().parents[1]
+
+
+def _box_root() -> Path:
+    """Machine-shared base: ``PROTOAGENT_BOX_ROOT`` override else ``data_home()``.
+    Never scoped — the Host cascade layer + commons live here, inherited by every
+    instance this machine owns (the default, the dev sandbox, every fleet member)."""
+    raw = os.environ.get("PROTOAGENT_BOX_ROOT", "").strip()
+    return Path(raw).expanduser() if raw else data_home()
+
+
+@dataclass(frozen=True)
+class InstancePaths:
+    """Every on-disk location for one agent instance, resolved once from the
+    environment (see ``instance_paths()``). Derived accessors compose the three
+    roots; nothing here is computed at import time."""
+
+    instance_id: str
+    box_root: Path
+    instance_root: Path
+    app_root: Path
+
+    # ── App tier (read-only bundle seed) ──
+    @property
+    def bundle_dir(self) -> Path:
+        return self.app_root / "config"
+
+    @property
+    def config_example(self) -> Path:
+        return self.bundle_dir / "langgraph-config.example.yaml"
+
+    @property
+    def soul_source(self) -> Path:
+        return self.bundle_dir / "SOUL.md"
+
+    @property
+    def presets_dir(self) -> Path:
+        return self.bundle_dir / "soul-presets"
+
+    # ── Box tier (machine-shared) ──
+    @property
+    def host_config(self) -> Path:
+        raw = os.environ.get("PROTOAGENT_HOST_CONFIG", "").strip()
+        return Path(raw).expanduser() if raw else self.box_root / "host-config.yaml"
+
+    @property
+    def commons_dir(self) -> Path:
+        return self.box_root / "commons"
+
+    @property
+    def commons_skills_db(self) -> Path:
+        return self.commons_dir / "skills.db"
+
+    @property
+    def instances_dir(self) -> Path:
+        return self.box_root / ".instances"
+
+    @property
+    def data_version_file(self) -> Path:
+        return self.box_root / ".data-version"
+
+    @property
+    def cache_dir(self) -> Path:
+        return self.box_root / "cache"
+
+    # ── Instance tier (per-agent) ──
+    @property
+    def config_dir(self) -> Path:
+        return self.instance_root / "config"
+
+    @property
+    def config_yaml(self) -> Path:
+        return self.config_dir / "langgraph-config.yaml"
+
+    @property
+    def secrets_yaml(self) -> Path:
+        return self.config_dir / "secrets.yaml"
+
+    @property
+    def setup_marker(self) -> Path:
+        return self.config_dir / ".setup-complete"
+
+    @property
+    def theme_json(self) -> Path:
+        return self.config_dir / "theme.json"
+
+    @property
+    def soul_path(self) -> Path:
+        return self.config_dir / "SOUL.md"
+
+    @property
+    def plugins_dir(self) -> Path:
+        raw = os.environ.get("PROTOAGENT_PLUGINS_DIR", "").strip()
+        return Path(raw).expanduser() if raw else self.instance_root / "plugins"
+
+    @property
+    def plugins_lock(self) -> Path:
+        raw = os.environ.get("PROTOAGENT_PLUGINS_LOCK", "").strip()
+        return Path(raw).expanduser() if raw else self.instance_root / "plugins.lock"
+
+    @property
+    def workspace_dir(self) -> Path:
+        """Fenced filesystem-toolset sandbox (the agent's working dir)."""
+        raw = os.environ.get("PROTOAGENT_WORKSPACE", "").strip()
+        return Path(raw).expanduser() if raw else self.instance_root / "workspace"
+
+    @property
+    def skills_dir(self) -> Path:
+        return self.instance_root / "skills"
+
+    @property
+    def instance_uid_file(self) -> Path:
+        return self.instance_root / ".instance-uid"
+
+    # Fleet registry — HUB-instance-scoped (NOT box-shared). A member's instance_root
+    # has its own (empty) workspaces/, so the supervisor's shutdown_all stays "hub-only
+    # by construction" — a booting member can't read the hub registry and SIGTERM siblings.
+    @property
+    def workspaces_dir(self) -> Path:
+        return self.instance_root / "workspaces"
+
+    @property
+    def fleet_json(self) -> Path:
+        return self.workspaces_dir / "fleet.json"
+
+    @property
+    def remotes_json(self) -> Path:
+        return self.workspaces_dir / "remotes.json"
+
+    def store(self, name: str) -> Path:
+        """A per-instance store path under ``instance_root`` (e.g. ``store("knowledge")``)."""
+        return self.instance_root / name
+
+    def explain(self) -> dict:
+        """Flat dict of id + roots + every resolved path (powers ``config explain``)."""
+        return {
+            "instance_id": self.instance_id,
+            "box_root": str(self.box_root),
+            "instance_root": str(self.instance_root),
+            "app_root": str(self.app_root),
+            "paths": {
+                "config_yaml": str(self.config_yaml),
+                "secrets_yaml": str(self.secrets_yaml),
+                "setup_marker": str(self.setup_marker),
+                "theme_json": str(self.theme_json),
+                "soul_path": str(self.soul_path),
+                "plugins_dir": str(self.plugins_dir),
+                "plugins_lock": str(self.plugins_lock),
+                "workspace_dir": str(self.workspace_dir),
+                "skills_dir": str(self.skills_dir),
+                "workspaces_dir": str(self.workspaces_dir),
+                "fleet_json": str(self.fleet_json),
+                "host_config": str(self.host_config),
+                "commons_dir": str(self.commons_dir),
+                "instances_dir": str(self.instances_dir),
+                "data_version_file": str(self.data_version_file),
+                "cache_dir": str(self.cache_dir),
+                "bundle_dir": str(self.bundle_dir),
+            },
+        }
+
+
+def _resolve_instance_paths() -> InstancePaths:
+    box = _box_root()
+    home = os.environ.get("PROTOAGENT_HOME", "").strip()
+    inst = os.environ.get("PROTOAGENT_INSTANCE", "").strip()
+    if home:
+        root = Path(home).expanduser()
+        iid = _safe_segment(inst) if inst else _safe_segment(root.name)
+    elif inst:
+        iid = _safe_segment(inst)
+        root = box / iid
+    else:
+        iid = "default"
+        root = box / "default"
+    return InstancePaths(instance_id=iid, box_root=box, instance_root=root, app_root=_app_root())
+
+
+_CURRENT_PATHS: InstancePaths | None = None
+
+
+def instance_paths() -> InstancePaths:
+    """The resolved paths for THIS process — resolved once from the environment on
+    first call, then cached. Identity comes from env only (``PROTOAGENT_HOME`` /
+    ``PROTOAGENT_INSTANCE`` / ``PROTOAGENT_BOX_ROOT``), never from config-file
+    content, so a correctly-scoped config is read on the first try (no
+    chicken-and-egg, no ``_seed_instance_env`` re-scope window)."""
+    global _CURRENT_PATHS
+    if _CURRENT_PATHS is None:
+        _CURRENT_PATHS = _resolve_instance_paths()
+    return _CURRENT_PATHS
+
+
+def reset_instance_paths() -> None:
+    """Clear the cached singleton so the next ``instance_paths()`` re-resolves from
+    the (possibly monkeypatched) environment. Any test that sets a ``PROTOAGENT_*``
+    root var or patches ``data_home`` MUST call this — use the autouse fixture."""
+    global _CURRENT_PATHS
+    _CURRENT_PATHS = None

--- a/tests/test_instance_paths.py
+++ b/tests/test_instance_paths.py
@@ -1,0 +1,183 @@
+"""Tests for the two-tier (box / instance) path resolution — ``infra.paths.InstancePaths``.
+
+Covers the four deployment shapes (HOME / INSTANCE / default / frozen), the
+box-vs-instance split, the env overrides, and the cached-singleton hygiene that
+``reset_instance_paths()`` guarantees.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import infra.paths as paths
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch, tmp_path):
+    """Pin box_root to a tmp dir, clear every root env var, and reset the cached
+    singleton before AND after each test so resolution is deterministic and never
+    leaks the dev shell's PROTOAGENT_INSTANCE."""
+    box = tmp_path / "box"
+    box.mkdir()
+    monkeypatch.setattr(paths, "data_home", lambda: box)
+    for var in (
+        "PROTOAGENT_HOME",
+        "PROTOAGENT_INSTANCE",
+        "PROTOAGENT_BOX_ROOT",
+        "PROTOAGENT_HOST_CONFIG",
+        "PROTOAGENT_PLUGINS_DIR",
+        "PROTOAGENT_PLUGINS_LOCK",
+        "PROTOAGENT_WORKSPACE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    paths.reset_instance_paths()
+    yield box
+    paths.reset_instance_paths()
+
+
+def test_default_shape(_isolate):
+    box = _isolate
+    p = paths.instance_paths()
+    assert p.instance_id == "default"
+    assert p.box_root == box
+    assert p.instance_root == box / "default"
+    # config + plugins + every store sit under the instance root
+    assert p.config_yaml == box / "default" / "config" / "langgraph-config.yaml"
+    assert p.secrets_yaml == box / "default" / "config" / "secrets.yaml"
+    assert p.plugins_dir == box / "default" / "plugins"
+    assert p.store("knowledge") == box / "default" / "knowledge"
+
+
+def test_instance_shape(monkeypatch, _isolate):
+    box = _isolate
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "alice")
+    paths.reset_instance_paths()
+    p = paths.instance_paths()
+    assert p.instance_id == "alice"
+    assert p.box_root == box
+    assert p.instance_root == box / "alice"
+    assert p.config_yaml == box / "alice" / "config" / "langgraph-config.yaml"
+
+
+def test_home_shape_is_terminal(monkeypatch, tmp_path, _isolate):
+    """PROTOAGENT_HOME relocates ONLY the instance tier; box_root stays data_home()."""
+    box = _isolate
+    home = tmp_path / "app-data"
+    monkeypatch.setenv("PROTOAGENT_HOME", str(home))
+    paths.reset_instance_paths()
+    p = paths.instance_paths()
+    assert p.instance_root == home
+    assert p.instance_id == "app-data"  # basename of HOME
+    assert p.box_root == box  # NOT moved by HOME
+    assert p.config_yaml == home / "config" / "langgraph-config.yaml"
+
+
+def test_home_plus_instance_is_fleet_member(monkeypatch, tmp_path, _isolate):
+    """Fleet member: HOME=<workspace> + INSTANCE=<wid>. Root is the workspace,
+    id is the workspace id, and the box tier is still the shared data home."""
+    box = _isolate
+    ws = tmp_path / "workspaces" / "ava-7f3a"
+    monkeypatch.setenv("PROTOAGENT_HOME", str(ws))
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "ava-7f3a")
+    paths.reset_instance_paths()
+    p = paths.instance_paths()
+    assert p.instance_root == ws
+    assert p.instance_id == "ava-7f3a"
+    assert p.box_root == box
+    # the member shares the box-level host layer + commons with the hub
+    assert p.host_config == box / "host-config.yaml"
+    assert p.commons_dir == box / "commons"
+
+
+def test_box_root_override(monkeypatch, tmp_path, _isolate):
+    other = tmp_path / "other-box"
+    monkeypatch.setenv("PROTOAGENT_BOX_ROOT", str(other))
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "dev")
+    paths.reset_instance_paths()
+    p = paths.instance_paths()
+    assert p.box_root == other
+    assert p.instance_root == other / "dev"
+    assert p.host_config == other / "host-config.yaml"
+
+
+def test_box_tier_is_shared_not_under_instance(_isolate):
+    """host-config / commons / heartbeats / data-version live at box_root, NOT under
+    the instance root (the machine-wide Host layer + shared library)."""
+    box = _isolate
+    p = paths.instance_paths()
+    assert p.host_config == box / "host-config.yaml"
+    assert p.commons_dir == box / "commons"
+    assert p.commons_skills_db == box / "commons" / "skills.db"
+    assert p.instances_dir == box / ".instances"
+    assert p.data_version_file == box / ".data-version"
+    # explicitly NOT nested under the instance root
+    assert p.instance_root not in p.host_config.parents
+
+
+def test_fleet_registry_is_hub_instance_scoped(_isolate):
+    """fleet.json / workspaces live under the instance root (the hub's), so a member's
+    own (empty) workspaces/ keeps shutdown_all hub-only by construction."""
+    box = _isolate
+    p = paths.instance_paths()
+    assert p.workspaces_dir == box / "default" / "workspaces"
+    assert p.fleet_json == box / "default" / "workspaces" / "fleet.json"
+    assert p.remotes_json == box / "default" / "workspaces" / "remotes.json"
+
+
+def test_env_overrides(monkeypatch, tmp_path, _isolate):
+    monkeypatch.setenv("PROTOAGENT_HOST_CONFIG", str(tmp_path / "h.yaml"))
+    monkeypatch.setenv("PROTOAGENT_PLUGINS_DIR", str(tmp_path / "plug"))
+    monkeypatch.setenv("PROTOAGENT_PLUGINS_LOCK", str(tmp_path / "plug.lock"))
+    monkeypatch.setenv("PROTOAGENT_WORKSPACE", str(tmp_path / "fence"))
+    paths.reset_instance_paths()
+    p = paths.instance_paths()
+    assert p.host_config == tmp_path / "h.yaml"
+    assert p.plugins_dir == tmp_path / "plug"
+    assert p.plugins_lock == tmp_path / "plug.lock"
+    assert p.workspace_dir == tmp_path / "fence"
+
+
+def test_frozen_app_root(monkeypatch, tmp_path, _isolate):
+    """When PyInstaller-frozen, app_root is _MEIPASS; otherwise the repo root."""
+    meipass = tmp_path / "meipass"
+    monkeypatch.setattr(paths.sys if hasattr(paths, "sys") else __import__("sys"), "frozen", True, raising=False)
+    monkeypatch.setattr(__import__("sys"), "_MEIPASS", str(meipass), raising=False)
+    paths.reset_instance_paths()
+    p = paths.instance_paths()
+    assert p.app_root == meipass
+    assert p.config_example == meipass / "config" / "langgraph-config.example.yaml"
+
+
+def test_app_root_is_repo_when_not_frozen(_isolate):
+    p = paths.instance_paths()
+    # the repo root holds pyproject.toml + the config bundle dir
+    assert (p.app_root / "pyproject.toml").exists()
+    assert p.bundle_dir == p.app_root / "config"
+
+
+def test_singleton_is_cached_and_resettable(monkeypatch, _isolate):
+    first = paths.instance_paths()
+    assert paths.instance_paths() is first  # cached
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "bob")
+    assert paths.instance_paths() is first  # still cached — env change not seen yet
+    paths.reset_instance_paths()
+    second = paths.instance_paths()
+    assert second is not first
+    assert second.instance_id == "bob"
+
+
+def test_id_is_path_safe(monkeypatch, _isolate):
+    box = _isolate
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "../../etc/evil")
+    paths.reset_instance_paths()
+    p = paths.instance_paths()
+    assert "/" not in p.instance_id
+    assert p.instance_root.parent == box  # stays a single leaf under the box
+
+
+def test_explain_shape(_isolate):
+    p = paths.instance_paths()
+    ex = p.explain()
+    assert ex["instance_id"] == "default"
+    assert set(ex) == {"instance_id", "box_root", "instance_root", "app_root", "paths"}
+    assert ex["paths"]["config_yaml"].endswith("default/config/langgraph-config.yaml")


### PR DESCRIPTION
## What

Adds `InstancePaths` to `infra/paths.py` — **one resolution model** for every on-disk location of an agent instance, resolved **once** from the environment into a frozen, injectable object. This is the foundation under the fleet/multi-agent work (#1459 footgun class).

Three tiers mirror the ADR-0047 cascade:

| Tier | Root | Holds |
|---|---|---|
| **App** | `app_root/config` | read-only bundle seed (example yaml, SOUL source, presets) |
| **Box** (machine-shared) | `box_root` | `host-config.yaml` (Host layer), `commons/`, `.instances/`, `.data-version`, cache |
| **Instance** (per-agent) | `instance_root` | config leaf, `secrets.yaml`, plugins, **every** per-instance store |

**Two orthogonal knobs** — `PROTOAGENT_HOME` moves *only* the instance tier:
```
box_root      = PROTOAGENT_BOX_ROOT else data_home()          # shared, never scoped
instance_root = PROTOAGENT_HOME                               # terminal: the dir IS the root
              | box_root / PROTOAGENT_INSTANCE                # named instance
              | box_root / "default"                         # neither → "default"
```

`instance_root` **is** the scoped leaf — `scope_leaf` is never applied to it, which deletes the whole double-scope bug class that `_reset_double_scoped_config` (the self-heal that deleted a live dev key) papered over. Identity is derived from **env only**, never config-file content — killing the chicken-and-egg that forced `_seed_instance_env`.

## Why now

Fleet members are launched with `CONFIG_DIR`+`INSTANCE` together — exactly the collision the old double-scoping mishandled. A clean, observable path model is the prerequisite for hardening the cross-machine fleet (see the approved plan).

## Scope

**Purely additive** — nothing consumes `InstancePaths` yet. The config-tier cutover (constants→functions, deletions, launcher env) lands in the follow-up keystone PR. `instance_paths()` caches a lazy singleton; `reset_instance_paths()` re-resolves for tests.

## Tests

`tests/test_instance_paths.py` — 13 tests covering the four shapes (HOME / INSTANCE / default / frozen), the box-vs-instance split, env overrides, path-safe id sanitization, and singleton hygiene. All green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more flexible instance path system that cleanly separates shared app locations from per-instance locations.
  * Environment variables can now control the box root, home directory, and instance ID, with sensible defaults when unset.

* **Bug Fixes**
  * Improved path resolution so shared resources stay outside instance-specific folders.
  * Added safer handling for instance names to prevent invalid path traversal.

* **Tests**
  * Added coverage for default paths, environment overrides, caching behavior, and frozen vs. non-frozen app startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->