### PR TITLE
feat(hitl): autonomous-turn guard + multi-step wizard / choice-card forms

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -787,6 +787,22 @@ function ChatSessionSlot({
     );
   }
 
+  // Dismiss a paused (input-required) form/question WITHOUT answering it. Clearing the card
+  // alone would leave the task parked in input-required forever — that state is exempt from
+  // the server TTL sweep, so the LangGraph thread would never settle. Instead RESUME the turn
+  // with an explicit "dismissed" sentinel so the agent continues and the task reaches a
+  // terminal state. A dismissal isn't conversation content, so resume silently and continue
+  // the paused assistant message (matching the approval-resume path) rather than minting a
+  // new bubble.
+  async function dismissHitl() {
+    setHitl(null);
+    void runTurn(
+      "[dismissed] The operator dismissed this request without providing input. Continue " +
+        "without it — proceed using your best judgment, or stop and explain what you need.",
+      { hidden: true, resumeMessageId: lastAssistantId },
+    );
+  }
+
   async function runTurn(
     content: string,
     opts: {
@@ -1147,7 +1163,7 @@ function ChatSessionSlot({
           payload={hitl}
           busy={status === "streaming"}
           onSubmit={resumeHitl}
-          onCancel={() => setHitl(null)}
+          onCancel={dismissHitl}
           onApproveAlways={
             hitl.kind === "approval" && session
               ? () => {

--- a/apps/web/src/chat/HitlForm.tsx
+++ b/apps/web/src/chat/HitlForm.tsx
@@ -4,31 +4,23 @@ import { Button } from "@protolabsai/ui/primitives";
 import { useState } from "react";
 
 
-import type { HitlFormStep, HitlPayload } from "../lib/types";
+import type { HitlPayload } from "../lib/types";
+import {
+  type FieldSchema,
+  anyStepMissing,
+  fieldsOf,
+  isCardChoice,
+  isMultiChoice,
+  missingInStep,
+  optionsOf,
+} from "./hitl-form";
 
-// A lightweight JSON-schema form for HITL requests (request_user_input) and a
-// plain prompt for ask_human. Renders the common field types
-// (string/number/boolean/enum/textarea) — not a full @rjsf, but enough for the
-// config/choice/approval forms agents actually ask for. Multi-step = a single
-// scrollable form (all steps collected, submitted together).
-
-type FieldSchema = {
-  type?: string;
-  title?: string;
-  description?: string;
-  enum?: unknown[];
-  format?: string;
-  default?: unknown;
-};
-
-function fieldsOf(step: HitlFormStep): Array<[string, FieldSchema, boolean]> {
-  const schema = (step.schema || {}) as {
-    properties?: Record<string, FieldSchema>;
-    required?: string[];
-  };
-  const required = new Set(schema.required || []);
-  return Object.entries(schema.properties || {}).map(([key, fs]) => [key, fs, required.has(key)]);
-}
+// A lightweight JSON-schema form for HITL requests (request_user_input) and a plain prompt
+// for ask_human. Renders the common field types (string/number/boolean/enum/textarea) plus
+// AskUserQuestion-style option cards (a field with `oneOf` [{const,title,description}], single
+// or multi-select). Multi-step payloads render as a sequential Back/Next wizard with a step
+// indicator; a single step shows just the fields + Submit. All steps' answers are collected
+// into one object and submitted together.
 
 function Field({
   name,
@@ -44,6 +36,58 @@ function Field({
   onChange: (v: unknown) => void;
 }) {
   const label = (schema.title || name) + (required ? " *" : "");
+
+  // Option cards (AskUserQuestion-style): single-select (radio) or multi-select (checkbox).
+  if (isCardChoice(schema)) {
+    const multi = isMultiChoice(schema);
+    const selected = new Set(
+      multi
+        ? (Array.isArray(value) ? value : []).map(String)
+        : value != null && value !== ""
+          ? [String(value)]
+          : [],
+    );
+    const toggle = (v: string) => {
+      if (!multi) {
+        onChange(v);
+        return;
+      }
+      const next = new Set(selected);
+      if (next.has(v)) next.delete(v);
+      else next.add(v);
+      onChange([...next]);
+    };
+    return (
+      <div className="hitl-field hitl-field-choice">
+        <span>{label}</span>
+        <div className="hitl-cards" role={multi ? "group" : "radiogroup"} aria-label={schema.title || name}>
+          {optionsOf(schema).map((opt) => {
+            const on = selected.has(opt.value);
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                className="hitl-card-option"
+                role={multi ? "checkbox" : "radio"}
+                aria-checked={on}
+                data-selected={on || undefined}
+                onClick={() => toggle(opt.value)}
+              >
+                <span className="hitl-card-mark" aria-hidden>
+                  {on ? (multi ? "☑" : "◉") : multi ? "☐" : "○"}
+                </span>
+                <span className="hitl-card-body">
+                  <span className="hitl-card-label">{opt.label}</span>
+                  {opt.description && <span className="hitl-card-desc">{opt.description}</span>}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        {schema.description && <small>{schema.description}</small>}
+      </div>
+    );
+  }
 
   if (schema.type === "boolean") {
     return (
@@ -104,10 +148,12 @@ export function HitlForm({
   // bypass-permissions for the tab (skip future approvals). Omitted ⇒ the button is hidden.
   onApproveAlways?: () => void;
 }) {
-  const isForm = payload.kind === "form" && (payload.steps?.length ?? 0) > 0;
+  const steps = payload.steps || [];
+  const isForm = payload.kind === "form" && steps.length > 0;
   const isApproval = payload.kind === "approval";
   const [values, setValues] = useState<Record<string, unknown>>({});
   const [text, setText] = useState("");
+  const [current, setCurrent] = useState(0);
 
   // Approval gate (e.g. run_command) — Approve / Deny on the action.
   if (isApproval) {
@@ -171,44 +217,87 @@ export function HitlForm({
     );
   }
 
+  // request_user_input — a stepped wizard. One step per screen with Back/Next; the last step
+  // submits all collected answers together. A single step drops the navigation chrome.
   const set = (k: string, v: unknown) => setValues((prev) => ({ ...prev, [k]: v }));
-  // Required fields across all steps must be filled before submit.
-  const missing = (payload.steps || []).some((step) =>
-    fieldsOf(step).some(([key, , req]) => req && (values[key] === undefined || values[key] === "")),
-  );
+  const stepIdx = Math.min(current, steps.length - 1);
+  const step = steps[stepIdx];
+  const onLast = stepIdx >= steps.length - 1;
+  const stepBlocked = missingInStep(step, values).length > 0; // gates Next on this step
+  const submitBlocked = anyStepMissing(steps, values); // gates final Submit across all steps
+  const multiStep = steps.length > 1;
 
   return (
     <div className="hitl-card" role="dialog" aria-label={payload.title || "Form requested"}>
-      <div className="hitl-title">{payload.title || "Input requested"}</div>
+      <div className="hitl-wizard-head">
+        <div className="hitl-title">{payload.title || "Input requested"}</div>
+        {multiStep && (
+          <div className="hitl-stepper" aria-label={`Step ${stepIdx + 1} of ${steps.length}`}>
+            <span className="hitl-step-count">
+              Step {stepIdx + 1} / {steps.length}
+            </span>
+            <span className="hitl-dots" aria-hidden>
+              {steps.map((_, i) => (
+                <span
+                  key={i}
+                  className="hitl-dot"
+                  data-state={i === stepIdx ? "active" : i < stepIdx ? "done" : "todo"}
+                />
+              ))}
+            </span>
+          </div>
+        )}
+      </div>
       {payload.description && <div className="hitl-prompt">{payload.description}</div>}
-      {(payload.steps || []).map((step, i) => (
-        <div className="hitl-step" key={i}>
-          {step.title && <div className="hitl-step-title">{step.title}</div>}
-          {step.description && <div className="hitl-prompt">{step.description}</div>}
-          {fieldsOf(step).map(([key, schema, req]) => (
-            <Field
-              key={key}
-              name={key}
-              schema={schema}
-              required={req}
-              value={values[key]}
-              onChange={(v) => set(key, v)}
-            />
-          ))}
-        </div>
-      ))}
+
+      <div className="hitl-step" key={stepIdx}>
+        {step.title && <div className="hitl-step-title">{step.title}</div>}
+        {step.description && <div className="hitl-prompt">{step.description}</div>}
+        {fieldsOf(step).map(([key, schema, req]) => (
+          <Field
+            key={key}
+            name={key}
+            schema={schema}
+            required={req}
+            value={values[key]}
+            onChange={(v) => set(key, v)}
+          />
+        ))}
+      </div>
+
       <div className="hitl-actions">
         <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>
           Dismiss
         </Button>
-        <Button
-          type="button"
-          variant="primary"
-          onClick={() => onSubmit(values)}
-          disabled={busy || missing}
-        >
-          Submit
-        </Button>
+        {multiStep && stepIdx > 0 && (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setCurrent((c) => Math.max(0, c - 1))}
+            disabled={busy}
+          >
+            Back
+          </Button>
+        )}
+        {!onLast ? (
+          <Button
+            type="button"
+            variant="primary"
+            onClick={() => setCurrent((c) => Math.min(steps.length - 1, c + 1))}
+            disabled={busy || stepBlocked}
+          >
+            Next
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="primary"
+            onClick={() => onSubmit(values)}
+            disabled={busy || submitBlocked}
+          >
+            Submit
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/chat/hitl-form.test.ts
+++ b/apps/web/src/chat/hitl-form.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import type { HitlFormStep } from "../lib/types";
+import {
+  anyStepMissing,
+  fieldsOf,
+  hasValue,
+  isCardChoice,
+  isMultiChoice,
+  missingInStep,
+  optionsOf,
+} from "./hitl-form";
+
+const step = (schema: Record<string, unknown>): HitlFormStep => ({ schema });
+
+describe("fieldsOf", () => {
+  it("returns [key, schema, required] for each property", () => {
+    const s = step({
+      properties: { env: { type: "string" }, note: { type: "string" } },
+      required: ["env"],
+    });
+    expect(fieldsOf(s)).toEqual([
+      ["env", { type: "string" }, true],
+      ["note", { type: "string" }, false],
+    ]);
+  });
+
+  it("is empty for an undefined step or a step with no properties", () => {
+    expect(fieldsOf(undefined)).toEqual([]);
+    expect(fieldsOf(step({}))).toEqual([]);
+  });
+});
+
+describe("optionsOf", () => {
+  it("normalizes rich oneOf options (value/label/description)", () => {
+    const schema = {
+      type: "string",
+      oneOf: [
+        { const: "pg", title: "Postgres", description: "Durable" },
+        { const: "sqlite", title: "SQLite" },
+      ],
+    };
+    expect(optionsOf(schema)).toEqual([
+      { value: "pg", label: "Postgres", description: "Durable" },
+      { value: "sqlite", label: "SQLite", description: undefined },
+    ]);
+  });
+
+  it("falls back to a plain enum (label === value, no description)", () => {
+    expect(optionsOf({ type: "string", enum: ["a", "b"] })).toEqual([
+      { value: "a", label: "a" },
+      { value: "b", label: "b" },
+    ]);
+  });
+
+  it("reads options off `items` for a multi-select array", () => {
+    const schema = { type: "array", items: { oneOf: [{ const: "x", title: "X" }] } };
+    expect(optionsOf(schema)).toEqual([{ value: "x", label: "X", description: undefined }]);
+  });
+});
+
+describe("isCardChoice / isMultiChoice", () => {
+  it("treats oneOf and x-display:cards as cards, but a bare single enum as a dropdown", () => {
+    expect(isCardChoice({ type: "string", oneOf: [{ const: "a" }] })).toBe(true);
+    expect(isCardChoice({ type: "string", enum: ["a"], "x-display": "cards" })).toBe(true);
+    expect(isCardChoice({ type: "string", enum: ["a"] })).toBe(false); // dropdown
+    expect(isCardChoice({ type: "string" })).toBe(false);
+  });
+
+  it("renders any multi-select (array) of options as cards", () => {
+    expect(isMultiChoice({ type: "array" })).toBe(true);
+    expect(isCardChoice({ type: "array", items: { enum: ["a", "b"] } })).toBe(true);
+  });
+});
+
+describe("hasValue", () => {
+  it("booleans are always answered (unchecked = a valid false)", () => {
+    expect(hasValue({ type: "boolean" }, undefined)).toBe(true);
+    expect(hasValue({ type: "boolean" }, false)).toBe(true);
+  });
+
+  it("multi-select needs at least one selection", () => {
+    expect(hasValue({ type: "array" }, [])).toBe(false);
+    expect(hasValue({ type: "array" }, ["a"])).toBe(true);
+  });
+
+  it("scalar fields need a non-empty value", () => {
+    expect(hasValue({ type: "string" }, "")).toBe(false);
+    expect(hasValue({ type: "string" }, undefined)).toBe(false);
+    expect(hasValue({ type: "string" }, "x")).toBe(true);
+    expect(hasValue({ type: "number" }, 0)).toBe(true); // 0 is a real answer
+  });
+});
+
+describe("missingInStep / anyStepMissing", () => {
+  const s1 = step({ properties: { env: { type: "string" } }, required: ["env"] });
+  const s2 = step({ properties: { region: { type: "array" } }, required: ["region"] });
+
+  it("reports required fields that are still empty in a step", () => {
+    expect(missingInStep(s1, {})).toEqual(["env"]);
+    expect(missingInStep(s1, { env: "prod" })).toEqual([]);
+  });
+
+  it("ignores empty optional fields", () => {
+    const opt = step({ properties: { note: { type: "string" } } });
+    expect(missingInStep(opt, {})).toEqual([]);
+  });
+
+  it("gates the final submit until every step is satisfied", () => {
+    expect(anyStepMissing([s1, s2], { env: "prod" })).toBe(true); // region still missing
+    expect(anyStepMissing([s1, s2], { env: "prod", region: ["eu"] })).toBe(false);
+  });
+});

--- a/apps/web/src/chat/hitl-form.ts
+++ b/apps/web/src/chat/hitl-form.ts
@@ -1,0 +1,92 @@
+// Pure logic for the HITL wizard (request_user_input) — kept out of HitlForm.tsx so it can
+// be unit-tested (the web suite runs `src/**/*.test.ts`, no React renderer). Covers reading a
+// step's fields, normalizing choice options (AskUserQuestion-style cards), and per-step
+// required-field validation that gates Back/Next/Submit.
+
+import type { HitlFormStep } from "../lib/types";
+
+export type FieldSchema = {
+  type?: string;
+  title?: string;
+  description?: string;
+  enum?: unknown[];
+  // JSON-schema-idiomatic labelled options (rjsf convention): each is a value + human label
+  // + optional description. Presence of `oneOf` is what turns a field into option cards.
+  oneOf?: Array<{ const?: unknown; title?: string; description?: string }>;
+  items?: FieldSchema; // element schema for a multi-select (`type: "array"`)
+  format?: string;
+  default?: unknown;
+  // Opt a bare `enum` into card rendering (otherwise an enum stays a dropdown).
+  "x-display"?: string;
+};
+
+export type FieldEntry = [key: string, schema: FieldSchema, required: boolean];
+
+export type ChoiceOption = { value: string; label: string; description?: string };
+
+/** `[key, schema, required]` for every property declared in a step's JSON schema. */
+export function fieldsOf(step: HitlFormStep | undefined): FieldEntry[] {
+  const schema = (step?.schema || {}) as {
+    properties?: Record<string, FieldSchema>;
+    required?: string[];
+  };
+  const required = new Set(schema.required || []);
+  return Object.entries(schema.properties || {}).map(([key, fs]) => [key, fs, required.has(key)]);
+}
+
+/** A multi-select choice is a JSON-schema array; its options live on `items`. */
+export function isMultiChoice(schema: FieldSchema): boolean {
+  return schema?.type === "array";
+}
+
+/** The schema that actually carries the options (the element schema for multi-select). */
+function optionSource(schema: FieldSchema): FieldSchema {
+  return isMultiChoice(schema) ? (schema.items as FieldSchema) || {} : schema;
+}
+
+/** Normalized option cards from `oneOf` [{const,title,description}] (preferred, carries
+ *  descriptions) or a plain `enum` (label only). Empty when the field isn't a choice. */
+export function optionsOf(schema: FieldSchema): ChoiceOption[] {
+  const src = optionSource(schema);
+  if (Array.isArray(src?.oneOf)) {
+    return src.oneOf.map((o) => ({
+      value: String(o.const ?? o.title ?? ""),
+      label: String(o.title ?? o.const ?? ""),
+      description: o.description ? String(o.description) : undefined,
+    }));
+  }
+  if (Array.isArray(src?.enum)) {
+    return src.enum.map((v) => ({ value: String(v), label: String(v) }));
+  }
+  return [];
+}
+
+/** Render this field as option cards rather than a dropdown/input? Cards when it has
+ *  rich `oneOf` options, is explicitly `x-display: "cards"`, or is any multi-select
+ *  (there's no native multi-dropdown). A bare single-select `enum` stays a dropdown. */
+export function isCardChoice(schema: FieldSchema): boolean {
+  const src = optionSource(schema);
+  if (isMultiChoice(schema)) return Array.isArray(src?.oneOf) || Array.isArray(src?.enum);
+  return Array.isArray(src?.oneOf) || schema?.["x-display"] === "cards";
+}
+
+/** Is a single field's value present (for required-gating)? A boolean is always answered
+ *  (unchecked = a valid `false`); a multi-select needs ≥1 selection; everything else needs
+ *  a non-empty value. */
+export function hasValue(schema: FieldSchema, value: unknown): boolean {
+  if (isMultiChoice(schema)) return Array.isArray(value) && value.length > 0;
+  if (schema?.type === "boolean") return true;
+  return value !== undefined && value !== null && value !== "";
+}
+
+/** Required field keys in this step that are still empty — non-empty ⇒ block Next/Submit. */
+export function missingInStep(step: HitlFormStep | undefined, values: Record<string, unknown>): string[] {
+  return fieldsOf(step)
+    .filter(([key, schema, required]) => required && !hasValue(schema, values[key]))
+    .map(([key]) => key);
+}
+
+/** Any required field empty across ALL steps — gates the final Submit. */
+export function anyStepMissing(steps: HitlFormStep[], values: Record<string, unknown>): boolean {
+  return (steps || []).some((s) => missingInStep(s, values).length > 0);
+}

--- a/apps/web/src/chat/hitl.css
+++ b/apps/web/src/chat/hitl.css
@@ -92,3 +92,99 @@
   justify-content: flex-end;
   gap: 8px;
 }
+
+/* Wizard header + step indicator (multi-step request_user_input). */
+.hitl-wizard-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hitl-stepper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hitl-step-count {
+  font-size: 11px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+
+.hitl-dots {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.hitl-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--border);
+}
+
+.hitl-dot[data-state="active"] {
+  background: var(--brand-indigo, #6366f1);
+}
+
+.hitl-dot[data-state="done"] {
+  background: var(--fg-muted);
+}
+
+/* Option cards (AskUserQuestion-style choice fields). */
+.hitl-field-choice > span {
+  color: var(--fg-secondary);
+}
+
+.hitl-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px;
+}
+
+.hitl-card-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  text-align: left;
+  padding: 10px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+  transition: border-color 0.1s ease, background 0.1s ease;
+}
+
+.hitl-card-option:hover {
+  border-color: var(--brand-indigo, #6366f1);
+}
+
+.hitl-card-option[data-selected] {
+  border-color: var(--brand-indigo, #6366f1);
+  background: color-mix(in srgb, var(--brand-indigo, #6366f1) 12%, var(--bg));
+}
+
+.hitl-card-mark {
+  line-height: 1.2;
+  color: var(--brand-indigo, #6366f1);
+}
+
+.hitl-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hitl-card-label {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.hitl-card-desc {
+  font-size: 12px;
+  color: var(--fg-muted);
+}

--- a/server/chat.py
+++ b/server/chat.py
@@ -756,6 +756,25 @@ def _thread_lock(thread_id: str) -> asyncio.Lock:
     return lock
 
 
+# Origins (ADR 0022) whose turns run with NO operator watching the chat: a HITL pause
+# (ask_human / request_user_input) on one of these would park the task in input-required
+# FOREVER — and that state is deliberately exempt from the TTL sweep, so it never settles.
+# Live operator turns carry an empty origin (they keep parking — a human is watching);
+# inbound `a2a` calls are excluded too, because the remote caller can itself resume the
+# input-required task. For everything here, we auto-answer the interrupt instead of parking.
+_AUTONOMOUS_ORIGINS = frozenset({"scheduler", "inbox", "webhook", "background"})
+
+# What we resume an autonomous turn's HITL interrupt with, so the agent stops waiting and
+# finishes the turn instead of deadlocking. Bounded by the cap below so a model that keeps
+# re-asking can't auto-answer in an infinite loop (past the cap we fall back to parking).
+_AUTONOMOUS_HITL_SENTINEL = (
+    "[no interactive operator available] This turn is running autonomously "
+    "(scheduled / inbox / background), so no human can answer right now. Do not wait for "
+    "input — proceed using your best judgment and explicitly state any assumption you made."
+)
+_MAX_AUTONOMOUS_AUTOANSWERS = 3
+
+
 async def _run_native_turn(message, session_id, config, *, request_metadata=None, resume=False, images=None):
     """One native LangGraph turn (the non-ACP path): run the graph, the dropped-turn
     kicker retry, and goal-mode continuations, then yield the terminal confidence + done
@@ -777,28 +796,50 @@ async def _run_native_turn(message, session_id, config, *, request_metadata=None
     accumulated_raw = ""
     paused = False
     last_tool_out = ""  # streaming equivalent of _last_tool_text — the empty-turn fallback answer
+    # An autonomous turn (no operator watching) must never deadlock on a HITL pause: when one
+    # of these turns hits input_required we resume the graph with a "no operator" sentinel and
+    # run another pass, up to a cap, instead of parking the task forever (see _AUTONOMOUS_*).
+    _autonomous = ((request_metadata or {}).get("origin") or "").strip().lower() in _AUTONOMOUS_ORIGINS
+    _resume_value = (message if resume else None)
+    _auto_answers = 0
     with goal_turn(goal_active):
-        async for kind, payload in _run_turn_stream(
-            message,
-            session_id,
-            config,
-            resume_value=(message if resume else None),
-            images=images,
-            model=_model,
-            reasoning_effort=_effort,
-        ):
-            if kind == "__raw__":
-                accumulated_raw = payload
-            elif kind == "input_required":
-                # Agent paused for human input — surface it and park the turn; the A2A
-                # runner sets the task input-required and the caller resumes via
-                # message/send on the same taskId.
-                yield (kind, payload)
-                paused = True
-            else:
-                if kind == "tool_end" and isinstance(payload, dict) and payload.get("output"):
-                    last_tool_out = str(payload["output"])
-                yield (kind, payload)
+        while True:
+            _autoanswer_pending = False
+            async for kind, payload in _run_turn_stream(
+                message,
+                session_id,
+                config,
+                resume_value=_resume_value,
+                images=images,
+                model=_model,
+                reasoning_effort=_effort,
+            ):
+                if kind == "__raw__":
+                    accumulated_raw = payload
+                elif kind == "input_required":
+                    if _autonomous and _auto_answers < _MAX_AUTONOMOUS_AUTOANSWERS:
+                        # No human can answer — auto-answer this interrupt and re-run the turn
+                        # so it completes, rather than parking an (un-sweepable) input-required
+                        # task. The graph is checkpointed at the interrupt; the resume below
+                        # feeds the sentinel as ask_human / request_user_input's return value.
+                        _autoanswer_pending = True
+                    else:
+                        # Operator/a2a turn (or the auto-answer budget is spent): surface it and
+                        # park the turn; the A2A runner sets the task input-required and the
+                        # caller resumes via message/send on the same taskId.
+                        yield (kind, payload)
+                        paused = True
+                else:
+                    if kind == "tool_end" and isinstance(payload, dict) and payload.get("output"):
+                        last_tool_out = str(payload["output"])
+                    yield (kind, payload)
+            if not _autoanswer_pending:
+                break
+            # Resume past the interrupt with the no-operator sentinel and run another pass;
+            # images belong only to the first (fresh) pass, so drop them on resume.
+            _auto_answers += 1
+            _resume_value = _AUTONOMOUS_HITL_SENTINEL
+            images = None
 
     # A paused turn produced no final answer — don't run the dropped-scratch kicker or
     # goal verification; the task is parked.

--- a/tests/test_hitl_forms.py
+++ b/tests/test_hitl_forms.py
@@ -23,6 +23,16 @@ def test_request_user_input_in_deferred_base():
     assert "request_user_input" in DEFERRED_BASE_TOOL_NAMES
 
 
+def test_request_user_input_rejects_empty_steps():
+    # A zero-step form degrades to a bare free-text box (dropping the structured
+    # contract), so the tool guards it and returns guidance instead of interrupting.
+    from tools.lg_tools import request_user_input
+
+    out = request_user_input.invoke({"title": "Pick", "steps": []})
+    assert isinstance(out, str) and out.startswith("Error:")
+    assert "ask_human" in out
+
+
 # ── interrupt → input-required payload shaping ────────────────────────────────
 
 
@@ -42,3 +52,87 @@ def test_plain_value_degrades_to_question():
     # (never silently dropped).
     out = server._interrupt_payload({"foo": 1})
     assert "question" in out and "foo" in out["question"]
+
+
+# ── autonomous-turn HITL guard ────────────────────────────────────────────────
+# A scheduler/inbox/webhook/background turn has no operator watching the chat, so a HITL
+# pause would park the task in input-required forever (and that state is TTL-exempt). The
+# native turn must auto-answer the interrupt and complete instead of parking.
+
+import importlib
+
+import pytest
+
+from runtime.state import STATE
+
+# `server.chat` the attribute is shadowed by the re-exported `chat` function in
+# server/__init__.py, so resolve the actual submodule from sys.modules.
+chat_mod = importlib.import_module("server.chat")
+
+
+class _FakeTurnStream:
+    """Stand-in for ``_run_turn_stream``: records each pass's ``resume_value`` and yields a
+    HITL interrupt on the first (fresh) pass, then a real answer once resumed."""
+
+    def __init__(self):
+        self.resume_values: list = []
+
+    def __call__(self, message, session_id, config, *, resume_value=None, **_kw):
+        self.resume_values.append(resume_value)
+        first = len(self.resume_values) == 1
+
+        async def _gen():
+            if first:
+                yield ("input_required", {"question": "Which environment?"})
+            else:
+                yield ("text", "Proceeding with staging.")
+                yield ("__raw__", "Proceeding with staging.")
+
+        return _gen()
+
+
+async def _collect(agen):
+    return [frame async for frame in agen]
+
+
+@pytest.mark.asyncio
+async def test_autonomous_turn_auto_answers_hitl(monkeypatch):
+    # No goal controller → the goal-verification block is skipped; isolate the turn loop.
+    monkeypatch.setattr(STATE, "goal_controller", None, raising=False)
+    fake = _FakeTurnStream()
+    monkeypatch.setattr(chat_mod, "_run_turn_stream", fake)
+
+    frames = await _collect(
+        chat_mod._run_native_turn(
+            "run the deploy",
+            "s-auto",
+            {"configurable": {"thread_id": "t-auto"}},
+            request_metadata={"origin": "scheduler"},
+        )
+    )
+    kinds = [k for k, _ in frames]
+    assert "input_required" not in kinds  # never parks an autonomous turn
+    assert ("done", "Proceeding with staging.") in frames  # it ran to completion
+    # The interrupt was resumed with the no-operator sentinel (first pass is the fresh input).
+    assert fake.resume_values[0] is None
+    assert chat_mod._AUTONOMOUS_HITL_SENTINEL in fake.resume_values
+
+
+@pytest.mark.asyncio
+async def test_operator_turn_still_parks_on_hitl(monkeypatch):
+    monkeypatch.setattr(STATE, "goal_controller", None, raising=False)
+    fake = _FakeTurnStream()
+    monkeypatch.setattr(chat_mod, "_run_turn_stream", fake)
+
+    frames = await _collect(
+        chat_mod._run_native_turn(
+            "merge it",
+            "s-op",
+            {"configurable": {"thread_id": "t-op"}},
+            request_metadata={},  # empty origin = live operator → must still park
+        )
+    )
+    kinds = [k for k, _ in frames]
+    assert "input_required" in kinds  # parked for the human to answer
+    assert "done" not in kinds  # a parked turn yields no terminal answer
+    assert fake.resume_values == [None]  # never auto-resumed

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -65,6 +65,11 @@ def ask_human(question: str) -> str:
     from this call so you can continue. Do NOT use it for narration or status —
     only for an answer you must wait on. Phrase ``question`` as a clear,
     self-contained ask.
+
+    Autonomous turns (scheduled / inbox / background) have no operator watching the
+    chat, so don't block on a human here — prefer proceeding with your best judgment
+    and stating the assumption. (If you do ask on such a turn, the runtime
+    auto-answers it so the turn can't deadlock.)
     """
     # LangGraph HITL: interrupt() checkpoints the graph at this exact point. On
     # resume (Command(resume=answer)) it returns the operator's reply. Requires a
@@ -80,17 +85,47 @@ def request_user_input(title: str, steps: list[dict], description: str = "") -> 
     """Ask the operator for **structured** input via a form dialog, then continue
     with their response. Use when you need specific values, choices, credentials,
     or config — anything better captured as form fields than free text. The task
-    pauses (surfaced as ``input-required``) until they submit; their response (a
-    JSON object keyed by field name) is returned from this call.
+    pauses (surfaced as ``input-required``) until they submit; their response (the
+    submitted fields, as a JSON object) is returned from this call.
 
-    ``steps`` is a list of form steps — multiple steps render as a wizard. Each
-    step is ``{"schema": <JSON Schema draft-07 of the fields>, "uiSchema"?: <layout
-    hints>, "title"?: str, "description"?: str}``. Phrase the ask clearly and only
-    request fields you actually need. For a single free-text or yes/no question,
-    use ``ask_human`` instead.
+    ``steps`` is a list of form steps. Multiple steps render as a sequential
+    **wizard** (one step per screen with Back / Next and a progress indicator); the
+    operator advances through them and the final step submits every step's answers
+    together as one object. Use several steps to pace a longer series of questions;
+    use one step for a simple form. Each step is ``{"schema": <JSON Schema draft-07
+    of the step's fields>, "title"?: str, "description"?: str}`` — supply at least
+    one step that defines fields.
+
+    Field types (per property in a step's ``schema.properties``):
+    - text / number / boolean → ``{"type": "string"|"number"|"integer"|"boolean"}``;
+      add ``"format": "textarea"`` for multi-line text.
+    - **single-choice cards** (preferred for "pick one of these") →
+      ``{"type": "string", "oneOf": [{"const": "pg", "title": "Postgres",
+      "description": "Durable, multi-writer"}, {"const": "sqlite", "title": "SQLite",
+      "description": "Zero-config"}]}``. Each option shows its label + description as
+      a selectable card. (A bare ``"enum": [...]`` renders as a plain dropdown.)
+    - **multi-choice cards** ("pick any") → wrap the same options in an array:
+      ``{"type": "array", "items": {"oneOf": [...]}}`` → the value is a list.
+    Mark a field required via the step schema's ``"required": [...]``; required
+    fields gate Next / Submit.
+
+    Phrase the ask clearly and only request fields you actually need. For a single
+    free-text or yes/no question, use ``ask_human`` instead. As with ``ask_human``,
+    don't block on this in an autonomous turn — there may be no operator to submit
+    the form (the runtime auto-answers it there).
     """
     import json
     from langgraph.types import interrupt
+
+    # A form with no steps renders as a bare free-text box (the console treats zero-step
+    # payloads as an ask_human prompt), silently dropping the structured contract — guide
+    # the model back instead of degrading. The LLM reads this and retries.
+    if not steps:
+        return (
+            "Error: request_user_input needs at least one form step. Pass "
+            'steps=[{"schema": {"type": "object", "properties": {…}, "required": […]}}], '
+            "or use ask_human for a single free-text or yes/no question."
+        )
 
     response = interrupt(
         {
@@ -1089,10 +1124,11 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, tasks_
     Pass ``None`` to disable either subsystem — the lead agent runs
     fine with just the four keyless general tools.
     """
-    # ask_human is a lead-agent HITL tool — it pauses the A2A turn via a
-    # LangGraph interrupt that only the lead turn's runner resumes. Subagents
-    # (run outside that runner) must not get it, so it's gated by allowlist:
-    # present in the full set for the lead agent, absent from subagent allowlists.
+    # ask_human AND request_user_input are lead-agent HITL tools — each pauses the A2A
+    # turn via a LangGraph interrupt that only the lead turn's runner resumes. Subagents
+    # (run outside that runner, on a graph with no checkpointer) must not get either, so
+    # they're gated by allowlist: present in the full set for the lead agent, absent from
+    # every subagent allowlist in graph/subagents/config.py. Don't add them to one.
     # show_component (inline component rendering, ADR 0051 / #1323): table/keyvalue/timeline
     # widgets rendered inline in chat by the console's extensible component registry.
     tools = [current_time, calculator, web_search, fetch_url, ask_human, request_user_input, load_skill, show_component]


### PR DESCRIPTION
Hardens and extends the human-in-the-loop tools (`ask_human`, `request_user_input`), from an audit of the HITL surface plus a requested forms upgrade.

## Correctness fixes (audit)
- **Autonomous turns no longer deadlock on a HITL pause.** A `scheduler`/`inbox`/`webhook`/`background` turn (ADR 0022) has no operator watching the chat, so an `ask_human`/`request_user_input` interrupt would park the task in `input-required` **forever** — and that state is deliberately exempt from the TTL sweep (`test_task_ttl_sweep_preserves_hitl_pauses`). `_run_native_turn` now auto-answers such interrupts with a "no operator — proceed" sentinel (bounded by a cap; falls back to parking past it) so the turn completes. Live operator turns (empty origin) and inbound `a2a` calls (the remote caller can resume) still park as before.
- **"Dismiss" resolves the parked server task.** Dismissing a HITL card used to only clear it client-side, leaving the (un-sweepable) task parked. It now resumes the turn with an explicit "dismissed" sentinel so the LangGraph thread settles.
- **`request_user_input` rejects empty `steps=[]`** (it used to silently degrade to a bare free-text box, dropping the structured contract).
- **Docstrings:** warn against blocking in autonomous turns; the subagent-gating comment now covers `request_user_input` too (both interrupt).

## Forms feature (`request_user_input`)
- **Multi-step → real sequential wizard.** Multiple `steps` render as a Back/Next wizard with a step indicator; the last step submits all steps' answers together. Single-step payloads keep the plain form. (Previously the docstring promised a "wizard" but the renderer showed one scrollable form — now it genuinely is one.)
- **First-class option cards (AskUserQuestion-style).** A field with `oneOf:[{const,title,description}]` renders as selectable cards (label + description), single-select (`type:string`) or multi-select (`type:array`). Bare `enum`s still render as a dropdown.
- Wizard logic extracted to `hitl-form.ts` (unit-tested); `HitlForm.tsx` is the thin renderer; `hitl.css` gains stepper + card styles.

## Tests / gates
- `tests/test_hitl_forms.py`: autonomous auto-answer vs. operator-parks regression + empty-steps guard.
- `apps/web/src/chat/hitl-form.test.ts`: 13 wizard-logic cases.
- Green locally: `ruff` ✓ · full `pytest tests/` **2447 passed** ✓ · web `vitest` **206 passed** ✓ · `tsc --noEmit` ✓. (`lint-imports` not installed in the local venv; no cross-layer imports were added.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)