### PR TITLE
test(integration): real-subprocess multi-instance fleet harness (skeleton)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,196 @@
+"""Real-subprocess multi-instance fleet harness.
+
+Boots actual ``python -m server`` processes (a hub, and members the hub spawns)
+against a fake OpenAI gateway, on temp roots + free ports, and tears everything
+down. This is the integration layer the fleet had no coverage for — every prior
+fleet test mocked ``subprocess`` or ran single-instance.
+
+Isolation: each server gets its own tmp ``HOME`` so the (still-legacy, pre-Phase-4)
+``data_home()`` stores land under ``<tmp>/.protoagent`` instead of the real one,
+and ``PROTOAGENT_HOME`` puts its config at ``<tmp-home>/config`` (the new layout).
+Members the hub spawns inherit that tmp ``HOME``, so the whole fleet stays in tmp.
+
+These tests are SLOW (real boots) and opt-in: set ``PA_RUN_INTEGRATION=1`` to run
+them; the default ``pytest tests/`` skips them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PY = sys.executable
+
+RUN_INTEGRATION = bool(os.environ.get("PA_RUN_INTEGRATION"))
+requires_integration = pytest.mark.skipif(
+    not RUN_INTEGRATION,
+    reason="real-subprocess fleet integration — set PA_RUN_INTEGRATION=1 to run",
+)
+
+
+def free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def wait_healthz(port: int, timeout: float = 90.0) -> bool:
+    end = time.time() + timeout
+    url = f"http://127.0.0.1:{port}/healthz"
+    while time.time() < end:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as r:
+                if r.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(0.5)
+    return False
+
+
+def http_get(url: str, timeout: float = 10.0, headers: dict | None = None) -> tuple[int, str]:
+    req = urllib.request.Request(url, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, r.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")
+
+
+def http_post(url: str, body: dict, timeout: float = 30.0, headers: dict | None = None) -> tuple[int, str]:
+    data = json.dumps(body).encode()
+    h = {"Content-Type": "application/json", **(headers or {})}
+    req = urllib.request.Request(url, data=data, headers=h)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.status, r.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")
+
+
+def poll(fn, *, timeout: float = 60.0, interval: float = 1.0):
+    """Call ``fn`` until it returns a truthy value or the timeout elapses; returns
+    the last value (falsy on timeout)."""
+    end = time.time() + timeout
+    val = None
+    while time.time() < end:
+        try:
+            val = fn()
+            if val:
+                return val
+        except Exception:
+            val = None
+        time.sleep(interval)
+    return val
+
+
+@dataclass
+class Server:
+    name: str
+    port: int
+    home: Path
+    data_root: Path
+    proc: subprocess.Popen
+
+    @property
+    def base(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+
+@pytest.fixture(scope="module")
+def fake_gateway():
+    """A fake OpenAI-compatible endpoint (canned completions) so booted agents can
+    take a real turn without a live gateway. Referenced by every booted config."""
+    port = free_port()
+    proc = subprocess.Popen([PY, str(ROOT / "scripts" / "fake_openai_server.py"), str(port)])
+    # wait for it to bind
+    for _ in range(40):
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                break
+        except OSError:
+            time.sleep(0.25)
+    yield port
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except Exception:
+        proc.kill()
+
+
+@pytest.fixture
+def fleet(tmp_path_factory, fake_gateway):
+    """Factory that boots isolated real servers and tears them (and any members
+    they spawned) down. Returns ``boot(name=..., instance=..., ui=...)`` → ``Server``."""
+    servers: list[Server] = []
+
+    def boot(*, name: str = "hub", instance: str | None = None, ui: str = "none", timeout: float = 120.0) -> Server:
+        data_root = tmp_path_factory.mktemp(f"{name}-data")
+        home = tmp_path_factory.mktemp(f"{name}-home")
+        (home / "config").mkdir(parents=True, exist_ok=True)
+        (home / "config" / "langgraph-config.yaml").write_text(
+            "model:\n"
+            "  name: protolabs/reasoning\n"
+            f"  api_base: http://127.0.0.1:{fake_gateway}/v1\n"
+            "middleware:\n  knowledge: false\n  scheduler: false\n"
+        )
+        port = free_port()
+        env = {
+            **os.environ,
+            "HOME": str(data_root),  # isolate data_home() → <data_root>/.protoagent (legacy stores)
+            "PROTOAGENT_HOME": str(home),  # instance_root → config at <home>/config (new layout)
+            "PROTOAGENT_HEADLESS_SETUP": "1",
+            "OPENAI_API_KEY": "fake-integration-key",
+            "PYTHONPATH": str(ROOT),
+        }
+        env.pop("PROTOAGENT_BOX_ROOT", None)
+        env.pop("PROTOAGENT_CONFIG_DIR", None)
+        env.pop("PROTOAGENT_INSTANCE", None)
+        if instance:
+            env["PROTOAGENT_INSTANCE"] = instance
+        proc = subprocess.Popen([PY, "-m", "server", "--ui", ui, "--port", str(port)], cwd=str(ROOT), env=env)
+        s = Server(name=name, port=port, home=home, data_root=data_root, proc=proc)
+        servers.append(s)
+        if not wait_healthz(port, timeout):
+            proc.terminate()
+            raise RuntimeError(f"server {name!r} on :{port} never became healthy (timeout {timeout}s)")
+        return s
+
+    yield boot
+
+    # Teardown: collect member pids from each hub's fleet status, then stop hubs + members.
+    member_pids: set[int] = set()
+    for s in servers:
+        try:
+            st, raw = http_get(f"{s.base}/api/fleet", timeout=5)
+            if st == 200:
+                for a in json.loads(raw).get("agents", []) or []:
+                    if a.get("pid") and not a.get("remote"):
+                        member_pids.add(int(a["pid"]))
+        except Exception:
+            pass
+    for s in servers:
+        s.proc.terminate()
+    for s in servers:
+        try:
+            s.proc.wait(timeout=10)
+        except Exception:
+            s.proc.kill()
+    for pid in member_pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except Exception:
+            pass

--- a/tests/integration/test_fleet_smoke.py
+++ b/tests/integration/test_fleet_smoke.py
@@ -1,0 +1,89 @@
+"""Foundational real-subprocess fleet tests (the harness skeleton).
+
+Covers the three things the fleet had NO live coverage for: two isolated
+instances, a hub spawning a real member + proxying to it, and a member resolving
+its config under the new ``<ws>/config`` layout (the old double-scope footgun).
+
+Slow + opt-in: ``PA_RUN_INTEGRATION=1 pytest tests/integration``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from tests.integration.conftest import http_get, http_post, poll, requires_integration
+
+pytestmark = requires_integration
+
+
+def test_two_instances_boot_isolated(fleet):
+    a = fleet(name="inst-a")
+    b = fleet(name="inst-b")
+
+    for s in (a, b):
+        st, raw = http_get(f"{s.base}/.well-known/agent-card.json")
+        assert st == 200, (s.name, st, raw[:200])
+        assert json.loads(raw).get("name"), f"{s.name} agent card has no name"
+
+    # Disjoint roots — config (new layout) under each PROTOAGENT_HOME, stores under each tmp HOME.
+    assert a.home != b.home
+    assert a.data_root != b.data_root
+    assert (a.home / "config" / "langgraph-config.yaml").exists()
+    assert (b.home / "config" / "langgraph-config.yaml").exists()
+    # Each instance keeps its own data root (no cross-talk).
+    assert not (b.data_root / ".protoagent").is_relative_to(a.data_root)
+
+
+def test_hub_spawns_member_and_proxies(fleet):
+    hub = fleet(name="hub")
+
+    st, raw = http_post(f"{hub.base}/api/fleet", {"name": "alpha", "inherit_config": True, "start": True}, timeout=180)
+    assert st == 200, f"create member failed: {st} {raw[:300]}"
+    agent = json.loads(raw)["agent"]
+    assert agent.get("running"), f"member did not start: {agent}"
+    mid = agent["id"]
+
+    # The hub's fleet registry lists the member (agents = [host, ...members, ...remotes]).
+    st, raw = http_get(f"{hub.base}/api/fleet")
+    assert st == 200, raw[:200]
+    ids = [a.get("id") for a in json.loads(raw).get("agents", [])]
+    assert mid in ids, f"member {mid} not in fleet {ids}"
+
+    # Proxy round-trip: the hub forwards /agents/<id>/healthz to the real member process.
+    reached = poll(lambda: http_get(f"{hub.base}/agents/{mid}/healthz", timeout=3)[0] == 200, timeout=90)
+    assert reached, "member never reachable through the hub proxy"
+
+    # The member serves its OWN agent card through the proxy.
+    st, raw = http_get(f"{hub.base}/agents/{mid}/.well-known/agent-card.json", timeout=10)
+    assert st == 200, f"proxied agent card: {st} {raw[:200]}"
+    assert json.loads(raw).get("name"), "proxied member card has no name"
+
+
+def test_member_config_resolves_under_new_layout(fleet):
+    """A member is launched with PROTOAGENT_HOME=<ws>; its config must land at
+    <ws>/config/ (NOT double-scoped under <ws>/<id>/), and the inherited gateway
+    must read back — the exact regression the old _config_scope/_reset bug caused."""
+    hub = fleet(name="hubcfg")
+
+    st, raw = http_post(f"{hub.base}/api/fleet", {"name": "beta", "inherit_config": True, "start": True}, timeout=180)
+    assert st == 200, f"create member failed: {st} {raw[:300]}"
+    mid = json.loads(raw)["agent"]["id"]
+
+    # The member's config lives at <ws>/config/langgraph-config.yaml under the isolated data root.
+    matches = list(hub.data_root.glob(f"**/workspaces/{mid}/config/langgraph-config.yaml"))
+    assert matches, (
+        "member config not at <ws>/config/ (new layout). langgraph-config.yaml files under root: "
+        f"{[str(p) for p in hub.data_root.rglob('langgraph-config.yaml')]}"
+    )
+    # It carries the inherited fake gateway — i.e. config wrote + read back at the un-double-scoped path.
+    assert "127.0.0.1" in matches[0].read_text(), "member config did not inherit the host gateway"
+
+    # And the member serves that config back through the proxy (the running process reads the same path).
+    cfg = poll(
+        lambda: (lambda r: json.loads(r[1]) if r[0] == 200 else None)(
+            http_get(f"{hub.base}/agents/{mid}/api/config", timeout=5)
+        ),
+        timeout=90,
+    )
+    assert cfg is not None, "member /api/config not reachable through the proxy"
+    assert "127.0.0.1" in json.dumps(cfg), f"member config api missing inherited gateway: {json.dumps(cfg)[:300]}"


### PR DESCRIPTION
## What

The fleet had **zero live multi-instance coverage** — every prior fleet test mocked `subprocess` or ran single-instance, and CI never spawned a fleet. This adds the real-process integration harness that closes that gap and that **Phase 2's distributed hardening lands test-first on**.

`tests/integration/conftest.py` boots actual `python -m server` processes (a hub, and members the hub spawns via `/api/fleet`) against the fake OpenAI gateway, on temp roots + free ports, with teardown that stops hubs and their spawned members.

**Isolation trick:** each server gets its own tmp `HOME`, so the (still-legacy, pre-Phase-4) `data_home()` stores land under `<tmp>/.protoagent` instead of the real `~/.protoagent`; `PROTOAGENT_HOME` puts config at `<home>/config` (the new layout).

## Three foundational tests
- **two instances boot fully isolated** — disjoint config + data roots, each serves its own card.
- **hub spawns a REAL member + proxy round-trip** — `POST /api/fleet` starts a member subprocess; the hub forwards `/agents/<id>/healthz` and the agent card to it.
- **member config resolves under the new layout** — config lands at `<ws>/config/` (NOT double-scoped under `<ws>/<id>/`) and inherits the host gateway: the exact regression the old `_config_scope`/`_reset_double_scoped_config` bug caused.

## Opt-in + fast default
Slow (real boots), so gated behind `PA_RUN_INTEGRATION=1`. The default `pytest tests/` **skips them in 0.02s** (collection-imports the harness, so CI still catches import breakage). Verified: `PA_RUN_INTEGRATION=1 pytest tests/integration` → **3 passed (28.6s)**; default → 3 skipped; ruff clean.

## Follow-ups (Phase 3 expand)
A dedicated CI job to actually run the harness + a fleet-aware `live_smoke` (2 instances, switch, cross-instance delegate), plus member-crash→restart and cross-instance A2A tests, land in the expand PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)