### PR TITLE
feat(delegates): configurable A2A poll timeout + error transparency

### DIFF
--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -67,6 +67,7 @@ class Delegate:
     url: str = ""
     auth_scheme: str = ""  # "" | bearer | apiKey
     auth_token: str = ""  # secret value (from secrets.yaml overlay)
+    poll_timeout_s: float = 300.0  # a2a: max seconds to await a long-running delegated task
 
     # openai
     model: str = ""
@@ -146,6 +147,19 @@ async def _timed(coro) -> tuple[object, int]:
     return res, int((time.monotonic() - t0) * 1000)
 
 
+def _a2a_error_detail(d: Delegate, err: object) -> str:
+    """Turn a JSON-RPC error payload into an operator-legible cause — especially the
+    version-skew case, which otherwise surfaces as an opaque ``-32009``."""
+    code = err.get("code") if isinstance(err, dict) else None
+    msg = str(err.get("message")) if isinstance(err, dict) else str(err)
+    if code == -32009 or "VERSION_NOT_SUPPORTED" in str(err).upper():
+        return (
+            f"delegate {d.name!r}: peer rejected A2A-Version 1.0 (VERSION_NOT_SUPPORTED) — it speaks "
+            "an older A2A dialect. Upgrade the peer, or point its url at a 1.0 /a2a endpoint."
+        )
+    return f"delegate {d.name!r}: {msg or err}"
+
+
 class A2aAdapter(Adapter):
     type = "a2a"
     label = "A2A agent"
@@ -175,6 +189,15 @@ class A2aAdapter(Adapter):
                 "secret",
                 help="Stored in secrets.yaml (gitignored), never in tracked config.",
             ),
+            FieldSpec(
+                "poll_timeout_s",
+                "Task poll timeout (s)",
+                "number",
+                default=300,
+                help="Max seconds to wait for a long-running delegated task to finish before "
+                "giving up locally — the peer keeps working. Raise it for slow agents (e.g. a "
+                "code build); the old fixed 30s cut long tasks off mid-flight.",
+            ),
         ]
 
     def parse(self, raw: dict) -> Delegate:
@@ -185,9 +208,15 @@ class A2aAdapter(Adapter):
         auth = raw.get("auth") or {}
         d.auth_scheme = str(auth.get("scheme", "")).strip()
         d.auth_token = _secret(auth, "token", "credentialsEnv")
+        try:
+            d.poll_timeout_s = float(raw.get("poll_timeout_s") or 300.0)
+        except (TypeError, ValueError):
+            d.poll_timeout_s = 300.0
         return d
 
     async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
+        import time
+
         import httpx
 
         from security import policy
@@ -207,17 +236,30 @@ class A2aAdapter(Adapter):
 
         async def _rpc(client, method, params):
             body = {"jsonrpc": "2.0", "id": str(uuid.uuid4()), "method": method, "params": params}
-            r = await client.post(d.url, json=body, headers=headers)
+            # Map transport failures to a legible CAUSE — a delegating agent (and the
+            # operator) needs "unreachable" vs "timed out" vs "version-incompatible",
+            # not an opaque stack trace or a bare connection error.
+            try:
+                r = await client.post(d.url, json=body, headers=headers)
+            except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+                raise DelegateError(f"delegate {d.name!r} unreachable at {d.url} ({type(exc).__name__})") from exc
+            except httpx.TimeoutException as exc:
+                raise DelegateError(f"delegate {d.name!r} timed out contacting {d.url}") from exc
+            except httpx.HTTPError as exc:
+                raise DelegateError(f"delegate {d.name!r} transport error: {str(exc)[:160]}") from exc
             if r.status_code >= 400:
-                raise DelegateError(f"HTTP {r.status_code}: {r.text[:200]}")
+                raise DelegateError(f"delegate {d.name!r} HTTP {r.status_code}: {r.text[:200]}")
             data = r.json()
             if data.get("error"):
-                raise DelegateError(str(data["error"]))
+                raise DelegateError(_a2a_error_detail(d, data["error"]))
             return data.get("result") or {}
 
+        poll_timeout = d.poll_timeout_s if d.poll_timeout_s and d.poll_timeout_s > 0 else 300.0
         # A2A 1.0 (a2a-sdk >=1.0): JSON-RPC `SendMessage` / `GetTask`, the ROLE_USER
         # enum, and a `result.task` envelope. (`message/send` + lowercase `user` is
-        # the v0.3 legacy dialect, which 1.0 servers reject with -32601.)
+        # the v0.3 legacy dialect, which 1.0 servers reject with -32601.) The per-request
+        # client timeout caps a single call; the poll DEADLINE caps the overall wait for a
+        # long-running task — so a 2-minute delegated task no longer fails at the old 30s.
         async with httpx.AsyncClient(timeout=timeout or 60) as client:
             result = await _rpc(
                 client,
@@ -236,17 +278,22 @@ class A2aAdapter(Adapter):
             task = result.get("task", result) or {}
             task_id = task.get("id")
             state = (task.get("status") or {}).get("state")
-            polls = 0
-            while task_id and not _is_terminal(state) and polls < 30:
+            deadline = time.monotonic() + poll_timeout
+            while task_id and not _is_terminal(state) and time.monotonic() < deadline:
                 await asyncio.sleep(1.0)
-                polls += 1
                 result = await _rpc(client, "GetTask", {"name": task_id})
                 task = result.get("task", result) or {}
                 state = (task.get("status") or {}).get("state")
             text = _extract_text(result)
             if text:
                 return text
-            raise DelegateError(f"no text returned (state={state})")
+            if task_id and not _is_terminal(state):
+                raise DelegateError(
+                    f"delegate {d.name!r} still running after {int(poll_timeout)}s — the peer may "
+                    f"still be working; raise its poll timeout if tasks legitimately take longer "
+                    f"(state={state})"
+                )
+            raise DelegateError(f"delegate {d.name!r} returned no text (state={state})")
 
     async def probe(self, d: Delegate) -> dict:
         import httpx

--- a/tests/integration/test_fleet_a2a.py
+++ b/tests/integration/test_fleet_a2a.py
@@ -1,0 +1,28 @@
+"""Cross-instance A2A federation — the real wire path.
+
+Boots a real instance and drives the actual ``A2aAdapter.dispatch`` (the code the
+``delegate_to`` tool runs) against its ``/a2a`` endpoint: SendMessage → GetTask
+poll → text extraction, with the new configurable poll timeout. This is the
+federation path the same-box-vs-cross-machine fleet relies on; a loopback peer
+stands in for a remote one (CI has no LAN/tailnet).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from plugins.delegates.adapters import A2aAdapter, Delegate
+from tests.integration.conftest import requires_integration
+
+pytestmark = requires_integration
+
+
+def test_adapter_dispatches_to_real_instance(fleet, monkeypatch):
+    peer = fleet(name="peer")
+    # We're exercising the A2A wire path, not the egress policy — allow the loopback url.
+    monkeypatch.setattr("security.policy.check_url", lambda *_a, **_k: None)
+
+    d = Delegate(name="peer", type="a2a", url=f"{peer.base}/a2a", poll_timeout_s=120)
+    out = asyncio.run(A2aAdapter().dispatch(d, "ping"))
+
+    assert isinstance(out, str) and out.strip(), f"adapter returned no text: {out!r}"

--- a/tests/test_delegate_a2a_robustness.py
+++ b/tests/test_delegate_a2a_robustness.py
@@ -1,0 +1,147 @@
+"""A2A delegate robustness — configurable poll timeout + error transparency.
+
+The old dispatch hard-capped polling at 30s (long delegated tasks were cut off
+mid-flight) and surfaced opaque errors. These cover the configurable
+``poll_timeout_s`` and the legible cause mapping (unreachable / timed-out /
+version-incompatible).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json as _json
+
+import httpx
+import pytest
+
+from plugins.delegates.adapters import A2aAdapter, Delegate, DelegateError, _a2a_error_detail
+
+A = A2aAdapter()
+
+
+def _parse(**raw):
+    return A.parse({"name": "peer", "type": "a2a", "url": "http://127.0.0.1:9/a2a", **raw})
+
+
+# ── parse: poll_timeout_s ──────────────────────────────────────────────────────
+
+
+def test_parse_poll_timeout_default():
+    assert _parse().poll_timeout_s == 300.0
+
+
+def test_parse_poll_timeout_override():
+    assert _parse(poll_timeout_s=120).poll_timeout_s == 120.0
+
+
+def test_parse_poll_timeout_invalid_falls_back():
+    assert _parse(poll_timeout_s="nope").poll_timeout_s == 300.0
+
+
+def test_a2a_schema_exposes_poll_timeout():
+    keys = [f.key for f in A.config_schema()]
+    assert "poll_timeout_s" in keys
+
+
+# ── error-detail mapping ───────────────────────────────────────────────────────
+
+
+def test_error_detail_version_skew():
+    d = Delegate(name="peer", type="a2a")
+    msg = _a2a_error_detail(d, {"code": -32009, "message": "anything"})
+    assert "VERSION_NOT_SUPPORTED" in msg
+    assert "peer" in msg
+
+
+def test_error_detail_generic_keeps_message():
+    d = Delegate(name="peer", type="a2a")
+    msg = _a2a_error_detail(d, {"code": -1, "message": "boom"})
+    assert "boom" in msg
+
+
+# ── dispatch: transport + protocol error transparency ──────────────────────────
+
+
+class _Resp:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+        self.text = _json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    """Returns ``send_resp`` for SendMessage and ``get_resp`` for GetTask forever
+    (no queue to exhaust), or raises ``raise_exc`` on every post."""
+
+    def __init__(self, *, send_resp=None, get_resp=None, raise_exc=None, **_kw):
+        self.send_resp = send_resp
+        self.get_resp = get_resp if get_resp is not None else send_resp
+        self.raise_exc = raise_exc
+        self.posts = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        self.posts += 1
+        if self.raise_exc:
+            raise self.raise_exc
+        return self.send_resp if (json or {}).get("method") == "SendMessage" else self.get_resp
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Allow the url (skip the egress policy) and skip real sleeps."""
+    monkeypatch.setattr("security.policy.check_url", lambda *_a, **_k: None)
+
+    async def _noop(_):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _noop)
+    return monkeypatch
+
+
+def _install_client(monkeypatch, **kw):
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **client_kw: _FakeClient(**kw, **client_kw))
+
+
+def test_dispatch_unreachable_maps_to_clear_error(patched):
+    _install_client(patched, raise_exc=httpx.ConnectError("refused"))
+    d = _parse()
+    with pytest.raises(DelegateError) as ei:
+        asyncio.run(A.dispatch(d, "hi"))
+    assert "unreachable" in str(ei.value)
+
+
+def test_dispatch_version_error_maps_to_clear_error(patched):
+    _install_client(patched, send_resp=_Resp({"jsonrpc": "2.0", "error": {"code": -32009, "message": "x"}}))
+    d = _parse()
+    with pytest.raises(DelegateError) as ei:
+        asyncio.run(A.dispatch(d, "hi"))
+    assert "VERSION_NOT_SUPPORTED" in str(ei.value)
+
+
+def test_dispatch_deadline_exceeded_reports_still_running(patched):
+    # A task that never reaches a terminal state; with a tiny poll timeout the dispatch
+    # must give up locally with a "still running" message (not hang, not the old 30s cap).
+    patched.setattr("tools.a2a_parse._extract_text", lambda *_a, **_k: "")
+    patched.setattr("tools.a2a_parse._is_terminal", lambda *_a, **_k: False)
+    running = _Resp({"jsonrpc": "2.0", "result": {"task": {"id": "t1", "status": {"state": "RUNNING"}}}})
+    _install_client(patched, send_resp=running)
+    d = _parse(poll_timeout_s=0.01)
+    with pytest.raises(DelegateError) as ei:
+        asyncio.run(A.dispatch(d, "hi"))
+    assert "still running" in str(ei.value)
+
+
+def test_dispatch_returns_immediate_text(patched):
+    patched.setattr("tools.a2a_parse._extract_text", lambda result, *a, **k: "pong" if result else "")
+    _install_client(patched, send_resp=_Resp({"jsonrpc": "2.0", "result": {"text": "pong"}}))
+    d = _parse()
+    assert asyncio.run(A.dispatch(d, "ping")) == "pong"


### PR DESCRIPTION
## What

Cross-machine **A2A federation** hardening (Phase 2 of the fleet initiative). The `a2a` delegate dispatch hard-capped task polling at **30 iterations (~30s)**, so a long-running delegated task (a code build, a deep-research turn) **failed from the delegator's side while the peer was still working** — and surfaced opaque errors.

- **Configurable poll timeout** — `poll_timeout_s` (default **300s**) on the a2a `Delegate` + its settings schema; the `GetTask` poll loop now runs to a **deadline** (`adapters.py`) instead of a fixed count.
- **Error transparency** — transport + protocol failures now map to a legible CAUSE:
  - `ConnectError`/`ConnectTimeout` → *"delegate 'X' unreachable at <url>"*
  - `TimeoutException` → *"timed out contacting <url>"*
  - JSON-RPC `-32009` → a clear **VERSION_NOT_SUPPORTED** message (peer speaks an older A2A dialect) instead of an opaque code
  - local deadline hit → *"still running after Ns — the peer may still be working"* instead of a bare *"no text returned"*

## Tests
- `tests/test_delegate_a2a_robustness.py` — parse defaults/override, schema exposure, the error-detail mapping, unreachable + version-skew dispatch errors, the deadline cutoff, and the immediate-text happy path (10 tests).
- `tests/integration/test_fleet_a2a.py` — drives the **real `A2aAdapter.dispatch`** (the code `delegate_to` runs) against a **live instance's `/a2a`**, a loopback peer standing in for a remote one. This is the actual federation wire path; opt-in via `PA_RUN_INTEGRATION` (passes in 4.5s).
- Full suite **2457 passed, 4 skipped**; ruff clean.

## Context
First of the Phase 2 cross-machine PRs (the stated goal). Next: A2A version negotiation in the agent card, remote register-time health probe, and the discovery auto-sweep — each landing test-first on the new integration harness (#1467).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable wait time for delegated long-running tasks, with clearer feedback when work is still in progress.
  * Improved error messages for delegation failures, including better handling of version mismatch and transport issues.

* **Bug Fixes**
  * Task polling now stops based on a time limit instead of a fixed number of checks.
  * Delegated responses return text as soon as it’s available, with clearer failures when no text is returned.

* **Tests**
  * Added coverage for polling settings, error formatting, and real cross-instance delegation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->