### PR TITLE
fix(hitl): hard-deny HITL tools from subagents + multi-interrupt tripwire

### DIFF
--- a/graph/agent.py
+++ b/graph/agent.py
@@ -20,7 +20,7 @@ from graph.middleware.memory import SessionSummaryMiddleware
 from graph.middleware.message_capture import MessageCaptureMiddleware
 from graph.state import ProtoAgentState
 from graph.subagents.config import SUBAGENT_REGISTRY
-from tools.lg_tools import _session_id_from, get_all_tools
+from tools.lg_tools import HITL_TOOL_NAMES, _session_id_from, get_all_tools
 
 
 def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_index=None, extra_middleware=None):
@@ -209,6 +209,25 @@ class SubagentError(RuntimeError):
     string (which read as success). ``task_batch`` reports it inline and continues."""
 
 
+def _subagent_tools(sub_config, tool_map: dict) -> list:
+    """Resolve a subagent's bound tools from its allowlist, hard-denying the lead-only HITL
+    interrupt tools (``HITL_TOOL_NAMES``) even if the config lists them. A subagent runs on a
+    checkpointer-less graph, so ``ask_human`` / ``request_user_input`` would fail opaquely
+    mid-delegation — this is the enforced backstop to the convention that no subagent allowlist
+    names them, so a fork can't enable one by editing a ``SubagentConfig.tools`` list."""
+    blocked = [n for n in sub_config.tools if n in HITL_TOOL_NAMES]
+    if blocked:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "[subagent] '%s' lists HITL tool(s) %s — dropping them; a subagent can't resume a "
+            "LangGraph interrupt (no checkpointer). Remove them from its tools list.",
+            sub_config.name,
+            blocked,
+        )
+    return [tool_map[name] for name in sub_config.tools if name in tool_map and name not in HITL_TOOL_NAMES]
+
+
 async def _run_subagent(
     *,
     config,
@@ -233,7 +252,7 @@ async def _run_subagent(
     if not sub_config:
         return f"Error: Unknown subagent '{subagent_type}'. Available: {available_subagents}"
 
-    sub_tools = [tool_map[name] for name in sub_config.tools if name in tool_map]
+    sub_tools = _subagent_tools(sub_config, tool_map)
     if not sub_tools:
         return f"Error: No tools available for subagent '{subagent_type}'."
 

--- a/server/chat.py
+++ b/server/chat.py
@@ -324,7 +324,13 @@ def _interrupt_payload(val) -> dict:
 async def _pending_interrupt_value(config: dict):
     """Return the value of a pending LangGraph interrupt (ask_human / HITL) for
     this thread, or ``None``. Both chat paths read the same snapshot to detect a
-    turn that paused for human input instead of producing a final answer."""
+    turn that paused for human input instead of producing a final answer.
+
+    Returns a single value because the graph only ever has one interrupt pending:
+    ``create_agent`` / ``ToolNode`` runs an assistant turn's tool calls SEQUENTIALLY, so the
+    first ask_human / request_user_input ``interrupt()`` halts the tool node before the next
+    tool runs (verified). Multiple HITL calls therefore surface as back-to-back pauses — each
+    drained on its own resume by the lead/autonomous turn loop — not as one batch."""
     try:
         snapshot = await STATE.graph.aget_state(config)
     except Exception:
@@ -335,6 +341,15 @@ async def _pending_interrupt_value(config: dict):
             pending.extend(getattr(t, "interrupts", ()) or ())
     if not pending:
         return None
+    if len(pending) > 1:
+        # Tripwire: with sequential tool execution this can't happen. If a LangGraph change
+        # ever makes interrupts pend simultaneously, surfacing only pending[0] would silently
+        # drop the rest — warn loudly so we build real multi-interrupt handling instead.
+        log.warning(
+            "[hitl] %d pending interrupts at once — only the first is surfaced; tool execution "
+            "is expected to be sequential, so this signals a behavior change to handle.",
+            len(pending),
+        )
     return getattr(pending[0], "value", pending[0])
 
 

--- a/tests/test_hitl_forms.py
+++ b/tests/test_hitl_forms.py
@@ -183,3 +183,47 @@ async def test_autonomous_turn_force_completes_after_cap(monkeypatch):
     assert fake.resume_values.count(chat_mod._AUTONOMOUS_HITL_SENTINEL) == chat_mod._MAX_AUTONOMOUS_AUTOANSWERS
     assert len(fake.resume_values) == chat_mod._MAX_AUTONOMOUS_AUTOANSWERS + 1
     assert len(cleared) == 1  # the stray interrupt was cleared exactly once
+
+
+# ── multiple-pending-interrupt tripwire ───────────────────────────────────────
+# create_agent runs an assistant turn's tool calls sequentially, so only ONE interrupt ever
+# pends; _pending_interrupt_value returns it. If multiple ever pend (a LangGraph behavior
+# change), it warns rather than silently dropping the rest.
+
+
+class _FakeInterrupt:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeSnapshot:
+    def __init__(self, interrupts):
+        self.interrupts = interrupts
+        self.tasks = ()
+
+
+class _FakeGraph:
+    def __init__(self, interrupts):
+        self._interrupts = interrupts
+
+    async def aget_state(self, config):
+        return _FakeSnapshot(self._interrupts)
+
+
+@pytest.mark.asyncio
+async def test_single_pending_interrupt_returns_value(monkeypatch):
+    monkeypatch.setattr(STATE, "graph", _FakeGraph([_FakeInterrupt("merge it?")]), raising=False)
+    assert await chat_mod._pending_interrupt_value({"configurable": {"thread_id": "t"}}) == "merge it?"
+
+
+@pytest.mark.asyncio
+async def test_multiple_pending_interrupts_warn_and_return_first(monkeypatch, caplog):
+    import logging
+
+    monkeypatch.setattr(
+        STATE, "graph", _FakeGraph([_FakeInterrupt("first"), _FakeInterrupt("second")]), raising=False
+    )
+    with caplog.at_level(logging.WARNING, logger="protoagent.server"):
+        val = await chat_mod._pending_interrupt_value({"configurable": {"thread_id": "t"}})
+    assert val == "first"  # still surfaces the first; never drops silently or raises
+    assert any("pending interrupts at once" in r.getMessage() for r in caplog.records)

--- a/tests/test_subagent_hitl_deny.py
+++ b/tests/test_subagent_hitl_deny.py
@@ -1,0 +1,42 @@
+"""Subagents must never be bound the lead-only HITL interrupt tools (ask_human /
+request_user_input): they run on a checkpointer-less graph and can't resume an interrupt.
+graph.agent._subagent_tools hard-denies them even if a SubagentConfig.tools allowlist names
+one — the enforced backstop to the convention."""
+
+from __future__ import annotations
+
+from graph.agent import _subagent_tools
+from graph.subagents.config import SUBAGENT_REGISTRY, SubagentConfig
+from tools.lg_tools import HITL_TOOL_NAMES, get_all_tools
+
+
+def _tool_map() -> dict:
+    return {t.name: t for t in get_all_tools()}
+
+
+def _cfg(tools: list[str]) -> SubagentConfig:
+    return SubagentConfig(name="probe", description="", system_prompt="", tools=tools)
+
+
+def test_hitl_tools_exist_in_full_lead_set():
+    # Guards the test's premise: the lead agent DOES get these (they're only denied to subagents).
+    assert HITL_TOOL_NAMES <= set(_tool_map())
+
+
+def test_subagent_tools_hard_denies_hitl_even_when_listed():
+    tm = _tool_map()
+    bound = {t.name for t in _subagent_tools(_cfg(["current_time", "ask_human", "request_user_input"]), tm)}
+    assert "current_time" in bound  # the legitimate tool is kept
+    assert bound.isdisjoint(HITL_TOOL_NAMES)  # both HITL tools dropped
+
+
+def test_subagent_tools_leaves_normal_allowlist_untouched():
+    tm = _tool_map()
+    bound = {t.name for t in _subagent_tools(_cfg(["current_time", "web_search"]), tm)}
+    assert bound == {"current_time", "web_search"}
+
+
+def test_no_registered_subagent_lists_a_hitl_tool():
+    # The convention itself: no shipped subagent allowlist names a HITL tool.
+    for name, cfg in SUBAGENT_REGISTRY.items():
+        assert set(cfg.tools).isdisjoint(HITL_TOOL_NAMES), f"subagent '{name}' lists a HITL tool"

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -1110,6 +1110,14 @@ def _build_curation_tools():
     return [recent_activity, list_skills, save_skill]
 
 
+# Lead-only HITL tools: each pauses the lead A2A turn via a LangGraph interrupt that only the
+# lead turn's runner resumes. A subagent runs on a checkpointer-less graph, so binding one
+# would fail opaquely mid-delegation — graph.agent hard-denies these from every subagent's
+# tool set (``_subagent_tools``) regardless of its allowlist. Keep this in sync if a new
+# interrupt-based tool is added.
+HITL_TOOL_NAMES = frozenset({"ask_human", "request_user_input"})
+
+
 def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, tasks_store=None, goal_enabled=False):
     """Return every LangChain tool the lead agent + subagents can use.
 
@@ -1124,11 +1132,11 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, tasks_
     Pass ``None`` to disable either subsystem — the lead agent runs
     fine with just the four keyless general tools.
     """
-    # ask_human AND request_user_input are lead-agent HITL tools — each pauses the A2A
-    # turn via a LangGraph interrupt that only the lead turn's runner resumes. Subagents
-    # (run outside that runner, on a graph with no checkpointer) must not get either, so
-    # they're gated by allowlist: present in the full set for the lead agent, absent from
-    # every subagent allowlist in graph/subagents/config.py. Don't add them to one.
+    # ask_human AND request_user_input are lead-agent HITL tools (HITL_TOOL_NAMES) — each
+    # pauses the A2A turn via a LangGraph interrupt that only the lead turn's runner resumes.
+    # Subagents (run outside that runner, on a graph with no checkpointer) must not get either:
+    # they're absent from every subagent allowlist in graph/subagents/config.py AND hard-denied
+    # in graph.agent._subagent_tools, so a fork can't enable one via a tools list either.
     # show_component (inline component rendering, ADR 0051 / #1323): table/keyvalue/timeline
     # widgets rendered inline in chat by the console's extensible component registry.
     tools = [current_time, calculator, web_search, fetch_url, ask_human, request_user_input, load_skill, show_component]


### PR DESCRIPTION
The two deferred HITL hardening follow-ups from the audit (#1464 / #1466). Both are small; neither was a live bug, but one closes a real fork footgun and the other adds a tripwire after verifying the concern was unfounded.

## 1. Hard-deny HITL interrupt tools from subagents (real hardening)
`ask_human` / `request_user_input` pause the lead A2A turn via a LangGraph interrupt that only the lead turn's runner resumes. A subagent runs on a checkpointer-less graph, so binding one fails opaquely mid-delegation. They were kept out by **convention only** (absent from every `SubagentConfig.tools` allowlist) — a fork that added one to an allowlist got a confusing failure.

Now enforced: `HITL_TOOL_NAMES` is hard-denied in `graph.agent._subagent_tools` regardless of the allowlist, with a warning naming the offending subagent. Covers every subagent path (`task`, `task_batch`, the manual console fan-outs) since all funnel through `_run_subagent`.

## 2. Multi-pending-interrupt tripwire (verified non-bug + safety net)
Investigated the "`_pending_interrupt_value` returns only `pending[0]`, dropping the rest" concern. **Verified against LangGraph** that `create_agent`/`ToolNode` executes an assistant turn's tool calls **sequentially** — the first `interrupt()` halts the tool node before the next tool runs, so exactly one interrupt pends at a time. Multiple HITL calls surface as back-to-back pauses, each drained on its own resume by the lead/autonomous turn loop. So `pending[0]` is correct and nothing is dropped today.

Added a tripwire: if interrupts ever pend simultaneously (a future LangGraph behavior change), the reader now **warns** instead of silently dropping all but the first — so we'd build real multi-interrupt handling rather than fail quiet. Documented the sequential-execution invariant.

## Gates
`ruff` ✓ · full `pytest tests/` → **2463 passed, 4 skipped** ✓. No frontend touched. `uv.lock` untouched.

Probe scripts (not committed) confirmed both LangGraph behaviors directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)