### PR TITLE
feat(fleet): remote-member health robustness — probe-on-register, fresher TTL, per-delegate backoff

### DIFF
--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -321,35 +321,62 @@ def remove_remote(ident: str) -> dict:
 # Reachability probes are network calls — keep them OFF the status() path (it runs on
 # every 3s console poll). `refresh_remote_probes()` is sync + TTL-guarded; the fleet
 # route calls it via asyncio.to_thread before status(), so the loop never blocks.
-_PROBE_TTL = 10.0
+# TTL aligns with the 3s console poll so a just-downed remote doesn't keep showing
+# 'running' for a full poll-and-a-bit after it dies.
+_PROBE_TTL = 3.0
 _probe_cache: dict[str, tuple[bool, float]] = {}
 
 
-def refresh_remote_probes(timeout: float = 1.0) -> None:
+def _probe_one(rec: dict, timeout: float) -> tuple[bool, str]:
+    """Probe ONE remote's A2A card: refresh its reachability cache + persist a changed
+    version. Returns ``(reachable, version-from-card-or-blank)``. Network call — keep it
+    off the event loop."""
     import httpx
 
+    version = ""
+    try:
+        r = httpx.get(f"{rec['url']}/.well-known/agent-card.json", timeout=timeout)
+        alive = r.status_code == 200
+        if alive:
+            try:
+                # The A2A card carries the remote's app version (pyproject
+                # [project].version) — same unauthenticated endpoint the
+                # reachability probe already hits, no extra round-trip.
+                version = str(r.json().get("version", "") or "")
+            except ValueError:
+                version = ""
+    except httpx.HTTPError:
+        alive = False
+    _probe_cache[rec["id"]] = (alive, time.monotonic())
+    if version and version != rec.get("version"):
+        _record_remote_version(rec["id"], version)
+    return alive, version
+
+
+def refresh_remote_probes(timeout: float = 1.0) -> None:
     now = time.monotonic()
     for rec in list_remotes():
         hit = _probe_cache.get(rec["id"])
         if hit and now - hit[1] < _PROBE_TTL:
             continue
-        version = ""
-        try:
-            r = httpx.get(f"{rec['url']}/.well-known/agent-card.json", timeout=timeout)
-            alive = r.status_code == 200
-            if alive:
-                try:
-                    # The A2A card carries the remote's app version (pyproject
-                    # [project].version) — same unauthenticated endpoint the
-                    # reachability probe already hits, no extra round-trip.
-                    version = str(r.json().get("version", "") or "")
-                except ValueError:
-                    version = ""
-        except httpx.HTTPError:
-            alive = False
-        _probe_cache[rec["id"]] = (alive, now)
-        if version and version != rec.get("version"):
-            _record_remote_version(rec["id"], version)
+        _probe_one(rec, timeout)
+
+
+def probe_remote(ident: str, timeout: float = 1.0) -> tuple[bool, str]:
+    """Probe a SINGLE remote member (by id or name) NOW, bypassing the TTL — used at
+    register time so the caller (console/CLI) learns reachability immediately instead of
+    waiting for the next 3s poll. Returns ``(reachable, version)`` where version falls back
+    to the last-known when the card carries none. ``FleetError`` if no such remote.
+
+    Registration is never rejected for an unreachable peer (deferred registration is
+    intentional — a peer can come online later); this just lets the caller warn up front."""
+    remotes = _load_remotes()
+    rid = ident if ident in remotes else next((k for k, r in remotes.items() if r["name"] == ident), None)
+    if rid is None:
+        raise FleetError(f"no remote member {ident!r}")
+    rec = remotes[rid]
+    alive, version = _probe_one(rec, timeout)
+    return alive, version or str(rec.get("version", "") or "")
 
 
 def _record_remote_version(rid: str, version: str) -> None:

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -46,7 +46,12 @@ def register_fleet_routes(app) -> None:
                 str((req or {}).get("url", "")),
                 token=str((req or {}).get("token", "") or ""),
             )
-            return {"ok": True, "agent": rec}
+            # Probe the new remote's agent card immediately (off the loop — it's a network
+            # call) so the response can warn at register time. We DON'T reject an unreachable
+            # peer — deferred registration is intentional (it can come online later); the
+            # caller just learns `reachable:false` now instead of waiting for the next poll.
+            reachable, version = await asyncio.to_thread(supervisor.probe_remote, rec["id"])
+            return {"ok": True, "agent": rec, "reachable": reachable, "version": version}
         except (supervisor.FleetError, manager.WorkspaceError) as exc:
             raise HTTPException(400, str(exc))
 

--- a/plugins/delegates/health.py
+++ b/plugins/delegates/health.py
@@ -5,8 +5,11 @@ delegate and caches the result, so the panel shows a live status badge instead o
 only on-demand Test. Reads ``merged_delegates()`` each tick, so it tracks
 add/edit/remove without a restart; entries for removed delegates are pruned.
 
-Ported in spirit from ORBIS's ``health_loop`` (simplified: fixed interval + jitter,
-no per-delegate backoff yet).
+Ported in spirit from ORBIS's ``health_loop``, now with PER-DELEGATE exponential
+backoff: the loop still ticks on a fixed base interval, but a delegate that keeps
+failing is re-probed less often (its next-due time backs off) so a flaky peer degrades
+gracefully instead of getting hammered every tick. A success resets it to the base
+cadence.
 """
 
 from __future__ import annotations
@@ -21,8 +24,15 @@ log = logging.getLogger("protoagent.plugins.delegates")
 
 # name -> {ok, latency_ms?, error?, detail?, checked_at}
 _HEALTH: dict[str, dict] = {}
+# Per-delegate adaptive backoff state: consecutive-failure count + the monotonic-ish
+# wall-clock time the delegate is next due for a probe. A healthy delegate is probed
+# every base interval; each consecutive failure roughly doubles the wait, capped.
+_FAILURES: dict[str, int] = {}
+_NEXT_DUE: dict[str, float] = {}
 _INTERVAL_S = 120.0
 _INITIAL_DELAY_S = 15.0
+_BACKOFF_BASE_S = 120.0
+_BACKOFF_MAX_S = 960.0
 _task: asyncio.Task | None = None
 
 
@@ -31,9 +41,31 @@ def health_snapshot() -> dict[str, dict]:
     return {k: dict(v) for k, v in _HEALTH.items()}
 
 
-async def _probe_all() -> None:
+def _backoff_delay(failures: int) -> float:
+    """Seconds until a delegate's next probe given its consecutive-failure count:
+    ``base`` when healthy (failures<=0), ``base * 2**failures`` capped at ``max`` after
+    that — so the cadence grows monotonically with failures then pins at the ceiling."""
+    if failures <= 0:
+        return _BACKOFF_BASE_S
+    return min(_BACKOFF_BASE_S * (2**failures), _BACKOFF_MAX_S)
+
+
+def _record_result(name: str, ok: bool, now: float) -> None:
+    """Update a delegate's backoff state after a probe: reset to the base cadence on
+    success, otherwise count the failure and push the next-due time out per
+    ``_backoff_delay``."""
+    if ok:
+        _FAILURES.pop(name, None)
+    else:
+        _FAILURES[name] = _FAILURES.get(name, 0) + 1
+    _NEXT_DUE[name] = now + _backoff_delay(_FAILURES.get(name, 0))
+
+
+async def _probe_all(now: float | None = None) -> None:
     from .store import merged_delegates
 
+    if now is None:
+        now = time.time()
     seen: set[str] = set()
     for raw in merged_delegates():
         if not isinstance(raw, dict):
@@ -43,15 +75,22 @@ async def _probe_all() -> None:
         if not (name and adapter):
             continue
         seen.add(name)
+        # Per-delegate backoff: a flaky delegate that isn't due yet is skipped this tick
+        # (its cached health is left intact) so we don't ping-pong a known-bad peer.
+        if now < _NEXT_DUE.get(name, 0.0):
+            continue
         try:
             d = adapter.parse(raw)
             res = await adapter.probe(d)
         except Exception as exc:  # noqa: BLE001 — a bad delegate shouldn't kill the loop
             res = {"ok": False, "error": str(exc)[:200]}
-        res["checked_at"] = time.time()
+        res["checked_at"] = now
         _HEALTH[name] = res
+        _record_result(name, bool(res.get("ok")), now)
     for stale in [n for n in _HEALTH if n not in seen]:
         _HEALTH.pop(stale, None)
+        _FAILURES.pop(stale, None)
+        _NEXT_DUE.pop(stale, None)
 
 
 async def _loop(interval: float = _INTERVAL_S, initial_delay: float = _INITIAL_DELAY_S) -> None:

--- a/tests/test_delegates_plugin.py
+++ b/tests/test_delegates_plugin.py
@@ -395,3 +395,80 @@ async def test_health_probe_records_failure(monkeypatch):
     monkeypatch.setattr(ADAPTERS["acp"], "probe", boom)
     await H._probe_all()
     assert H._HEALTH["p"]["ok"] is False and "nope" in H._HEALTH["p"]["error"]
+
+
+# ── per-delegate backoff (remote-member health robustness) ─────────────────────
+
+
+def test_backoff_delay_grows_then_caps():
+    # healthy → base; each consecutive failure doubles; pinned at the ceiling.
+    assert H._backoff_delay(0) == H._BACKOFF_BASE_S
+    assert H._backoff_delay(1) == H._BACKOFF_BASE_S * 2
+    assert H._backoff_delay(2) == H._BACKOFF_BASE_S * 4
+    seq = [H._backoff_delay(i) for i in range(0, 8)]
+    assert seq == sorted(seq)  # monotonically non-decreasing
+    assert max(seq) == H._BACKOFF_MAX_S  # eventually caps
+    assert H._backoff_delay(100) == H._BACKOFF_MAX_S  # stays capped
+
+
+async def test_health_backoff_skips_until_due_then_resets_on_success(monkeypatch):
+    H._HEALTH.clear()
+    H._FAILURES.clear()
+    H._NEXT_DUE.clear()
+    import plugins.delegates.store as store
+
+    monkeypatch.setattr(
+        store, "merged_delegates", lambda: [{"name": "p", "type": "acp", "command": "proto", "workdir": "/tmp"}]
+    )
+    calls = {"n": 0}
+    outcome = {"ok": False}
+
+    async def probe(d):
+        calls["n"] += 1
+        return {"ok": outcome["ok"]}
+
+    monkeypatch.setattr(ADAPTERS["acp"], "probe", probe)
+
+    # t=0: first probe FAILS → backed off to base*2 out.
+    await H._probe_all(now=0.0)
+    assert calls["n"] == 1 and H._FAILURES["p"] == 1
+    assert H._NEXT_DUE["p"] == H._backoff_delay(1)  # 0 + base*2
+
+    # not yet due → skipped (a flaky peer isn't hammered every tick).
+    await H._probe_all(now=H._backoff_delay(1) - 1.0)
+    assert calls["n"] == 1
+
+    # exactly due → re-probed, fails again → window widens further.
+    due1 = H._NEXT_DUE["p"]
+    await H._probe_all(now=due1)
+    assert calls["n"] == 2 and H._FAILURES["p"] == 2
+    assert H._NEXT_DUE["p"] == due1 + H._backoff_delay(2)
+
+    # success resets to the base cadence and clears the failure count.
+    outcome["ok"] = True
+    due2 = H._NEXT_DUE["p"]
+    await H._probe_all(now=due2)
+    assert calls["n"] == 3 and "p" not in H._FAILURES
+    assert H._NEXT_DUE["p"] == due2 + H._BACKOFF_BASE_S
+
+
+async def test_health_backoff_state_pruned_with_delegate(monkeypatch):
+    H._HEALTH.clear()
+    H._FAILURES.clear()
+    H._NEXT_DUE.clear()
+    import plugins.delegates.store as store
+
+    monkeypatch.setattr(
+        store, "merged_delegates", lambda: [{"name": "p", "type": "acp", "command": "proto", "workdir": "/tmp"}]
+    )
+
+    async def boom(d):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(ADAPTERS["acp"], "probe", boom)
+    await H._probe_all(now=0.0)
+    assert "p" in H._FAILURES and "p" in H._NEXT_DUE
+
+    monkeypatch.setattr(store, "merged_delegates", lambda: [])
+    await H._probe_all(now=1.0)
+    assert "p" not in H._HEALTH and "p" not in H._FAILURES and "p" not in H._NEXT_DUE

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -130,6 +130,48 @@ def test_fleet_list_carries_versions(client, monkeypatch):
     assert "token" not in remote and "sek" not in str(agents)
 
 
+def test_add_remote_probes_on_register_reachable(client, monkeypatch):
+    """POST /api/fleet/remotes probes the new peer immediately and returns
+    reachable+version, so the console/CLI can confirm at register time."""
+    import httpx
+    from graph.fleet import supervisor
+
+    supervisor._probe_cache.clear()
+
+    class FakeCard:
+        status_code = 200
+
+        def json(self):
+            return {"name": "ava", "version": "0.31.0"}
+
+    monkeypatch.setattr(httpx, "get", lambda url, timeout: FakeCard())
+    body = client.post("/api/fleet/remotes", json={"name": "ava", "url": "http://1.2.3.4:7871"}).json()
+    assert body["ok"] is True and body["agent"]["name"] == "ava"
+    assert body["reachable"] is True and body["version"] == "0.31.0"
+    assert "token" not in body["agent"]
+
+
+def test_add_remote_unreachable_is_registered_not_rejected(client, monkeypatch):
+    """An unreachable peer is STILL registered (deferred registration is intentional) —
+    the response just reports reachable:false so the caller can warn."""
+    import httpx
+    from graph.fleet import supervisor
+
+    supervisor._probe_cache.clear()
+
+    def boom(url, timeout):
+        raise httpx.HTTPError("connection refused")
+
+    monkeypatch.setattr(httpx, "get", boom)
+    r = client.post("/api/fleet/remotes", json={"name": "ghosty", "url": "http://1.2.3.4:7999"})
+    assert r.status_code == 200  # NOT a hard reject
+    body = r.json()
+    assert body["ok"] is True and body["reachable"] is False and body["version"] == ""
+    # it's actually in the fleet, just shown not-running
+    entry = next(a for a in client.get("/api/fleet").json()["agents"] if a.get("remote"))
+    assert entry["name"] == "ghosty" and entry["running"] is False
+
+
 def test_discover_endpoint(client, monkeypatch):
     # /api/fleet/discover returns OTHER protoAgents (mock the scan); the route's host self-exclusion
     # + supervisor scan run, discover() internals are unit-tested elsewhere.

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -186,6 +186,63 @@ def test_probe_captures_remote_version(tmp_path, monkeypatch):
     assert host["version"]
 
 
+def test_probe_ttl_is_three_seconds():
+    """The reachability cache TTL is aligned to the 3s console poll (remote-member
+    health robustness) so a just-downed remote isn't shown 'running' for ~10s."""
+    assert supervisor._PROBE_TTL == 3.0
+
+
+def test_probe_remote_reachable_returns_version(tmp_path, monkeypatch):
+    """probe_remote() probes ONE member immediately (TTL-bypass) and returns
+    (reachable, version) — what the register route surfaces so the console can warn
+    up front. It refreshes the cache and persists the probed version."""
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    supervisor._probe_cache.clear()
+    rec = supervisor.add_remote("ava", "http://h:9", token="sek")
+
+    class FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"name": "ava", "version": "0.31.0"}
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", lambda url, timeout: FakeResp())
+    reachable, version = supervisor.probe_remote(rec["id"])
+    assert reachable is True and version == "0.31.0"
+    assert supervisor._probe_cache[rec["id"]][0] is True
+    # persisted on the record (token left intact for the proxy)
+    stored = supervisor.remote_for_slug(rec["id"])
+    assert stored["version"] == "0.31.0" and stored["token"] == "sek"
+    # by NAME resolves too
+    assert supervisor.probe_remote("ava")[0] is True
+
+
+def test_probe_remote_unreachable_is_false(tmp_path, monkeypatch):
+    """An unreachable peer probes reachable:false (no version) — registration is NOT
+    rejected for it (deferred registration is intentional)."""
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    supervisor._probe_cache.clear()
+    rec = supervisor.add_remote("ghosty", "http://h:9")
+
+    import httpx
+
+    def boom(url, timeout):
+        raise httpx.HTTPError("connection refused")
+
+    monkeypatch.setattr(httpx, "get", boom)
+    reachable, version = supervisor.probe_remote(rec["id"])
+    assert reachable is False and version == ""
+    assert supervisor._probe_cache[rec["id"]][0] is False
+
+
+def test_probe_remote_unknown_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    with pytest.raises(supervisor.FleetError):
+        supervisor.probe_remote("nope")
+
+
 def test_probe_card_without_version_keeps_last_known(tmp_path, monkeypatch):
     """A card with no/blank version (or unparseable JSON) must not clobber the
     last-known value — last-good wins until the remote reports something new."""


### PR DESCRIPTION
## What

Three cohesive hardenings for the cross-machine fleet's **remote-member health** (ADR 0042 §I), so a remote peer's reachability is visible *immediately* and a flaky peer degrades gracefully.

### 1. Probe-on-register (`operator_api/fleet_routes.py`, `graph/fleet/supervisor.py`)
`POST /api/fleet/remotes` now probes the newly-registered remote's `.well-known/agent-card.json` **immediately** (off the event loop) and returns `reachable` + `version`:

```json
{ "ok": true, "agent": {…}, "reachable": false, "version": "" }
```

An unreachable remote is **not** rejected — deferred registration is intentional (a peer can come online later); the response just tells the caller it's currently unreachable so the console/CLI can warn up front instead of waiting for the next 3s poll. Backed by a new focused `supervisor.probe_remote(id)` (probes one member, TTL-bypassed, reuses the same probe path as `refresh_remote_probes`).

### 2. Probe freshness (`graph/fleet/supervisor.py`)
`_PROBE_TTL` 10.0 → **3.0**, aligned to the 3s console poll so a just-downed remote doesn't keep showing `running` for up to ~10s.

### 3. Per-delegate exponential backoff (`plugins/delegates/health.py`)
The delegates health prober used a fixed ~120s sweep that hit every delegate each tick. Now each delegate carries consecutive-failure + next-due state: on failure the next probe is pushed out to `min(base * 2**failures, max)` (base 120s, max 960s); a success resets it to the base cadence. The loop structure is unchanged — only the per-delegate next-due is adaptive — so a flaky peer is no longer re-probed every tick. Backoff state is pruned when a delegate is removed.

## Tests
- Route: probe-on-register returns `reachable:true`+version for a reachable peer; `reachable:false` (and still registered, shown not-running) for an unreachable one.
- Supervisor: `probe_remote` reachable/unreachable/unknown; `_PROBE_TTL == 3.0`.
- Health: `_backoff_delay` grows then caps; `_probe_all` skips-until-due, widens on repeat failure, resets on success; backoff state pruned with the delegate.

All offline (mock `httpx` / the probe). Gates: `ruff check .` clean; full `pytest tests/ -q` → 2466 passed, 4 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)