### PR TITLE
feat(fleet): auto-sweep discovery on hub boot

### DIFF
--- a/graph/fleet/discovery.py
+++ b/graph/fleet/discovery.py
@@ -24,6 +24,8 @@ import logging
 import os
 import socket
 import subprocess
+import time
+from collections.abc import Iterable
 
 import httpx
 
@@ -32,6 +34,42 @@ log = logging.getLogger(__name__)
 _SERVICE_TYPE = "_protoagent._tcp.local."
 _zc = None  # the advertised Zeroconf instance (None until advertise())
 _info = None
+
+# ── boot-sweep peer cache (ADR 0042 §I) ───────────────────────────────────────
+# Peers found by the at-boot background sweep (and every subsequent ``discover()``)
+# are remembered here keyed by ``(host, port)`` with a wall-clock timestamp, so the
+# FIRST console ``GET /api/fleet/discover`` is instant — siblings that booted
+# alongside us are surfaced from the cache while the live scan runs, rather than only
+# after a manual rescan. Entries age out after ``_CACHE_TTL_S`` so a peer that goes
+# away stops surfacing. Read/written only on the event loop (inside ``discover()`` or
+# the sweep task), so no lock is needed.
+_peer_cache: dict[tuple, tuple[dict, float]] = {}
+_CACHE_TTL_S = 300.0  # cached peers surface for 5 min after they were last seen
+_sweep_task = None  # holds the boot-sweep task so it isn't GC'd mid-flight
+
+
+def _remember(peers: Iterable[dict]) -> None:
+    """Stamp ``peers`` into the boot-sweep cache (each with ``time.time()``)."""
+    now = time.time()
+    for p in peers:
+        _peer_cache[(p["host"], p["port"])] = (dict(p), now)
+
+
+def _cached_peers() -> list[tuple[tuple, dict]]:
+    """``(key, peer)`` for cached peers still within TTL; ages the stale ones out."""
+    now = time.time()
+    live: list[tuple[tuple, dict]] = []
+    for key, (peer, ts) in list(_peer_cache.items()):
+        if now - ts <= _CACHE_TTL_S:
+            live.append((key, peer))
+        else:
+            _peer_cache.pop(key, None)
+    return live
+
+
+def cached_peers() -> list[dict]:
+    """Currently-cached discovery candidates (within TTL). Best-effort, may be stale."""
+    return [peer for _, peer in _cached_peers()]
 
 # App-layer defaults for the discovery knobs (Host layer, ADR 0047 D8) — used when no
 # live config is loaded (CLI/test context). Mirror the LangGraphConfig dataclass defaults.
@@ -291,4 +329,51 @@ async def discover(
         if (a["host"], a["port"]) in known:
             continue
         out[(a["host"], a["port"])] = a
+    _remember(out.values())  # warm the boot-sweep cache with THIS scan's live hits
+    # Merge in still-fresh cached peers (e.g. from the at-boot sweep) that this live scan
+    # missed, so the first console open is instant instead of waiting on a manual rescan.
+    # Filtered by ``known`` (don't surface a peer already in the fleet) and aged out by TTL.
+    for key, peer in _cached_peers():
+        if key in known:
+            continue
+        out.setdefault(key, peer)
     return list(out.values())
+
+
+# ── boot sweep ─────────────────────────────────────────────────────────────────
+async def boot_sweep(
+    *,
+    known: set | None = None,
+    port_range: tuple[int, int] | None = None,
+    timeout: float = 1.5,
+    mdns: bool | None = None,
+) -> list[dict]:
+    """One-shot background discovery sweep run at hub boot. Warms ``_peer_cache`` so peers
+    that booted alongside us are surfaced on the first ``discover()`` without a manual scan.
+
+    Best-effort: every failure (a channel raising, no network, etc.) is swallowed and logged
+    at info — discovery only ever *surfaces* candidates, so a miss never breaks anything."""
+    try:
+        peers = await discover(known=known, port_range=port_range, timeout=timeout, mdns=mdns)
+        log.info("[discovery] boot sweep cached %d peer(s)", len(peers))
+        return peers
+    except Exception:  # noqa: BLE001 — discovery is best-effort, never blocks/breaks boot
+        log.info("[discovery] boot sweep failed — continuing without a warm cache", exc_info=True)
+        return []
+
+
+def start_boot_sweep(**kwargs) -> None:
+    """Fire-and-forget the boot sweep on the running loop (idempotent, non-blocking).
+
+    ``discover()`` offloads the sync zeroconf browse to a thread itself, so scheduling the
+    coroutine on the loop is safe. A reference is held in ``_sweep_task`` so the task isn't
+    garbage-collected mid-flight. No running loop (CLI context) ⇒ skipped, never raises."""
+    global _sweep_task
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        log.debug("[discovery] start_boot_sweep called without a running loop — skipping")
+        return
+    if _sweep_task is not None and not _sweep_task.done():
+        return  # already sweeping — don't pile on
+    _sweep_task = loop.create_task(boot_sweep(**kwargs))

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -540,6 +540,13 @@ def _main():
             from graph.fleet import discovery
 
             await asyncio.to_thread(discovery.advertise, agent_name(), int(getattr(STATE, "active_port", 0) or 0))
+            # …and kick off a one-shot BACKGROUND sweep so peers that booted alongside us are
+            # cached and the first console GET /api/fleet/discover is instant (instead of only
+            # finding them after a manual rescan). Fire-and-forget on the loop — discover()
+            # offloads the sync zeroconf browse to a thread itself, so boot is never blocked;
+            # every failure is swallowed inside, and discovered peers are only surfaced as
+            # candidates (never auto-added to the fleet).
+            discovery.start_boot_sweep()
         except Exception:
             log.exception("[discovery] mDNS advertise failed")
 

--- a/tests/test_fleet_discovery.py
+++ b/tests/test_fleet_discovery.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import time
 import types
 
 import pytest
@@ -21,6 +22,8 @@ from graph.fleet import discovery
 def _reset_zc(monkeypatch):
     monkeypatch.setattr(discovery, "_zc", None)
     monkeypatch.setattr(discovery, "_info", None)
+    monkeypatch.setattr(discovery, "_peer_cache", {})  # fresh boot-sweep cache per test
+    monkeypatch.setattr(discovery, "_sweep_task", None)
 
 
 class _FakeZeroconf:
@@ -187,3 +190,101 @@ def test_discover_collapses_colocated_mdns_with_local_scan(monkeypatch):
     # And a KNOWN fleet peer's own advert (LAN ip + its port) is excluded the same way.
     found = asyncio.run(discovery.discover(known={("127.0.0.1", 7874)}))
     assert [f["name"] for f in found] == ["remote"]
+
+
+# ── boot sweep + peer cache (auto-sweep on hub boot) ──────────────────────────
+def _stub_channels(monkeypatch, *, local=None, tailnet=None, mdns=None):
+    """Replace the three live discovery channels with fixed results (or a raiser)."""
+
+    async def fake_local(port_range, skip):
+        if isinstance(local, Exception):
+            raise local
+        return list(local or [])
+
+    async def fake_tailnet(port_range, known):
+        if isinstance(tailnet, Exception):
+            raise tailnet
+        return list(tailnet or [])
+
+    def fake_mdns(timeout):
+        if isinstance(mdns, Exception):
+            raise mdns
+        return list(mdns or [])
+
+    monkeypatch.setattr(discovery, "_scan_local", fake_local)
+    monkeypatch.setattr(discovery, "_scan_tailnet", fake_tailnet)
+    monkeypatch.setattr(discovery, "_browse_mdns", fake_mdns)
+    monkeypatch.setattr(discovery, "_local_ip", lambda: "10.0.0.9")  # never matches the fakes
+
+
+def test_boot_sweep_populates_cache(monkeypatch):
+    """The at-boot sweep caches whatever the channels surfaced, keyed by (host, port)."""
+    _stub_channels(
+        monkeypatch,
+        local=[{"name": "loc", "url": "http://127.0.0.1:7871", "host": "127.0.0.1", "port": 7871}],
+        mdns=[{"name": "lan", "url": "http://192.168.5.40:7871", "host": "192.168.5.40", "port": 7871}],
+    )
+    assert discovery.cached_peers() == []  # cold before the sweep
+
+    swept = asyncio.run(discovery.boot_sweep())
+    assert sorted(p["name"] for p in swept) == ["lan", "loc"]
+    assert sorted(p["name"] for p in discovery.cached_peers()) == ["lan", "loc"]
+    assert ("192.168.5.40", 7871) in discovery._peer_cache  # stamped by (host, port)
+
+
+def test_cached_peers_returned_without_fresh_scan(monkeypatch):
+    """Once the cache is warm, a later discover() surfaces the cached peer even though the
+    live scan finds nothing — the first console open is instant, not blank."""
+    discovery._remember(
+        [{"name": "booted-sibling", "url": "http://192.168.5.50:7872", "host": "192.168.5.50", "port": 7872}]
+    )
+    _stub_channels(monkeypatch)  # all three channels return nothing
+
+    found = asyncio.run(discovery.discover())
+    assert [f["name"] for f in found] == ["booted-sibling"]
+
+    # …but a cached peer that's since been added to the fleet (in `known`) is NOT re-surfaced.
+    found = asyncio.run(discovery.discover(known={("192.168.5.50", 7872)}))
+    assert found == []
+
+
+def test_boot_sweep_swallows_channel_failure(monkeypatch):
+    """A channel blowing up never propagates out of the sweep — it returns [] and the cache
+    stays empty rather than crashing boot."""
+    _stub_channels(monkeypatch, local=RuntimeError("scan exploded"))
+
+    result = asyncio.run(discovery.boot_sweep())  # must not raise
+    assert result == []
+    assert discovery.cached_peers() == []
+
+
+def test_stale_cached_peers_age_out(monkeypatch):
+    """Cached peers older than the TTL stop surfacing (a peer that went away)."""
+    discovery._remember([{"name": "gone", "url": "http://192.168.5.60:7873", "host": "192.168.5.60", "port": 7873}])
+    # Backdate the entry past the TTL.
+    peer, _ = discovery._peer_cache[("192.168.5.60", 7873)]
+    discovery._peer_cache[("192.168.5.60", 7873)] = (peer, time.time() - discovery._CACHE_TTL_S - 1)
+    _stub_channels(monkeypatch)
+
+    assert asyncio.run(discovery.discover()) == []
+    assert ("192.168.5.60", 7873) not in discovery._peer_cache  # aged out on read
+
+
+def test_start_boot_sweep_schedules_task_on_loop(monkeypatch):
+    """start_boot_sweep() fires the sweep on the running loop and holds a task ref; with no
+    running loop it just no-ops."""
+    discovery.start_boot_sweep()  # no running loop here → skipped, no raise
+    assert discovery._sweep_task is None
+
+    _stub_channels(
+        monkeypatch,
+        local=[{"name": "loc", "url": "http://127.0.0.1:7871", "host": "127.0.0.1", "port": 7871}],
+    )
+
+    async def _drive():
+        discovery.start_boot_sweep()
+        assert discovery._sweep_task is not None
+        await discovery._sweep_task  # let the fire-and-forget task complete
+
+    asyncio.run(_drive())
+    assert [p["name"] for p in discovery.cached_peers()] == ["loc"]


### PR DESCRIPTION
## What

On hub boot, also kick off a **background discovery sweep** so peers that boot together are found without waiting for a manual scan. Today discovery (ADR 0042 §I) only runs when the console hits `GET /api/fleet/discover`, so siblings that come up alongside the hub aren't surfaced until the operator clicks rescan.

## How

- **`graph/fleet/discovery.py`**
  - New module-level peer cache keyed by `(host, port)` with a per-entry wall-clock timestamp and a 5-minute TTL (`_peer_cache`, `_remember`, `_cached_peers`, public `cached_peers()`).
  - `discover()` now warms the cache with each live scan's hits and **merges in still-fresh cached peers the live scan missed** — filtered by `known` (never re-surface a peer already in the fleet) and aged out by TTL. So the first console open is instant instead of blank.
  - New `boot_sweep()` / `start_boot_sweep()`: fire-and-forget on the running loop. `discover()` already offloads the sync zeroconf browse to a thread, so scheduling the coroutine never blocks boot and never runs sync zeroconf on the loop. A task ref is held so it isn't GC'd; no running loop (CLI) ⇒ no-op. **Every failure is swallowed and logged at info.**
- **`server/__init__.py`**: call `discovery.start_boot_sweep()` right after `advertise()` at boot.

Discovered peers are only **surfaced as candidates** — never auto-added to the fleet. The user still adds them (unchanged route behavior).

## Tests (`tests/test_fleet_discovery.py`, channels mocked)

- boot sweep populates the cache (keyed by `(host, port)`)
- cached peers are returned without a fresh live scan, and a cached peer now in `known` is not re-surfaced
- channel failures are swallowed — `boot_sweep()` returns `[]`, never raises
- stale cache entries age out past the TTL
- `start_boot_sweep()` schedules on the loop and no-ops without one

## Gates

- `ruff check .` — clean
- `python -m pytest tests/ -q` — 2462 passed, 4 skipped (+ the 5 new discovery tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)