### PR TITLE
test(integration): fleet member crash -> detect -> restart

### DIFF
--- a/tests/integration/test_fleet_crash_restart.py
+++ b/tests/integration/test_fleet_crash_restart.py
@@ -1,0 +1,111 @@
+"""Real-subprocess fleet CRASH -> DETECT -> RESTART coverage.
+
+Boots a hub, has it spawn a real member, hard-kills the member with SIGKILL
+(no graceful shutdown), then drives the operator's recovery path: the hub stops
+seeing the member (its port is dead -> the reverse proxy can't reach it), the
+crashed member is reconciled out of the fleet registry (``/api/fleet`` reports it
+not-running), and it is restarted to a fresh, healthy process with a NEW pid and
+its data dir intact.
+
+This is the failure mode the harness had no coverage for: every prior fleet test
+only exercised the happy spawn/proxy path, never a member dying underneath the hub.
+
+NOTE on the reconcile ``stop`` between crash and restart: a SIGKILLed member is a
+zombie child of the hub until the hub reaps it, and ``os.kill(pid, 0)`` reports a
+zombie as alive. So a *passive* ``/api/fleet`` poll keeps showing ``running: True``,
+and ``supervisor.start`` would short-circuit on the still-"alive" pid (a no-op that
+returns the dead pid). The hub reaps the zombie the next time it spawns a
+subprocess; ``POST /api/fleet/{name}/stop`` (the console's "clear a dead member"
+action) does exactly that, after which ``status()`` reports the member down and a
+restart spawns a genuinely new process. See the PR notes / ``risks``.
+
+Slow + opt-in: ``PA_RUN_INTEGRATION=1 pytest tests/integration``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+
+from tests.integration.conftest import http_get, http_post, poll, requires_integration
+
+pytestmark = requires_integration
+
+
+def _fleet_agents(hub) -> list[dict]:
+    st, raw = http_get(f"{hub.base}/api/fleet", timeout=10)
+    assert st == 200, raw[:200]
+    return json.loads(raw).get("agents", []) or []
+
+
+def _member(hub, mid: str) -> dict | None:
+    return next((a for a in _fleet_agents(hub) if a.get("id") == mid), None)
+
+
+def test_member_crash_detected_then_restart(fleet):
+    hub = fleet(name="hub-crash")
+
+    # Create + start a real member process.
+    st, raw = http_post(
+        f"{hub.base}/api/fleet",
+        {"name": "victim", "inherit_config": True, "start": True},
+        timeout=180,
+    )
+    assert st == 200, f"create member failed: {st} {raw[:300]}"
+    agent = json.loads(raw)["agent"]
+    assert agent.get("running"), f"member did not start: {agent}"
+    mid = agent["id"]
+    pid1 = int(agent["pid"])
+
+    # It answers through the hub proxy before we crash it.
+    reached = poll(lambda: http_get(f"{hub.base}/agents/{mid}/healthz", timeout=3)[0] == 200, timeout=90)
+    assert reached, "member never reachable through the hub proxy before crash"
+
+    # Fleet status agrees it's up.
+    m = _member(hub, mid)
+    assert m and m.get("running") and int(m.get("pid")) == pid1, f"member not listed as running: {m}"
+
+    # Where the member's data lives -- we confirm it survives the restart.
+    ws_dirs = list(hub.data_root.glob(f"**/workspaces/{mid}"))
+    assert ws_dirs, "member workspace dir not found before crash"
+    ws_dir = ws_dirs[0]
+
+    # CRASH: hard-kill the member (SIGKILL = no shutdown hook, like a real crash).
+    os.kill(pid1, signal.SIGKILL)
+
+    # DETECT (immediate, real): the member's port is dead, so the hub proxy can no
+    # longer reach it -- /agents/<id>/healthz stops returning 200.
+    down = poll(lambda: http_get(f"{hub.base}/agents/{mid}/healthz", timeout=3)[0] != 200, timeout=30)
+    assert down, "hub proxy still reached the member after it was killed"
+
+    # RECONCILE: clear the dead member from the fleet registry. This reaps the zombie
+    # and removes the stale entry; tolerate 200 (stopped now) or 400 (already gone).
+    st, _ = http_post(f"{hub.base}/api/fleet/victim/stop", {}, timeout=30)
+    assert st in (200, 400), f"unexpected stop status for crashed member: {st}"
+
+    # /api/fleet now reports the member not-running (status() pruned the dead pid).
+    dead = poll(lambda: (_member(hub, mid) or {}).get("running") is False, timeout=30)
+    assert dead, f"hub never marked the crashed member dead: {_member(hub, mid)}"
+
+    # RESTART by NAME (the /api/fleet/{name}/start route resolves id-or-name -> supervisor.start).
+    st, raw = http_post(f"{hub.base}/api/fleet/victim/start", {}, timeout=180)
+    assert st == 200, f"restart failed: {st} {raw[:300]}"
+    restarted = json.loads(raw)["agent"]
+    assert restarted.get("running"), f"member did not restart: {restarted}"
+    pid2 = int(restarted["pid"])
+    assert pid2 != pid1, f"restart reused the crashed pid ({pid1})"
+
+    # HEALTHY AGAIN: the new process answers through the proxy.
+    reached2 = poll(lambda: http_get(f"{hub.base}/agents/{mid}/healthz", timeout=3)[0] == 200, timeout=90)
+    assert reached2, "member never reachable through the hub proxy after restart"
+
+    # Fleet status agrees: running again, with the NEW pid.
+    back = poll(
+        lambda: (lambda a: bool(a) and a.get("running") and a.get("pid") == pid2)(_member(hub, mid)),
+        timeout=30,
+    )
+    assert back, f"fleet status did not show the restarted member with the new pid: {_member(hub, mid)}"
+
+    # The member's data dir persisted across the crash + restart.
+    assert ws_dir.exists(), "member workspace dir did not survive the restart"


### PR DESCRIPTION
## What

Adds `tests/integration/test_fleet_crash_restart.py` to the real-subprocess fleet harness — the first coverage for a fleet **member dying underneath the hub**. Every prior fleet test only exercised the happy spawn/proxy path.

**Test code only — no production changes.** Opt-in/slow: runs only under `PA_RUN_INTEGRATION=1`, skips by default.

## Flow exercised

1. Boot a hub; create + start a real member (`POST /api/fleet`); capture its pid; confirm `/agents/<id>/healthz` is 200 through the hub proxy.
2. **Crash** it: `os.kill(pid, SIGKILL)`.
3. **Detect**: the member's port is dead, so the hub proxy can no longer reach it — `/agents/<id>/healthz` stops returning 200.
4. **Reconcile**: `POST /api/fleet/{name}/stop` clears the dead entry; `/api/fleet` then reports the member `running == False`.
5. **Restart** by name: `POST /api/fleet/{name}/start` → a **new** pid (different from the crashed one); `/agents/<id>/healthz` is 200 again; `/api/fleet` shows it running with the new pid.
6. Assert the member's workspace data dir persisted across the crash + restart.

All async transitions use the conftest `poll()` helper with generous timeouts (member boot ~10–20s).

## Why the reconcile `stop` between crash and restart

A SIGKILLed member is a zombie child of the hub until the hub reaps it, and `os.kill(pid, 0)` reports a zombie as **alive**. So:
- a *passive* `/api/fleet` poll keeps showing `running: True` (`status()` won't prune it), and
- `supervisor.start` would short-circuit on the still-"alive" pid (a no-op returning the dead pid, so no fresh process).

The hub reaps the zombie the next time it spawns a subprocess. `POST /api/fleet/{name}/stop` (the console's "clear a dead member" action) does that via its `_is_our_agent` `ps` subprocess, after which `status()` reports the member down and the restart spawns a genuinely new process. The test therefore models the **real operator recovery path** (clear the dead member, then start) rather than a passive poll that can't work on this platform.

## Gates

- `ruff check tests/integration/` — clean (also `ruff check .` clean)
- `PA_RUN_INTEGRATION=1 python -m pytest tests/integration/test_fleet_crash_restart.py -q` — **1 passed** (~16s, real subprocesses); full integration suite **5 passed**
- `python -m pytest tests/integration -q` (no env) — **skipped**; full `python -m pytest tests/ -q` — **2457 passed, 5 skipped**
- `uv.lock` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)