### PR TITLE
feat(config): add `config explain` diagnostic (CLI + operator API)

### DIFF
--- a/graph/config_explain.py
+++ b/graph/config_explain.py
@@ -1,0 +1,148 @@
+"""``config explain`` — the read-only diagnostic that answers "where did my
+config / key go?".
+
+It prints this instance's **identity** (the env-derived id + the three roots),
+**every resolved on-disk path** (so you can see exactly which file a store lives
+in), and the **per-field cascade provenance** — for each settings key, the scope
+it homes at (agent leaf vs box-shared Host layer), the live value, and which
+cascade layer that value actually came from (agent / host / default).
+
+This is the non-destructive replacement for the old self-heal: it never moves or
+rewrites anything, it just shows you the resolution. The same builder powers both
+the CLI (``python -m server config explain``) and the operator API
+(``GET /api/config/explain``), so they can't drift.
+
+Lives in ``graph/`` (a leaf layer): it imports only ``infra.paths`` + ``graph.*``,
+never ``server``/``operator_api`` — so the CLI front-end *and* the operator route
+can both import it without crossing the import-layering contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_config_explain(config: Any = None) -> dict:
+    """Assemble the full explain payload: id + roots + every resolved path
+    (from :meth:`InstancePaths.explain`) plus the per-field ``cascade`` list.
+
+    ``config`` lets the operator route pass the LIVE ``STATE.graph_config`` (what's
+    actually running); when ``None`` (the CLI path) the agent leaf is loaded fresh
+    from disk via the standard cascade, so the diagnostic reflects the on-disk
+    config even with no server running.
+    """
+    from infra.paths import instance_paths
+
+    out = instance_paths().explain()  # {instance_id, box_root, instance_root, app_root, paths}
+    out["cascade"] = _build_cascade(config)
+    return out
+
+
+def _build_cascade(config: Any = None) -> list[dict]:
+    """Per-field provenance, reusing the settings-schema source logic (one source
+    of truth with the Settings UI). Loads the live config, the raw agent leaf doc,
+    and the filtered Host layer, then asks ``build_schema`` to stamp each field's
+    ``source`` (agent / host / default). Returns ``[{key, scope, value, source}]``.
+
+    Secrets are never echoed: ``build_schema`` already redacts secret-typed fields
+    to ``value: ""`` + ``is_set``; we surface that as a ``"<set>"`` / ``"<unset>"``
+    marker so the operator can see a key IS configured without printing it.
+    """
+    from graph.config import LangGraphConfig, _load_host_layer
+    from graph.config_io import config_yaml_path, load_yaml_doc
+    from graph.settings_schema import build_schema
+
+    cfg_yaml = config_yaml_path()
+    if config is None:
+        config = LangGraphConfig.from_yaml(cfg_yaml)
+    # Per-layer provenance (ADR 0047), exactly as /api/settings/schema reads it: the
+    # raw agent leaf doc + the host-key-filtered Host layer drive build_schema's
+    # `source` stamp. No gateway probe (model_options=None) — explain stays offline.
+    agent_doc = load_yaml_doc(cfg_yaml) if cfg_yaml.exists() else {}
+    if not isinstance(agent_doc, dict):
+        agent_doc = {}
+    host_doc = _load_host_layer()
+
+    cascade: list[dict] = []
+    for group in build_schema(config, agent_doc=agent_doc, host_doc=host_doc):
+        for f in group["fields"]:
+            if f.get("type") == "secret":
+                value: Any = "<set>" if f.get("is_set") else "<unset>"
+            else:
+                value = f.get("value")
+            cascade.append(
+                {
+                    "key": f["key"],
+                    "scope": f.get("scope", "agent"),
+                    "value": value,
+                    "source": f.get("source", "default"),
+                }
+            )
+    return cascade
+
+
+# ---------------------------------------------------------------------------
+# CLI front-end (`python -m server config explain`)
+# ---------------------------------------------------------------------------
+
+
+def render_config_explain(data: dict) -> str:
+    """Human-readable rendering of a :func:`build_config_explain` payload: an
+    identity block, a path list, and a compact cascade table."""
+    lines: list[str] = []
+    lines.append("Instance")
+    lines.append(f"  id:             {data['instance_id']}")
+    lines.append(f"  box root:       {data['box_root']}")
+    lines.append(f"  instance root:  {data['instance_root']}")
+    lines.append(f"  app root:       {data['app_root']}")
+
+    paths = data.get("paths", {})
+    lines.append("")
+    lines.append("Paths")
+    width = max((len(k) for k in paths), default=0)
+    for key in sorted(paths):
+        lines.append(f"  {key.ljust(width)}  {paths[key]}")
+
+    cascade = data.get("cascade", [])
+    lines.append("")
+    lines.append("Cascade (per-field provenance — source = which layer set the live value)")
+    if cascade:
+        kw = max(len(c["key"]) for c in cascade)
+        sw = max(len(str(c["scope"])) for c in cascade)
+        ow = max(len(str(c["source"])) for c in cascade)
+        header = f"  {'KEY'.ljust(kw)}  {'SCOPE'.ljust(sw)}  {'SOURCE'.ljust(ow)}  VALUE"
+        lines.append(header)
+        for c in cascade:
+            val = "" if c["value"] is None else str(c["value"])
+            lines.append(f"  {c['key'].ljust(kw)}  {str(c['scope']).ljust(sw)}  {str(c['source']).ljust(ow)}  {val}")
+    else:
+        lines.append("  (no settings fields)")
+    return "\n".join(lines)
+
+
+def run_config_cli(argv: list[str]) -> int:
+    """``python -m server config <action>`` dispatch. Today the one action is
+    ``explain`` (read-only); ``--json`` emits the raw payload for scripting."""
+    import argparse
+    import json
+
+    parser = argparse.ArgumentParser(
+        prog="python -m server config",
+        description="Inspect this instance's config resolution (read-only diagnostic).",
+    )
+    sub = parser.add_subparsers(dest="action", required=True)
+    ep = sub.add_parser(
+        "explain",
+        help="print this instance's identity, roots, every resolved path, and per-field cascade provenance",
+    )
+    ep.add_argument("--json", action="store_true", help="emit the raw payload as JSON instead of the human table")
+    args = parser.parse_args(argv)
+
+    if args.action == "explain":
+        data = build_config_explain()
+        if args.json:
+            print(json.dumps(data, indent=2))
+        else:
+            print(render_config_explain(data))
+        return 0
+    return 2  # unreachable: argparse rejects an unknown action first

--- a/operator_api/config_routes.py
+++ b/operator_api/config_routes.py
@@ -86,6 +86,17 @@ def register_config_routes(app) -> None:
             "soul": read_soul(),
         }
 
+    @app.get("/api/config/explain")
+    async def _api_config_explain():
+        """Read-only diagnostic: this instance's identity, both roots, every
+        resolved path, and the per-field cascade provenance — the console/curl
+        counterpart of ``python -m server config explain``. Passes the LIVE
+        config so the cascade reflects what's actually running; secrets are
+        redacted to a set/unset marker, never echoed."""
+        from graph.config_explain import build_config_explain
+
+        return build_config_explain(STATE.graph_config)
+
     @app.post("/api/config")
     async def _api_post_config(req: ConfigReloadRequest):
         # Offload off the event loop (#497) — the reload's graph compile is heavy

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -293,6 +293,15 @@ def _main():
 
         raise SystemExit(run_fleet_cli(sys.argv[2:]))
 
+    # Config subcommand: `python -m server config explain` — a read-only diagnostic
+    # that prints this instance's identity, both roots, every resolved path, and the
+    # per-field cascade provenance (the "where did my config/key go?" answer). Acts
+    # on disk + the env, then exits; never starts the server.
+    if len(sys.argv) > 1 and sys.argv[1] == "config":
+        from graph.config_explain import run_config_cli
+
+        raise SystemExit(run_config_cli(sys.argv[2:]))
+
     # Frozen-binary entrypoint for a plugin's managed MCP server (ADR 0019): the
     # bundled desktop app has no `python` on PATH, so a plugin's managed-server
     # factory re-invokes this binary with `--mcp-plugin <id>` instead of `-m

--- a/tests/test_config_explain.py
+++ b/tests/test_config_explain.py
@@ -1,0 +1,136 @@
+"""``config explain`` diagnostic — the read-only "where did my config/key go?"
+builder shared by the CLI (`python -m server config explain`) and the operator
+route (`GET /api/config/explain`).
+
+Covers: the builder reports the env-resolved roots/id; secrets are redacted (never
+echoed); the cascade lists a known field with a plausible source; the CLI renderer
+runs; and the API route returns the expected top-level shape.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from infra.paths import reset_instance_paths
+
+
+def _isolate(monkeypatch, tmp_path, instance="alpha"):
+    """Point this instance at an empty tmp box so the builder reads no real
+    on-disk config, then re-resolve the cached InstancePaths singleton."""
+    box = tmp_path / "box"
+    box.mkdir()
+    monkeypatch.setenv("PROTOAGENT_BOX_ROOT", str(box))
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", instance)
+    monkeypatch.delenv("PROTOAGENT_HOME", raising=False)
+    # conftest pins PROTOAGENT_HOST_CONFIG to an absent path for cascade isolation;
+    # clear it so host_config resolves box-relatively (the real two-tier default).
+    monkeypatch.delenv("PROTOAGENT_HOST_CONFIG", raising=False)
+    reset_instance_paths()
+    return box
+
+
+def test_explain_reports_env_resolved_roots(monkeypatch, tmp_path):
+    from graph.config_explain import build_config_explain
+
+    box = _isolate(monkeypatch, tmp_path, instance="alpha")
+    data = build_config_explain()
+
+    assert data["instance_id"] == "alpha"
+    assert data["box_root"] == str(box)
+    assert data["instance_root"] == str(box / "alpha")
+    # Every resolved path nests under the instance root (or the box, for shared tiers).
+    assert data["paths"]["config_yaml"] == str(box / "alpha" / "config" / "langgraph-config.yaml")
+    assert data["paths"]["host_config"] == str(box / "host-config.yaml")
+
+
+def test_secret_values_are_redacted(monkeypatch, tmp_path):
+    from graph.config import LangGraphConfig
+    from graph.config_explain import build_config_explain
+
+    _isolate(monkeypatch, tmp_path)
+    secret = "sk-SUPERSECRET-must-not-leak-123"
+    cfg = LangGraphConfig(api_key=secret, auth_token="tok-SECRET-also-hidden")
+    data = build_config_explain(cfg)
+
+    # The raw secret never appears anywhere in the serialized payload.
+    assert secret not in json.dumps(data)
+    assert "tok-SECRET-also-hidden" not in json.dumps(data)
+    # ...but the diagnostic still tells you the key IS configured.
+    api_key = next(c for c in data["cascade"] if c["key"] == "model.api_key")
+    assert api_key["value"] == "<set>"
+    token = next(c for c in data["cascade"] if c["key"] == "auth.token")
+    assert token["value"] == "<set>"
+
+
+def test_unset_secret_marks_unset(monkeypatch, tmp_path):
+    from graph.config import LangGraphConfig
+    from graph.config_explain import build_config_explain
+
+    _isolate(monkeypatch, tmp_path)
+    data = build_config_explain(LangGraphConfig(api_key="", auth_token=""))
+    api_key = next(c for c in data["cascade"] if c["key"] == "model.api_key")
+    assert api_key["value"] == "<unset>"
+
+
+def test_cascade_lists_known_field_with_source(monkeypatch, tmp_path):
+    from graph.config_explain import build_config_explain
+
+    _isolate(monkeypatch, tmp_path)
+    data = build_config_explain()
+    by_key = {c["key"]: c for c in data["cascade"]}
+
+    # A known host-scoped field is present, with a plausible (default — no agent
+    # leaf, no host file in the isolated box) source and its declared scope.
+    assert "model.name" in by_key
+    assert by_key["model.name"]["scope"] == "host"
+    assert by_key["model.name"]["source"] in {"agent", "host", "default"}
+    # And a known agent-scoped field.
+    assert by_key["model.temperature"]["scope"] == "agent"
+
+
+def test_cli_renderer_and_smoke(monkeypatch, tmp_path, capsys):
+    from graph.config_explain import build_config_explain, render_config_explain, run_config_cli
+
+    _isolate(monkeypatch, tmp_path, instance="beta")
+    text = render_config_explain(build_config_explain())
+    assert "Instance" in text
+    assert "id:             beta" in text
+    assert "Cascade" in text
+    assert "model.name" in text
+
+    rc = run_config_cli(["explain"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "beta" in out and "Paths" in out
+
+
+def test_cli_json_output(monkeypatch, tmp_path, capsys):
+    from graph.config_explain import run_config_cli
+
+    _isolate(monkeypatch, tmp_path, instance="gamma")
+    rc = run_config_cli(["explain", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["instance_id"] == "gamma"
+    assert {"instance_id", "box_root", "instance_root", "app_root", "paths", "cascade"} <= payload.keys()
+
+
+def test_api_route_returns_expected_keys(monkeypatch, tmp_path):
+    from operator_api.config_routes import register_config_routes
+
+    _isolate(monkeypatch, tmp_path, instance="delta")
+    import runtime.state as rs
+
+    monkeypatch.setattr(rs.STATE, "graph_config", None, raising=False)
+
+    app = FastAPI()
+    register_config_routes(app)
+    resp = TestClient(app).get("/api/config/explain")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert {"instance_id", "box_root", "instance_root", "app_root", "paths", "cascade"} <= body.keys()
+    assert body["instance_id"] == "delta"
+    assert isinstance(body["cascade"], list) and body["cascade"]


### PR DESCRIPTION
## What

Adds a read-only **`config explain`** diagnostic — the non-destructive replacement for the deleted self-heal, and the way to answer *"where did my config / key go?"*. It prints this instance's **identity** (env-derived id + both roots), **every resolved on-disk path**, and the **per-field cascade provenance** (each setting's scope, live value, and which cascade layer — agent / host / default — actually set it).

Available two ways, sharing one builder so they can't drift:
- **CLI:** `python -m server config explain` (human table) or `--json` (raw payload)
- **Operator API:** `GET /api/config/explain` (same dict; bearer-gated like the other config routes)

## How

- **`graph/config_explain.py`** — `build_config_explain(config=None)` returns `{instance_id, box_root, instance_root, app_root, paths{…}, cascade[{key, scope, value, source}]}`. It reuses `InstancePaths.explain()` for the id/roots/paths and the existing settings-schema source logic (`build_schema` over the live config + the raw agent leaf doc + the filtered Host layer) for the cascade — the same provenance the Settings UI shows. Lives in `graph/` (a leaf layer) and imports only `infra.paths` + `graph.*`, so both front-ends can import it **without crossing the import-layering contract**.
- **Secrets are never echoed:** `build_schema` already redacts secret-typed fields; the cascade surfaces them as a `<set>` / `<unset>` marker so you can see a key *is* configured without printing it.
- **`server/__init__.py`** — dispatch the `config` subcommand before server startup, mirroring `plugin` / `workspace` / `skills` / `fleet`.
- **`operator_api/config_routes.py`** — `GET /api/config/explain` passes the live `STATE.graph_config` (falls back to loading from disk when `None`).

## Tests (`tests/test_config_explain.py`)

- Builder reports the roots/id resolved from `PROTOAGENT_BOX_ROOT` / `PROTOAGENT_INSTANCE` (autouse `reset_instance_paths` fixture).
- Secrets redacted — the real `api_key` / `auth.token` value never appears in the serialized payload; set vs unset markers are correct.
- Cascade lists a known field (`model.name`, host-scoped) with a plausible source + an agent-scoped field.
- CLI renderer + `--json` smoke (invoking the builder, not a subprocess).
- `GET /api/config/explain` returns 200 with the expected top-level keys.

## Gates

- `ruff check .` — pass
- `python -m pytest tests/ -q` — 2484 passed, 5 skipped (incl. 7 new)
- Import layering: new `graph/` module imports only `infra.paths` + `graph.*`; `operator_api`→`graph` and `server`→`graph` are both legal directions (import-linter not installed in this env; verified manually).
- `uv.lock` untouched.

## Note

On a brand-new instance, running `explain` seeds the live config from the `.example` template (the standard first-run behavior, via the existing `build_schema` → plugin-discovery path that `/api/settings/schema` already triggers). Read-only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)