### PR TITLE
feat(a2a): protocol-version negotiation — fail fast on an older peer

### DIFF
--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -160,6 +160,42 @@ def _a2a_error_detail(d: Delegate, err: object) -> str:
     return f"delegate {d.name!r}: {msg or err}"
 
 
+# The A2A protocol version(s) our delegate client can speak (it sends the
+# ``A2A-Version: 1.0`` header + the 1.0 SendMessage/GetTask dialect). Used to
+# pre-check a peer's advertised version and fail fast on a clear mismatch.
+_A2A_SUPPORTED_VERSIONS = ("1.0",)
+
+
+def _advertised_a2a_versions(card: dict) -> list[str]:
+    """Every A2A protocol version a peer's agent-card advertises (de-duped, in
+    first-seen order), or ``[]`` if the card says nothing about it.
+
+    Reads the native proto field (``supportedInterfaces[].protocolVersion``) AND
+    the proto-free top-level hint (``protocolVersion`` / ``supportedVersions``)
+    that protoLabs agents also expose — so an older or non-protoLabs peer is still
+    understood when it advertises its version in either shape. ``[]`` means
+    *don't know* (older peers, partial cards): callers must treat that as
+    best-effort and NOT block."""
+    if not isinstance(card, dict):
+        return []
+    seen: list[str] = []
+
+    def _add(v: object) -> None:
+        s = str(v or "").strip()
+        if s and s not in seen:
+            seen.append(s)
+
+    for iface in card.get("supportedInterfaces") or []:
+        if isinstance(iface, dict):
+            _add(iface.get("protocolVersion"))
+    _add(card.get("protocolVersion"))
+    versions = card.get("supportedVersions")
+    if isinstance(versions, (list, tuple)):
+        for v in versions:
+            _add(v)
+    return seen
+
+
 class A2aAdapter(Adapter):
     type = "a2a"
     label = "A2A agent"
@@ -225,6 +261,20 @@ class A2aAdapter(Adapter):
         blocked = policy.check_url(d.url)
         if blocked:
             raise DelegateError(blocked.replace("destination", f"delegate {d.name!r}", 1))
+        # Pre-flight protocol-version check (best-effort). Fetch the peer's card and, if
+        # it CLEARLY advertises an A2A protocol version we can't speak, fail fast with a
+        # legible mismatch instead of sending and waiting for the opaque -32009
+        # VERSION_NOT_SUPPORTED mid-dispatch. A silent/unreachable card never blocks — we
+        # fall through to dispatch, whose -32009 mapping (``_a2a_error_detail``) still applies.
+        info = await self.probe(d)
+        advertised = info.get("supported_versions") or []
+        if advertised and not any(v in _A2A_SUPPORTED_VERSIONS for v in advertised):
+            raise DelegateError(
+                f"delegate {d.name!r} advertises A2A protocol {'/'.join(advertised)} but this agent "
+                f"speaks {'/'.join(_A2A_SUPPORTED_VERSIONS)} — refusing to dispatch (an older peer "
+                "would reject the call with -32009 VERSION_NOT_SUPPORTED). Upgrade the peer, or point "
+                "its url at a 1.0 /a2a endpoint."
+            )
         # A2A-Version is mandatory for an a2a-sdk >=1.0 peer: a missing header defaults
         # to 0.3 on the receiver → -32009 VERSION_NOT_SUPPORTED (ADR 0051 audit). The
         # scheduler/inbox/background self-POSTs already set it; the delegate client must too.
@@ -310,8 +360,23 @@ class A2aAdapter(Adapter):
                 r, ms = await _timed(client.get(card))
             if r.status_code >= 400:
                 return {"ok": False, "latency_ms": ms, "error": f"HTTP {r.status_code}"}
-            name = (r.json() or {}).get("name", "")
-            return {"ok": True, "latency_ms": ms, "detail": f"agent-card OK ({name})"}
+            body = r.json() or {}
+            name = body.get("name", "")
+            # Capture the peer's advertised A2A protocol version(s) so a caller (and
+            # dispatch's pre-check) can fail fast on a version mismatch. ``version`` is
+            # the peer's APP version (distinct); ``protocol_version`` is the primary
+            # advertised protocol, "" when the card is silent (older peers).
+            advertised = _advertised_a2a_versions(body)
+            pv = advertised[0] if advertised else ""
+            detail = f"agent-card OK ({name})" + (f", A2A {pv}" if pv else "")
+            return {
+                "ok": True,
+                "latency_ms": ms,
+                "protocol_version": pv,
+                "supported_versions": advertised,
+                "version": body.get("version", ""),
+                "detail": detail,
+            }
         except Exception as exc:  # noqa: BLE001
             return {"ok": False, "error": str(exc)[:200]}
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -213,6 +213,7 @@ from server.a2a import (  # noqa: E402,F401 — re-export of the extracted A2A s
     _agent_skills,
     _bearer_configured,
     _build_agent_card_proto,
+    agent_card_routes,
     assert_routable_card_url,
     _package_version,
     _record_a2a_telemetry,
@@ -689,7 +690,6 @@ def _main():
     # emits the four custom extensions. Task + push-config state is durable
     # (SQLite via a2a_impl.stores), and push callbacks are SSRF-guarded.
     from a2a.server.request_handlers import DefaultRequestHandler
-    from a2a.server.routes.agent_card_routes import create_agent_card_routes
     from a2a.server.routes.fastapi_routes import add_a2a_routes_to_fastapi
     from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
 
@@ -805,7 +805,10 @@ def _main():
     )
     add_a2a_routes_to_fastapi(
         fastapi_app,
-        agent_card_routes=create_agent_card_routes(a2a_card),
+        # ``agent_card_routes`` (server.a2a) serves the same well-known card as
+        # a2a-sdk's ``create_agent_card_routes`` plus a proto-free protocolVersion
+        # hint, so a delegating peer can pre-check version compatibility (ADR 0051).
+        agent_card_routes=agent_card_routes(a2a_card),
         jsonrpc_routes=create_jsonrpc_routes(a2a_request_handler, rpc_url="/a2a"),
     )
     log.info("[a2a] a2a-sdk routes mounted (JSON-RPC at /a2a, card at /.well-known/agent-card.json)")

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -292,6 +292,50 @@ def _build_agent_card_proto():
     return card
 
 
+# The A2A *protocol* version this agent speaks — distinct from the agent's app
+# version (``_package_version`` → the card's ``version``). It mirrors the a2a-sdk
+# ``PROTOCOL_VERSION_1_0`` that ``build_agent_card`` writes into
+# ``supported_interfaces[].protocol_version`` and the ``A2A-Version: 1.0`` header
+# the runtime sends everywhere. One value, advertised in two shapes (see below).
+A2A_PROTOCOL_VERSION = "1.0"
+A2A_SUPPORTED_VERSIONS = (A2A_PROTOCOL_VERSION,)
+
+
+def agent_card_dict(card) -> dict:
+    """The JSON served at ``/.well-known/agent-card.json`` — a2a-sdk's canonical
+    camelCase card dict plus a small, proto-free protocol-version hint.
+
+    The proto ``AgentCard`` already carries the protocol version natively in
+    ``supportedInterfaces[].protocolVersion`` (``build_agent_card`` sets it to
+    1.0), but that's nested inside the proto-shaped interface list. We ALSO surface
+    a top-level ``protocolVersion`` + ``supportedVersions`` so a delegating peer can
+    pre-check version compatibility — and fail fast on a mismatch — without proto
+    knowledge or walking ``supportedInterfaces``. The proto card has no slot for
+    these extra top-level keys, so they're injected into the served JSON here
+    (``setdefault`` — never clobber a native key the sdk may add later)."""
+    from a2a.server.routes.agent_card_routes import agent_card_to_dict
+
+    d = agent_card_to_dict(card)
+    d.setdefault("protocolVersion", A2A_PROTOCOL_VERSION)
+    d.setdefault("supportedVersions", list(A2A_SUPPORTED_VERSIONS))
+    return d
+
+
+def agent_card_routes(card) -> list:
+    """Starlette route(s) for the agent card — like a2a-sdk's
+    ``create_agent_card_routes`` but serving ``agent_card_dict`` so the JSON carries
+    the proto-free protocol-version hint. Same well-known path + GET, so
+    ``add_a2a_routes_to_fastapi`` mounts it identically."""
+    from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
+
+    async def _get_agent_card(_request) -> JSONResponse:
+        return JSONResponse(agent_card_dict(card))
+
+    return [Route(path=AGENT_CARD_WELL_KNOWN_PATH, endpoint=_get_agent_card, methods=["GET"])]
+
+
 def _record_a2a_telemetry(outcome) -> None:
     """Write one per-turn telemetry row from an executor ``TurnOutcome``
     (ADR 0006 Slice 2). No-op when the telemetry store is off; best-effort so a

--- a/tests/test_a2a_card_identity.py
+++ b/tests/test_a2a_card_identity.py
@@ -120,3 +120,36 @@ def test_card_description_default(monkeypatch):
     monkeypatch.setattr(server.STATE, "active_port", 7870, raising=False)
     card = a2a._build_agent_card_proto()
     assert card.description == a2a._DEFAULT_CARD_DESCRIPTION
+
+
+# ── protocol-version advertisement (A2A version negotiation) ─────────────────
+
+
+def test_card_dict_carries_protocol_version_hint(monkeypatch):
+    """The served card JSON exposes a top-level, proto-free protocolVersion hint —
+    so a delegating peer can pre-check compatibility without walking the proto
+    supportedInterfaces — and it AGREES with the native interface field."""
+    monkeypatch.setattr(server.STATE, "graph_config", _cfg(), raising=False)
+    monkeypatch.setattr(server.STATE, "plugin_a2a_skills", [], raising=False)
+    monkeypatch.setattr(server.STATE, "active_port", 7870, raising=False)
+    d = a2a.agent_card_dict(a2a._build_agent_card_proto())
+    assert d["protocolVersion"] == "1.0"
+    assert d["supportedVersions"] == ["1.0"]
+    # native proto field stays populated and agrees with the proto-free hint
+    jsonrpc = next(i for i in d["supportedInterfaces"] if i["protocolBinding"] == "JSONRPC")
+    assert jsonrpc["protocolVersion"] == d["protocolVersion"] == a2a.A2A_PROTOCOL_VERSION
+
+
+async def test_agent_card_route_serves_protocol_version(monkeypatch):
+    """The /.well-known/agent-card.json route serves the protocol-version hint."""
+    import json
+
+    monkeypatch.setattr(server.STATE, "graph_config", _cfg(), raising=False)
+    monkeypatch.setattr(server.STATE, "plugin_a2a_skills", [], raising=False)
+    monkeypatch.setattr(server.STATE, "active_port", 7870, raising=False)
+    routes = a2a.agent_card_routes(a2a._build_agent_card_proto())
+    assert routes and routes[0].path == "/.well-known/agent-card.json"
+    resp = await routes[0].endpoint(None)  # request is unused
+    body = json.loads(resp.body)
+    assert body["protocolVersion"] == "1.0"
+    assert body["supportedVersions"] == ["1.0"]

--- a/tests/test_delegates_plugin.py
+++ b/tests/test_delegates_plugin.py
@@ -315,6 +315,95 @@ async def test_a2a_dispatch_sends_version_header(monkeypatch):
     assert captured["headers"].get("A2A-Version") == "1.0"
 
 
+# ── a2a protocol-version negotiation ──────────────────────────────────────────
+
+
+class _CardClient(_FakeClient):
+    """Fake httpx client answering BOTH the agent-card GET (probe / version
+    pre-check) and the JSON-RPC POST (dispatch), so the a2a version pre-flight is
+    exercised fully offline."""
+
+    def __init__(self, card, rpc=None, **kw):
+        self._card = card
+        self._rpc = rpc or {"result": {"artifacts": [{"parts": [{"kind": "text", "text": "hi from peer"}]}]}}
+
+    async def get(self, url, **kw):
+        return _FakeResp(self._card)
+
+    async def post(self, url, **kw):
+        return _FakeResp(self._rpc)
+
+
+async def test_a2a_probe_returns_peer_protocol_version(monkeypatch):
+    """probe() captures the peer's advertised A2A protocol version (the native
+    supportedInterfaces field) — distinct from the peer's app `version`."""
+    import httpx
+
+    from security import policy
+
+    card = {
+        "name": "peer",
+        "version": "1.2.3",
+        "supportedInterfaces": [{"protocolBinding": "JSONRPC", "protocolVersion": "1.0"}],
+    }
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _CardClient(card))
+    monkeypatch.setattr(policy, "check_url", lambda url: None)
+    d = ADAPTERS["a2a"].parse({"name": "p", "type": "a2a", "url": "https://p/a2a"})
+    res = await ADAPTERS["a2a"].probe(d)
+    assert res["ok"] is True
+    assert res["protocol_version"] == "1.0"
+    assert res["supported_versions"] == ["1.0"]
+    assert res["version"] == "1.2.3"  # peer APP version, distinct from the protocol version
+
+
+async def test_a2a_probe_reads_proto_free_hint(monkeypatch):
+    """probe() also understands the top-level protocolVersion/supportedVersions
+    hint a peer may expose without the proto supportedInterfaces list."""
+    import httpx
+
+    from security import policy
+
+    card = {"name": "peer", "protocolVersion": "1.0", "supportedVersions": ["1.0"]}
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _CardClient(card))
+    monkeypatch.setattr(policy, "check_url", lambda url: None)
+    d = ADAPTERS["a2a"].parse({"name": "p", "type": "a2a", "url": "https://p/a2a"})
+    res = await ADAPTERS["a2a"].probe(d)
+    assert res["protocol_version"] == "1.0" and res["supported_versions"] == ["1.0"]
+
+
+async def test_a2a_dispatch_rejects_version_mismatch(monkeypatch):
+    """A peer that clearly advertises an A2A version we can't speak (e.g. 0.3) must
+    fail fast with a legible mismatch — not get a 1.0 call sent and wait for an
+    opaque -32009 mid-dispatch."""
+    import httpx
+
+    from security import policy
+
+    card = {"name": "old-peer", "supportedInterfaces": [{"protocolVersion": "0.3"}]}
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _CardClient(card))
+    monkeypatch.setattr(policy, "check_url", lambda url: None)
+    d = ADAPTERS["a2a"].parse({"name": "p", "type": "a2a", "url": "https://p/a2a"})
+    with pytest.raises(DelegateError) as ei:
+        await ADAPTERS["a2a"].dispatch(d, "q")
+    msg = str(ei.value)
+    assert "0.3" in msg and "refusing" in msg.lower()
+
+
+async def test_a2a_dispatch_proceeds_when_card_omits_version(monkeypatch):
+    """An older peer / partial card that advertises no protocol version must NOT be
+    blocked by the best-effort pre-check — dispatch falls through (the -32009
+    mapping still covers a genuine incompatibility)."""
+    import httpx
+
+    from security import policy
+
+    card = {"name": "peer"}  # nothing about protocol version anywhere
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _CardClient(card))
+    monkeypatch.setattr(policy, "check_url", lambda url: None)
+    d = ADAPTERS["a2a"].parse({"name": "p", "type": "a2a", "url": "https://p/a2a"})
+    assert await ADAPTERS["a2a"].dispatch(d, "q") == "hi from peer"
+
+
 async def test_acp_dispatch_reuses_client(monkeypatch):
     import plugins.coding_agent as CA
 


### PR DESCRIPTION
## Why

A delegating agent that dispatches to a peer speaking an older A2A dialect today sends the 1.0 `SendMessage` and only learns of the skew from an opaque `-32009 VERSION_NOT_SUPPORTED` mid-dispatch. This makes the protocol version explicit on our own card and pre-checks the peer's before sending, so a mismatch fails fast and legibly.

## Changes

**1) Advertise our supported A2A protocol version (server)**
- The proto `AgentCard` already carries the protocol version natively in `supportedInterfaces[].protocolVersion` (`build_agent_card` → `PROTOCOL_VERSION_1_0`). We ALSO surface a small, proto-free top-level `protocolVersion` + `supportedVersions: ["1.0"]` hint in the served `/.well-known/agent-card.json`, so a consumer can read it without proto knowledge or walking `supportedInterfaces`.
- New `server.a2a.agent_card_dict()` / `agent_card_routes()` serve the same well-known card as a2a-sdk's `create_agent_card_routes` plus the hint (`setdefault`, never clobbering a native key). `server/__init__.py` wiring swapped to use them — same path + GET, mounted identically.

**2) Pre-check the peer's version in the a2a delegate (`plugins/delegates/adapters.py`)**
- `A2aAdapter.probe()` now captures the peer's advertised protocol version(s) from its card (native field first, else the proto-free hint) and returns `protocol_version` / `supported_versions` / `version` (the peer's app version, kept distinct).
- `A2aAdapter.dispatch()` does a best-effort card fetch BEFORE sending; if the peer clearly advertises a version we can't speak (e.g. `0.3`), it raises a legible `DelegateError` naming the mismatch instead of sending and waiting for `-32009`. A silent/unreachable card never blocks — it falls through to dispatch, whose existing `_a2a_error_detail` `-32009` mapping still applies.

## Tests (offline, mocked httpx / card fetch)
- Served card JSON carries `protocolVersion`/`supportedVersions` = 1.0 and agrees with the native interface field; the route serves it.
- `probe()` returns the peer's advertised protocol version (native + proto-free shapes).
- `dispatch()` rejects a `0.3` peer with a clear mismatch and proceeds normally when the card omits a version.

## Gates
- `ruff check .` — clean
- `python -m pytest tests/ -q` — 2483 passed, 5 skipped
- New tests pass; `uv.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)