### PR TITLE
docs(knowledge): document fleet/commons sharing + fix stale top_k default

### DIFF
--- a/docs/explanation/memory-and-knowledge.md
+++ b/docs/explanation/memory-and-knowledge.md
@@ -110,7 +110,8 @@ All under the `knowledge:` block (see [Configuration](../reference/configuration
 | `embeddings` | `true` | hybrid semantic + keyword search (vs keyword-only) |
 | `embed_model` | `qwen3-embedding` | gateway embedding model (set per your gateway) |
 | `facts` | `true` | extract semantic facts during the harvest pass |
-| `top_k` | `5` | how many chunks retrieval injects per turn |
+| `top_k` | `10` | how many chunks retrieval injects per turn |
+| `scope` | `scoped` | tier ([ADR 0041](../adr/0041-workspaces-and-tiered-stores.md)): `scoped` (private) · `shared` (host commons) · `layered` (read commons ∪ private, write private). See [Tune the knowledge store → Sharing across a fleet](../guides/knowledge.md#sharing-knowledge-across-a-fleet-the-commons) |
 | `middleware.knowledge` | `true` | turn the whole subsystem on/off |
 
 Tip: enabling embeddings is measurable — add a recall eval and compare keyword vs
@@ -119,6 +120,8 @@ hybrid via `evals.sweep`. See [Eval your fork](../guides/evals.md).
 ## See also
 
 - [ADR 0021 — Agent memory: extract, don't dump](../adr/0021-agent-memory-architecture.md)
+- [ADR 0041 — Workspaces & tiered stores](../adr/0041-workspaces-and-tiered-stores.md) — the private/commons tiering behind `knowledge.scope`
+- [Run a fleet](../guides/fleet.md) — sharing a knowledge commons across many agents on one host
 - [Model output](output-protocol.md) — native reasoning + the leaked-reasoning guard this enforces
 - [Skills](../guides/skills.md) — procedural memory (Playbooks)
 - [Starter tools](../reference/starter-tools.md) — the `memory_*` tools

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -62,3 +62,42 @@ When a knowledge store is wired, the agent gets these (operator-curatable under
 
 `GET /api/runtime/status` reports the store status; `GET /api/knowledge/search`
 backs the console browser.
+
+## Sharing knowledge across a fleet (the commons)
+
+By default each agent's knowledge store is **private** (`scope: scoped`) — what one
+agent learns, harvests, or ingests stays with it. To let a fleet pool knowledge, opt
+a store into a shared **commons** ([ADR 0041](/adr/0041-workspaces-and-tiered-stores)),
+the same tiering model as [skills](/guides/skills#sharing-skills-across-a-fleet-the-commons):
+
+```yaml
+knowledge:
+  scope: layered          # read commons ∪ private, write private, promote to share
+commons:
+  path: ~/.protoagent/commons   # host-level, shared by every agent that points here
+```
+
+- **`scope: shared`** — the whole store *is* the commons (every write lands in it).
+- **`scope: layered`** — "shared brain, private hands": the agent reads
+  `commons ∪ private` (a second-level RRF fuses the two tiers, deduped by content) and
+  writes to its **private** tier, so in-progress facts never pollute the fleet. You lift
+  a proven chunk into the commons explicitly.
+
+The commons is **host-level and un-scoped** — every agent pointing at the same
+`commons.path` reads it, regardless of `instance.id`. Run two *isolated* fleets on one
+host by giving each a distinct `commons.path`. The boot log names the active tier and
+path (`[knowledge] tier=layered (… ∪ …)`).
+
+Promotion is operator-curated from the **console**, not a CLI: in **Knowledge → Store**,
+layered-mode chunks carry a `private`/`commons` tier badge with **Share** (lift a private
+chunk into the commons — every agent on the box can then recall it) and **Unshare**
+(remove it from the commons; the private copy, if any, is untouched). The same gestures
+are `POST /api/knowledge/{id}/promote` and `POST /api/knowledge/{id}/forget`. Nothing is
+auto-shared — the commons is trusted because promotion is explicit.
+
+::: warning One embed model per shared fleet
+A `shared`/`layered` fleet must agree on one `embed_model`. The commons is stamped with
+the model that first wrote it; an agent that joins with a different `embed_model` serves
+the commons tier **FTS5-only** (no incompatible-vector fusion) and logs a warning. Keep
+`embed_model` identical across every agent that shares a `commons.path`.
+:::


### PR DESCRIPTION
## What

Two fixes to the **knowledge** docs, found while auditing how well the subsystem is documented for users.

### 1. Gap — fleet/commons sharing missing from the knowledge pages
The tiering shipped in [ADR 0041](../adr/0041-workspaces-and-tiered-stores.md) (private/commons, `knowledge.scope`, **Share/Unshare** in the console) was documented only in `reference/configuration.md` and `guides/fleet.md` — **neither of the two pages a user reading about knowledge actually lands on** (`guides/knowledge.md`, `explanation/memory-and-knowledge.md`). Skills got a first-class *"Sharing skills across a fleet (the commons)"* section; knowledge never got the equivalent, and the console Share/Unshare gesture was undocumented anywhere.

Added **"Sharing knowledge across a fleet (the commons)"** to `guides/knowledge.md`, mirroring the skills guide but accurate to knowledge:
- `scoped` / `shared` / `layered`, the host-level un-scoped commons, second-level RRF tier fusion.
- Promotion is **console + REST only** (`Knowledge → Store` Share/Unshare → `POST /api/knowledge/{id}/promote|forget`) — **no CLI**, unlike skills. (Verified: no `python -m server knowledge` subcommand exists.)
- The one-`embed_model`-per-shared-fleet caveat (the commons is stamped with its embed model; a mismatched agent serves the commons tier FTS5-only).

### 2. Bug — stale `top_k` default
`explanation/memory-and-knowledge.md` listed `top_k` default as **5**; the real config default is **10** (`graph/config.py` `knowledge_top_k: int = 10`). The `5` was the `KnowledgeMiddleware` constructor's fallback param, but agent.py passes the config value. `guides/knowledge.md` already said 10 — the two pages disagreed. Fixed, and added a `scope` row + ADR 0041 / fleet links to *See also*.

## Test
`vitepress build docs` passes — strict dead-link checking (`ignoreDeadLinks: "localhostLinks"`) confirms every new anchor and cross-page link resolves.

Docs-only; no code, no nav/sidebar change (no new pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)