### PR TITLE
feat(knowledge): give the agent a knowledge_ingest tool (URLs + media)

### DIFF
--- a/docs/guides/ingestion.md
+++ b/docs/guides/ingestion.md
@@ -15,6 +15,21 @@ handles plain text, Markdown, HTML, PDF, audio, video, and web/YouTube URLs.
 and audio/video (`mp3, wav, m4a, flac, ogg, opus, aac, mp4, mov, mkv, webm, avi, m4v`).
 You'll see `Added N chunks from "<title>"`.
 
+## From the agent
+
+The agent can ingest **on its own** with the `knowledge_ingest(source, domain, title?)`
+tool — `source` is an `http(s)` URL (including YouTube) or a local file path. Hand it a
+link or a file in chat ("read this and remember it", "ingest this PDF") and it runs the
+same pipeline below, rather than trying to `web_search`/`fetch_url` a media link (which
+can't get a transcript). It's distinct from `memory_ingest`, which only stores text the
+agent already has — see the [tool table](/guides/knowledge#the-agents-memory-tools).
+
+Audio/video/image paths need the same setup as the console (`knowledge.transcribe_model`
+/ `knowledge.image_describe_model`, plus `ffmpeg` on PATH for video); if one isn't
+configured the tool says so instead of failing silently. The tool is on whenever a
+knowledge store is wired — the agent runs `knowledge_ingest` as one turn, so a long
+recording will take as long as its transcription does.
+
 ## From the API
 
 ```bash

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -55,6 +55,7 @@ When a knowledge store is wired, the agent gets these (operator-curatable under
 | Tool | What it does |
 |---|---|
 | `memory_ingest(content, domain, heading?)` | store a self-contained fact/note for later recall |
+| `knowledge_ingest(source, domain, title?)` | fetch + extract + store a **URL or local file** — YouTube/web/PDF/audio/video — through the full [ingestion pipeline](/guides/ingestion#from-the-agent) |
 | `memory_recall(query, k=5)` | search long-term memory (hybrid, or FTS5 if the breaker is open) |
 | `memory_list(domain?, limit=10)` | browse recent chunks (used by `/dream` consolidation) |
 | `memory_stats()` | per-domain chunk counts |

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -362,6 +362,7 @@ async def run_manual_subagent(
         inbox_store=STATE.inbox_store,
         tasks_store=STATE.tasks_store,
         goal_enabled=getattr(config, "goal_enabled", False),
+        graph_config=config,
     )
     if extra_tools:
         all_tools = all_tools + list(extra_tools)
@@ -808,6 +809,8 @@ def create_agent_graph(
         # Subagent builds deliberately omit it: subagents are bounded by
         # max_turns and must not self-set goals.
         goal_enabled=config.goal_enabled,
+        # Lets knowledge_ingest build the gateway STT/vision fns for audio/video/image.
+        graph_config=config,
     )
 
     if extra_tools:
@@ -894,7 +897,7 @@ def create_simple_agent(config: LangGraphConfig, knowledge_store=None, scheduler
     from langgraph.prebuilt import create_react_agent
 
     llm = create_llm(config)
-    all_tools = get_all_tools(knowledge_store, scheduler=scheduler)
+    all_tools = get_all_tools(knowledge_store, scheduler=scheduler, graph_config=config)
 
     system_prompt = build_system_prompt(include_subagents=False)
 

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -129,6 +129,7 @@ _TOOL_CATEGORY = {
     "fetch_url": "Web & research",
     # Memory
     "memory_ingest": "Memory",
+    "knowledge_ingest": "Memory",
     "memory_recall": "Memory",
     "memory_list": "Memory",
     "memory_stats": "Memory",

--- a/tests/test_knowledge_ingest_tool.py
+++ b/tests/test_knowledge_ingest_tool.py
@@ -1,0 +1,104 @@
+"""knowledge_ingest tool — the agent-facing half of the console
+``/api/knowledge/ingest`` route. The ingestion engine itself is covered by
+test_ingestion.py; here we test the *tool wiring*: get_all_tools exposes it when
+a store is present, URLs and files route through the engine into the store, and
+the missing-file / media-not-configured paths degrade with a clear message
+instead of crashing the turn.
+"""
+
+from __future__ import annotations
+
+import ingestion
+from ingestion import ExtractResult, MissingDependency
+from tools.lg_tools import MEMORY_TOOL_NAMES, get_all_tools
+
+
+class _FakeStore:
+    """Minimal KnowledgeStore stand-in: records add_document calls."""
+
+    def __init__(self) -> None:
+        self.docs: list[tuple[str, dict]] = []
+
+    def add_document(self, content, **kw):
+        self.docs.append((content, kw))
+        return [1, 2]  # pretend two chunks landed
+
+
+def _ingest_tool(store):
+    return {t.name: t for t in get_all_tools(store)}["knowledge_ingest"]
+
+
+def test_get_all_tools_exposes_knowledge_ingest_when_store_wired():
+    names = {t.name for t in get_all_tools(_FakeStore())}
+    assert "knowledge_ingest" in names
+    # also advertised in the pre-setup roster list (config_io._extra_tool_names)
+    assert "knowledge_ingest" in MEMORY_TOOL_NAMES
+
+
+def test_knowledge_ingest_absent_without_store():
+    assert "knowledge_ingest" not in {t.name for t in get_all_tools(None)}
+
+
+async def test_knowledge_ingest_url_routes_through_engine(monkeypatch):
+    store = _FakeStore()
+    monkeypatch.setattr(
+        ingestion,
+        "extract_url",
+        lambda url, **kw: ExtractResult(text="article body", title="An Article", source_type="html"),
+    )
+    out = await _ingest_tool(store).ainvoke({"source": "https://example.com/post", "domain": "research"})
+
+    assert "An Article" in out and "html" in out and "research" in out
+    content, kw = store.docs[0]
+    assert content == "article body"
+    assert kw["domain"] == "research"
+    assert kw["source"] == "https://example.com/post"
+    assert kw["heading"] == "An Article"
+    assert kw["source_type"] == "html"
+
+
+async def test_knowledge_ingest_file_routes_through_engine(tmp_path, monkeypatch):
+    store = _FakeStore()
+    f = tmp_path / "notes.txt"
+    f.write_text("file body")
+    captured: dict = {}
+
+    def fake_extract_bytes(filename, data, content_type, **kw):
+        captured.update(filename=filename, data=data)
+        return ExtractResult(text="file body", title=None, source_type="text")
+
+    monkeypatch.setattr(ingestion, "extract_bytes", fake_extract_bytes)
+    out = await _ingest_tool(store).ainvoke({"source": str(f)})
+
+    assert "text" in out
+    assert captured["filename"] == "notes.txt"
+    assert captured["data"] == b"file body"
+    # title falls back to None → heading is None, source is the resolved path
+    _content, kw = store.docs[0]
+    assert kw["source"] == str(f) and kw["heading"] is None
+
+
+async def test_knowledge_ingest_missing_file_gives_clear_message():
+    store = _FakeStore()
+    out = await _ingest_tool(store).ainvoke({"source": "/no/such/file.pdf"})
+    assert "no such file" in out.lower()
+    assert store.docs == []  # nothing written
+
+
+async def test_knowledge_ingest_media_not_configured_message(monkeypatch):
+    store = _FakeStore()
+
+    def boom(url, **kw):
+        raise MissingDependency("audio/video needs knowledge.transcribe_model")
+
+    monkeypatch.setattr(ingestion, "extract_url", boom)
+    out = await _ingest_tool(store).ainvoke({"source": "https://example.com/talk.mp3"})
+    assert "transcribe_model" in out
+    assert store.docs == []
+
+
+async def test_knowledge_ingest_empty_source_rejected():
+    store = _FakeStore()
+    out = await _ingest_tool(store).ainvoke({"source": "   "})
+    assert "Error" in out
+    assert store.docs == []

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -462,6 +462,7 @@ SCHEDULER_TOOL_NAMES: tuple[str, ...] = (
 )
 MEMORY_TOOL_NAMES: tuple[str, ...] = (
     "memory_ingest",
+    "knowledge_ingest",
     "memory_recall",
     "memory_list",
     "memory_stats",
@@ -504,8 +505,14 @@ def _build_inbox_tools(inbox_store) -> list:
     return [check_inbox]
 
 
-def _build_memory_tools(knowledge_store) -> list:
-    """Bind memory tools to a ``KnowledgeStore``. Returns a list."""
+def _build_memory_tools(knowledge_store, graph_config=None) -> list:
+    """Bind memory tools to a ``KnowledgeStore``. Returns a list.
+
+    ``graph_config`` (the ``LangGraphConfig``) is threaded only so
+    ``knowledge_ingest`` can build the gateway speech-to-text / vision functions
+    for audio/video/image sources. It's optional — without it those media paths
+    report "not configured" and the text/URL/PDF paths work unchanged.
+    """
 
     @tool
     async def memory_ingest(
@@ -536,6 +543,99 @@ def _build_memory_tools(knowledge_store) -> list:
         if chunk_id is None:
             return "Error: failed to store chunk (knowledge store unavailable)."
         return f"Stored chunk {chunk_id} in {domain!r}."
+
+    @tool
+    async def knowledge_ingest(source: str, domain: str = "general", title: str | None = None) -> str:
+        """Fetch, extract, and store a URL or local file into long-term knowledge.
+
+        Unlike ``memory_ingest`` (which stores text you already have), this runs
+        the full ingestion pipeline: it pulls the SOURCE, turns it into text, and
+        chunks + embeds it for recall. Reach for this the moment the operator
+        hands you a link or a file to "remember", "read", "ingest", "add to the
+        knowledge base", or "summarize and keep". Do NOT try to web_search or
+        fetch_url a YouTube/media link yourself — this is the only path that gets
+        a transcript or decodes a file.
+
+        Handles:
+          - URLs — web articles (HTML) and YouTube links (transcript)
+          - documents — PDF, plain text, Markdown (by local file path)
+          - media — audio (mp3/wav/m4a…) and video (mp4/mov/mkv…) by local file
+            path, transcribed via the gateway speech-to-text model (slow for long
+            recordings — it runs the whole track through STT)
+          - images — described via the gateway vision model
+
+        Args:
+            source: an ``http(s)`` URL (including YouTube) OR a local file path.
+            domain: knowledge bucket to file it under (default ``"general"``).
+            title: optional heading; otherwise the source's own title is used.
+
+        Returns a one-line summary (title, type, chars, chunk count). If a source
+        needs something that isn't configured (e.g. video needs ``ffmpeg`` plus
+        ``knowledge.transcribe_model``), it says so rather than failing opaquely.
+        """
+        import asyncio
+        from pathlib import Path
+
+        from ingestion import (
+            MissingDependency,
+            UnsupportedSource,
+            extract_bytes,
+            extract_url,
+        )
+        from knowledge import add_document
+
+        src = (source or "").strip()
+        if not src:
+            return "Error: provide a URL or a local file path to ingest."
+
+        # Gateway STT/vision for media — None if no model is configured, which
+        # makes audio/video/image raise a clean "not configured" error while
+        # text/URL/PDF/YouTube paths are unaffected.
+        transcribe = describe = None
+        if graph_config is not None:
+            try:
+                from graph.llm import create_describe_image_fn, create_transcribe_fn
+
+                transcribe = create_transcribe_fn(graph_config)
+                describe = create_describe_image_fn(graph_config)
+            except Exception:  # noqa: BLE001 — media stays optional; text/URL unaffected
+                pass
+
+        try:
+            if src.lower().startswith(("http://", "https://")):
+                result = await asyncio.to_thread(extract_url, src, transcribe=transcribe)
+                origin = src
+            else:
+                path = Path(src).expanduser()
+                if not path.is_file():
+                    return f"Error: no such file: {src} — pass an http(s) URL or an existing local file path."
+                data = await asyncio.to_thread(path.read_bytes)
+                result = await asyncio.to_thread(
+                    extract_bytes, path.name, data, None, transcribe=transcribe, describe=describe
+                )
+                origin = str(path)
+        except MissingDependency as exc:
+            return f"Can't ingest that source — a required dependency or model isn't available: {exc}"
+        except UnsupportedSource as exc:
+            return f"Unsupported source type: {exc}"
+        except Exception as exc:  # noqa: BLE001 — surface extraction failure to the model, never crash the turn
+            return f"Extraction failed: {exc}"
+
+        heading = (title or "").strip() or result.title or None
+        ids = await asyncio.to_thread(
+            lambda: add_document(
+                knowledge_store,
+                result.text,
+                domain=(domain or "general").strip() or "general",
+                heading=heading,
+                source=origin,
+                source_type=result.source_type,
+            )
+        )
+        if not ids:
+            return "Nothing ingested — no text could be extracted from that source."
+        label = heading or origin
+        return f"Ingested {label!r} ({result.source_type}, {len(result.text)} chars) → {len(ids)} chunk(s) in {domain!r}."
 
     @tool
     async def memory_recall(query: str, k: int = 5) -> str:
@@ -615,7 +715,7 @@ def _build_memory_tools(knowledge_store) -> list:
             return f"No memory chunk #{cid} found — nothing deleted."
         return f"Forgot memory chunk #{cid}." + (f" ({reason})" if reason else "")
 
-    return [memory_ingest, memory_recall, memory_list, memory_stats, forget_memory]
+    return [memory_ingest, knowledge_ingest, memory_recall, memory_list, memory_stats, forget_memory]
 
 
 # ── scheduler tools ──────────────────────────────────────────────────────────
@@ -1118,16 +1218,21 @@ def _build_curation_tools():
 HITL_TOOL_NAMES = frozenset({"ask_human", "request_user_input"})
 
 
-def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, tasks_store=None, goal_enabled=False):
+def get_all_tools(
+    knowledge_store=None, scheduler=None, inbox_store=None, tasks_store=None, goal_enabled=False, graph_config=None
+):
     """Return every LangChain tool the lead agent + subagents can use.
 
     Optional dependencies:
 
     - ``knowledge_store`` enables the memory tools (memory_ingest,
-      memory_recall, memory_list, memory_stats).
+      knowledge_ingest, memory_recall, memory_list, memory_stats).
     - ``scheduler`` enables the scheduler tools (schedule_task,
       list_schedules, cancel_schedule). Accepts any backend that
       implements ``scheduler.interface.SchedulerBackend``.
+    - ``graph_config`` (the ``LangGraphConfig``) lets ``knowledge_ingest``
+      build the gateway STT/vision functions for audio/video/image sources.
+      Optional — without it, only the text/URL/PDF/YouTube ingest paths work.
 
     Pass ``None`` to disable either subsystem — the lead agent runs
     fine with just the four keyless general tools.
@@ -1153,7 +1258,7 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, tasks_
     # 0018/0019) — an installed comms plugin registers its tools when a token is set;
     # nothing to wire here.
     if knowledge_store is not None:
-        tools.extend(_build_memory_tools(knowledge_store))
+        tools.extend(_build_memory_tools(knowledge_store, graph_config))
     if scheduler is not None:
         tools.extend(_build_scheduler_tools(scheduler))
     if inbox_store is not None:


### PR DESCRIPTION
## Problem

Hand the agent a **YouTube link** (or an `.mp4`, a PDF, an article URL) and it falls back to `web_search`/`fetch_url` and gets nothing useful. Not a reasoning failure — a **capability gap**: the agent's only ingest tool was `memory_ingest`, which stores **raw text it already has** (`add_chunk`). The full processing pipeline — YouTube transcripts, web HTML extraction, PDF, audio/video gateway-STT, image vision — lives in `ingestion/engine.py` and was wired **only to the console** (`POST /api/knowledge/ingest`). The agent had no path to it.

## Fix

Add **`knowledge_ingest(source, domain, title?)`** to the core memory-tool set — the agent-facing half of the console route. `source` is an `http(s)` URL (incl. YouTube) or a local file path; it auto-detects which, runs the **same** `ingestion` engine → `add_document` path the console uses, and returns a one-line summary (title, type, chars, chunk count).

**Degrade-safe:** the engine already raises `MissingDependency` for a missing `ffmpeg`/`pypdf`/transcribe-model; the tool catches it and tells the model *"video needs ffmpeg + `knowledge.transcribe_model`"* instead of failing opaquely. URL fetches keep the engine's SSRF guard.

### Changes
- **`tools/lg_tools.py`** — new `knowledge_ingest` tool in `_build_memory_tools`; added to `MEMORY_TOOL_NAMES` (pre-setup roster); `get_all_tools` gains an optional `graph_config` kwarg (default `None`, backward-compatible) so the tool can build the gateway STT/vision fns.
- **`graph/agent.py`** — thread `graph_config=config` into the three runtime `get_all_tools` call sites (lead build, out-of-graph runner, simple agent).
- **`operator_api/console_handlers.py`** — categorize it under "Memory" in the Tools view.
- **docs** — added to the knowledge tool table + a new *"From the agent"* section in the ingestion guide (which previously read as console/API-only).
- **tests** — `tests/test_knowledge_ingest_tool.py`: roster exposure, URL + file routing into the store, missing-file + media-not-configured messages, empty-source guard.

### Scope notes
- **Core tool, always-on** when a knowledge store is wired (matches the other `memory_*` tools) — chosen over a plugin/opt-in since the engine already ships in core and the console already uses it.
- Full media range incl. **video** (per the ask). Audio/video/image need `knowledge.transcribe_model` / `image_describe_model` (+ `ffmpeg` for video); the tool degrades with a clear message when they're absent. A long recording ingests as one turn — it takes as long as its transcription.
- `tools/ → ingestion` and `tools/ → graph.llm` are import-contract-legal (only `server`/`operator_api` are forbidden).

## Test
- `ruff check` ✓
- `lint-imports` ✓ (3 contracts kept)
- `pytest tests/ -q` ✓ — **2502 passed, 5 skipped** (incl. the tools-inventory single-source check + agent-graph build tests)
- `python scripts/live_smoke.py` ✓ — lean server boots, graph compiles with the new binding, real A2A turn reaches terminal
- `vitepress build docs` ✓ — strict dead-link check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new knowledge ingestion option for agents and the console, letting content be imported from web links, YouTube, and local files into long-term memory.
  * Media sources can now be ingested when the required transcription/vision settings are available.

* **Documentation**
  * Updated the knowledge and ingestion guides with usage details, supported source types, setup requirements, and expected behavior when configuration is missing.

* **Bug Fixes**
  * Improved handling for blank inputs, missing files, and unavailable media settings with clearer user-facing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->