### PR TITLE
fix(docs): route in-content cross-reference links in-app, not inside the iframe (#1456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instance's data) into the new location. Use `config explain` to see the resolved layout.
 
 ### Fixed
+- **Docs reader: in-content cross-reference links route in-app instead of breaking the iframe**
+  (#1456) — clicking a cross-reference link inside a rendered doc page used to navigate *inside*
+  the embed frame, loading a bare page stripped of the docs nav/search in a cramped frame. The
+  reader now intercepts content-link clicks: a link that resolves to a bundled doc — relative
+  (`./adr.md`, `../guides/skills.md`) or VitePress abs-rooted (`/adr/0060-…`, `/guides/`) — opens
+  **in-panel** (carrying any `#anchor`, with client-side heading slugs so anchors land); anything
+  else (external, or a doc not in the bundle) opens at the live docs site in a new tab. In-page
+  `#section` links scroll the reader instead of reloading it.
 - **A crashed co-located fleet member is now detected and restartable** (#1474) — a member the hub
   spawned is its child process, so a SIGKILL crash left it a zombie that `os.kill(pid, 0)` reported
   as *alive*: `/api/fleet` kept showing it running and a restart no-op'd on the dead pid. `_alive()`

--- a/plugins/docs/__init__.py
+++ b/plugins/docs/__init__.py
@@ -171,12 +171,56 @@ if (new URLSearchParams(location.search).get("mode")==="search") document.body.c
 const $list=document.getElementById("list"), $reader=document.getElementById("reader"), $q=document.getElementById("q");
 const esc=s=>String(s).replace(/[&<>"]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]));
 async function api(p){ try{ const r=await kit.apiFetch("/api/plugins/docs"+p); return r.ok?await r.json():null; }catch(e){ return null; } }
-async function openDoc(path){
-  const d=await api("/doc?path="+encodeURIComponent(path));
-  $reader.innerHTML = d ? '<article class="md">'+d.html+'</article>' : '<div class="empty">Could not load.</div>';
-  $reader.scrollTop=0;
-  [...document.querySelectorAll(".item")].forEach(a=>a.classList.toggle("active", a.dataset.path===path));
+const LIVE_DOCS="https://agent.protolabs.studio/docs/";  // Cloudflare build folds the docs in here (config.mts)
+const slugify=s=>String(s).normalize("NFKD").replace(/[\u0300-\u036f]/g,"").replace(/[^\w\- ]+/g,"").trim().replace(/\s+/g,"-").toLowerCase();
+let currentPath=null;
+// Resolve a doc link — relative (`./x.md`, `../sec/y.md`) or VitePress abs-rooted (`/sec/z`,
+// `/sec/`) — against the current doc's dir into ORDERED corpus rel-path candidates to try.
+// Clean links (no .md) may map to `z.md` OR a section index `z/index.md`; a trailing slash
+// is always a section index. Returns [] for an unresolvable link (→ live-docs fallback).
+function candidatePaths(fromPath, rawPath){
+  let parts;
+  if(rawPath.startsWith("/")) parts=[];
+  else { const dir=fromPath.includes("/")?fromPath.slice(0,fromPath.lastIndexOf("/")):""; parts=dir?dir.split("/"):[]; }
+  const trailingSlash=/\/$/.test(rawPath);
+  for(const seg of rawPath.split("/")){ if(seg===""||seg===".")continue; if(seg==="..")parts.pop(); else parts.push(seg); }
+  const joined=parts.join("/");
+  if(!joined) return [];
+  if(trailingSlash) return [joined+"/index.md"];
+  if(/\.md$/i.test(joined)) return [joined];
+  return [joined+".md", joined+"/index.md"];
 }
+function liveDocsUrl(fromPath, rawPath, anchor){
+  const c=candidatePaths(fromPath, rawPath);
+  const p=(c[0]||rawPath.replace(/^\/+/,"")).replace(/\/index\.md$/i,"/").replace(/\.md$/i,"");
+  return LIVE_DOCS+p+(anchor?("#"+anchor):"");
+}
+function addHeadingIds(){ $reader.querySelectorAll(".md h1,.md h2,.md h3,.md h4,.md h5,.md h6").forEach(h=>{ if(!h.id) h.id=slugify(h.textContent||""); }); }
+function scrollToAnchor(anchor){ if(!anchor){ $reader.scrollTop=0; return; } const a=decodeURIComponent(anchor); const el=document.getElementById(a)||document.getElementById(slugify(a)); if(el)el.scrollIntoView({block:"start"}); else $reader.scrollTop=0; }
+async function fetchDoc(path){ return api("/doc?path="+encodeURIComponent(path)); }
+function renderDoc(path, d, anchor){
+  currentPath=path;
+  $reader.innerHTML='<article class="md">'+d.html+'</article>';
+  addHeadingIds();
+  [...document.querySelectorAll(".item")].forEach(a=>a.classList.toggle("active", a.dataset.path===path));
+  scrollToAnchor(anchor);
+}
+async function openDoc(path){ const d=await fetchDoc(path); if(d) renderDoc(path,d); else $reader.innerHTML='<div class="empty">Could not load.</div>'; }
+// In-content cross-reference links: don't let the click reload the target INSIDE this iframe
+// (cramped, loses the docs chrome). Resolve to a corpus doc → open in-panel (preferred);
+// else open the live docs site in a new tab (fallback). In-page anchors scroll the reader;
+// external/scheme links open a new tab (browser: a tab; desktop: the system browser, #1450).
+$reader.addEventListener("click", async (e)=>{
+  const a=e.target.closest("a[href]"); if(!a||!$reader.contains(a)) return;
+  const href=a.getAttribute("href")||""; if(!href) return;
+  if(href.startsWith("#")){ e.preventDefault(); scrollToAnchor(href.slice(1)); return; }
+  if(/^[a-z][\w+.-]*:/i.test(href)||href.startsWith("//")){ e.preventDefault(); window.open(href,"_blank","noopener,noreferrer"); return; }
+  e.preventDefault();
+  const hi=href.indexOf("#"); const rawPath=hi>=0?href.slice(0,hi):href; const anchor=hi>=0?href.slice(hi+1):"";
+  if(!rawPath){ scrollToAnchor(anchor); return; }
+  for(const c of candidatePaths(currentPath||"", rawPath)){ const d=await fetchDoc(c); if(d){ renderDoc(c,d,anchor); return; } }
+  window.open(liveDocsUrl(currentPath||"", rawPath, anchor), "_blank", "noopener,noreferrer");
+});
 function renderTree(sections){
   const item=it=>'<a class="item" data-path="'+esc(it.path)+'" title="'+esc(it.path)+'">'+esc(it.title)+'</a>';
   $list.innerHTML = sections.map(s=>'<div class="sec">'+esc(s.label)+'</div>'+


### PR DESCRIPTION
Closes #1456.

## Problem
The docs reader view renders markdown server-side and injects it as `<article class="md">`. The **sidebar** nav intercepts clicks (JS `openDoc`), but **in-content cross-reference links** — markdown-rendered `<a href>` inside a doc page — had no handler. Clicking one navigated the *iframe itself*, loading a bare page stripped of the docs nav/search in a cramped embed frame.

## Fix
Scoped entirely to the docs plugin view JS (`plugins/docs/__init__.py`'s `_VIEW_HTML`). Delegate clicks on the reader and route each content link:

- **In-corpus docs → open in-panel (preferred).** Relative (`./0019-….md`, `../guides/skills.md`) and VitePress abs-rooted clean (`/adr/0060-…`, `/guides/`) links resolve against the current doc's directory into ordered corpus rel-path candidates (clean links → `z.md` *or* a section index `z/index.md`; a trailing slash → section index). The authoritative `/doc` corpus gate decides membership — no client-side path-set to drift. Any `#anchor` is carried and scrolled to.
- **Everything else → open in a new tab (fallback).** External / scheme links (`http(s):`, `mailto:`, `//`) and any target not in the bundled corpus open in a new tab — a browser tab, or the system browser in the desktop app (handled by #1450's `on_new_window`).
- **In-page `#section` links** scroll the reader (headings get client-side slug `id`s matching VitePress's slugify) instead of reloading the iframe.

This is the same shape as the issue's triage note and the recent plugin-iframe link work (#1450 / #1454).

The live-docs fallback base is `https://agent.protolabs.studio/docs/` (the Cloudflare build folds the docs in at `/docs/`, per `docs/.vitepress/config.mts`).

## Testing
- `ruff check` ✅ · existing `tests/test_docs_plugin.py` (9 tests) ✅
- Resolver logic verified in node against the **live corpus** for all four link shapes present in the docs (314 abs-rooted, 243 relative-`.md`, 77 external, 12 anchor-only): abs-rooted, relative `.md`, parent `../`, anchored, directory-index (`/adr/` → `adr/index.md`), and the excluded/nonexistent → live-docs fallback. 9/9 cases route as expected.
- ⚠️ **Not yet verified clicking in the running console** — this is a plugin-view behavior change; recommend a quick in-app smoke (open Docs, click a cross-ref link, an external link, and a `#section` link) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)