### PR TITLE
refactor(paths): complete the two-tier path model — store-tier migration + scope_leaf removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   required a destructive self-heal. **Existing installs upgrade with no action** — a one-shot,
   idempotent, non-destructive boot migration copies old-layout config + secrets (and the default
   instance's data) into the new location. Use `config explain` to see the resolved layout.
+  Every data store (checkpoints, knowledge, memory, scheduler, inbox, activity, telemetry, audit,
+  tasks, a2a, workflows, …) now lives under the instance root; the Host config layer is box-shared
+  (one machine-wide `host-config.yaml`, the layer's intent); shared commons stay shared; and the
+  legacy `scope_leaf` scoping knob is removed. (ADR 0065; supersedes the path mechanics of ADR
+  0004/0041 and re-amends the host-file location in ADR 0047.)
 
 ### Fixed
 - **A crashed co-located fleet member is now detected and restartable** (#1474) — a member the hub

--- a/PROTO.md
+++ b/PROTO.md
@@ -15,23 +15,26 @@ TypeScript is the console.
   was retired in ADR 0023 and CI fails on it). Console is served from
   `apps/web/dist`; `/healthz` is the readiness probe.
 - **Isolated dev instance (don't stomp prod data):** `scripts/dev.sh` runs a
-  sandboxed instance via `PROTOAGENT_INSTANCE=dev` (ADR 0004 scoping) on `:7871` —
-  its own `config/dev/` + `~/.protoagent/{dev,*/dev}` data, **seeded from your
-  default config** (boots with your gateway, no re-setup) but with fresh, separate
-  chat/tasks/knowledge. The default instance (`config/` + `~/.protoagent`, `:7870`)
-  is untouched. `scripts/dev-reset.sh` wipes just the sandbox. Use this for feature
+  sandboxed instance via `PROTOAGENT_INSTANCE=dev` (ADR 0065 two-tier paths) on
+  `:7871` — its whole root is `~/.protoagent/dev/` (config + every store under it),
+  and it inherits the machine-wide **box** layer (`~/.protoagent/host-config.yaml`,
+  gateway/model defaults) so it boots configured with fresh, separate
+  chat/tasks/knowledge. The default instance is `~/.protoagent/default/` on `:7870`,
+  untouched. `scripts/dev-reset.sh` wipes just the sandbox. Use this for feature
   testing instead of the default instance.
 - **Factory-reset the default instance:** `scripts/reset.sh` wipes the **prod**
-  instance's data + local config back to a clean slate (next boot runs the setup
-  wizard) — for testing the fresh-user flow via CLI (there is no in-app reset).
-  **Always `scripts/reset.sh --dry-run` first** to read the plan. It's safe on a
-  multi-instance machine: every *other* instance (any `~/.protoagent/<name>` with an
-  `.instance-uid`, the dev sandbox, fleet members) and every scoped
-  `<store>/<instance>` leaf is preserved — only prod's unscoped DBs + the direct
-  files in shared store dirs are removed; tracked `config/` files are `git checkout`-
-  restored, gitignored local config deleted. Flags: `--yes`, `--backup`,
+  instance back to a clean slate (next boot runs the setup wizard) — for testing the
+  fresh-user flow via CLI (there is no in-app reset). **Always `--dry-run` first** to
+  read the plan. It's safe on a multi-instance machine: every *other* instance
+  (`~/.protoagent/<name>`, the dev sandbox, fleet members) and the machine-wide **box**
+  layer (`host-config.yaml`, `commons/`) are preserved. Flags: `--yes`, `--backup`,
   `--keep-secrets` (keep gateway creds), `--include-dev`, `--force` (stop a bound
-  server first).
+  server first). *(Reset-script rewrite for the ADR-0065 single-subtree layout is a
+  follow-up; see [the env-vars gotcha](#house-rules--gotchas-that-bite).)*
+- **See where state lives:** `python -m server config explain` (or
+  `GET /api/config/explain`) prints this instance's id, both roots (box + instance),
+  every resolved path, and the per-field settings cascade with provenance (secrets
+  redacted) — the way to answer "where is my config / where did my key go".
 - **Python deps:** managed with `uv` (`pyproject.toml [project.dependencies]` is
   the source of truth; `uv.lock` is tracked). `uv sync` to install.
 - **Console deps:** `npm ci` at the repo root (npm workspaces; the web app is
@@ -70,6 +73,17 @@ proposed-direction / acceptance (enhancements). Intentional free-form → add th
 ## House rules & gotchas that bite
 
 These are the failures that actually recur — read them before you edit.
+
+- **Instance paths are two-tier (box / instance) — one rule, resolve once (ADR 0065).**
+  Every on-disk location comes from `infra.paths.instance_paths()` (a frozen
+  `InstancePaths`): the **box** tier (`box_root` = `~/.protoagent` or `/sandbox`) holds
+  machine-shared state (`host-config.yaml`, `commons/`, heartbeats); the **instance**
+  tier (`instance_root`) holds this agent's config + every store. `instance_root =
+  PROTOAGENT_HOME | box_root/PROTOAGENT_INSTANCE | box_root/default`. **Don't** compute
+  store paths by hand or reach for the deleted `scope_leaf` / `PROTOAGENT_CONFIG_DIR`
+  (both retired — desktop/Docker/fleet now set `PROTOAGENT_HOME`); add a per-store
+  accessor or use `instance_paths().store("<name>")`. Identity comes from env only —
+  never config-file content. `config explain` prints the resolved layout.
 
 - **No unused variables.** ruff selects `F` (pyflakes); `F841` (assigned-but-
   unused) **fails CI** and `ruff check --fix` does **not** auto-fix it. Don't

--- a/a2a_impl/stores.py
+++ b/a2a_impl/stores.py
@@ -233,25 +233,16 @@ class ValidatingPushNotificationSender(BasePushNotificationSender):
 
 
 def _resolve_db_path(leaf: str) -> str:
-    """Resolve a writable SQLite path for ``leaf`` (e.g. ``a2a-tasks.db``).
+    """Resolve the writable SQLite path for ``leaf`` (e.g. ``a2a-tasks.db``).
 
-    Mirrors the bespoke stores: prefer ``/sandbox/<leaf>``; fall back to
-    ``~/.protoagent/<leaf>`` when the sandbox dir isn't writable (local dev).
-    Both run through ``scope_leaf`` for per-instance scoping (ADR 0004), so the
-    instance segment survives the fallback.
+    A file directly under the per-instance ``instance_root`` (``store(leaf)`` →
+    ``instance_root/<leaf>``), so co-located instances keep disjoint task/push DBs.
     """
-    from infra.paths import scope_leaf
+    from infra.paths import instance_paths
 
-    configured = scope_leaf(Path("/sandbox") / leaf)
-    try:
-        configured.parent.mkdir(parents=True, exist_ok=True)
-        if not os.access(configured.parent, os.W_OK):
-            raise OSError
-        return str(configured)
-    except OSError:
-        fallback = scope_leaf(Path.home() / ".protoagent" / leaf)
-        fallback.parent.mkdir(parents=True, exist_ok=True)
-        return str(fallback)
+    path = instance_paths().store(leaf)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return str(path)
 
 
 def make_sqlite_engine(db_path: str) -> AsyncEngine:

--- a/docs/adr/0004-multi-instance-data-scoping.md
+++ b/docs/adr/0004-multi-instance-data-scoping.md
@@ -1,6 +1,9 @@
 # ADR 0004 — Multi-Instance Data Scoping
 
-- **Status:** Accepted (2026-05-30) — implemented (instance scoping + scheduler owner-lock)
+- **Status:** Accepted (2026-05-30) — implemented (instance scoping + scheduler owner-lock).
+  **The path-scoping *mechanism* (`scope_leaf`, unset-id = unscoped) is superseded by
+  [ADR 0065](0065-two-tier-instance-paths.md)** (two-tier box/instance paths, single resolution
+  rule, every instance scoped). The multi-instance *goal* stands; only the mechanism changed.
 - **Date:** 2026-05-30
 - **Deciders:** Josh Mabry; protoAgent maintainers
 - **Tags:** architecture, deployment, state, scheduler, knowledge, multi-instance

--- a/docs/adr/0041-workspaces-and-tiered-stores.md
+++ b/docs/adr/0041-workspaces-and-tiered-stores.md
@@ -1,6 +1,9 @@
 # 0041 — Workspaces & tiered stores (the fleet-on-one-host model)
 
-- Status: Accepted (v0.31.0)
+- Status: Accepted (v0.31.0). The `PROTOAGENT_CONFIG_DIR` / "a workspace *is* a config dir" path
+  model here is superseded by [ADR 0065](0065-two-tier-instance-paths.md) — a workspace is now an
+  `instance_root` (launched with `PROTOAGENT_HOME`), and the tiered-store layout moved to the
+  box/instance model. The workspace + tiered-store concepts stand; only the path mechanism changed.
 - Date: 2026-06-09
 - Builds on: ADR 0004 (per-instance data scoping), ADR 0027 (git-installable plugins), ADR 0040
   (plugin bundles).

--- a/docs/adr/0042-fleet-supervisor-unified-console.md
+++ b/docs/adr/0042-fleet-supervisor-unified-console.md
@@ -1,6 +1,8 @@
 # 0042 — Fleet supervisor & unified console (background agents, in-place switching)
 
-- Status: Accepted (v0.31.0)
+- Status: Accepted (v0.31.0). Member launch now sets `PROTOAGENT_HOME=<workspace>` (not the retired
+  `PROTOAGENT_CONFIG_DIR`) per [ADR 0065](0065-two-tier-instance-paths.md); the fleet model is
+  otherwise unchanged.
 - Date: 2026-06-09
 - Builds on: ADR 0004 (per-instance scoping), 0027 (plugins), 0040 (bundles), 0041
   (workspaces & tiered stores).

--- a/docs/adr/0047-layered-settings-cascade.md
+++ b/docs/adr/0047-layered-settings-cascade.md
@@ -1,8 +1,13 @@
 # ADR 0047 — Layered settings cascade (App→Host→Agent, per-field, `Field.scope`)
 
 - **Status:** Accepted (2026-06-10; decisions locked in the operator walkthrough — see §2.1).
-  **Host-file scoping ratified _per-hub_ on 2026-06-16 (#1077)** — `host_config_path()` is
-  `scope_leaf`'d; the original §D2 unscoped-`data_home()` (per-physical-box) proposal is superseded.
+  **Host-file scoping ratified _per-hub_ on 2026-06-16 (#1077)** — `host_config_path()` was
+  `scope_leaf`'d; the original §D2 unscoped-`data_home()` (per-physical-box) proposal was superseded.
+  **Re-amended 2026-06-30 by [ADR 0065](0065-two-tier-instance-paths.md):** the Host file is
+  **box-shared again** — it lives at `box_root/host-config.yaml` (the box tier of the two-tier path
+  model), so every instance on the machine reads one machine-wide Host layer, which is the layer's
+  purpose. The per-field cascade semantics and `Field.scope` below are unchanged — only the file's
+  *location* moved.
 - **Date:** 2026-06-10
 - **Deciders:** Josh Mabry; protoAgent maintainers
 - **Tags:** config, settings, fleet, host, architecture, cascade, schema-driven

--- a/docs/adr/0065-two-tier-instance-paths.md
+++ b/docs/adr/0065-two-tier-instance-paths.md
@@ -1,0 +1,104 @@
+# 0065 — Two-tier instance paths (box / instance) + single resolution rule
+
+- Status: Accepted
+- Date: 2026-06-30
+- Supersedes: the path-scoping mechanism of [ADR 0004](0004-multi-instance-data-scoping.md); the
+  `PROTOAGENT_CONFIG_DIR` / "a workspace *is* a config dir" parts of
+  [ADR 0041](0041-workspaces-and-tiered-stores.md) and
+  [ADR 0042](0042-fleet-supervisor-unified-console.md)
+- Amends: [ADR 0047](0047-layered-settings-cascade.md) (the Host layer file is now box-shared)
+
+## Context
+
+protoAgent located on-disk state through **two roots scoped by two different rules**:
+
+- the **agent config** (`langgraph-config.yaml`, `secrets.yaml`, `.setup-complete`, `theme.json`)
+  lived under a *config dir* (`PROTOAGENT_CONFIG_DIR` or `REPO/config`), scoped by `_config_scope`,
+  which **skipped** instance-scoping whenever `PROTOAGENT_CONFIG_DIR` was set; and
+- the **data stores** + the **Host cascade layer** lived under the *data home* (`/sandbox` or
+  `~/.protoagent`), scoped by `scope_leaf` (the instance id inserted as the leaf's parent).
+
+Those rules collided exactly where it mattered most: a **fleet member** launches with *both*
+`PROTOAGENT_CONFIG_DIR=<workspace>` and `PROTOAGENT_INSTANCE=<id>`, so the two scopings disagreed,
+and a destructive self-heal (`_reset_double_scoped_config`) existed only to delete the wreckage —
+which at one point deleted a live instance's gateway key. Path locations were also frozen as
+**import-time module constants**, computed before the instance id was even known, so config-leaf and
+data-store paths could scope differently within one process (the chicken-and-egg that forced an
+`_seed_instance_env` re-scope step at boot). The Host layer — meant to be *machine-wide* — was
+wedged into the data home and `scope_leaf`'d per instance (#813), contradicting its purpose.
+
+## Decision
+
+One model, three directory tiers that mirror the ADR-0047 cascade (App → Host → Agent), resolved
+**once** from the environment into a frozen, injectable `infra.paths.InstancePaths`:
+
+- **App** = `app_root/config` — read-only bundle seed (example YAML, `SOUL.md` source, presets).
+  Live config is **never written into the repo tree** again.
+- **Box** = `box_root` — **machine-shared, never scoped**: `host-config.yaml` (the Host cascade
+  layer, now genuinely box-wide), `commons/` (shared skills), `.instances/` heartbeats,
+  `.data-version`, response cache.
+- **Instance** = `instance_root` — **per-agent; it IS the scoped leaf** (`scope_leaf` is never
+  applied to it — the single fact that deletes the entire double-scope bug class): `config/`,
+  `plugins/`, and every per-instance store (`checkpoints.db`, `knowledge/`, `memory/`, `scheduler/`,
+  `inbox/`, `activity/`, `telemetry.db`, `skills.db`, `audit/`, `a2a-*.db`, `tasks/`, `workflows/`,
+  `workspace/`, …).
+
+**One resolution rule** — two orthogonal knobs, so `PROTOAGENT_HOME` relocates *only* the instance
+tier and the box tier stays shared (fleet members under their own `HOME` still inherit one
+machine-wide Host layer + commons):
+
+```
+box_root      = PROTOAGENT_BOX_ROOT  else  data_home()        # /sandbox if a dir else ~/.protoagent
+instance_root = PROTOAGENT_HOME                               # terminal: the dir IS the root
+              | box_root / PROTOAGENT_INSTANCE                # a named instance under the box
+              | box_root / "default"                          # neither set → "default"
+instance_id   = PROTOAGENT_INSTANCE | basename(PROTOAGENT_HOME) | "default"
+```
+
+**Identity comes from the environment only** — never config-file content — so a correctly-scoped
+config is read on the first try (no chicken-and-egg, no `_seed_instance_env`). Every instance is
+scoped (the default is just the named instance `default`); the legacy *unscoped* branch is gone.
+
+Deleted: `_config_scope`, `_reset_double_scoped_config`, the import-time path constants,
+`_seed_instance_env`, `PROTOAGENT_CONFIG_DIR`, `PROTOAGENT_AUTO_SCOPE`, and `scope_leaf` itself.
+The fleet registry (`fleet.json` / `workspaces/`) stays under the **hub's** `instance_root`, not the
+box tier — so a booting member reads its own empty registry and `shutdown_all` stays "hub-only by
+construction" (it cannot SIGTERM its siblings).
+
+### Deployment shapes
+
+| Shape | env | box_root | instance_root |
+|---|---|---|---|
+| Local default | — | `~/.protoagent` | `~/.protoagent/default` |
+| Dev sandbox | `PROTOAGENT_INSTANCE=dev` | `~/.protoagent` | `~/.protoagent/dev` |
+| Docker | `PROTOAGENT_HOME=/sandbox` | `/sandbox` | `/sandbox` |
+| Desktop | `PROTOAGENT_HOME=<app-data>` | `~/.protoagent` | `<app-data>` |
+| Fleet member | `PROTOAGENT_HOME=<ws>` + `PROTOAGENT_INSTANCE=<id>` | `~/.protoagent` | `<ws>` |
+
+### Seamless upgrade (no back-compat in the runtime, but no stranded data)
+
+The runtime carries **no** legacy dual-mode logic. A single, self-contained, deletable
+`migrate_legacy_layout()` runs at first boot under the new layout: when the new config is absent it
+**copies** (never moves; `copy2` preserves `secrets.yaml`'s 0600) the old-layout config + secrets +
+setup-marker + theme into `instance_root/config`, and carries the **default** instance's data stores
+from their old `box_root/<store>` locations into `box_root/default/<store>`. Idempotent,
+non-destructive, logged. Scoped sandboxes (e.g. `dev`) re-initialise (they are wipeable test state).
+
+## Observability
+
+`config explain` (CLI `python -m server config explain` + `GET /api/config/explain`) prints the
+instance id, both roots, every resolved path, and the per-field cascade provenance with secrets
+redacted — the supported way to answer "where did my config/key go", replacing the deleted
+self-heal.
+
+## Consequences
+
+- The double-scope bug class is **structurally impossible** (one scoping input; `instance_root` is
+  the leaf). The fleet member `CONFIG_DIR`+`INSTANCE` collision cannot recur.
+- The Host layer is **box-shared** (reverses #813): two co-located hubs now read one machine-wide
+  `host-config.yaml`. This is the intended "machine-wide host" semantics — a Settings save of a
+  host-scoped field is box-wide.
+- Per-field cascade semantics and `Field.scope` from ADR 0047 are unchanged; only the Host file's
+  *location* moves (box-shared, no `scope_leaf`).
+- A workspace is now simply an `instance_root` (the ADR-0041 "workspace == config dir" model
+  collapses); fleet member launch sets `PROTOAGENT_HOME=<ws>` rather than `PROTOAGENT_CONFIG_DIR`.

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -150,6 +150,28 @@ except ImportError:
 # legacy-layout bridge below.
 _MIGRATED_CONFIG_FILES = ("langgraph-config.yaml", "secrets.yaml", ".setup-complete", "theme.json")
 
+# Per-instance DATA stores that lived flat under the box root in the old layout
+# (``~/.protoagent/checkpoints.db``, ``~/.protoagent/knowledge``, …) and now live
+# under ``instance_root`` (``~/.protoagent/default/...``). The store-tier bridge
+# below carries them for the DEFAULT instance only. Box-tier shared state
+# (host-config.yaml, commons, .instances, .data-version, workspaces) is deliberately
+# NOT in either list — it stays at the box root, shared by every instance.
+_LEGACY_STORE_FILES = ("checkpoints.db", "telemetry.db", "skills.db", "a2a-tasks.db", "a2a-push.db")
+_LEGACY_STORE_DIRS = (
+    "knowledge",
+    "memory",
+    "scheduler",
+    "inbox",
+    "background",
+    "activity",
+    "audit",
+    "tasks",
+    "workflows",
+    "acp_sessions",
+    "goals",
+    "workspace",
+)
+
 
 def _legacy_config_dirs() -> list[Path]:
     """Old-layout directories that may hold this instance's pre-redesign config, in
@@ -217,7 +239,55 @@ def migrate_legacy_layout() -> bool:
         p.soul_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(legacy_soul, p.soul_path)
         migrated = True
+    # Carry the default instance's data stores into the new instance_root (first
+    # boot only — gated by the same absent-live-config condition above so a store
+    # the operator later clears is never resurrected). Only the DEFAULT instance
+    # auto-migrates; scoped sandboxes (e.g. the dev instance) re-init from scratch.
+    migrated = _migrate_legacy_stores(p) or migrated
     return migrated
+
+
+def _migrate_legacy_stores(p) -> bool:
+    """One-shot, idempotent, non-destructive copy of the pre-redesign data stores from
+    the flat box root into ``instance_root`` (``box_root/<store>`` → ``box_root/default/
+    <store>``). Returns True if it copied anything.
+
+    Only runs for the standard local DEFAULT instance (``instance_id == "default"`` and
+    ``box_root`` is the parent of ``instance_root``) — a ``PROTOAGENT_HOME`` deploy or a
+    named/dev instance has a distinct root and re-inits rather than inheriting the
+    default's data. Copy (never move); skip any store whose destination already exists.
+    Box-tier shared state is never touched. Best-effort — a copy failure must never
+    block boot."""
+    import shutil
+
+    if p.instance_id != "default" or p.box_root != p.instance_root.parent:
+        return False
+    moved: list[str] = []
+    for name in _LEGACY_STORE_FILES:
+        src, dst = p.box_root / name, p.instance_root / name
+        if src.is_file() and not dst.exists():
+            try:
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+                moved.append(name)
+            except OSError as exc:
+                log.warning("[migrate] could not carry store file %s: %s", name, exc)
+    for name in _LEGACY_STORE_DIRS:
+        src, dst = p.box_root / name, p.instance_root / name
+        if src.is_dir() and not dst.exists():
+            try:
+                shutil.copytree(src, dst)
+                moved.append(f"{name}/")
+            except OSError as exc:
+                log.warning("[migrate] could not carry store dir %s: %s", name, exc)
+    if moved:
+        log.warning(
+            "[migrate] carried default-instance data stores into %s (one-time; originals "
+            "left untouched, removable once you've confirmed the upgrade): %s",
+            p.instance_root,
+            ", ".join(moved),
+        )
+    return bool(moved)
 
 
 def ensure_live_config() -> bool:

--- a/graph/goals/store.py
+++ b/graph/goals/store.py
@@ -2,9 +2,9 @@
 
 Goals outlive a single graph run (and the frequent graph rebuilds the server
 does on config reload), so state is written to disk keyed by ``session_id``.
-Path resolution mirrors the memory/knowledge subsystems: ``GOAL_PATH`` env →
-``/sandbox/goals`` → ``~/.protoagent/goals`` fallback when the sandbox path
-isn't writable (e.g. running locally without ``/sandbox``).
+Path resolution mirrors the memory/knowledge subsystems: ``GOAL_PATH`` env
+(verbatim) → the per-instance ``instance_root/goals`` store → a temp dir as a
+last resort if nothing is writable.
 """
 
 from __future__ import annotations
@@ -34,20 +34,18 @@ def _publish(topic: str, data: dict) -> None:
 
 
 def _resolve_base() -> Path:
-    # Per-instance scoping (ADR 0004): namespace by PROTOAGENT_INSTANCE so two
-    # agents on one machine don't share a goals dir — without this, scheduled /
+    # Per-instance (ADR 0004): the default sits at ``instance_root/goals`` so two
+    # agents on one machine don't share a goals dir — without isolation, scheduled /
     # activity turns (shared session id "system:activity") collide and goals leak
-    # across agents. No-op when PROTOAGENT_INSTANCE is unset (single instance).
-    from infra.paths import scope_leaf
+    # across agents. ``GOAL_PATH`` env overrides verbatim.
+    from infra.paths import instance_paths
 
     candidates = []
     env = os.environ.get("GOAL_PATH", "").strip()
     if env:
-        candidates.append(Path(env))
-    candidates.append(Path("/sandbox/goals"))
-    candidates.append(Path.home() / ".protoagent" / "goals")
-    for raw in candidates:
-        path = scope_leaf(raw)
+        candidates.append(Path(env).expanduser())
+    candidates.append(instance_paths().store("goals"))
+    for path in candidates:
         try:
             path.mkdir(parents=True, exist_ok=True)
             # confirm writable
@@ -58,7 +56,7 @@ def _resolve_base() -> Path:
         except OSError:
             continue
     # Last resort: a temp dir (keeps the server alive even if nothing is writable).
-    fallback = scope_leaf(Path(tempfile.gettempdir()) / "protoagent_goals")
+    fallback = Path(tempfile.gettempdir()) / "protoagent_goals"
     fallback.mkdir(parents=True, exist_ok=True)
     return fallback
 

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -93,12 +93,13 @@ class KnowledgeMiddleware(AgentMiddleware):
         Delegates to the shared :func:`graph.middleware.memory.load_prior_sessions`
         (ADR 0021) — one source of truth, with read-time reasoning stripping —
         so this and ``SessionSummaryMiddleware`` can't drift. ``memory_path`` defaults
-        to the writer's resolved ``MEMORY_PATH`` (no duplicate path literal,
+        to the writer's resolved ``memory_path()`` (no duplicate path literal,
         same can't-drift reasoning). Never raises.
         """
-        from graph.middleware.memory import MEMORY_PATH, load_prior_sessions
+        from graph.middleware.memory import load_prior_sessions
+        from graph.middleware.memory import memory_path as _memory_path
 
-        return load_prior_sessions(memory_path or MEMORY_PATH, max_sessions, max_tokens)
+        return load_prior_sessions(memory_path or _memory_path(), max_sessions, max_tokens)
 
     # ---------------------------------------------------------------------------
     # Skill index (progressive disclosure — ADR 0060)

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -1,6 +1,6 @@
 """SessionSummaryMiddleware — persists a session summary on each terminal turn.
 
-Writes a reasoning-stripped JSON summary of the session to disk (``MEMORY_PATH``)
+Writes a reasoning-stripped JSON summary of the session to disk (``memory_path()``)
 on the terminal turn and on session end, enabling cross-session memory across
 restarts — read back by ``KnowledgeMiddleware`` as a ``<prior_sessions>`` block.
 
@@ -15,6 +15,7 @@ import logging
 import os
 import tempfile
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
@@ -24,28 +25,31 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Configuration — read once at module init
+# Configuration
 # ---------------------------------------------------------------------------
 
-from infra.paths import data_home, scope_leaf  # ADR 0004 — per-instance scoping (no-op when unset)
-
-# ``PROTOAGENT_INSTANCE`` is seeded by server init before the graph (and this
-# middleware) is built, so the instance segment applies here too.
-#
-# Default via data_home(): ``/sandbox/memory`` in a container, else
-# ``~/.protoagent/memory`` — the writable fallback every other store already
-# uses. The old literal ``/sandbox/memory/`` silently skipped persistence on
-# any non-container host (read-only ``/``), and on Windows resolved
-# drive-relative and wrote to ``\sandbox`` at the drive root (caught by the
-# desktop sidecar smoke).
-MEMORY_PATH = str(scope_leaf(os.environ.get("MEMORY_PATH") or data_home() / "memory"))
 _DISABLE_ENV = os.environ.get("PROTOAGENT_DISABLE_MEMORY", "")
 _PERSISTENCE_DISABLED = _DISABLE_ENV.lower() in ("1", "true", "yes")
 
 if _PERSISTENCE_DISABLED:
     log.debug("[memory] persistence disabled via PROTOAGENT_DISABLE_MEMORY")
 else:
-    log.info("[memory] session persistence enabled — path: %s", MEMORY_PATH)
+    log.info("[memory] session persistence enabled")
+
+
+def memory_path() -> str:
+    """The session-memory dir, resolved lazily on each call — NOT an import-time
+    constant (env identity is finalized after this module imports).
+
+    ``MEMORY_PATH`` env wins (verbatim); else the per-instance ``instance_root/memory``
+    store. The old literal ``/sandbox/memory`` silently skipped persistence on any
+    non-container host (read-only ``/``); the instance store is always writable."""
+    raw = os.environ.get("MEMORY_PATH", "").strip()
+    if raw:
+        return str(Path(raw).expanduser())
+    from infra.paths import instance_paths
+
+    return str(instance_paths().store("memory"))
 
 
 # ---------------------------------------------------------------------------
@@ -147,20 +151,21 @@ def _persist_session(state: dict, trace_id: str) -> None:
         summary["tool_calls_total_count"] = total_count
 
     # --- Ensure directory exists ---
+    base = memory_path()
     try:
-        os.makedirs(MEMORY_PATH, exist_ok=True)
-        log.debug("[memory] ensured directory: %s", MEMORY_PATH)
+        os.makedirs(base, exist_ok=True)
+        log.debug("[memory] ensured directory: %s", base)
     except OSError as exc:
-        log.warning("[memory] cannot create directory %s: %s — skipping persistence", MEMORY_PATH, exc)
+        log.warning("[memory] cannot create directory %s: %s — skipping persistence", base, exc)
         return
 
     # --- Atomic write ---
     filename = f"{session_id or 'unknown'}.json"
-    dest = os.path.join(MEMORY_PATH, filename)
+    dest = os.path.join(base, filename)
     tmp_fd = None
     tmp_path = None
     try:
-        tmp_fd, tmp_path = tempfile.mkstemp(dir=MEMORY_PATH, suffix=".tmp")
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=base, suffix=".tmp")
         with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
             json.dump(summary, fh, indent=2, default=str)
             tmp_fd = None  # fdopen took ownership
@@ -189,7 +194,7 @@ def _persist_session(state: dict, trace_id: str) -> None:
 
 
 def load_prior_sessions(
-    memory_path: str = MEMORY_PATH,
+    memory_dir: str | None = None,
     max_sessions: int = 10,
     max_tokens: int = 2000,
 ) -> str:
@@ -200,18 +205,21 @@ def load_prior_sessions(
     up to ``max_sessions`` newest JSON files, drops oldest-first to fit
     ``max_tokens`` (char/4 approximation), and **strips reasoning at read** so a
     file written before the persist-time strip (or by an older build) still
-    can't inject ``<scratch_pad>`` into the prompt. Never raises.
+    can't inject ``<scratch_pad>`` into the prompt. ``memory_dir`` defaults to the
+    writer's resolved ``memory_path()``. Never raises.
     """
     from graph.output_format import strip_reasoning
 
-    if not os.path.isdir(memory_path):
+    if memory_dir is None:
+        memory_dir = memory_path()
+    if not os.path.isdir(memory_dir):
         return ""
     try:
         entries: list[tuple[float, str]] = []
-        for fname in os.listdir(memory_path):
+        for fname in os.listdir(memory_dir):
             if not fname.endswith(".json"):
                 continue
-            fpath = os.path.join(memory_path, fname)
+            fpath = os.path.join(memory_dir, fname)
             try:
                 entries.append((os.path.getmtime(fpath), fpath))
             except OSError:
@@ -268,7 +276,7 @@ def load_prior_sessions(
 class SessionSummaryMiddleware(AgentMiddleware):
     """Persist a session summary on the terminal turn (+ on session end).
 
-    Writes a reasoning-stripped JSON summary to ``MEMORY_PATH``, read back by
+    Writes a reasoning-stripped JSON summary to ``memory_path()``, read back by
     ``KnowledgeMiddleware`` as ``<prior_sessions>`` for cross-session continuity.
 
     **Write-only.** It does not write to the knowledge store (ADR 0021 — see

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -38,21 +38,19 @@ _RESERVED_NAMES = {"host"}
 
 
 def workspaces_root() -> Path:
-    """Where workspaces live. ``PROTOAGENT_WORKSPACES_DIR`` overrides; default
-    ``~/.protoagent/workspaces``.
+    """Where workspaces live. ``PROTOAGENT_WORKSPACES_DIR`` overrides (verbatim);
+    default the per-instance ``instance_root/workspaces`` store.
 
-    Instance-scoped (ADR 0004) like every other store — ``scope_leaf`` on the final
-    resolved path, so a scoped hub owns its own fleet (``~/.protoagent/<iid>/workspaces``
-    + its ``fleet.json``) instead of sharing one registry with every co-located instance
-    (two hubs pruning/evicting each other's agents). This also fences peers: workspace
-    agents run with ``PROTOAGENT_INSTANCE=<name>``, so a peer's fleet view is its own,
-    not the parent hub's. Unscoped stays the shared legacy root (#706 warning covers it).
-    """
-    from infra.paths import scope_leaf
+    HUB-instance-scoped (ADR 0004), so a scoped hub owns its own fleet
+    (``<instance_root>/workspaces`` + its ``fleet.json``) instead of sharing one registry
+    with every co-located instance (two hubs pruning/evicting each other's agents). This
+    also fences peers: workspace agents run with ``PROTOAGENT_HOME=<ws>``, so a member's
+    own (empty) workspaces root keeps the supervisor's ``shutdown_all`` hub-only by
+    construction."""
+    from infra.paths import instance_paths
 
     override = os.environ.get("PROTOAGENT_WORKSPACES_DIR", "").strip()
-    base = Path(override).expanduser() if override else (Path.home() / ".protoagent" / "workspaces")
-    return scope_leaf(base)
+    return Path(override).expanduser() if override else instance_paths().workspaces_dir
 
 
 def _safe(name: str) -> str:

--- a/infra/paths.py
+++ b/infra/paths.py
@@ -1,16 +1,17 @@
 """Per-instance data-path scoping (ADR 0004).
 
 Multiple protoAgent instances on one shared filesystem must not clobber each
-other's on-disk state. When an **instance id** is set (``PROTOAGENT_INSTANCE``
-env, seeded from ``instance_id`` config at startup), every store nests its files
-under that id; when unset, paths are byte-identical to the single-instance
-default — so existing deployments need no migration, and containers (each with
-its own ``/sandbox``) are unaffected.
+other's on-disk state. Identity comes from the environment only
+(``PROTOAGENT_HOME`` / ``PROTOAGENT_INSTANCE`` / ``PROTOAGENT_BOX_ROOT``) and
+resolves once into the frozen ``InstancePaths`` object (see ``instance_paths()``).
 
-``scope_leaf`` is the one knob: applied to a store's final resolved path, it
-inserts the instance segment as the leaf's parent dir (a no-op when no id is
-set). Apply it at the end of each resolver, *after* the writable-fallback choice,
-so the segment survives a ``/sandbox`` → ``~/.protoagent`` fallback.
+The resolution is two-tier: the **instance root** is the per-agent scoped leaf
+(``box_root/<id>`` or ``PROTOAGENT_HOME``) and every data store sits directly
+under it (``store("knowledge")`` → ``instance_root/knowledge``); the **box root**
+is the machine-shared base that holds the Host-layer config, the commons library
+and the live-instance heartbeats, inherited by every instance this machine owns.
+``instance_root`` IS the scope leaf, so no per-call segment-insertion knob is
+needed — the old ``scope_leaf`` double-scoping is gone.
 """
 
 from __future__ import annotations
@@ -208,50 +209,27 @@ def check_data_version() -> str | None:
     return None
 
 
-def scope_leaf(path: str | Path) -> Path:
-    """Insert the instance id as the parent dir of ``path``'s leaf when set.
-
-    ``/sandbox/checkpoints.db`` → ``/sandbox/<id>/checkpoints.db``;
-    ``~/.protoagent/knowledge/agent.db`` → ``~/.protoagent/knowledge/<id>/agent.db``.
-    A no-op (returns ``path`` unchanged) when no instance id is configured.
-    """
-    p = Path(str(path)).expanduser()
-    iid = instance_id()
-    if not iid:
-        return p
-    return p.parent / _safe_segment(iid) / p.name
-
-
 def host_config_path() -> Path:
     """The Host-layer config file (ADR 0047) — box-shared settings (gateway/model/
     routing/telemetry defaults that all agents this machine owns inherit).
 
-    ``scope_leaf``'d per instance like every other store, so co-located hubs stay
-    isolated (#813); one-hub-per-box ≡ per-box. ``PROTOAGENT_HOST_CONFIG`` overrides
-    with an explicit file path (e.g. a read-only desktop sidecar). The file is
-    optional — absent ⇒ the cascade collapses to App defaults + the agent leaf.
+    Lives at the BOX tier (``box_root/host-config.yaml``) so every instance this
+    machine owns reads one machine-wide Host layer — that's the point of the layer.
+    ``PROTOAGENT_HOST_CONFIG`` overrides with an explicit file path (e.g. a read-only
+    desktop sidecar). The file is optional — absent ⇒ the cascade collapses to App
+    defaults + the agent leaf.
     """
-    raw = os.environ.get("PROTOAGENT_HOST_CONFIG")
-    if raw:
-        return Path(raw).expanduser()
-    return scope_leaf(data_home() / "host-config.yaml")
+    return instance_paths().host_config
 
 
 def workspace_dir(*, create: bool = False) -> Path:
     """The agent's default fenced workspace — where the on-by-default filesystem
     toolset can read/write/edit (the fence the agent lives inside).
 
-    Resolution: ``PROTOAGENT_WORKSPACE`` env wins (point it at a friendlier dir,
-    e.g. from the desktop); else ``/sandbox/workspace`` in a container, falling
-    back to ``~/.protoagent/workspace`` for local dev — instance-scoped either
-    way. ``create=True`` mkdirs it (writes need the dir to exist)."""
-    raw = os.environ.get("PROTOAGENT_WORKSPACE")
-    if raw:
-        base = Path(raw).expanduser()
-    else:
-        sandbox = Path("/sandbox/workspace")
-        base = sandbox if sandbox.parent.is_dir() else Path.home() / ".protoagent" / "workspace"
-        base = scope_leaf(base)
+    Per-instance (``instance_root/workspace``); ``PROTOAGENT_WORKSPACE`` overrides
+    (point it at a friendlier dir, e.g. from the desktop). ``create=True`` mkdirs it
+    (writes need the dir to exist)."""
+    base = instance_paths().workspace_dir
     if create:
         base.mkdir(parents=True, exist_ok=True)
     return base.resolve()
@@ -260,36 +238,29 @@ def workspace_dir(*, create: bool = False) -> Path:
 # ── co-location detection (#706) ──────────────────────────────────────────────
 # `unscoped_warning` above is a static boot hint — it fires for every normal
 # single-instance setup, so it stays a log line. The signal worth a console
-# banner is a LIVE sibling sharing this data root (two unscoped instances, or
-# two scoped ones with the same id — the exact two-hubs bug): each instance
-# drops a `<pid>.json` heartbeat under `<root>/.instances/` at boot, removes it
-# at shutdown, and anyone can ask who else is alive in the same root.
-
-
-def instance_root() -> Path:
-    """THIS instance's data root: ``data_home()/<iid>`` when scoped, else the shared home."""
-    home = data_home()
-    iid = instance_id()
-    return home / _safe_segment(iid) if iid else home
+# banner is a LIVE sibling sharing this box (two instances on one machine): each
+# drops a `<pid>.json` heartbeat under the box-tier `<box_root>/.instances/` at
+# boot, removes it at shutdown, and anyone can ask who else is alive on the box.
 
 
 def user_skills_dir(*, create: bool = False) -> Path:
-    """Writable root for operator-authored ``SKILL.md`` skills (``instance_root()/skills``).
+    """Writable root for operator-authored ``SKILL.md`` skills (``instance_root/skills``).
 
     Distinct from the bundled ``config/skills`` (git-tracked, shipped examples) and
-    the live ``<config_dir>/skills`` drop-in: this lives under the data home, so
+    the live ``<config_dir>/skills`` drop-in: this lives under the instance root, so
     UI-managed skills survive a reboot (it's a skill seed root, re-seeded each boot)
-    and stay OUT of the repo working tree. Instance-scoped, same as ``skills.db``.
+    and stay OUT of the repo working tree. Per-instance, same as ``skills.db``.
     ``create=True`` mkdirs it."""
-    d = instance_root() / "skills"
+    d = instance_paths().skills_dir
     if create:
         d.mkdir(parents=True, exist_ok=True)
     return d
 
 
 def _instances_dir() -> Path:
-    """`.instances/` under THIS instance's data root (scoped or shared)."""
-    return instance_root() / ".instances"
+    """`.instances/` heartbeat dir — BOX tier (``box_root/.instances``), shared by
+    every instance on the machine so a live sibling on the box is detectable."""
+    return instance_paths().instances_dir
 
 
 def instance_uid() -> str:
@@ -302,7 +273,7 @@ def instance_uid() -> str:
     import uuid
 
     try:
-        f = instance_root() / ".instance-uid"
+        f = instance_paths().instance_uid_file
         if f.exists():
             got = f.read_text().strip()
             if got:
@@ -401,10 +372,9 @@ def colocation_warning() -> str | None:
         f"{o['identity'] or 'unknown'} (pid {o['pid']}" + (f", port {o['port']})" if o.get("port") else ")")
         for o in others
     )
-    iid = instance_id()
-    root = (data_home() / _safe_segment(iid)) if iid else data_home()
+    root = instance_paths().box_root
     return (
-        f"Another running instance shares this agent's data ({root}): {who}. "
+        f"Another running instance shares this machine's data root ({root}): {who}. "
         "They can clobber each other's chat history, knowledge and stores — give each "
         "instance its own PROTOAGENT_INSTANCE id (or stop the extra one)."
     )

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -104,38 +104,34 @@ class Chunk:
 
 
 def _resolve_path(db_path: str | Path | None, *, scoped: bool = True) -> Path:
-    """Pick a writable DB path. Env > arg > default; fall back to ~/.protoagent.
+    """Pick the DB path. ``KNOWLEDGE_DB_PATH`` env (or the ``db_path`` arg) is used
+    verbatim; otherwise the per-instance ``instance_root/knowledge/agent.db`` store.
 
-    ``scoped=False`` (ADR 0041, tiered stores) skips both the ``KNOWLEDGE_DB_PATH``
-    env override and ``scope_leaf`` — the path is used verbatim. The shared
-    **commons** knowledge store is host-level + un-scoped, so every agent on the box
-    reads one DB regardless of ``instance.id`` (mirrors ``_resolve_skills_db(shared=True)``).
+    ``scoped=False`` (ADR 0041, tiered stores) skips the ``KNOWLEDGE_DB_PATH`` env
+    override and the per-instance default — the ``db_path`` is used verbatim. The
+    shared **commons** knowledge store is host-level + un-scoped, so every agent on
+    the box reads one DB regardless of ``instance.id`` (mirrors
+    ``_resolve_skills_db(shared=True)``).
     """
-    from infra.paths import scope_leaf  # ADR 0004 — per-instance scoping (no-op when unset)
-
     if not scoped:
         p = Path(db_path or DEFAULT_DB_PATH)
         p.parent.mkdir(parents=True, exist_ok=True)
         return p
 
-    raw = os.environ.get("KNOWLEDGE_DB_PATH") or db_path or DEFAULT_DB_PATH
-    p = scope_leaf(raw)
-    try:
-        p.parent.mkdir(parents=True, exist_ok=True)
-        # Probe writability
-        probe = p.parent / ".write-probe"
-        probe.touch()
-        probe.unlink()
-        return p
-    except OSError:
-        fallback = scope_leaf(Path.home() / ".protoagent" / "knowledge" / "agent.db")
-        fallback.parent.mkdir(parents=True, exist_ok=True)
-        log.info(
-            "[knowledge] %s not writable; using %s instead",
-            p,
-            fallback,
-        )
-        return fallback
+    # ``KNOWLEDGE_DB_PATH`` env is an explicit operator override (verbatim). The
+    # ``db_path`` arg is an override too UNLESS it's the legacy ``/sandbox`` default
+    # (the config-field default), which now maps to the per-instance store.
+    env = os.environ.get("KNOWLEDGE_DB_PATH", "").strip()
+    if env:
+        p = Path(env).expanduser()
+    elif db_path and not str(db_path).startswith("/sandbox"):
+        p = Path(db_path).expanduser()
+    else:
+        from infra.paths import instance_paths
+
+        p = instance_paths().store("knowledge") / "agent.db"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
 
 
 def _now_iso() -> str:

--- a/observability/audit.py
+++ b/observability/audit.py
@@ -1,10 +1,10 @@
 """Audit logging for protoAgent tool executions.
 
 Append-only JSONL of tool-call metadata, enriched with Langfuse trace context for
-cross-referencing. The path is **instance-scoped** (ADR 0004) and resolved lazily
-so it picks up ``PROTOAGENT_INSTANCE`` (seeded during boot, after this module is
-imported). The file **rotates** at a size cap so a busy agent can't fill the disk,
-and ``get_recent`` reads only a bounded tail so a large log can't OOM a read.
+cross-referencing. The path is **per-instance** (ADR 0004 — ``instance_root/audit/
+audit.jsonl``) and resolved lazily so the env identity is finalized first. The file
+**rotates** at a size cap so a busy agent can't fill the disk, and ``get_recent``
+reads only a bounded tail so a large log can't OOM a read.
 """
 
 import json
@@ -20,45 +20,40 @@ _MAX_BYTES = 50 * 1024 * 1024  # 50 MB
 _TAIL_BYTES = 512 * 1024  # get_recent reads at most the last 512 KB
 _MAX_SESSIONS = 1000  # cap the in-memory per-session stats dict
 
-_DEFAULT_LEAF = Path("/sandbox") / "audit" / "audit.jsonl"
-
-
 class AuditLogger:
-    """Append-only JSONL audit log for tool executions (rotating, instance-scoped)."""
+    """Append-only JSONL audit log for tool executions (rotating, per-instance)."""
 
     def __init__(self, path: str | Path | None = None):
-        # Configured base path; the real (instance-scoped, writable) path is
-        # resolved on first use so PROTOAGENT_INSTANCE is already seeded.
-        self._base = Path(path) if path else _DEFAULT_LEAF
+        # An explicit path is used verbatim; otherwise the real (per-instance,
+        # writable) path is resolved on first use so the env identity is finalized.
+        self._base = Path(path) if path else None
         self._resolved: Path | None = None
         self._session_stats: "OrderedDict[str, dict]" = OrderedDict()
 
     def _ensure_path(self) -> Path | None:
-        """Resolve + create the instance-scoped path, with the standard
-        ``/sandbox`` → ``~/.protoagent`` writable fallback. Memoized. ``None`` if
-        nothing is writable (audit then degrades to a no-op)."""
+        """Resolve + create the audit path. Memoized. ``None`` if the dir isn't
+        creatable (audit then degrades to a no-op)."""
         if self._resolved is not None:
             return self._resolved
-        from infra.paths import scope_leaf  # ADR 0004 — per-instance scoping (no-op when unset)
-
-        candidate = scope_leaf(self._base)
+        candidate = self._default_path() if self._base is None else self._base
         try:
             candidate.parent.mkdir(parents=True, exist_ok=True)
             self._resolved = candidate
             return candidate
         except OSError:
-            fb = scope_leaf(Path.home() / ".protoagent" / "audit" / candidate.name)
-            try:
-                fb.parent.mkdir(parents=True, exist_ok=True)
-            except OSError:
-                return None
-            self._resolved = fb
-            return fb
+            return None
+
+    @staticmethod
+    def _default_path() -> Path:
+        """The per-instance default: ``instance_root/audit/audit.jsonl``."""
+        from infra.paths import instance_paths
+
+        return instance_paths().store("audit") / "audit.jsonl"
 
     @property
     def path(self) -> Path:
         """The resolved on-disk path (for callers/tests that read it directly)."""
-        return self._ensure_path() or scope_leaf_safe(self._base)
+        return self._ensure_path() or (self._base or self._default_path())
 
     def _maybe_rotate(self, path: Path) -> None:
         try:
@@ -166,16 +161,6 @@ class AuditLogger:
             "avg_ms": stats["total_ms"] // max(stats["tool_calls"], 1),
             "tools_used": sorted(stats.get("tools_used", set())),
         }
-
-
-def scope_leaf_safe(p: Path) -> Path:
-    """``scope_leaf`` without raising — used only for the ``.path`` fallback."""
-    try:
-        from infra.paths import scope_leaf
-
-        return scope_leaf(p)
-    except Exception:
-        return p
 
 
 def _sanitize_args(args: dict[str, Any]) -> dict[str, Any]:

--- a/plugins/coding_agent/__init__.py
+++ b/plugins/coding_agent/__init__.py
@@ -95,12 +95,12 @@ def _session_id_path(spec: dict) -> Path:
     """Where this agent's ACP session id is persisted, so a restart can
     ``session/load`` the same thread instead of starting fresh (#970). Keyed by a
     digest of the full launch+policy signature (the same tuple as the client cache),
-    and ``scope_leaf``'d per instance like every other store so co-located hubs stay
-    isolated. Imported lazily to keep this library host-free for its unit tests."""
-    from infra.paths import data_home, scope_leaf
+    a file under the per-instance ``instance_root/acp_sessions`` store so co-located
+    hubs stay isolated. Imported lazily to keep this library host-free for its unit tests."""
+    from infra.paths import instance_paths
 
     digest = hashlib.sha256(repr(_cache_key(spec)).encode()).hexdigest()[:16]
-    return scope_leaf(data_home() / "acp_sessions" / f"{digest}.json")
+    return instance_paths().store("acp_sessions") / f"{digest}.json"
 
 
 def _client_for(spec: dict) -> AcpClient:

--- a/plugins/docs/nav.json
+++ b/plugins/docs/nav.json
@@ -601,6 +601,10 @@
           "title": "0064 — `coder`: execution-grounded code-solve (the board's verifier-grounded coder)"
         },
         {
+          "path": "adr/0065-two-tier-instance-paths.md",
+          "title": "0065 — Two-tier instance paths (box / instance) + single resolution rule"
+        },
+        {
           "path": "adr/index.md",
           "title": "Architecture Decision Records"
         }

--- a/plugins/workflows/__init__.py
+++ b/plugins/workflows/__init__.py
@@ -27,20 +27,22 @@ _RECIPES = Path(__file__).parent / "recipes"
 
 def _build_registry(extra_dirs: list[str] | None) -> WorkflowRegistry:
     """Bundled recipes + other enabled plugins' recipe dirs (ADR 0027) + a writable dir
-    (user/agent-saved recipes win on a name clash)."""
-    from infra.paths import scope_leaf
+    (user/agent-saved recipes win on a name clash). ``workflow_dir`` config is used
+    verbatim when an operator overrides it; the legacy ``/sandbox`` default maps to the
+    per-instance ``instance_root/workflows`` store."""
+    from infra.paths import instance_paths
 
     dirs: list[str] = [str(_RECIPES)]
     for d in extra_dirs or []:
         if Path(d).is_dir():
             dirs.append(str(d))
     cfg = sdk.config()
-    writable = scope_leaf(Path(getattr(cfg, "workflow_dir", "~/.protoagent/workflows")).expanduser())
-    try:
-        writable.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        writable = scope_leaf(Path.home() / ".protoagent" / "workflows")
-        writable.mkdir(parents=True, exist_ok=True)
+    configured = getattr(cfg, "workflow_dir", "") or ""
+    if configured and not str(configured).startswith("/sandbox"):
+        writable = Path(configured).expanduser()
+    else:
+        writable = instance_paths().store("workflows")
+    writable.mkdir(parents=True, exist_ok=True)
     dirs.append(str(writable))
     return WorkflowRegistry(dirs, writable_dir=str(writable))
 

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -41,7 +41,6 @@ from scheduler.interface import Job, is_cron, parse_iso_to_utc
 
 log = logging.getLogger(__name__)
 
-DEFAULT_DB_DIR = "/sandbox/scheduler"
 _POLL_INTERVAL_S = 1.0
 _MISSED_FIRE_WINDOW_S = 24 * 60 * 60  # 24h
 
@@ -105,22 +104,16 @@ def _resolve_db_path(db_dir: str | Path | None, agent_name: str) -> Path:
     cheap and prevents an exotic typo from putting a sqlite file
     outside the configured scheduler dir.
     """
-    from infra.paths import scope_leaf  # ADR 0004 — per-instance scoping (no-op when unset)
-
     safe_name = _safe_segment(agent_name)
-    raw = os.environ.get("SCHEDULER_DB_DIR") or db_dir or DEFAULT_DB_DIR
-    base = scope_leaf(Path(str(raw)).expanduser() / safe_name)
-    try:
-        base.mkdir(parents=True, exist_ok=True)
-        probe = base / ".write-probe"
-        probe.touch()
-        probe.unlink()
-        return base / "jobs.db"
-    except OSError:
-        fallback = scope_leaf(Path.home() / ".protoagent" / "scheduler" / safe_name)
-        fallback.mkdir(parents=True, exist_ok=True)
-        log.info("[scheduler] %s not writable; using %s instead", base, fallback)
-        return fallback / "jobs.db"
+    override = os.environ.get("SCHEDULER_DB_DIR") or db_dir
+    if override:
+        base = Path(str(override)).expanduser() / safe_name
+    else:
+        from infra.paths import instance_paths
+
+        base = instance_paths().store("scheduler") / safe_name
+    base.mkdir(parents=True, exist_ok=True)
+    return base / "jobs.db"
 
 
 def _safe_segment(name: str) -> str:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -39,7 +39,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from events import ACTIVITY_CONTEXT, EventBus
-from infra.paths import scope_leaf
 from runtime.state import STATE, get_state
 from graph.output_format import extract_output
 

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -24,7 +24,7 @@ import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from infra.paths import scope_leaf
+from infra.paths import instance_paths
 from runtime.state import STATE
 from server import AGENT_NAME_ENV, _event_bus, agent_name
 from server.chat import chat
@@ -650,23 +650,14 @@ def _build_plugins(config, existing_tools=None):
 
 
 def _resolve_checkpoint_db(configured: str) -> str:
-    """Pick a writable checkpoint DB path; fall back to ~/.protoagent when the
-    configured dir (default /sandbox) isn't creatable (e.g. local dev)."""
-    import os
-    from pathlib import Path
+    """The durable checkpoint DB — ``instance_root/checkpoints.db`` (per-instance).
 
-    candidate = Path(configured).expanduser()
-    try:
-        candidate.parent.mkdir(parents=True, exist_ok=True)
-        if os.access(candidate.parent, os.W_OK):
-            scoped = scope_leaf(candidate)
-            scoped.parent.mkdir(parents=True, exist_ok=True)
-            return str(scoped)
-    except OSError:
-        pass
-    fallback = scope_leaf(Path.home() / ".protoagent" / "checkpoints.db")
-    fallback.parent.mkdir(parents=True, exist_ok=True)
-    return str(fallback)
+    ``configured`` (``config.checkpoint_db_path``) only gates persistence on/off in
+    ``_build_checkpointer``; the path itself is the per-instance store, always
+    writable, so there's no /sandbox→~/.protoagent fallback dance any more."""
+    path = instance_paths().store("checkpoints.db")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return str(path)
 
 
 def _build_checkpointer(config):
@@ -868,21 +859,16 @@ async def _retire_thread(thread_id: str, *, harvest: bool | None = None, cascade
 
 
 def _build_inbox_store(config):
-    """Durable inbound inbox (ADR 0003). Path resolves like the other stores
-    (/sandbox → ~/.protoagent fallback), namespaced by agent name."""
+    """Durable inbound inbox (ADR 0003), namespaced by agent name. ``inbox_db_path``
+    config (a dir) is used verbatim; else the per-instance ``instance_root/inbox`` store."""
     from inbox import InboxStore
 
     name = re.sub(r"[^a-zA-Z0-9._-]", "_", agent_name()) or "agent"
-    configured = scope_leaf(Path(getattr(config, "inbox_db_path", "") or "/sandbox/inbox") / f"{name}.db")
-    try:
-        configured.parent.mkdir(parents=True, exist_ok=True)
-        if not os.access(configured.parent, os.W_OK):
-            raise OSError
-        path = str(configured)
-    except OSError:
-        fallback = scope_leaf(Path.home() / ".protoagent" / "inbox" / f"{name}.db")
-        fallback.parent.mkdir(parents=True, exist_ok=True)
-        path = str(fallback)
+    configured = getattr(config, "inbox_db_path", "") or ""
+    base = Path(configured).expanduser() if configured else instance_paths().store("inbox")
+    db = base / f"{name}.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    path = str(db)
     try:
         return InboxStore(path)
     except Exception:
@@ -893,8 +879,8 @@ def _build_inbox_store(config):
 def _build_background_manager(config):
     """Background subagent manager (ADR 0050). Fires detached jobs as self-POSTed A2A
     turns, so it derives the invoke URL + auth exactly like ``_build_scheduler`` (so a
-    wizard rename can't break self-invocation). The store path resolves like the other
-    stores (/sandbox → ~/.protoagent fallback), namespaced by agent name. Reconciles any
+    wizard rename can't break self-invocation). The store is the per-instance
+    ``instance_root/background`` store, namespaced by agent name. Reconciles any
     job left ``running`` by a prior crash on startup. Returns ``None`` when disabled or
     the store can't be built (the ``task`` tool then falls back to synchronous execution)."""
     if os.environ.get("BACKGROUND_DISABLED", "").lower() in ("1", "true", "yes"):
@@ -903,16 +889,9 @@ def _build_background_manager(config):
     from background import BackgroundManager, BackgroundStore
 
     name = re.sub(r"[^a-zA-Z0-9._-]", "_", agent_name()) or "agent"
-    configured = scope_leaf(Path("/sandbox/background") / f"{name}.db")
-    try:
-        configured.parent.mkdir(parents=True, exist_ok=True)
-        if not os.access(configured.parent, os.W_OK):
-            raise OSError
-        path = str(configured)
-    except OSError:
-        fallback = scope_leaf(Path.home() / ".protoagent" / "background" / f"{name}.db")
-        fallback.parent.mkdir(parents=True, exist_ok=True)
-        path = str(fallback)
+    db = instance_paths().store("background") / f"{name}.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    path = str(db)
     try:
         store = BackgroundStore(path)
     except Exception:
@@ -957,21 +936,14 @@ def _build_background_manager(config):
 
 
 def _build_activity_log(config):
-    """Provenance feed store (ADR 0022). Path resolves like the inbox store
-    (/sandbox → ~/.protoagent fallback), namespaced by agent name."""
+    """Provenance feed store (ADR 0022) — the per-instance ``instance_root/activity``
+    store, namespaced by agent name."""
     from activity import ActivityLog
 
     name = re.sub(r"[^a-zA-Z0-9._-]", "_", agent_name()) or "agent"
-    configured = scope_leaf(Path("/sandbox/activity") / f"{name}.db")
-    try:
-        configured.parent.mkdir(parents=True, exist_ok=True)
-        if not os.access(configured.parent, os.W_OK):
-            raise OSError
-        path = str(configured)
-    except OSError:
-        fallback = scope_leaf(Path.home() / ".protoagent" / "activity" / f"{name}.db")
-        fallback.parent.mkdir(parents=True, exist_ok=True)
-        path = str(fallback)
+    db = instance_paths().store("activity") / f"{name}.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    path = str(db)
     try:
         return ActivityLog(path)
     except Exception:
@@ -980,23 +952,21 @@ def _build_activity_log(config):
 
 
 def _build_telemetry_store(config):
-    """Local per-turn telemetry store (ADR 0006 Slice 2). Path resolves like the
-    other stores (/sandbox → ~/.protoagent fallback) and is instance-scoped
-    (ADR 0004). Off when ``telemetry.enabled`` is false; best-effort otherwise."""
+    """Local per-turn telemetry store (ADR 0006 Slice 2). ``telemetry.db_path`` config
+    is used verbatim when an operator overrides it; the legacy ``/sandbox`` default maps
+    to the per-instance ``instance_root/telemetry.db`` store. Off when ``telemetry.enabled``
+    is false; best-effort otherwise."""
     if not getattr(config, "telemetry_enabled", True):
         return None
     from observability.telemetry_store import TelemetryStore
 
-    configured = scope_leaf(Path(getattr(config, "telemetry_db_path", "") or "/sandbox/telemetry.db"))
-    try:
-        configured.parent.mkdir(parents=True, exist_ok=True)
-        if not os.access(configured.parent, os.W_OK):
-            raise OSError
-        path = str(configured)
-    except OSError:
-        fallback = scope_leaf(Path.home() / ".protoagent" / "telemetry.db")
-        fallback.parent.mkdir(parents=True, exist_ok=True)
-        path = str(fallback)
+    configured = getattr(config, "telemetry_db_path", "") or ""
+    if configured and not str(configured).startswith("/sandbox"):
+        db = Path(configured).expanduser()
+    else:
+        db = instance_paths().store("telemetry.db")
+    db.parent.mkdir(parents=True, exist_ok=True)
+    path = str(db)
     try:
         store = TelemetryStore(path)
         log.info("[telemetry] store ready at %s", path)
@@ -1017,32 +987,22 @@ def _commons_dir(config):
 
 
 def _resolve_skills_db(configured: str, *, shared: bool = False, commons=None) -> str:
-    """Pick a writable skills DB path.
+    """Pick the skills DB path.
 
     When ``shared`` (ADR 0041, tiered stores), the skills library is the COMMONS:
-    resolved un-scoped so every agent on the host shares one DB. Otherwise it's
-    per-instance scoped (``scope_leaf``), falling back to ~/.protoagent when the
-    configured dir (default /sandbox) isn't creatable."""
-    import os
+    box-level + un-scoped so every agent on the host shares one DB. Otherwise it's
+    the per-instance ``instance_root/skills.db`` (``configured`` is no longer a
+    location knob — the instance root IS the scope)."""
     from pathlib import Path
 
     if shared:
-        path = Path(commons or (Path.home() / ".protoagent" / "commons")) / "skills.db"
+        path = Path(commons or instance_paths().commons_dir) / "skills.db"
         path.parent.mkdir(parents=True, exist_ok=True)
         return str(path)
 
-    candidate = Path(configured)
-    try:
-        candidate.parent.mkdir(parents=True, exist_ok=True)
-        if os.access(candidate.parent, os.W_OK):
-            scoped = scope_leaf(candidate)
-            scoped.parent.mkdir(parents=True, exist_ok=True)
-            return str(scoped)
-    except OSError:
-        pass
-    fallback = scope_leaf(Path.home() / ".protoagent" / "skills.db")
-    fallback.parent.mkdir(parents=True, exist_ok=True)
-    return str(fallback)
+    db = instance_paths().store("skills.db")
+    db.parent.mkdir(parents=True, exist_ok=True)
+    return str(db)
 
 
 def _run_on_server_loop(make_coro, what: str) -> None:

--- a/tasks/store.py
+++ b/tasks/store.py
@@ -1,9 +1,9 @@
 """In-process tasks issue store (Sprint B).
 
 A small SQLite-backed issue tracker the server owns — the agent's planning/task
-surface and the console's Tasks panel both read/write it. Instance-scoped
-(``paths.scope_leaf``) so several agents don't share one board. No `br` CLI, no
-per-project `.tasks/` directory.
+surface and the console's Tasks panel both read/write it. Per-instance
+(``instance_root/tasks/issues.db``) so several agents don't share one board. No
+`br` CLI, no per-project `.tasks/` directory.
 
 Issue shape (the fields the console + tools use):
   id, title, description, status, priority, issue_type, assignee,
@@ -19,9 +19,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from infra.paths import scope_leaf
-
-
 def _publish(topic: str, data: dict) -> None:
     """Best-effort bus push so the console Tasks panel can invalidate live on a change
     instead of polling every 5s (#1310). No-op when the host hasn't wired a publisher
@@ -34,8 +31,6 @@ def _publish(topic: str, data: dict) -> None:
     except Exception:  # noqa: BLE001
         pass
 
-DEFAULT_DB_PATH = "/sandbox/tasks/issues.db"
-
 # Open lifecycle states (closed is terminal). Mirrors the console's
 # issueStatusOrder; `tombstone` is intentionally absent (we hard-delete).
 VALID_STATUSES = ("open", "in_progress", "blocked", "deferred", "closed")
@@ -47,14 +42,14 @@ def _now() -> str:
 
 
 def _resolve_db_path(db_path: str | None) -> Path:
-    """``TASKS_DB_PATH`` (or legacy ``BEADS_DB_PATH``) env → constructor arg →
-    default. Falls back from a non-writable ``/sandbox`` to ``~/.protoagent`` for
-    local dev, then instance-scoped — same shape as the knowledge store."""
-    raw = os.environ.get("TASKS_DB_PATH") or os.environ.get("BEADS_DB_PATH") or db_path or DEFAULT_DB_PATH
-    p = Path(raw).expanduser()
-    if str(p).startswith("/sandbox") and not Path("/sandbox").is_dir():
-        p = Path.home() / ".protoagent" / "tasks" / "issues.db"
-    return scope_leaf(p)
+    """``TASKS_DB_PATH`` (or legacy ``BEADS_DB_PATH``) env → constructor arg
+    (both verbatim) → the per-instance ``instance_root/tasks/issues.db`` store."""
+    raw = os.environ.get("TASKS_DB_PATH") or os.environ.get("BEADS_DB_PATH") or db_path
+    if raw:
+        return Path(raw).expanduser()
+    from infra.paths import instance_paths
+
+    return instance_paths().store("tasks") / "issues.db"
 
 
 class TaskStore:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,10 +5,11 @@ against a fake OpenAI gateway, on temp roots + free ports, and tears everything
 down. This is the integration layer the fleet had no coverage for — every prior
 fleet test mocked ``subprocess`` or ran single-instance.
 
-Isolation: each server gets its own tmp ``HOME`` so the (still-legacy, pre-Phase-4)
-``data_home()`` stores land under ``<tmp>/.protoagent`` instead of the real one,
-and ``PROTOAGENT_HOME`` puts its config at ``<tmp-home>/config`` (the new layout).
-Members the hub spawns inherit that tmp ``HOME``, so the whole fleet stays in tmp.
+Isolation: each server gets its own tmp ``HOME`` so the box tier (host-config,
+commons, heartbeats) lands under ``<tmp>/.protoagent`` instead of the real one, and
+``PROTOAGENT_HOME`` puts its config AND every per-instance data store under
+``<tmp-home>`` (the new instance_root layout). Members the hub spawns inherit that
+tmp ``HOME`` and get their own ``PROTOAGENT_HOME=<ws>``, so the whole fleet stays in tmp.
 
 These tests are SLOW (real boots) and opt-in: set ``PA_RUN_INTEGRATION=1`` to run
 them; the default ``pytest tests/`` skips them.
@@ -150,8 +151,8 @@ def fleet(tmp_path_factory, fake_gateway):
         port = free_port()
         env = {
             **os.environ,
-            "HOME": str(data_root),  # isolate data_home() → <data_root>/.protoagent (legacy stores)
-            "PROTOAGENT_HOME": str(home),  # instance_root → config at <home>/config (new layout)
+            "HOME": str(data_root),  # isolate data_home() → <data_root>/.protoagent (box tier: host/commons/heartbeats)
+            "PROTOAGENT_HOME": str(home),  # instance_root → config + every per-instance store under <home>
             "PROTOAGENT_HEADLESS_SETUP": "1",
             "OPENAI_API_KEY": "fake-integration-key",
             "PYTHONPATH": str(ROOT),

--- a/tests/integration/test_fleet_crash_restart.py
+++ b/tests/integration/test_fleet_crash_restart.py
@@ -62,8 +62,9 @@ def test_member_crash_detected_then_restart(fleet):
     m = _member(hub, mid)
     assert m and m.get("running") and int(m.get("pid")) == pid1, f"member not listed as running: {m}"
 
-    # Where the member's data lives -- we confirm it survives the restart.
-    ws_dirs = list(hub.data_root.glob(f"**/workspaces/{mid}"))
+    # Where the member's data lives -- we confirm it survives the restart. Workspaces are
+    # HUB-instance-scoped (instance_root/workspaces = PROTOAGENT_HOME/workspaces = hub.home).
+    ws_dirs = list(hub.home.glob(f"workspaces/{mid}"))
     assert ws_dirs, "member workspace dir not found before crash"
     ws_dir = ws_dirs[0]
 

--- a/tests/integration/test_fleet_smoke.py
+++ b/tests/integration/test_fleet_smoke.py
@@ -69,11 +69,13 @@ def test_member_config_resolves_under_new_layout(fleet):
     assert st == 200, f"create member failed: {st} {raw[:300]}"
     mid = json.loads(raw)["agent"]["id"]
 
-    # The member's config lives at <ws>/config/langgraph-config.yaml under the isolated data root.
-    matches = list(hub.data_root.glob(f"**/workspaces/{mid}/config/langgraph-config.yaml"))
+    # Workspaces are HUB-instance-scoped now (``instance_root/workspaces`` =
+    # ``PROTOAGENT_HOME/workspaces`` = under hub.home), so the member's config lives at
+    # <hub.home>/workspaces/<ws>/config/langgraph-config.yaml.
+    matches = list(hub.home.glob(f"workspaces/{mid}/config/langgraph-config.yaml"))
     assert matches, (
-        "member config not at <ws>/config/ (new layout). langgraph-config.yaml files under root: "
-        f"{[str(p) for p in hub.data_root.rglob('langgraph-config.yaml')]}"
+        "member config not at <ws>/config/ (new layout). langgraph-config.yaml files under hub home: "
+        f"{[str(p) for p in hub.home.rglob('langgraph-config.yaml')]}"
     )
     # It carries the inherited fake gateway — i.e. config wrote + read back at the un-double-scoped path.
     assert "127.0.0.1" in matches[0].read_text(), "member config did not inherit the host gateway"

--- a/tests/test_audit_hardening.py
+++ b/tests/test_audit_hardening.py
@@ -45,9 +45,14 @@ def test_session_stats_capped(tmp_path, monkeypatch):
 
 
 def test_instance_scoping(tmp_path, monkeypatch):
-    # PROTOAGENT_INSTANCE namespaces the path under an instance segment.
+    # The DEFAULT audit path is the per-instance instance_root/audit/audit.jsonl, so
+    # PROTOAGENT_INSTANCE namespaces it. An explicit path is honored verbatim.
+    import infra.paths as paths
+
+    monkeypatch.setenv("PROTOAGENT_BOX_ROOT", str(tmp_path))
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "inst-a")
-    a = AuditLogger(path=tmp_path / "audit.jsonl")
+    paths.reset_instance_paths()
+    a = AuditLogger()  # no explicit path → per-instance default
     a.log(session_id="s", tool="t", args={}, result_summary="", duration_ms=1, success=True)
-    assert "inst-a" in str(a.path)
+    assert a.path == tmp_path / "inst-a" / "audit" / "audit.jsonl"
     assert json.loads(a.path.read_text().splitlines()[0])["tool"] == "t"

--- a/tests/test_fleet_path_coverage.py
+++ b/tests/test_fleet_path_coverage.py
@@ -54,19 +54,23 @@ def test_plugin_roots_from_uses_plugins_root(tmp_path):
     assert overridden[-1] == tmp_path / "elsewhere"
 
 
-# ── Path: host_config_path's scope_leaf branch (cascade tests always override) ───
+# ── Path: host_config_path is BOX-tier, shared by every instance on the machine ──
 
 
-def test_host_config_path_scoped_per_instance(monkeypatch):
-    """``host_config_path()`` scope_leafs per instance when ``PROTOAGENT_HOST_CONFIG``
-    isn't set, so co-located hubs stay isolated (#813). The settings-cascade tests
-    always pin an explicit path, so this branch was never exercised."""
+def test_host_config_path_is_box_shared(monkeypatch, tmp_path):
+    """``host_config_path()`` is the BOX-tier Host layer (``box_root/host-config.yaml``),
+    NOT under the instance root — every instance the machine owns reads the one
+    machine-wide Host config (that's the point of the layer). The settings-cascade tests
+    always pin an explicit ``PROTOAGENT_HOST_CONFIG``, so this branch was never exercised."""
     import infra.paths as paths
 
     monkeypatch.delenv("PROTOAGENT_HOST_CONFIG", raising=False)
+    monkeypatch.setenv("PROTOAGENT_BOX_ROOT", str(tmp_path))
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "hub-9")
+    paths.reset_instance_paths()
     p = paths.host_config_path()
-    assert p.name == "host-config.yaml" and "hub-9" in p.parts
+    assert p == tmp_path / "host-config.yaml"  # box-shared — NOT under the hub-9 instance root
+    assert "hub-9" not in p.parts
 
 
 # ── Shared skills (ADR 0041): behavioral commons, not just the path string ───────

--- a/tests/test_goal_store.py
+++ b/tests/test_goal_store.py
@@ -64,24 +64,28 @@ def test_all_empty_and_skips_corrupt(tmp_path):
 
 
 def test_resolve_base_is_instance_scoped(monkeypatch, tmp_path):
-    """Two agents on one machine must not share a goals dir (ADR 0004) — else
-    scheduled/activity turns (shared session id) collide and goals leak across
-    agents. _resolve_base namespaces by PROTOAGENT_INSTANCE."""
+    """Two agents on one machine must not share a goals dir (ADR 0004) — the default
+    sits at instance_root/goals, so a different PROTOAGENT_INSTANCE → a different dir."""
+    import infra.paths as paths
     from graph.goals import store as goal_store
 
-    monkeypatch.setenv("GOAL_PATH", str(tmp_path))
+    monkeypatch.delenv("GOAL_PATH", raising=False)
+    monkeypatch.setenv("PROTOAGENT_BOX_ROOT", str(tmp_path))
 
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "alpha")
+    paths.reset_instance_paths()
     base_a = goal_store._resolve_base()
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "beta")
+    paths.reset_instance_paths()
     base_b = goal_store._resolve_base()
     assert base_a != base_b
-    assert base_a.name == tmp_path.name and base_a.parent.name == "alpha"
-    assert base_b.parent.name == "beta"
+    assert base_a == tmp_path / "alpha" / "goals"
+    assert base_b == tmp_path / "beta" / "goals"
 
-    # No instance id → unscoped (single-instance back-compat).
-    monkeypatch.delenv("PROTOAGENT_INSTANCE", raising=False)
-    assert goal_store._resolve_base() == tmp_path
+    # GOAL_PATH is an explicit override — used verbatim, no scoping.
+    monkeypatch.setenv("GOAL_PATH", str(tmp_path / "explicit"))
+    paths.reset_instance_paths()
+    assert goal_store._resolve_base() == tmp_path / "explicit"
 
 
 def test_set_and_clear_publish_goal_changed(tmp_path, monkeypatch):

--- a/tests/test_instance_scope.py
+++ b/tests/test_instance_scope.py
@@ -46,14 +46,18 @@ def test_shared_skills_resolve_to_commons_not_scoped(monkeypatch, tmp_path):
     from server.agent_init import _resolve_skills_db
 
     commons = tmp_path / "commons"
+    monkeypatch.setenv("PROTOAGENT_BOX_ROOT", str(tmp_path / "box"))
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "agentA")
+    paths.reset_instance_paths()
     shared_a = _resolve_skills_db("/x/skills.db", shared=True, commons=commons)
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "agentB")
+    paths.reset_instance_paths()
     shared_b = _resolve_skills_db("/x/skills.db", shared=True, commons=commons)
-    scoped_b = _resolve_skills_db(str(tmp_path / "cfg" / "skills.db"), shared=False)
+    scoped_b = _resolve_skills_db("/x/skills.db", shared=False)  # per-instance: instance_root/skills.db
 
     assert shared_a == shared_b == str(commons / "skills.db")  # one commons for all agents
     assert "agentB" in scoped_b and scoped_b != shared_a  # scoped is per-instance
+    assert scoped_b == str(tmp_path / "box" / "agentB" / "skills.db")
 
 
 def test_skills_tier_config_parses(tmp_path):
@@ -87,13 +91,17 @@ def test_register_unregister_heartbeat(monkeypatch, tmp_path):
     assert not f.exists()
 
 
-def test_scoped_heartbeats_live_in_scoped_root(monkeypatch, tmp_path):
+def test_heartbeats_live_at_box_root(monkeypatch, tmp_path):
+    """Heartbeats are BOX-tier — ``box_root/.instances`` regardless of the instance id,
+    so a live sibling anywhere on the machine is detectable (#813)."""
     _home(monkeypatch, tmp_path)
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "roxy")
+    paths.reset_instance_paths()
     paths.register_instance(7874, "roxy")
     import os
 
-    assert (tmp_path / "roxy" / ".instances" / f"{os.getpid()}.json").exists()
+    assert (tmp_path / ".instances" / f"{os.getpid()}.json").exists()  # box-tier, NOT under roxy
+    assert not (tmp_path / "roxy" / ".instances").exists()
     paths.unregister_instance()
 
 
@@ -135,13 +143,16 @@ def test_runtime_status_carries_warnings():
 
 def test_instance_uid_stable_and_scoped(monkeypatch, tmp_path):
     _home(monkeypatch, tmp_path)
+    paths.reset_instance_paths()
     uid = paths.instance_uid()
     assert uid and paths.instance_uid() == uid  # created once, then stable
-    assert (tmp_path / ".instance-uid").read_text().strip() == uid
+    # default instance → instance_root is box_root/default
+    assert (tmp_path / "default" / ".instance-uid").read_text().strip() == uid
 
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "roxy")
+    paths.reset_instance_paths()
     scoped = paths.instance_uid()
-    assert scoped and scoped != uid  # different data root → different uid
+    assert scoped and scoped != uid  # different instance root → different uid
     assert (tmp_path / "roxy" / ".instance-uid").exists()
 
 

--- a/tests/test_instance_scoping.py
+++ b/tests/test_instance_scoping.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 
-from infra import paths
+import infra.paths as paths
 from scheduler.local import (
     LocalScheduler,
     _acquire_jobs_lock,
@@ -12,51 +12,31 @@ from scheduler.local import (
 )
 
 
-# ── scope_leaf ───────────────────────────────────────────────────────────────
-
-
-def test_scope_leaf_is_noop_without_instance(monkeypatch):
-    monkeypatch.delenv("PROTOAGENT_INSTANCE", raising=False)
-    assert str(paths.scope_leaf("/sandbox/checkpoints.db")) == "/sandbox/checkpoints.db"
-    assert str(paths.scope_leaf("/sandbox/knowledge/agent.db")) == "/sandbox/knowledge/agent.db"
-
-
-def test_scope_leaf_nests_under_instance(monkeypatch):
-    monkeypatch.setenv("PROTOAGENT_INSTANCE", "alice")
-    assert str(paths.scope_leaf("/sandbox/checkpoints.db")) == "/sandbox/alice/checkpoints.db"
-    assert str(paths.scope_leaf("/sandbox/knowledge/agent.db")) == "/sandbox/knowledge/alice/agent.db"
-    assert str(paths.scope_leaf("/sandbox/workflows")) == "/sandbox/alice/workflows"
-
-
-def test_scope_leaf_sanitizes_dangerous_ids(monkeypatch):
-    monkeypatch.setenv("PROTOAGENT_INSTANCE", "../../etc")
-    out = paths.scope_leaf("/sandbox/x.db")
-    # Path separators are flattened to a single segment, so the id can't escape
-    # the intended directory (no "/" in the inserted segment).
-    assert out == __import__("pathlib").Path("/sandbox/.._.._etc/x.db")
-    assert "/" not in out.parent.name  # single sanitized segment
-    assert out.parts[:2] == ("/", "sandbox")  # stays under the base
-
-
-def test_two_instances_get_disjoint_paths(monkeypatch):
-    monkeypatch.setenv("PROTOAGENT_INSTANCE", "alice")
-    a = str(paths.scope_leaf("/sandbox/checkpoints.db"))
-    monkeypatch.setenv("PROTOAGENT_INSTANCE", "bob")
-    b = str(paths.scope_leaf("/sandbox/checkpoints.db"))
-    assert a != b
-
-
-# ── scheduler resolver honors the instance id ────────────────────────────────
+# ── scheduler resolver: per-instance default vs explicit override ─────────────
 
 
 def test_scheduler_db_path_nests_under_instance(tmp_path, monkeypatch):
+    """The default jobs.db sits under the per-instance store
+    (``instance_root/scheduler/<agent>/jobs.db``), so two instances don't collide."""
+    monkeypatch.delenv("SCHEDULER_DB_DIR", raising=False)
+    monkeypatch.setenv("PROTOAGENT_BOX_ROOT", str(tmp_path))
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "alice")
-    monkeypatch.setenv("SCHEDULER_DB_DIR", str(tmp_path))
+    paths.reset_instance_paths()
     from scheduler.local import _resolve_db_path
 
     p = _resolve_db_path(None, "myagent")
-    # .../alice/myagent/jobs.db — instance segment present, agent segment present
-    assert "alice" in p.parts and "myagent" in p.parts and p.name == "jobs.db"
+    assert p == tmp_path / "alice" / "scheduler" / "myagent" / "jobs.db"
+
+
+def test_scheduler_db_dir_override_is_verbatim(tmp_path, monkeypatch):
+    """``SCHEDULER_DB_DIR`` (or the ``db_dir`` arg) is an explicit override — used
+    verbatim, only the agent segment appended (no instance scoping on top)."""
+    monkeypatch.setenv("SCHEDULER_DB_DIR", str(tmp_path))
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "alice")
+    from scheduler.local import _resolve_db_path
+
+    p = _resolve_db_path(None, "myagent")
+    assert p == tmp_path / "myagent" / "jobs.db"  # no "alice" segment
 
 
 # ── owner-lock interlock ─────────────────────────────────────────────────────

--- a/tests/test_knowledge_layered.py
+++ b/tests/test_knowledge_layered.py
@@ -22,14 +22,18 @@ def _stores(tmp_path):
 
 
 def test_unscoped_path_is_verbatim(tmp_path, monkeypatch):
-    """scoped=False uses the path verbatim (no scope_leaf) — the host-level commons
-    every agent shares regardless of instance id."""
-    monkeypatch.setenv("PROTOAGENT_INSTANCE", "agent-7")
+    """scoped=False uses the path verbatim — the host-level commons every agent shares
+    regardless of instance id. A scoped store's DEFAULT lives under the instance root."""
+    import infra.paths as paths
+
     monkeypatch.delenv("KNOWLEDGE_DB_PATH", raising=False)
+    monkeypatch.setenv("PROTOAGENT_BOX_ROOT", str(tmp_path))
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "agent-7")
+    paths.reset_instance_paths()
     p = str(tmp_path / "commons" / "knowledge.db")
-    assert str(KnowledgeStore(p, scoped=False).path) == p  # un-scoped
-    # ...whereas a scoped store namespaces the path to the instance.
-    assert "agent-7" in str(KnowledgeStore(p, scoped=True).path)
+    assert str(KnowledgeStore(p, scoped=False).path) == p  # un-scoped, verbatim
+    # ...whereas a scoped store's default namespaces under the instance root.
+    assert KnowledgeStore(None, scoped=True).path == tmp_path / "agent-7" / "knowledge" / "agent.db"
 
 
 def test_meta_roundtrip(tmp_path):

--- a/tests/test_legacy_migration.py
+++ b/tests/test_legacy_migration.py
@@ -113,3 +113,81 @@ def test_ensure_live_config_runs_migration(monkeypatch, tmp_path):
     # seed nothing; migration must carry the old config across.
     cio.ensure_live_config()
     assert paths.instance_paths().config_yaml.read_text() == "carried: over\n"
+
+
+# ── store-tier migration (box_root/<store> → box_root/default/<store>) ───────────
+
+
+def _seed_legacy_stores(box):
+    """Drop pre-redesign data stores flat under the box root + box-tier shared state."""
+    # Per-instance stores (these MOVE into instance_root):
+    (box / "checkpoints.db").write_text("ckpt")
+    (box / "skills.db").write_text("skills")
+    (box / "knowledge").mkdir()
+    (box / "knowledge" / "agent.db").write_text("kb")
+    (box / "memory").mkdir()
+    (box / "memory" / "s1.json").write_text("{}")
+    (box / "goals").mkdir()
+    (box / "goals" / "g.json").write_text("{}")
+    # Box-tier shared state (these STAY at the box root — never copied):
+    (box / "host-config.yaml").write_text("host: cfg")
+    (box / "commons").mkdir()
+    (box / "commons" / "skills.db").write_text("shared")
+    (box / ".instances").mkdir()
+    (box / ".instances" / "123.json").write_text("{}")
+    (box / ".data-version").write_text("{}")
+    (box / "workspaces").mkdir()
+    (box / "workspaces" / "fleet.json").write_text("{}")
+
+
+def test_migrates_default_instance_stores(monkeypatch, tmp_path):
+    """First boot of the default instance carries the flat box-root data stores into
+    ``box_root/default/<store>``; box-tier shared state is left alone."""
+    box, _ = _setup(monkeypatch, tmp_path)  # default instance
+    _seed_legacy_stores(box)
+
+    assert cio.migrate_legacy_layout() is True
+    inst = box / "default"
+    # per-instance stores carried (files + dirs):
+    assert (inst / "checkpoints.db").read_text() == "ckpt"
+    assert (inst / "skills.db").read_text() == "skills"
+    assert (inst / "knowledge" / "agent.db").read_text() == "kb"
+    assert (inst / "memory" / "s1.json").exists()
+    assert (inst / "goals" / "g.json").exists()
+    # originals untouched (copy, not move):
+    assert (box / "checkpoints.db").exists()
+    # box-tier shared state NOT copied under the instance root:
+    assert not (inst / "host-config.yaml").exists()
+    assert not (inst / "commons").exists()
+    assert not (inst / ".instances").exists()
+    assert not (inst / ".data-version").exists()
+    assert not (inst / "workspaces").exists()
+
+
+def test_store_migration_is_idempotent(monkeypatch, tmp_path):
+    """Second pass copies nothing (destinations already exist)."""
+    box, _ = _setup(monkeypatch, tmp_path)
+    _seed_legacy_stores(box)
+    assert cio.migrate_legacy_layout() is True
+    assert cio.migrate_legacy_layout() is False  # no-op once carried
+
+
+def test_store_migration_skipped_for_scoped_instance(monkeypatch, tmp_path):
+    """Only the DEFAULT instance auto-migrates — a named/dev instance re-inits."""
+    box, _ = _setup(monkeypatch, tmp_path, PROTOAGENT_INSTANCE="dev")
+    _seed_legacy_stores(box)
+    assert cio.migrate_legacy_layout() is False
+    assert not (box / "dev" / "checkpoints.db").exists()
+
+
+def test_store_migration_not_resurrected_after_config_present(monkeypatch, tmp_path):
+    """Once the live config exists (post-first-boot), the bridge is skipped entirely —
+    so a store the operator later clears is never re-copied from a legacy orphan."""
+    box, _ = _setup(monkeypatch, tmp_path)
+    p = paths.instance_paths()
+    p.config_dir.mkdir(parents=True)
+    p.config_yaml.write_text("already: migrated\n")
+    _seed_legacy_stores(box)  # legacy orphans still sitting at the box root
+
+    assert cio.migrate_legacy_layout() is False
+    assert not (box / "default" / "checkpoints.db").exists()  # not resurrected

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -27,19 +27,28 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _restore_env():
+    """``_reload_memory`` applies env overrides persistently (the path is now resolved
+    lazily by ``memory_path()`` at write time, not captured at import), so snapshot +
+    restore ``os.environ`` around each test to keep MEMORY_PATH from leaking."""
+    snapshot = dict(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(snapshot)
+
+
 def _reload_memory(env_overrides: dict | None = None):
-    """Reload graph.middleware.memory with given env overrides active.
+    """Apply env overrides (persistently — see ``_restore_env``) and reload
+    graph.middleware.memory so the import-time ``PROTOAGENT_DISABLE_MEMORY`` flag is
+    re-read. Returns the module so tests can call ``_persist_session`` with a known
+    MEMORY_PATH / PROTOAGENT_DISABLE_MEMORY state (the path itself resolves lazily)."""
+    os.environ.update(env_overrides or {})
+    if "graph.middleware.memory" in sys.modules:
+        del sys.modules["graph.middleware.memory"]
+    import graph.middleware.memory as mod
 
-    Returns the freshly-imported module so tests can call _persist_session
-    with a known MEMORY_PATH / PROTOAGENT_DISABLE_MEMORY state.
-    """
-    env_overrides = env_overrides or {}
-    with patch.dict(os.environ, env_overrides, clear=False):
-        if "graph.middleware.memory" in sys.modules:
-            del sys.modules["graph.middleware.memory"]
-        import graph.middleware.memory as mod
-
-        return mod
+    return mod
 
 
 def _make_state(
@@ -565,20 +574,19 @@ def test_after_agent_does_not_persist_when_last_msg_not_ai(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_default_memory_path_uses_data_home(monkeypatch):
-    """Without MEMORY_PATH, the default resolves under data_home() — the
-    /sandbox-in-a-container, else ~/.protoagent writable fallback every other
-    store uses. The old literal /sandbox/memory/ silently skipped persistence
-    on non-container hosts and, on Windows, wrote to \\sandbox at the drive
-    root (caught by the desktop sidecar smoke)."""
+def test_default_memory_path_uses_instance_store(monkeypatch):
+    """Without MEMORY_PATH, the default resolves to the per-instance
+    ``instance_root/memory`` store — always writable (the old literal /sandbox/memory
+    silently skipped persistence on non-container hosts)."""
     from pathlib import Path
 
-    from infra.paths import data_home
+    from infra.paths import instance_paths, reset_instance_paths
 
     monkeypatch.delenv("MEMORY_PATH", raising=False)
     monkeypatch.delenv("PROTOAGENT_INSTANCE", raising=False)
     monkeypatch.delenv("PROTOAGENT_AUTO_SCOPE", raising=False)
+    reset_instance_paths()
     sys.modules.pop("graph.middleware.memory", None)
     import graph.middleware.memory as mod
 
-    assert Path(mod.MEMORY_PATH) == data_home() / "memory"
+    assert Path(mod.memory_path()) == instance_paths().store("memory")

--- a/tests/test_session_memory_integration.py
+++ b/tests/test_session_memory_integration.py
@@ -44,11 +44,11 @@ def _build_graph(monkeypatch, memory_dir, store, replies):
 
     # test_memory_persistence importlib.reload()s this module under various env,
     # which can leave the module in a polluted state for whatever runs after it:
-    #  - MEMORY_PATH pointing at a stale temp dir,
     #  - _PERSISTENCE_DISABLED left True (a reload with PROTOAGENT_DISABLE_MEMORY=1),
     #  - graph.agent's imported class pointing at the pre-reload version.
-    # Pin all three so this test is independent of run order and CI-vs-local env.
-    monkeypatch.setattr(memmod, "MEMORY_PATH", str(memory_dir), raising=False)
+    # Pin both, and route memory_path() at the temp dir (MEMORY_PATH env wins, read
+    # lazily), so this test is independent of run order and CI-vs-local env.
+    monkeypatch.setenv("MEMORY_PATH", str(memory_dir))
     monkeypatch.setattr(memmod, "_PERSISTENCE_DISABLED", False, raising=False)
     monkeypatch.setattr(agentmod, "SessionSummaryMiddleware", memmod.SessionSummaryMiddleware, raising=False)
 

--- a/tests/test_store_tier_resolvers.py
+++ b/tests/test_store_tier_resolvers.py
@@ -1,0 +1,84 @@
+"""Store-tier resolution (ADR 0004 capstone) — every per-instance store lands under
+``instance_root`` by default, and an explicit operator override is honored verbatim.
+
+Pins the contract the scope_leaf→instance_root cutover established: there is no
+per-call scoping knob any more, the instance root IS the scope, and a2a / telemetry /
+checkpoints / skills are FILES directly under it while the rest are dirs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import infra.paths as paths
+
+
+@pytest.fixture
+def box(monkeypatch, tmp_path):
+    """Pin box_root to a tmp dir, scope to instance ``alice``, re-resolve."""
+    monkeypatch.setenv("PROTOAGENT_BOX_ROOT", str(tmp_path / "box"))
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "alice")
+    for v in ("PROTOAGENT_HOME", "MEMORY_PATH", "GOAL_PATH", "TASKS_DB_PATH", "BEADS_DB_PATH", "KNOWLEDGE_DB_PATH"):
+        monkeypatch.delenv(v, raising=False)
+    paths.reset_instance_paths()
+    return tmp_path / "box" / "alice"  # the instance root for alice
+
+
+def test_memory_default_and_override(box, monkeypatch):
+    from graph.middleware.memory import memory_path
+
+    assert memory_path() == str(box / "memory")
+    monkeypatch.setenv("MEMORY_PATH", "/custom/mem")
+    assert memory_path() == "/custom/mem"  # env override verbatim
+
+
+def test_tasks_default_and_override(box, monkeypatch):
+    from tasks.store import _resolve_db_path
+
+    assert _resolve_db_path(None) == box / "tasks" / "issues.db"
+    monkeypatch.setenv("TASKS_DB_PATH", "/custom/tasks.db")
+    assert _resolve_db_path(None) == __import__("pathlib").Path("/custom/tasks.db")
+    monkeypatch.delenv("TASKS_DB_PATH")
+    monkeypatch.setenv("BEADS_DB_PATH", "/legacy/beads.db")  # legacy alias still honored
+    assert _resolve_db_path(None) == __import__("pathlib").Path("/legacy/beads.db")
+
+
+def test_a2a_stores_are_files_under_instance_root(box):
+    from a2a_impl.stores import _resolve_db_path
+
+    assert _resolve_db_path("a2a-tasks.db") == str(box / "a2a-tasks.db")
+    assert _resolve_db_path("a2a-push.db") == str(box / "a2a-push.db")
+
+
+def test_acp_session_id_path_under_instance_store(box):
+    from plugins.coding_agent import _session_id_path
+
+    spec = {
+        "name": "coder",
+        "command": "x",
+        "args": (),
+        "workdir": "/",
+        "permissions": "readonly",
+        "allow_kinds": (),
+        "deny_kinds": (),
+    }
+    p = _session_id_path(spec)
+    assert p.parent == box / "acp_sessions" and p.suffix == ".json"
+
+
+def test_checkpoint_and_skills_are_files_at_instance_root(box):
+    from server.agent_init import _resolve_checkpoint_db, _resolve_skills_db
+
+    assert _resolve_checkpoint_db("/sandbox/checkpoints.db") == str(box / "checkpoints.db")
+    assert _resolve_skills_db("/sandbox/skills.db", shared=False) == str(box / "skills.db")
+
+
+def test_two_instances_get_disjoint_store_roots(box, monkeypatch, tmp_path):
+    from tasks.store import _resolve_db_path
+
+    a = _resolve_db_path(None)
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "bob")
+    paths.reset_instance_paths()
+    b = _resolve_db_path(None)
+    assert a != b
+    assert b == tmp_path / "box" / "bob" / "tasks" / "issues.db"

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -94,25 +94,39 @@ def test_bad_name_rejected(root):
         manager.create("bad name")
 
 
-def test_root_is_instance_scoped(root, monkeypatch):
-    """ADR 0004: a scoped instance owns its own workspaces root (and so its own
-    fleet.json) — two co-located hubs must not share one fleet registry."""
-    assert manager.workspaces_root() == root  # unscoped → the plain root
+def test_root_override_wins(root):
+    """``PROTOAGENT_WORKSPACES_DIR`` is an explicit override — used verbatim (the
+    ``root`` fixture sets it), regardless of instance."""
+    assert manager.workspaces_root() == root
 
+
+def test_root_is_instance_scoped(tmp_path, monkeypatch):
+    """ADR 0004: a scoped instance owns its own workspaces root (``instance_root/
+    workspaces``, and so its own fleet.json) — two co-located hubs must not share one
+    fleet registry. Scope comes from the instance root now, not a scope_leaf knob."""
+    import infra.paths as paths
+
+    monkeypatch.delenv("PROTOAGENT_WORKSPACES_DIR", raising=False)
+    monkeypatch.setenv("PROTOAGENT_BOX_ROOT", str(tmp_path))
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "roxy")
+    paths.reset_instance_paths()
     scoped = manager.workspaces_root()
-    assert scoped == root.parent / "roxy" / root.name  # scope_leaf nesting
-    assert scoped != root
+    assert scoped == tmp_path / "roxy" / "workspaces"
 
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "other")
+    paths.reset_instance_paths()
     assert manager.workspaces_root() != scoped  # siblings don't share
 
 
-def test_fleet_state_follows_scoped_root(root, monkeypatch):
+def test_fleet_state_follows_scoped_root(tmp_path, monkeypatch):
     """fleet.json lives under the scoped root — a scoped hub's registry is its own."""
+    import infra.paths as paths
     from graph.fleet import supervisor
 
+    monkeypatch.delenv("PROTOAGENT_WORKSPACES_DIR", raising=False)
+    monkeypatch.setenv("PROTOAGENT_BOX_ROOT", str(tmp_path))
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "roxy")
+    paths.reset_instance_paths()
     assert supervisor._state_path() == manager.workspaces_root() / "fleet.json"
     assert "roxy" in supervisor._state_path().parts
 


### PR DESCRIPTION
## What

The **capstone** of the config/scoping redesign (#1463 → #1465 → this). Moves every per-instance data store onto the two-tier `InstancePaths` model, relocates the Host layer to the box tier, carries existing data forward on first boot, and **deletes `scope_leaf`** — the last of the old scattered-scoping machinery.

### Stores → `instance_root`
All 13+ resolvers (checkpoints, knowledge, memory, scheduler, inbox, background, activity, telemetry, audit, tasks, a2a-tasks/push, workflows, acp_sessions, goals, fenced workspace, user skills) now resolve under `instance_paths().store(...)` — one consistent `instance_root/<store>` layout instead of `scope_leaf`'s `<store>/<id>/…` scatter. An **explicit** operator override (env `KNOWLEDGE_DB_PATH`/`GOAL_PATH`/…, or a non-`/sandbox` config path) is still honored verbatim; the legacy `/sandbox/...` defaults map to the instance store.

### Box tier (machine-shared)
`host_config_path()` → `box_root/host-config.yaml` (the Host cascade layer is **box-shared** again — its intent; re-amends ADR 0047 #1077). Heartbeats → `box_root/.instances`. **Commons skills stay shared** at `box_root/commons/skills.db`; the **fleet registry** stays under the *hub's* `instance_root/workspaces` (so `shutdown_all` stays hub-only-by-construction).

### Seamless upgrade
`migrate_legacy_layout()` now also carries the **default** instance's data stores (`box_root/<store>` → `box_root/default/<store>`) on first boot — idempotent, non-destructive, gated to the standard local default, box-tier state never touched. Scoped sandboxes (dev) re-init.

### Deletions
`scope_leaf` (and the now-unused free `instance_root()`), the dead `scope_leaf` import in `server/__init__.py`. One scoping input remains; the double-scope bug class is gone for good.

### Docs (this PR)
- **ADR 0065** (two-tier box/instance paths, single resolution rule), superseding the path mechanics of ADR 0004/0041 and re-amending the Host-file location in ADR 0047; supersede/amend banners on 0004/0041/0042/0047 (no H1 retitle); docs-nav regenerated.
- **PROTO.md**: rewrote the stale dev-instance + reset bullets for the single-subtree layout, added a `config explain` pointer and a two-tier gotcha.
- **CHANGELOG**: extended the two-tier entry with the store relocation + box-shared host.

## Out of scope (immediate follow-up)
`scripts/reset.sh` / `dev-reset.sh` + their test still describe the old scattered layout (they run against a synthetic tree, so they stay green) — a focused rewrite for the single-subtree layout lands next.

## Verification
`ruff` clean · `pytest tests/` **2503 passed, 5 skipped** · `PA_RUN_INTEGRATION=1 pytest tests/integration` **5 passed** (real multi-instance boots — the strongest proof store resolution + isolation hold) · `scripts/live_smoke.py` **PASSED** (memory store resolved under the instance root). Boot-resolution sanity confirmed across no-env / `PROTOAGENT_INSTANCE=dev` / `PROTOAGENT_HOME`. 37 files, +752/−450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)