### PR TITLE
ci(checks): wire the real multi-instance fleet harness into CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -107,6 +107,38 @@ jobs:
           . .venv/bin/activate
           python -m pytest tests/ -q
 
+  fleet-integration:
+    name: Fleet integration (multi-instance)
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
+    # These tests boot real `python -m server` hub+member processes (against the
+    # local scripts/fake_openai_server.py) on free loopback ports + tmp roots, so
+    # they're much slower than the unit suite — allow ~10 min. Kept a SEPARATE job
+    # from `tests` so its real-boot slowness never gates the fast unit run.
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        # Mirror the `tests` job: full requirements.txt in a venv so
+        # tests/conftest.py's site.getsitepackages() reorder resolves (#175).
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest pytest-asyncio
+      - name: Boot real multi-instance fleet (hub + members) and exercise it
+        # PA_RUN_INTEGRATION=1 flips on the real-subprocess harness the default
+        # `pytest tests/` skips. Covers instance isolation, hub→member proxy
+        # round-trip, cross-instance A2A delegation, and member crash→detect→restart
+        # (POSIX zombie-reap — works on Linux). No network egress beyond loopback:
+        # the fake gateway is local; mDNS advertise binds loopback only.
+        run: |
+          . .venv/bin/activate
+          PA_RUN_INTEGRATION=1 python -m pytest tests/integration -q
+
   live-smoke:
     name: A2A live smoke (lean tier)
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free


### PR DESCRIPTION
## What

Adds a dedicated CI job that runs the real-subprocess multi-instance fleet integration harness (`tests/integration/`), which previously only ever ran locally.

New job **`fleet-integration`** ("Fleet integration (multi-instance)") in `.github/workflows/checks.yml`:
- Same trigger as the other gates (`pull_request` + `push` to `main`).
- Mirrors the existing **Python tests** job setup exactly: `actions/checkout@v5`, `setup-python@v6` (3.12, `cache: pip`), a venv, `pip install -r requirements.txt pytest pytest-asyncio`.
- Runs `PA_RUN_INTEGRATION=1 python -m pytest tests/integration -q` with a 12-minute timeout (real server boots are slow).
- Kept a **separate** job so its real-boot slowness never gates the fast unit run.

## Why

The harness boots actual `python -m server` hub + member processes against the local `scripts/fake_openai_server.py`, on free loopback ports + tmp roots. It covers the fleet paths unit/mock tests miss: instance isolation, hub→member proxy round-trip, cross-instance A2A delegation, and member crash→detect→restart. It's gated behind `PA_RUN_INTEGRATION=1` (the default `pytest tests/` skips it), so CI never exercised multi-instance until now.

## Notes

- No network egress beyond loopback: the fake gateway is local; mDNS advertise binds loopback only.
- No console dist / build step needed — members boot with `--ui none`.
- The crash→detect→restart zombie-reap is POSIX (`waitpid`), so it runs on the ubuntu runner.
- Harness tests themselves are unchanged — only the workflow.

## Local verification

- `PA_RUN_INTEGRATION=1 python -m pytest tests/integration -q` → **5 passed in ~36s**
- `ruff check .` → clean
- workflow YAML parses (`yaml.safe_load`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)