### PR TITLE
refactor(reset): rewrite factory-reset scripts for the ADR-0065 two-tier layout

### DIFF
--- a/scripts/dev-reset.sh
+++ b/scripts/dev-reset.sh
@@ -1,24 +1,31 @@
 #!/usr/bin/env bash
 #
-# Wipe the ISOLATED dev instance's state — its config + ALL its data — leaving your
-# default ("prod") agent under ~/.protoagent and config/ completely untouched.
+# Wipe the ISOLATED dev instance — its config AND all its data — leaving your
+# default agent and every box-shared item (the machine-wide gateway config in
+# host-config.yaml, the commons/ skill library) completely untouched.
+#
+# Under the two-tier layout (ADR 0065) one instance is ONE subtree:
+# box_root/<id>/ holds BOTH its config/ and every data store, so a reset is a
+# single rm -rf of that subtree. The box root itself (host-config.yaml, commons/,
+# .instances/, .data-version, cache/) is machine-shared and is NEVER touched — so
+# the re-init'd dev still inherits this machine's gateway config.
 #
 # Stop the dev server first (Ctrl-C the `scripts/dev.sh` process).
 #
-#   scripts/dev-reset.sh                       # resets instance 'dev'
-#   PROTOAGENT_INSTANCE=scratch scripts/dev-reset.sh   # resets a differently-named sandbox
+#   scripts/dev-reset.sh                                # resets instance 'dev'
+#   PROTOAGENT_INSTANCE=scratch scripts/dev-reset.sh    # resets a differently-named sandbox
 set -euo pipefail
-cd "$(dirname "$0")/.."
 
 IID="${PROTOAGENT_INSTANCE:-dev}"
-DATA="${HOME}/.protoagent"
+# Mirror infra.paths box_root: PROTOAGENT_BOX_ROOT override, else /sandbox in a
+# container, else ~/.protoagent. The box root is machine-shared and stays put.
+if [ -n "${PROTOAGENT_BOX_ROOT:-}" ]; then BOX="${PROTOAGENT_BOX_ROOT}"
+elif [ -d /sandbox ]; then BOX="/sandbox"
+else BOX="${HOME}/.protoagent"; fi
 
-echo "Resetting dev instance '${IID}' — your prod data under ${DATA} stays untouched."
-# Scoped config (seeded from the default on first run): config/<iid>/{langgraph-config,secrets,.setup-complete}
-rm -rf "config/${IID}"
-# Per-instance data root: ~/.protoagent/<iid>
-rm -rf "${DATA:?}/${IID}"
-# Per-store scoped leaves: ~/.protoagent/<store>/<iid>  (tasks, knowledge, inbox, activity, scheduler, background, …)
-find "${DATA}" -mindepth 2 -maxdepth 2 -type d -name "${IID}" -exec rm -rf {} + 2>/dev/null || true
+echo "Resetting dev instance '${IID}' — your default data and the box-shared"
+echo "host-config.yaml/commons under ${BOX} stay untouched."
+# One subtree holds BOTH the instance config and every data store (ADR 0065).
+rm -rf "${BOX:?}/${IID}"
 
 echo "✓ dev instance '${IID}' wiped. Re-launch a fresh one with scripts/dev.sh."

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -1,31 +1,30 @@
 #!/usr/bin/env bash
 #
-# Factory-reset the DEFAULT ("prod") protoAgent instance: wipe its data + local
-# config back to a clean slate so the next boot runs the setup wizard. For local
-# testing of the fresh-user flow. (Reset ONLY the dev sandbox instead with
-# scripts/dev-reset.sh; there is intentionally NO in-app factory reset — #1159.)
+# Factory-reset the DEFAULT protoAgent instance: wipe its single subtree —
+# box_root/default/ (its config/ AND every data store) — back to a clean slate so
+# the next boot runs the setup wizard. For local testing of the fresh-user flow.
+# (Reset ONLY the dev sandbox instead with scripts/dev-reset.sh; there is
+# intentionally NO in-app factory reset — #1159.)
 #
-# SAFE ON A MULTI-INSTANCE MACHINE — it preserves EVERY OTHER instance:
-#   * any  ~/.protoagent/<name>  that carries an instance marker (.instance-uid /
-#     checkpoints.db) is left untouched (the dev sandbox, fleet members, forks);
-#   * inside a shared store dir (knowledge/, memory/, tasks/, …) every
-#     <store>/<instance> leaf (a SUBDIRECTORY) is preserved — only prod's own
-#     unscoped top-level DBs and the direct files in those store dirs are removed.
-# Shipped/tracked files in config/ are RESTORED to pristine (git checkout); only
-# gitignored local config is deleted.
+# Two-tier layout (ADR 0065): one instance is ONE subtree, so a reset is a wipe of
+# box_root/default. This is SAFE on a multi-instance / shared machine — it preserves
+#   * every BOX-shared item (machine-wide): host-config.yaml (the gateway/Host
+#     config), commons/, .instances/, .data-version, cache/; and
+#   * every OTHER instance subtree (box_root/<name>, name != default) — the dev
+#     sandbox, fleet members, forks. --include-dev ALSO wipes box_root/dev.
+# Live config now lives under box_root/default/config, never in the repo tree, so
+# the old "restore tracked config/ via git checkout" step is gone.
 #
 #   scripts/reset.sh --dry-run       # print exactly what would change; delete nothing
-#   scripts/reset.sh                 # confirm, then reset prod (keeps every other instance)
+#   scripts/reset.sh                 # confirm, then reset default (keeps every other instance)
 #   scripts/reset.sh --yes           # skip the typed confirmation
-#   scripts/reset.sh --backup        # timestamped tar.gz of data + config first
-#   scripts/reset.sh --keep-secrets  # keep secrets.yaml + langgraph-config.yaml (no re-auth)
-#   scripts/reset.sh --include-dev   # ALSO wipe the `dev` sandbox (its data + config/dev)
+#   scripts/reset.sh --backup        # timestamped tar.gz of default + host-config first
+#   scripts/reset.sh --keep-secrets  # keep config/{secrets.yaml,langgraph-config.yaml} (no re-auth)
+#   scripts/reset.sh --include-dev   # ALSO wipe the `dev` sandbox subtree
 #   scripts/reset.sh --force         # stop a server still bound to the port first
 #
 # ALWAYS run --dry-run first on a busy machine and read the plan.
 set -euo pipefail
-cd "$(dirname "$0")/.."
-REPO="$(pwd)"
 
 # ── flags ─────────────────────────────────────────────────────────────────────
 DRY_RUN=false; ASSUME_YES=false; DO_BACKUP=false
@@ -38,30 +37,34 @@ for arg in "$@"; do
     --keep-secrets) KEEP_SECRETS=true ;;
     --include-dev) INCLUDE_DEV=true ;;
     --force) FORCE=true ;;
-    -h|--help) sed -n '2,33p' "$0"; exit 0 ;;
+    -h|--help) sed -n '2,/^set -euo/{/^set -euo/!p;}' "$0"; exit 0 ;;
     *) echo "unknown option: $arg (try --help)" >&2; exit 2 ;;
   esac
 done
 
 # ── paths ─────────────────────────────────────────────────────────────────────
-# Mirror infra.paths.data_home(): /sandbox in a container, else ~/.protoagent.
-if [ -d /sandbox ]; then DATA="/sandbox"; else DATA="${HOME}/.protoagent"; fi
-CONFIG="${PROTOAGENT_CONFIG_DIR:-${REPO}/config}"
+# Mirror infra.paths box_root: PROTOAGENT_BOX_ROOT override, else /sandbox in a
+# container, else ~/.protoagent. box_root is the machine-shared base; the default
+# instance is the subtree box_root/default (config + every store live under it).
+if [ -n "${PROTOAGENT_BOX_ROOT:-}" ]; then BOX="${PROTOAGENT_BOX_ROOT}"
+elif [ -d /sandbox ]; then BOX="/sandbox"
+else BOX="${HOME}/.protoagent"; fi
+DEFAULT="${BOX}/default"
 PORT="${PORT:-7870}"
 
-# Gitignored local config to DELETE (the prod instance's machine-local state).
-CONFIG_IGNORED=(langgraph-config.yaml secrets.yaml .setup-complete plugins)
-# Shipped/tracked config to RESTORE to pristine (git checkout, never delete).
-CONFIG_TRACKED=(config/SOUL.md config/skills config/plugin-catalog.json
-                config/mcp-catalog.json config/soul-presets config/langgraph-config.example.yaml
-                plugins.lock)
+# Box-tier shared items — machine-wide, NEVER wiped by a single-instance reset.
+BOX_SHARED=(host-config.yaml commons .instances .data-version cache)
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 say()  { printf '%s\n' "$*"; }
 plan() { printf '  %s\n' "$*"; }
-run() { if $DRY_RUN; then printf '  [dry-run] %s\n' "$*"; else "$@"; fi; }
+run()  { if $DRY_RUN; then printf '  [dry-run] %s\n' "$*"; else "$@"; fi; }
 
-is_instance_root() { [ -e "$1/.instance-uid" ] || [ -e "$1/checkpoints.db" ]; }
+is_box_shared() {
+  local n="$1" s
+  for s in "${BOX_SHARED[@]}"; do [ "$n" = "$s" ] && return 0; done
+  return 1
+}
 
 # A server still bound to PORT holds WAL handles — a wipe is pointless until it exits.
 running_pids() { command -v lsof >/dev/null 2>&1 && lsof -ti "tcp:${PORT}" -sTCP:LISTEN 2>/dev/null || true; }
@@ -85,49 +88,40 @@ if [ -n "$PIDS" ]; then
   fi
 fi
 
-# ── 1. the plan ───────────────────────────────────────────────────────────────
-KEEP="dev"; $INCLUDE_DEV && KEEP=""
-say ""
-say "Factory reset — DEFAULT (prod) instance"
-say "  data:   ${DATA}"
-say "  config: ${CONFIG}"
-$DRY_RUN && say "  mode:   DRY RUN (nothing will be deleted)"
-say ""
-
-if [ -d "$DATA" ]; then
-  say "Data home (${DATA}):"
-  PRESERVED=()
+# ── 1. classify what lives under the box root ─────────────────────────────────
+SHARED=(); OTHERS=()
+if [ -d "$BOX" ]; then
   while IFS= read -r entry; do
     name="$(basename "$entry")"
-    if [ -d "$entry" ] && is_instance_root "$entry"; then
-      if [ -n "$KEEP" ] || [ "$name" != "dev" ]; then PRESERVED+=("$name"); continue; fi
-    fi
-    if [ -f "$entry" ] || [ -L "$entry" ]; then
-      plan "delete prod file:  ${name}"
-    elif [ -d "$entry" ]; then
-      # A store dir: prod's content is its DIRECT FILES; every subdir is a
-      # <store>/<instance> leaf and is preserved (unless --include-dev → drop dev/).
-      files=$(find "$entry" -mindepth 1 -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
-      leaves=$(find "$entry" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
-      plan "store dir ${name}/: drop ${files} prod file(s); keep ${leaves} instance leaf(s)$( $INCLUDE_DEV && [ -d "$entry/dev" ] && echo ' (minus dev/)')"
-    fi
-  done < <(find "$DATA" -mindepth 1 -maxdepth 1 | sort)
-  [ ${#PRESERVED[@]} -gt 0 ] && plan "PRESERVE other instances: ${PRESERVED[*]}"
-else
-  plan "(no data home at ${DATA})"
+    [ "$name" = "default" ] && continue                 # the wipe target
+    $INCLUDE_DEV && [ "$name" = "dev" ] && continue     # also wiped (listed below)
+    if is_box_shared "$name"; then SHARED+=("$name"); else OTHERS+=("$name"); fi
+  done < <(find "$BOX" -mindepth 1 -maxdepth 1 | sort)
 fi
 
+# ── 2. the plan ───────────────────────────────────────────────────────────────
 say ""
-say "Config (${CONFIG}):"
-for f in "${CONFIG_IGNORED[@]}"; do
-  if $KEEP_SECRETS && { [ "$f" = "secrets.yaml" ] || [ "$f" = "langgraph-config.yaml" ]; }; then
-    [ -e "${CONFIG}/${f}" ] && plan "keep (--keep-secrets): ${f}"
-    continue
-  fi
-  [ -e "${CONFIG}/${f}" ] && plan "delete local:  ${f}"
-done
-$INCLUDE_DEV && [ -e "${CONFIG}/dev" ] && plan "delete dev config:  dev/"
-for p in "${CONFIG_TRACKED[@]}"; do plan "restore tracked: ${p}"; done
+say "Factory reset — DEFAULT instance"
+say "  box:      ${BOX}"
+say "  instance: ${DEFAULT}"
+$DRY_RUN && say "  mode:     DRY RUN (nothing will be deleted)"
+say ""
+
+say "Wipe (config + every data store in the subtree):"
+if [ -d "$DEFAULT" ]; then plan "delete instance: ${DEFAULT}"; else plan "(no default instance at ${DEFAULT})"; fi
+$INCLUDE_DEV && [ -d "${BOX}/dev" ] && plan "delete instance: ${BOX}/dev  (--include-dev)"
+if $KEEP_SECRETS; then
+  for f in secrets.yaml langgraph-config.yaml; do
+    [ -f "${DEFAULT}/config/${f}" ] && plan "keep (--keep-secrets): config/${f}"
+  done
+fi
+say ""
+
+say "Preserve (box-shared, machine-wide):"
+if [ ${#SHARED[@]} -gt 0 ]; then for s in "${SHARED[@]}"; do plan "$s"; done; else plan "(none present)"; fi
+say ""
+say "Preserve (other instances):"
+if [ ${#OTHERS[@]} -gt 0 ]; then for o in "${OTHERS[@]}"; do plan "$o"; done; else plan "(none)"; fi
 
 if $DRY_RUN; then
   say ""
@@ -135,57 +129,50 @@ if $DRY_RUN; then
   exit 0
 fi
 
-# ── 2. confirm ────────────────────────────────────────────────────────────────
+# ── 3. confirm ────────────────────────────────────────────────────────────────
 if ! $ASSUME_YES; then
   say ""
-  printf "Type 'reset' to wipe the prod instance (other instances are preserved): "
+  printf "Type 'reset' to wipe the default instance (other instances + box-shared config are preserved): "
   read -r reply
   [ "$reply" = "reset" ] || { say "aborted."; exit 1; }
 fi
 
-# ── 3. backup ─────────────────────────────────────────────────────────────────
+# ── 4. backup ─────────────────────────────────────────────────────────────────
 if $DO_BACKUP; then
   TS="$(date +%Y%m%d-%H%M%S)"
   BK="${HOME}/protoagent-backup-${TS}.tar.gz"
-  say "▶ backing up data + config → ${BK}"
-  tar czf "$BK" -C "$HOME" "$(realpath --relative-to="$HOME" "$DATA" 2>/dev/null || echo .protoagent)" \
-      -C "$REPO" config 2>/dev/null || say "  (backup best-effort; some paths skipped)"
+  say "▶ backing up default instance + host-config → ${BK}"
+  BK_ITEMS=()
+  [ -d "$DEFAULT" ] && BK_ITEMS+=("default")
+  [ -e "${BOX}/host-config.yaml" ] && BK_ITEMS+=("host-config.yaml")
+  if [ ${#BK_ITEMS[@]} -gt 0 ]; then
+    tar czf "$BK" -C "$BOX" "${BK_ITEMS[@]}" 2>/dev/null || say "  (backup best-effort; some paths skipped)"
+  else
+    say "  (nothing to back up)"
+  fi
 fi
 
-# ── 4. wipe prod data (preserving every other instance) ───────────────────────
-if [ -d "$DATA" ]; then
-  while IFS= read -r entry; do
-    name="$(basename "$entry")"
-    if [ -d "$entry" ] && is_instance_root "$entry"; then
-      if [ -n "$KEEP" ] || [ "$name" != "dev" ]; then continue; fi
-    fi
-    if [ -f "$entry" ] || [ -L "$entry" ]; then
-      run rm -f "$entry"
-    elif [ -d "$entry" ]; then
-      # delete prod's direct files; preserve every <store>/<instance> subdir
-      while IFS= read -r f; do run rm -f "$f"; done < <(find "$entry" -mindepth 1 -maxdepth 1 -type f)
-      if $INCLUDE_DEV && [ -d "$entry/dev" ]; then run rm -rf "$entry/dev"; fi
-      rmdir "$entry" 2>/dev/null || true  # remove if now empty (held no instance leaf)
-    fi
-  done < <(find "$DATA" -mindepth 1 -maxdepth 1 | sort)
+# ── 5. wipe the default instance (whole subtree), optionally keeping creds ─────
+if [ -d "$DEFAULT" ]; then
+  if $KEEP_SECRETS; then
+    # Stash the two cred files (same fs, preserving 0600), wipe, restore into a
+    # fresh empty config/ — no .setup-complete, so next boot still runs the wizard.
+    STASH="$(mktemp -d "${BOX}/.reset-keep.XXXXXX")"
+    for f in secrets.yaml langgraph-config.yaml; do
+      [ -f "${DEFAULT}/config/${f}" ] && cp -p "${DEFAULT}/config/${f}" "${STASH}/${f}"
+    done
+    run rm -rf "${DEFAULT:?}"
+    mkdir -p "${DEFAULT}/config"
+    for f in secrets.yaml langgraph-config.yaml; do
+      [ -f "${STASH}/${f}" ] && mv "${STASH}/${f}" "${DEFAULT}/config/${f}"
+    done
+    rmdir "$STASH" 2>/dev/null || true
+  else
+    run rm -rf "${DEFAULT:?}"
+  fi
 fi
-# --include-dev: also drop the dev instance root + its scoped data leaves.
-if $INCLUDE_DEV; then
-  run rm -rf "${DATA:?}/dev"
-  while IFS= read -r leaf; do run rm -rf "$leaf"; done \
-    < <(find "$DATA" -mindepth 2 -maxdepth 2 -type d -name dev 2>/dev/null)
-fi
-
-# ── 5. config: delete gitignored local state, restore tracked to pristine ─────
-for f in "${CONFIG_IGNORED[@]}"; do
-  if $KEEP_SECRETS && { [ "$f" = "secrets.yaml" ] || [ "$f" = "langgraph-config.yaml" ]; }; then continue; fi
-  [ -e "${CONFIG}/${f}" ] && run rm -rf "${CONFIG:?}/${f}"
-done
-$INCLUDE_DEV && [ -e "${CONFIG}/dev" ] && run rm -rf "${CONFIG:?}/dev"
-# Restore the shipped/tracked files only if they're tracked in this repo.
-for p in "${CONFIG_TRACKED[@]}"; do
-  git -C "$REPO" ls-files --error-unmatch "$p" >/dev/null 2>&1 && run git -C "$REPO" checkout -- "$p"
-done
+# --include-dev: also drop the dev sandbox subtree (box-shared items still kept).
+if $INCLUDE_DEV && [ -d "${BOX}/dev" ]; then run rm -rf "${BOX:?}/dev"; fi
 
 say ""
-say "✓ prod instance reset. Next boot (python -m server) runs the setup wizard."
+say "✓ default instance reset. Next boot (python -m server) runs the setup wizard."

--- a/tests/test_reset_script.py
+++ b/tests/test_reset_script.py
@@ -1,9 +1,10 @@
-"""`scripts/reset.sh` dry-run safety (#1159).
+"""`scripts/reset.sh` dry-run safety (#1159, ADR 0065).
 
-The factory-reset script is destructive, so its dangerous logic — "target prod's
-unscoped data, preserve EVERY sibling instance + every scoped <store>/<instance>
-leaf" — is pinned here by running it in `--dry-run` against a synthetic data tree
-and asserting (a) the plan targets the right things and (b) it deletes NOTHING.
+The factory-reset script is destructive, so its dangerous logic — "wipe the default
+instance's single subtree (box_root/default), preserve EVERY box-shared item and
+EVERY other instance subtree" — is pinned here by running it in `--dry-run` against a
+synthetic two-tier data tree and asserting (a) the plan targets the right things and
+(b) it deletes NOTHING.
 """
 
 from __future__ import annotations
@@ -17,98 +18,99 @@ import pytest
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "reset.sh"
 
-# data_home() prefers /sandbox over $HOME/.protoagent; if it exists the script
-# would target it instead of our test HOME, so skip there (CI has no /sandbox).
-_SANDBOX = pytest.mark.skipif(Path("/sandbox").is_dir(), reason="data_home() would target /sandbox")
+# box_root prefers /sandbox over $HOME/.protoagent; if it exists the script would
+# target it instead of our test HOME, so skip there (CI has no /sandbox).
+_SANDBOX = pytest.mark.skipif(Path("/sandbox").is_dir(), reason="box_root would target /sandbox")
 
 
-def _run(args: list[str], home: Path, cfg: Path):
-    env = {**os.environ, "HOME": str(home), "PROTOAGENT_CONFIG_DIR": str(cfg)}
+def _run(args: list[str], home: Path):
+    env = {**os.environ, "HOME": str(home)}
+    env.pop("PROTOAGENT_BOX_ROOT", None)  # let the script derive box_root from HOME
     return subprocess.run(
         ["bash", str(SCRIPT), *args], capture_output=True, text=True, env=env, cwd=str(REPO)
     )
 
 
+def _seed_instance(root: Path) -> None:
+    """A minimal two-tier instance subtree: config leaf + a couple of data stores,
+    all directly under the instance root (ADR 0065 — one subtree per instance)."""
+    (root / "config").mkdir(parents=True)
+    (root / "config" / "langgraph-config.yaml").write_text("x")
+    (root / "checkpoints.db").write_text("x")
+    (root / "knowledge").mkdir()
+    (root / "knowledge" / "agent.db").write_text("x")
+
+
 @_SANDBOX
-def test_dry_run_targets_prod_only_and_preserves_siblings(tmp_path):
+def test_dry_run_targets_default_only_and_preserves_the_rest(tmp_path):
     home = tmp_path / "home"
-    data = home / ".protoagent"
-    data.mkdir(parents=True)
-    # prod (unscoped) state
-    (data / "checkpoints.db").write_text("x")
-    (data / "telemetry.db").write_text("x")
-    (data / ".instance-uid").write_text("x")
-    # a shared store dir: prod's direct file + two scoped instance leaves
-    (data / "knowledge" / "dev").mkdir(parents=True)
-    (data / "knowledge" / "roxy").mkdir(parents=True)
-    (data / "knowledge" / "agent.db").write_text("prod")
-    (data / "knowledge" / "dev" / "agent.db").write_text("dev")
-    (data / "knowledge" / "roxy" / "agent.db").write_text("roxy")
-    # a sibling instance ROOT (must be preserved wholesale)
-    (data / "sib").mkdir()
-    (data / "sib" / ".instance-uid").write_text("sib")
+    box = home / ".protoagent"
+    # the default instance (the wipe target) + two other instance subtrees
+    _seed_instance(box / "default")
+    _seed_instance(box / "dev")
+    _seed_instance(box / "sib")
+    # box-tier shared state (machine-wide, must be preserved)
+    (box / "host-config.yaml").write_text("gateway: shared")
+    (box / "commons").mkdir()
+    (box / "commons" / "skills.db").write_text("x")
 
-    cfg = tmp_path / "config"
-    cfg.mkdir()
-    (cfg / "langgraph-config.yaml").write_text("x")
-    (cfg / "secrets.yaml").write_text("x")
-    (cfg / "plugins").mkdir()
-
-    out = _run(["--dry-run", "--yes"], home, cfg)
+    out = _run(["--dry-run", "--yes"], home)
     assert out.returncode == 0, out.stderr
     plan = out.stdout
 
-    assert "delete prod file:  checkpoints.db" in plan
-    assert "delete prod file:  telemetry.db" in plan
-    assert "delete prod file:  .instance-uid" in plan
-    # the shared store dir: drop prod's 1 file, KEEP the 2 instance leaves
-    assert "store dir knowledge/: drop 1 prod file(s); keep 2 instance leaf(s)" in plan
-    # sibling instance root preserved + dev (default keeps dev too)
-    assert "PRESERVE other instances:" in plan and "sib" in plan
-    assert "delete local:  langgraph-config.yaml" in plan
-    assert "delete local:  plugins" in plan
-    assert "restore tracked: config/SOUL.md" in plan
+    # (a) the plan targets box_root/default
+    assert f"delete instance: {box / 'default'}" in plan
+
+    # box-shared items are preserved (machine-wide)
+    shared = plan.split("Preserve (box-shared, machine-wide):")[1].split("Preserve (other instances):")[0]
+    assert "host-config.yaml" in shared
+    assert "commons" in shared
+
+    # every OTHER instance subtree is preserved
+    others = plan.split("Preserve (other instances):")[1]
+    assert "dev" in others
+    assert "sib" in others
 
     # CRITICAL: a dry run deletes NOTHING.
-    assert (data / "checkpoints.db").exists()
-    assert (data / "knowledge" / "agent.db").exists()
-    assert (data / "knowledge" / "dev" / "agent.db").exists()
-    assert (data / "sib" / ".instance-uid").exists()
-    assert (cfg / "langgraph-config.yaml").exists()
-    assert (cfg / "plugins").is_dir()
+    assert (box / "default" / "checkpoints.db").exists()
+    assert (box / "default" / "config" / "langgraph-config.yaml").exists()
+    assert (box / "dev" / "checkpoints.db").exists()
+    assert (box / "sib" / "checkpoints.db").exists()
+    assert (box / "host-config.yaml").exists()
+    assert (box / "commons" / "skills.db").exists()
 
 
 @_SANDBOX
 def test_dry_run_keep_secrets_preserves_creds(tmp_path):
     home = tmp_path / "home"
-    (home / ".protoagent").mkdir(parents=True)
-    cfg = tmp_path / "config"
-    cfg.mkdir()
-    (cfg / "secrets.yaml").write_text("x")
-    (cfg / "langgraph-config.yaml").write_text("x")
-    (cfg / "plugins").mkdir()
+    box = home / ".protoagent"
+    _seed_instance(box / "default")
+    (box / "default" / "config" / "secrets.yaml").write_text("token: x")
 
-    out = _run(["--dry-run", "--yes", "--keep-secrets"], home, cfg)
+    out = _run(["--dry-run", "--yes", "--keep-secrets"], home)
     assert out.returncode == 0, out.stderr
     plan = out.stdout
-    assert "keep (--keep-secrets): secrets.yaml" in plan
-    assert "keep (--keep-secrets): langgraph-config.yaml" in plan
-    assert "delete local:  langgraph-config.yaml" not in plan
-    assert "delete local:  plugins" in plan  # plugins still wiped
+    assert "keep (--keep-secrets): config/secrets.yaml" in plan
+    assert "keep (--keep-secrets): config/langgraph-config.yaml" in plan
+    # still targets the default subtree for the wipe
+    assert f"delete instance: {box / 'default'}" in plan
+    # dry run changed nothing
+    assert (box / "default" / "config" / "secrets.yaml").exists()
 
 
 @_SANDBOX
 def test_dry_run_include_dev_wipes_dev(tmp_path):
     home = tmp_path / "home"
-    data = home / ".protoagent"
-    (data / "dev").mkdir(parents=True)
-    (data / "dev" / ".instance-uid").write_text("dev")
-    cfg = tmp_path / "config"
-    (cfg / "dev").mkdir(parents=True)
+    box = home / ".protoagent"
+    _seed_instance(box / "default")
+    _seed_instance(box / "dev")
 
-    out = _run(["--dry-run", "--yes", "--include-dev"], home, cfg)
+    out = _run(["--dry-run", "--yes", "--include-dev"], home)
     assert out.returncode == 0, out.stderr
     plan = out.stdout
-    # default keeps dev; --include-dev drops it from the preserve set + wipes its config
-    assert "PRESERVE other instances:" not in plan or "dev" not in plan.split("PRESERVE")[-1]
-    assert "delete dev config:  dev/" in plan
+    # dev moves from "preserved" to a wipe target
+    assert f"delete instance: {box / 'dev'}  (--include-dev)" in plan
+    others = plan.split("Preserve (other instances):")[1]
+    assert "dev" not in others
+    # dry run still deletes nothing
+    assert (box / "dev" / "checkpoints.db").exists()


### PR DESCRIPTION
## What

Rewrites the factory-reset scripts for the new ADR-0065 two-tier single-subtree layout, where one instance is ONE subtree (`box_root/<id>/` holds both its `config/` and every data store). The old scattered `scope_leaf` model — prod's unscoped DBs at the box root, `<store>/<instance>` leaves, and restoring tracked `config/` via `git checkout` — no longer describes reality (live config never lives in the repo tree now), so all three files are rewritten.

### `scripts/dev-reset.sh`
Collapses to a single `rm -rf "${BOX}/${IID}"` (IID defaults to `dev`; `BOX` = `/sandbox` if present else `~/.protoagent`, honoring `PROTOAGENT_BOX_ROOT`). Never touches `host-config.yaml` or `commons/`, so a re-init'd dev still inherits the machine gateway. Keeps the friendly echo + `PROTOAGENT_INSTANCE` override.

### `scripts/reset.sh`
Factory-resets the **default** instance by wiping `box_root/default` wholesale. Preserves every box-tier shared item (`host-config.yaml`, `commons/`, `.instances/`, `.data-version`, `cache/`) **and** every other instance subtree; `--include-dev` also wipes `box_root/dev`. All existing flags kept: `--dry-run/-n`, `--yes/-y`, `--backup` (tar.gz of `default` + `host-config.yaml`), `--keep-secrets`, `--include-dev`, `--force`, `--help`. The repo-`config/` restore logic is dropped. `--keep-secrets` stashes `config/{secrets.yaml,langgraph-config.yaml}` (0600 preserved) across the wipe; `.setup-complete` is gone either way, so next boot runs the setup wizard.

### `tests/test_reset_script.py`
Rebuilt on a synthetic two-tier tree under a tmp HOME. Asserts (via `--dry-run`, deleting nothing) that the plan targets `box_root/default`, preserves `dev` + `sib` + `host-config.yaml` + `commons`, and that `--keep-secrets` keeps `default/config/secrets.yaml`. Retains the `/sandbox`-skip guard.

## Gates
- `ruff check .` — clean
- `python -m pytest tests/test_reset_script.py -q` — 3 passed
- `shellcheck scripts/reset.sh scripts/dev-reset.sh` — clean
- Manually ran `reset.sh --dry-run`, a real `--yes --keep-secrets` wipe (verified data/marker/stores gone, creds + 0600 + gateway config kept, siblings + box-shared preserved, no stash leftover), `--include-dev`, `--help`, and `dev-reset.sh` in throwaway HOMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)