### PR TITLE
feat(knowledge): run slow ingests in the background (ADR 0050 work jobs)

### DIFF
--- a/background/manager.py
+++ b/background/manager.py
@@ -43,6 +43,7 @@ class BackgroundManager:
         fire_timeout_s: float | None = None,
         max_concurrency: int | None = None,
         event_publish=None,
+        on_terminal=None,
     ) -> None:
         self.agent_name = agent_name
         self._invoke_url = invoke_url.rstrip("/")
@@ -51,8 +52,14 @@ class BackgroundManager:
         self._bearer = bearer_token or ""
         # (topic, data) -> None — the server's event bus, so a live console gets a
         # ``background.started`` push the moment a job is spawned (ADR 0050). Optional;
-        # completion is published by the terminal hook (which already holds the bus).
+        # a subagent-turn job's completion is published by the A2A terminal hook (which
+        # already holds the bus); a deterministic ``spawn_work`` job publishes its OWN
+        # completion here (no A2A turn fires, so the terminal hook never runs for it).
         self._publish = event_publish
+        # on_terminal(job) -> None — invoked when a ``spawn_work`` job settles, so the
+        # server can run the same idle-wake the A2A terminal hook does (ADR 0050 Phase 2)
+        # without this package importing ``server`` (injected to respect the layering).
+        self._on_terminal = on_terminal
         if fire_timeout_s is not None:
             self._fire_timeout_s = fire_timeout_s
         else:
@@ -78,6 +85,9 @@ class BackgroundManager:
         # Hold the detached fire tasks so they aren't GC'd mid-flight (the cause of
         # "Task was destroyed but it is pending"); discard on completion.
         self._fire_tasks: set[asyncio.Task] = set()
+        # job_id -> the running asyncio.Task for a ``spawn_work`` (deterministic) job, so
+        # ``cancel`` can stop the coroutine directly (a work job has no A2A task handle).
+        self._work_tasks: dict[str, asyncio.Task] = {}
 
     async def spawn(
         self,
@@ -101,21 +111,115 @@ class BackgroundManager:
         t.add_done_callback(self._fire_tasks.discard)
         log.info("[background] spawned %s (%s): %s", job_id, subagent_type, description)
         # Live push so a still-open spawning chat shows the job starting (ADR 0050).
-        if self._publish is not None:
-            try:
-                self._publish(
-                    "background.started",
-                    {
-                        "job_id": job_id,
-                        "status": "running",
-                        "subagent_type": subagent_type,
-                        "description": description,
-                        "origin_session": origin_session or "",
-                    },
-                )
-            except Exception:  # noqa: BLE001 — the event is best-effort
-                log.exception("[background] started-event publish failed for %s", job_id)
+        self._publish_started(job_id, subagent_type, description, origin_session or "")
         return job_id
+
+    # ── deterministic work jobs (ADR 0050 — non-subagent background) ──────────
+
+    async def spawn_work(
+        self,
+        *,
+        origin_session: str,
+        kind: str,
+        description: str,
+        work,
+        detail: str = "",
+    ) -> str:
+        """Register and run a deterministic background job — a plain coroutine, NOT an
+        LLM subagent turn — through the same durable store + concurrency cap + event
+        stream + drain-on-next-turn notification as ``spawn`` (ADR 0050).
+
+        ``work`` is a zero-arg async callable that does the work and returns the result
+        text to deliver back to the originating session. ``kind`` is a short label
+        (stored as ``subagent_type``, e.g. ``"ingest"``); ``detail`` is recorded as the
+        job's ``prompt`` (e.g. the source). Returns the opaque job id immediately. Use
+        this for long deterministic operations (media transcription/ingest) that must
+        not block the foreground turn."""
+        job_id = self.store.create(
+            agent_name=self.agent_name,
+            origin_session=origin_session or "",
+            subagent_type=kind,
+            description=description,
+            prompt=detail,
+        )
+        t = asyncio.create_task(
+            self._run_work(job_id, kind, description, origin_session or "", work),
+            name=f"background.work.{job_id}",
+        )
+        self._work_tasks[job_id] = t
+        self._fire_tasks.add(t)
+        t.add_done_callback(self._fire_tasks.discard)
+        t.add_done_callback(lambda _t, jid=job_id: self._work_tasks.pop(jid, None))
+        log.info("[background] spawned work %s (%s): %s", job_id, kind, description)
+        self._publish_started(job_id, kind, description, origin_session or "")
+        return job_id
+
+    async def _run_work(self, job_id: str, kind: str, description: str, origin_session: str, work) -> None:
+        """Run a ``spawn_work`` coroutine under the shared concurrency cap, settle the
+        store row, publish ``background.completed``, and fire the optional terminal hook
+        (idle-wake). Mirrors what the A2A terminal hook does for subagent-turn jobs."""
+        async with self._sem:  # same cap as background turns — one fan-out can't swamp the gateway
+            try:
+                result = await work()
+                status, text = "completed", (str(result) if result is not None else "")
+            except asyncio.CancelledError:
+                # cancel() already settled the row + published; just unwind.
+                raise
+            except Exception as exc:  # noqa: BLE001 — any failure settles the row, never hangs on running
+                log.exception("[background] work job %s failed", job_id)
+                status, text = "failed", (str(exc) or "Background work failed.")
+        if not self.store.mark_complete(job_id, status, text):
+            return  # already terminal (e.g. canceled mid-flight) — don't double-announce
+        self._publish_completed(job_id, status, kind, description, origin_session, text)
+        if self._on_terminal is not None:
+            try:
+                job = self.store.get(job_id)
+                if job is not None:
+                    self._on_terminal(job)
+            except Exception:  # noqa: BLE001 — the wake is best-effort
+                log.exception("[background] on_terminal hook failed for %s", job_id)
+
+    # ── event-bus helpers (shared by spawn + spawn_work) ──────────────────────
+
+    def _publish_started(self, job_id: str, kind: str, description: str, origin_session: str) -> None:
+        if self._publish is None:
+            return
+        try:
+            self._publish(
+                "background.started",
+                {
+                    "job_id": job_id,
+                    "status": "running",
+                    "subagent_type": kind,
+                    "description": description,
+                    "origin_session": origin_session,
+                },
+            )
+        except Exception:  # noqa: BLE001 — the event is best-effort
+            log.exception("[background] started-event publish failed for %s", job_id)
+
+    def _publish_completed(
+        self, job_id: str, status: str, kind: str, description: str, origin_session: str, text: str
+    ) -> None:
+        """Match the A2A terminal hook's ``background.completed`` payload (server/a2a.py)
+        so the console renders a work job's card identically to a subagent's."""
+        if self._publish is None:
+            return
+        preview = text if len(text) <= 2000 else text[:2000] + "\n\n…_[truncated]_"
+        try:
+            self._publish(
+                "background.completed",
+                {
+                    "job_id": job_id,
+                    "status": status,
+                    "subagent_type": kind,
+                    "description": description,
+                    "origin_session": origin_session,
+                    "result": preview,
+                },
+            )
+        except Exception:  # noqa: BLE001 — the event is best-effort
+            log.exception("[background] completed-event publish failed for %s", job_id)
 
     async def cancel(self, job_id: str) -> dict:
         """Stop a running background job by cancelling its detached A2A turn (ADR 0051).
@@ -129,6 +233,14 @@ class BackgroundManager:
             return {"ok": False, "status": "unknown", "detail": f"No background job {job_id}."}
         if job.status != "running":
             return {"ok": False, "status": job.status, "detail": f"Job {job_id} already {job.status}."}
+        # A deterministic ``spawn_work`` job runs as a local coroutine, not an A2A turn —
+        # cancel the task and settle the row directly (no CancelTask round-trip).
+        work_task = self._work_tasks.get(job_id)
+        if work_task is not None:
+            work_task.cancel()
+            self.store.mark_complete(job_id, "canceled", "Canceled.")
+            self._publish_completed(job_id, "canceled", job.subagent_type, job.description, job.origin_session, "Canceled.")
+            return {"ok": True, "status": "canceled", "detail": f"Canceled {job_id}."}
         task_id = job.a2a_task_id
         if not task_id:
             # The turn hasn't announced its task id yet — settle the row so it can't hang;

--- a/docs/adr/0050-background-subagents-reactive-notifications.md
+++ b/docs/adr/0050-background-subagents-reactive-notifications.md
@@ -193,6 +193,40 @@ the thing to check first when it lands.)
   queued job's row reads `running` until a slot frees (it is accepted); `cancel` and
   `reconcile_interrupted` both already handle a row whose turn hasn't fired yet.
 
+### Follow-up — deterministic work jobs (`spawn_work`, shipped)
+
+Phase 1 assumed every background job is an **LLM subagent turn** (§"Why self-POST"). But some
+long work is *deterministic* — a media-ingestion pipeline (fetch → transcribe → chunk → embed)
+is a fixed sequence of calls, not a reasoning task. Routing it through a self-POSTed lead-agent
+turn would spend model tokens + latency + nondeterminism just to invoke one pipeline. So the
+manager gains a second, non-turn spawn path:
+
+- **`BackgroundManager.spawn_work(origin_session, kind, description, work, detail)`** runs a plain
+  zero-arg coroutine `work()` as `asyncio.create_task`, under the **same** concurrency semaphore
+  as background turns. It reuses the durable `BackgroundStore` verbatim (`kind` is stored as
+  `subagent_type`; a work job simply has no `a2a_task_id`), so the exactly-once drain, restart
+  reconciliation, and `list`/`get`/`clear` all work unchanged.
+- **This is the deliberate exception to "self-POST, not `asyncio.create_task"** (§Decision). That
+  rationale holds for *turns* — they need the A2A task store's lifecycle/telemetry/pollable handle.
+  A deterministic job needs none of that machinery; it needs the *registry + notification*, which
+  the store already provides. So `create_task` is correct here precisely because there is no turn.
+- **Completion parity.** No A2A turn fires, so `_a2a_terminal` never runs for a work job. `_run_work`
+  therefore settles the row (`mark_complete`), publishes `background.completed` with the **same
+  payload** the terminal hook emits (so the console card is identical), and calls an injected
+  `on_terminal(job)` hook — which the server wires to the **same `_spawn_background_wake`** the turn
+  path uses (ADR 0003 idle-wake, gated by `BACKGROUND_WAKE`). All three completion channels
+  (live card, next-turn drain, autonomous wake) fire identically for a work job.
+- **Cancel.** A work job has no `a2a_task_id`; `cancel` stops its `asyncio.Task` directly and settles
+  the row (no `CancelTask` round-trip).
+
+**First consumer — `knowledge_ingest` (ADR 0031/ingestion).** The agent-facing ingest tool detaches
+any slow source — a URL fetch (web/YouTube) or media transcription (audio/video) — as a `spawn_work`
+job so it never blocks the chat turn; only a small local text/Markdown file (≤64 KB) ingests inline.
+With no manager wired it degrades to inline (blocking, but correct). This is the durable, non-blocking
+answer to "hand the agent a YouTube link / an `.mp4`" — the field-standard *return-handle → detached
+worker → reactive completion* shape (A2A task lifecycle, Microsoft Agent Framework background
+responses, classic job-queue-with-notify), reusing machinery this ADR already built.
+
 ## Consequences
 
 - **The chat stays live.** A delegation marked `run_in_background` returns in milliseconds; the

--- a/docs/guides/ingestion.md
+++ b/docs/guides/ingestion.md
@@ -26,9 +26,17 @@ agent already has — see the [tool table](/guides/knowledge#the-agents-memory-t
 
 Audio/video/image paths need the same setup as the console (`knowledge.transcribe_model`
 / `knowledge.image_describe_model`, plus `ffmpeg` on PATH for video); if one isn't
-configured the tool says so instead of failing silently. The tool is on whenever a
-knowledge store is wired — the agent runs `knowledge_ingest` as one turn, so a long
-recording will take as long as its transcription does.
+configured the tool says so instead of failing silently.
+
+**Slow sources run in the background so they never block the chat.** Anything that fetches
+over the network (any URL, including YouTube) or transcribes media (audio/video) is detached
+as a [background job](/adr/0050-background-subagents-reactive-notifications) — the tool
+returns a job id immediately, and the result is delivered back into the conversation (and the
+console's background jobs surface) when indexing finishes, so a 20-minute video never freezes
+the turn. Only a small local text/Markdown file (≤64 KB) ingests inline. It's the same
+durable background machinery as `task(run_in_background=true)`: concurrency-capped, cancellable,
+and it survives past the turn. (With the background subsystem disabled via `BACKGROUND_DISABLED`,
+the tool falls back to inline/blocking ingestion.)
 
 ## From the API
 

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -811,6 +811,8 @@ def create_agent_graph(
         goal_enabled=config.goal_enabled,
         # Lets knowledge_ingest build the gateway STT/vision fns for audio/video/image.
         graph_config=config,
+        # Lets knowledge_ingest detach a slow URL/media ingest as a background job (ADR 0050).
+        background_mgr=background_mgr,
     )
 
     if extra_tools:

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -942,6 +942,19 @@ def _build_background_manager(config):
         publish = _event_bus.publish
     except Exception:  # noqa: BLE001
         publish = None
+
+    def _on_work_terminal(job) -> None:
+        """Give a deterministic ``spawn_work`` job the SAME idle-wake the A2A terminal
+        hook gives a subagent-turn job (ADR 0050 Phase 2). Lazy import keeps the
+        manager off ``server`` and avoids a server.a2a ↔ agent_init cycle."""
+        try:
+            from server.a2a import _background_wake_enabled, _spawn_background_wake
+
+            if _background_wake_enabled():
+                _spawn_background_wake(job)
+        except Exception:  # noqa: BLE001 — the wake is best-effort
+            log.exception("[background] work-job terminal hook failed for %s", getattr(job, "id", "?"))
+
     try:
         return BackgroundManager(
             agent_name=name,
@@ -950,6 +963,7 @@ def _build_background_manager(config):
             api_key=api_key,
             bearer_token=bearer,
             event_publish=publish,
+            on_terminal=_on_work_terminal,
         )
     except Exception:
         log.exception("[background] manager init failed; background disabled")

--- a/tests/test_background_work.py
+++ b/tests/test_background_work.py
@@ -1,0 +1,116 @@
+"""Deterministic background work jobs (ADR 0050 — ``BackgroundManager.spawn_work``).
+
+``spawn_work`` runs a plain coroutine (NOT an LLM subagent turn) through the same
+durable store + concurrency cap + event stream + drain-on-next-turn notification as
+``spawn``. These tests cover the completion, failure, cancel, and notification paths
+without any A2A endpoint (a work job never self-POSTs).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from background.manager import BackgroundManager
+from background.store import BackgroundStore
+
+
+def _mgr(tmp_path: Path, *, events=None, terminals=None) -> BackgroundManager:
+    store = BackgroundStore(str(tmp_path / "background" / "jobs.db"))
+    return BackgroundManager(
+        agent_name="a",
+        invoke_url="http://127.0.0.1:0",
+        store=store,
+        event_publish=(lambda topic, data: events.append((topic, data))) if events is not None else None,
+        on_terminal=(lambda job: terminals.append(job.id)) if terminals is not None else None,
+    )
+
+
+async def _settle(store: BackgroundStore, job_id: str, tries: int = 400):
+    for _ in range(tries):
+        j = store.get(job_id)
+        if j is not None and j.status != "running":
+            return j
+        await asyncio.sleep(0.005)
+    raise AssertionError(f"job {job_id} never settled")
+
+
+async def test_spawn_work_completes_and_notifies_once(tmp_path):
+    events: list = []
+    terminals: list = []
+    mgr = _mgr(tmp_path, events=events, terminals=terminals)
+
+    async def work():
+        return "ingested 3 chunks"
+
+    job_id = await mgr.spawn_work(
+        origin_session="s1", kind="ingest", description="Ingest foo", detail="foo", work=work
+    )
+    assert job_id.startswith("bg-")
+
+    job = await _settle(mgr.store, job_id)
+    assert job.status == "completed"
+    assert job.result == "ingested 3 chunks"
+    assert job.subagent_type == "ingest"
+
+    topics = [t for t, _ in events]
+    assert "background.started" in topics and "background.completed" in topics
+    assert terminals == [job_id]  # idle-wake hook fired exactly once
+
+    # drained into the originating session exactly once
+    drained = mgr.store.drain_pending("s1")
+    assert [j.id for j in drained] == [job_id]
+    assert mgr.store.drain_pending("s1") == []
+
+
+async def test_spawn_work_failure_marks_failed(tmp_path):
+    events: list = []
+    mgr = _mgr(tmp_path, events=events)
+
+    async def work():
+        raise ValueError("gateway 500")
+
+    job_id = await mgr.spawn_work(origin_session="s1", kind="ingest", description="Ingest bar", work=work)
+    job = await _settle(mgr.store, job_id)
+    assert job.status == "failed"
+    assert "gateway 500" in job.result
+    completed = [d for t, d in events if t == "background.completed"]
+    assert completed and completed[0]["status"] == "failed"
+
+
+async def test_spawn_work_cancel(tmp_path):
+    mgr = _mgr(tmp_path)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def work():
+        started.set()
+        await release.wait()  # never released — the test cancels instead
+        return "unreachable"
+
+    job_id = await mgr.spawn_work(origin_session="s1", kind="ingest", description="slow", work=work)
+    await asyncio.wait_for(started.wait(), timeout=2)
+
+    res = await mgr.cancel(job_id)
+    assert res["ok"] is True and res["status"] == "canceled"
+    assert mgr.store.get(job_id).status == "canceled"
+    await asyncio.gather(*list(mgr._fire_tasks), return_exceptions=True)  # let the cancelled task unwind
+
+
+async def test_reconcile_fails_a_running_work_job(tmp_path):
+    # A work coroutine can't survive a restart — reconcile marks it failed (parity with turns).
+    mgr = _mgr(tmp_path)
+    hold = asyncio.Event()
+
+    async def work():
+        await hold.wait()
+        return "x"
+
+    job_id = await mgr.spawn_work(origin_session="s1", kind="ingest", description="held", work=work)
+    # simulate restart reconciliation while it's still running
+    assert mgr.store.reconcile_interrupted() >= 1
+    assert mgr.store.get(job_id).status == "failed"
+    hold.set()
+    await asyncio.gather(*list(mgr._fire_tasks), return_exceptions=True)
+    # the late completion is a no-op — reconcile's terminal state stands
+    assert mgr.store.get(job_id).status == "failed"

--- a/tests/test_knowledge_ingest_tool.py
+++ b/tests/test_knowledge_ingest_tool.py
@@ -28,6 +28,23 @@ def _ingest_tool(store):
     return {t.name: t for t in get_all_tools(store)}["knowledge_ingest"]
 
 
+class _FakeBgMgr:
+    """Captures spawn_work calls without running them, so the test controls timing."""
+
+    def __init__(self) -> None:
+        self.spawned: list[dict] = []
+
+    async def spawn_work(self, *, origin_session, kind, description, work, detail=""):
+        self.spawned.append(
+            {"origin_session": origin_session, "kind": kind, "description": description, "detail": detail, "work": work}
+        )
+        return "bg-fake123"
+
+
+def _ingest_tool_bg(store, mgr):
+    return {t.name: t for t in get_all_tools(store, background_mgr=mgr)}["knowledge_ingest"]
+
+
 def test_get_all_tools_exposes_knowledge_ingest_when_store_wired():
     names = {t.name for t in get_all_tools(_FakeStore())}
     assert "knowledge_ingest" in names
@@ -102,3 +119,75 @@ async def test_knowledge_ingest_empty_source_rejected():
     out = await _ingest_tool(store).ainvoke({"source": "   "})
     assert "Error" in out
     assert store.docs == []
+
+
+# ── inline vs. background (ADR 0050) ──────────────────────────────────────────
+
+
+async def test_url_goes_background(monkeypatch):
+    store = _FakeStore()
+    mgr = _FakeBgMgr()
+    out = await _ingest_tool_bg(store, mgr).ainvoke({"source": "https://youtu.be/abc", "domain": "talks"})
+
+    assert "background" in out.lower() and "bg-fake123" in out
+    assert len(mgr.spawned) == 1
+    sp = mgr.spawned[0]
+    assert sp["kind"] == "ingest" and sp["detail"] == "https://youtu.be/abc"
+    assert store.docs == []  # detached — the work hasn't run yet
+
+
+async def test_background_work_coroutine_actually_ingests(monkeypatch):
+    # The coroutine handed to spawn_work is what the manager runs in the background —
+    # verify it routes through the engine into the store when invoked.
+    store = _FakeStore()
+    mgr = _FakeBgMgr()
+    monkeypatch.setattr(
+        ingestion,
+        "extract_url",
+        lambda url, **kw: ExtractResult(text="transcript body", title="Talk", source_type="youtube"),
+    )
+    await _ingest_tool_bg(store, mgr).ainvoke({"source": "https://youtu.be/abc", "domain": "talks"})
+
+    result = await mgr.spawned[0]["work"]()  # run the detached coroutine
+    assert "Talk" in result and "youtube" in result and "talks" in result
+    content, kw = store.docs[0]
+    assert content == "transcript body" and kw["domain"] == "talks"
+
+
+async def test_small_text_file_ingests_inline(tmp_path, monkeypatch):
+    store = _FakeStore()
+    mgr = _FakeBgMgr()
+    f = tmp_path / "note.txt"
+    f.write_text("small body")
+    monkeypatch.setattr(
+        ingestion,
+        "extract_bytes",
+        lambda filename, data, content_type, **kw: ExtractResult(text="small body", title=None, source_type="text"),
+    )
+    out = await _ingest_tool_bg(store, mgr).ainvoke({"source": str(f)})
+
+    assert mgr.spawned == []  # stayed inline despite a manager being available
+    assert "Ingested" in out
+    assert store.docs and store.docs[0][0] == "small body"
+
+
+async def test_media_file_goes_background(tmp_path):
+    store = _FakeStore()
+    mgr = _FakeBgMgr()
+    f = tmp_path / "clip.mp4"
+    f.write_bytes(b"\x00fake-video")
+    out = await _ingest_tool_bg(store, mgr).ainvoke({"source": str(f)})
+
+    assert "background" in out.lower()
+    assert len(mgr.spawned) == 1 and mgr.spawned[0]["detail"] == str(f)
+    assert store.docs == []
+
+
+async def test_large_text_file_goes_background(tmp_path):
+    store = _FakeStore()
+    mgr = _FakeBgMgr()
+    f = tmp_path / "big.txt"
+    f.write_text("x" * (64 * 1024 + 1))  # over the inline byte budget
+    out = await _ingest_tool_bg(store, mgr).ainvoke({"source": str(f)})
+
+    assert "background" in out.lower() and len(mgr.spawned) == 1

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -505,13 +505,48 @@ def _build_inbox_tools(inbox_store) -> list:
     return [check_inbox]
 
 
-def _build_memory_tools(knowledge_store, graph_config=None) -> list:
+class _KnowledgeIngestError(Exception):
+    """An expected, user-legible ``knowledge_ingest`` failure (missing dependency,
+    unsupported type, no text, no such file). Its message is safe to show verbatim —
+    the inline path returns it; a background work job settles ``failed`` with it."""
+
+
+# A small local text/Markdown file ingests inline (instant); everything else — any URL
+# fetch, PDF, or audio/video transcription — goes to a background job (ADR 0050) so it
+# never blocks the chat turn.
+_INLINE_INGEST_EXTS = frozenset(
+    {".txt", ".text", ".log", ".md", ".markdown", ".mdown", ".mkd", ".mdx", ".rst", ".csv", ".tsv"}
+)
+_INLINE_INGEST_MAX_BYTES = 64 * 1024
+
+
+def _ingest_should_inline(src: str, is_url: bool) -> bool:
+    """True when a source is cheap enough to ingest on the turn (a small local text/
+    Markdown file); False for URLs and anything that fetches / transcribes / parses."""
+    if is_url:
+        return False
+    from pathlib import Path
+
+    try:
+        p = Path(src).expanduser()
+        if not p.is_file():
+            return True  # let the inline path return the clean "no such file" error at once
+        return p.suffix.lower() in _INLINE_INGEST_EXTS and p.stat().st_size <= _INLINE_INGEST_MAX_BYTES
+    except OSError:
+        return True
+
+
+def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None) -> list:
     """Bind memory tools to a ``KnowledgeStore``. Returns a list.
 
-    ``graph_config`` (the ``LangGraphConfig``) is threaded only so
-    ``knowledge_ingest`` can build the gateway speech-to-text / vision functions
-    for audio/video/image sources. It's optional — without it those media paths
-    report "not configured" and the text/URL/PDF paths work unchanged.
+    ``graph_config`` (the ``LangGraphConfig``) is threaded so ``knowledge_ingest``
+    can build the gateway speech-to-text / vision functions for audio/video/image
+    sources. It's optional — without it those media paths report "not configured"
+    and the text/URL/PDF paths work unchanged.
+
+    ``background_mgr`` (ADR 0050) lets ``knowledge_ingest`` run a slow source (any URL
+    fetch or media transcription) as a detached background job instead of blocking the
+    turn. Optional — without it the tool ingests inline (blocking, but correct).
     """
 
     @tool
@@ -544,35 +579,10 @@ def _build_memory_tools(knowledge_store, graph_config=None) -> list:
             return "Error: failed to store chunk (knowledge store unavailable)."
         return f"Stored chunk {chunk_id} in {domain!r}."
 
-    @tool
-    async def knowledge_ingest(source: str, domain: str = "general", title: str | None = None) -> str:
-        """Fetch, extract, and store a URL or local file into long-term knowledge.
-
-        Unlike ``memory_ingest`` (which stores text you already have), this runs
-        the full ingestion pipeline: it pulls the SOURCE, turns it into text, and
-        chunks + embeds it for recall. Reach for this the moment the operator
-        hands you a link or a file to "remember", "read", "ingest", "add to the
-        knowledge base", or "summarize and keep". Do NOT try to web_search or
-        fetch_url a YouTube/media link yourself — this is the only path that gets
-        a transcript or decodes a file.
-
-        Handles:
-          - URLs — web articles (HTML) and YouTube links (transcript)
-          - documents — PDF, plain text, Markdown (by local file path)
-          - media — audio (mp3/wav/m4a…) and video (mp4/mov/mkv…) by local file
-            path, transcribed via the gateway speech-to-text model (slow for long
-            recordings — it runs the whole track through STT)
-          - images — described via the gateway vision model
-
-        Args:
-            source: an ``http(s)`` URL (including YouTube) OR a local file path.
-            domain: knowledge bucket to file it under (default ``"general"``).
-            title: optional heading; otherwise the source's own title is used.
-
-        Returns a one-line summary (title, type, chars, chunk count). If a source
-        needs something that isn't configured (e.g. video needs ``ffmpeg`` plus
-        ``knowledge.transcribe_model``), it says so rather than failing opaquely.
-        """
+    async def _do_ingest(src: str, dom: str, title: str | None, is_url: bool) -> str:
+        """Run the ingestion pipeline for one source and store it; return a one-line
+        summary. Raises ``_KnowledgeIngestError`` (legible message) on an expected
+        failure. Shared by the inline path and the background work job."""
         import asyncio
         from pathlib import Path
 
@@ -584,13 +594,9 @@ def _build_memory_tools(knowledge_store, graph_config=None) -> list:
         )
         from knowledge import add_document
 
-        src = (source or "").strip()
-        if not src:
-            return "Error: provide a URL or a local file path to ingest."
-
-        # Gateway STT/vision for media — None if no model is configured, which
-        # makes audio/video/image raise a clean "not configured" error while
-        # text/URL/PDF/YouTube paths are unaffected.
+        # Gateway STT/vision for media — None if no model is configured, which makes
+        # audio/video/image raise a clean "not configured" error while text/URL/PDF/
+        # YouTube paths are unaffected.
         transcribe = describe = None
         if graph_config is not None:
             try:
@@ -602,40 +608,111 @@ def _build_memory_tools(knowledge_store, graph_config=None) -> list:
                 pass
 
         try:
-            if src.lower().startswith(("http://", "https://")):
+            if is_url:
                 result = await asyncio.to_thread(extract_url, src, transcribe=transcribe)
                 origin = src
             else:
                 path = Path(src).expanduser()
                 if not path.is_file():
-                    return f"Error: no such file: {src} — pass an http(s) URL or an existing local file path."
+                    raise _KnowledgeIngestError(
+                        f"No such file: {src} — pass an http(s) URL or an existing local file path."
+                    )
                 data = await asyncio.to_thread(path.read_bytes)
                 result = await asyncio.to_thread(
                     extract_bytes, path.name, data, None, transcribe=transcribe, describe=describe
                 )
                 origin = str(path)
         except MissingDependency as exc:
-            return f"Can't ingest that source — a required dependency or model isn't available: {exc}"
+            raise _KnowledgeIngestError(
+                f"Can't ingest that source — a required dependency or model isn't available: {exc}"
+            ) from exc
         except UnsupportedSource as exc:
-            return f"Unsupported source type: {exc}"
-        except Exception as exc:  # noqa: BLE001 — surface extraction failure to the model, never crash the turn
-            return f"Extraction failed: {exc}"
+            raise _KnowledgeIngestError(f"Unsupported source type: {exc}") from exc
+        except _KnowledgeIngestError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — surface extraction failure, never crash
+            raise _KnowledgeIngestError(f"Extraction failed: {exc}") from exc
 
         heading = (title or "").strip() or result.title or None
         ids = await asyncio.to_thread(
             lambda: add_document(
                 knowledge_store,
                 result.text,
-                domain=(domain or "general").strip() or "general",
+                domain=dom,
                 heading=heading,
                 source=origin,
                 source_type=result.source_type,
             )
         )
         if not ids:
-            return "Nothing ingested — no text could be extracted from that source."
+            raise _KnowledgeIngestError("Nothing ingested — no text could be extracted from that source.")
         label = heading or origin
-        return f"Ingested {label!r} ({result.source_type}, {len(result.text)} chars) → {len(ids)} chunk(s) in {domain!r}."
+        return f"Ingested {label!r} ({result.source_type}, {len(result.text)} chars) → {len(ids)} chunk(s) in {dom!r}."
+
+    @tool
+    async def knowledge_ingest(
+        source: str,
+        domain: str = "general",
+        title: str | None = None,
+        state: Annotated[Any, InjectedState] = None,
+    ) -> str:
+        """Fetch, extract, and store a URL or local file into long-term knowledge.
+
+        Unlike ``memory_ingest`` (which stores text you already have), this runs the
+        full ingestion pipeline: it pulls the SOURCE, turns it into text, and chunks +
+        embeds it for recall. Reach for this the moment the operator hands you a link or
+        a file to "remember", "read", "ingest", "add to the knowledge base", or
+        "summarize and keep". Do NOT web_search / fetch_url a YouTube or media link
+        yourself — this is the only path that gets a transcript or decodes a file.
+
+        Handles URLs (web articles + YouTube transcripts), documents (PDF, text,
+        Markdown), media (audio + video, transcribed via the gateway) and images
+        (described via the gateway vision model).
+
+        **Anything that fetches over the network or transcribes media runs in the
+        BACKGROUND** (ADR 0050): the call returns immediately with a job id and you're
+        notified when it finishes indexing, so a long video never blocks the
+        conversation. Only a small local text/Markdown file ingests inline (instant).
+        Tell the operator it's underway — do not wait or poll for it.
+
+        Args:
+            source: an ``http(s)`` URL (including YouTube) OR a local file path.
+            domain: knowledge bucket to file it under (default ``"general"``).
+            title: optional heading; otherwise the source's own title is used.
+
+        Returns a one-line summary when it ran inline, or a "started in the background"
+        acknowledgement (with the job id) when the work was detached.
+        """
+        from pathlib import Path
+
+        src = (source or "").strip()
+        if not src:
+            return "Error: provide a URL or a local file path to ingest."
+        dom = (domain or "general").strip() or "general"
+        is_url = src.lower().startswith(("http://", "https://"))
+
+        # Fast local text ingests inline; a network fetch / media transcription (which
+        # can take minutes) becomes a background job so it never blocks the turn. With no
+        # background manager wired, fall back to inline (blocking, but correct).
+        if background_mgr is None or _ingest_should_inline(src, is_url):
+            try:
+                return await _do_ingest(src, dom, title, is_url)
+            except _KnowledgeIngestError as exc:
+                return str(exc)
+
+        label = (title or "").strip() or (src if is_url else Path(src).expanduser().name)
+        job_id = await background_mgr.spawn_work(
+            origin_session=_session_id_from(state) or "",
+            kind="ingest",
+            description=f"Ingest {label}",
+            detail=src,
+            work=lambda: _do_ingest(src, dom, title, is_url),
+        )
+        return (
+            f"Ingesting {label!r} into knowledge (domain {dom!r}) in the background — job {job_id}. "
+            "It runs on its own and I'll report the result back to this conversation when it's "
+            "indexed; no need to wait or poll."
+        )
 
     @tool
     async def memory_recall(query: str, k: int = 5) -> str:
@@ -1219,7 +1296,13 @@ HITL_TOOL_NAMES = frozenset({"ask_human", "request_user_input"})
 
 
 def get_all_tools(
-    knowledge_store=None, scheduler=None, inbox_store=None, tasks_store=None, goal_enabled=False, graph_config=None
+    knowledge_store=None,
+    scheduler=None,
+    inbox_store=None,
+    tasks_store=None,
+    goal_enabled=False,
+    graph_config=None,
+    background_mgr=None,
 ):
     """Return every LangChain tool the lead agent + subagents can use.
 
@@ -1233,6 +1316,9 @@ def get_all_tools(
     - ``graph_config`` (the ``LangGraphConfig``) lets ``knowledge_ingest``
       build the gateway STT/vision functions for audio/video/image sources.
       Optional — without it, only the text/URL/PDF/YouTube ingest paths work.
+    - ``background_mgr`` (ADR 0050) lets ``knowledge_ingest`` run a slow
+      source (URL fetch / media transcription) as a detached background job
+      instead of blocking the turn. Optional — without it it ingests inline.
 
     Pass ``None`` to disable either subsystem — the lead agent runs
     fine with just the four keyless general tools.
@@ -1258,7 +1344,7 @@ def get_all_tools(
     # 0018/0019) — an installed comms plugin registers its tools when a token is set;
     # nothing to wire here.
     if knowledge_store is not None:
-        tools.extend(_build_memory_tools(knowledge_store, graph_config))
+        tools.extend(_build_memory_tools(knowledge_store, graph_config, background_mgr))
     if scheduler is not None:
         tools.extend(_build_scheduler_tools(scheduler))
     if inbox_store is not None:


### PR DESCRIPTION
**Stacked on #1479** (base = `feat/knowledge-ingest-tool`). Review/merge that first; this retargets to `main` after.

## Problem

`knowledge_ingest` from #1479 runs inline. Handing the agent a 20-minute video would **freeze the chat turn** for the entire transcription. That's unacceptable — the turn must not block.

## Due diligence — how others handle long tool calls

Consistent across the field: **return a handle immediately → run detached → report completion out-of-band** (poll / stream / push). Sources: [A2A task lifecycle](https://a2a-protocol.org/latest/specification/) `submitted→working→completed` (protoAgent *is* an A2A runtime), [Microsoft Agent Framework — background responses](https://devblogs.microsoft.com/agent-framework/handling-long-running-operations-with-background-responses/), [Anthropic `pause_turn`](https://www.anthropic.com/engineering/advanced-tool-use), [Google ADK durable pause/resume](https://developers.googleblog.com/build-long-running-ai-agents-that-pause-resume-and-never-lose-context-with-adk/), classic enqueue→worker→notify. The trend is toward *proactive* notification over passive polling.

**Key finding:** protoAgent already implements this exact shape in **ADR 0050** (background subagents) — durable store, concurrency cap, event-bus progress, drain-on-next-turn, autonomous idle-wake. It just wasn't wired to ingestion. So extend it, don't reinvent.

## Design (approved)

The existing background path spawns a **full LLM subagent turn** — wasteful for a *deterministic* pipeline. So add a non-turn path:

- **`BackgroundManager.spawn_work(...)`** runs a plain coroutine under the **same** durable `BackgroundStore` + concurrency semaphore + event stream + exactly-once drain as `spawn`. No store schema change (`kind` reuses `subagent_type`; a work job has no `a2a_task_id`).
- **Completion parity:** no A2A turn fires, so `_run_work` settles the row, publishes `background.completed` with the **same payload** as the terminal hook (identical console card), and calls an injected `on_terminal` hook → the server wires it to the **same `_spawn_background_wake`** the turn path uses (idle-wake, gated by `BACKGROUND_WAKE`). All three completion channels (live card, next-turn drain, autonomous wake) fire for a work job.
- **`cancel`** stops the coroutine directly; **`reconcile_interrupted`** fails a work job orphaned by restart (parity with turns).
- **`knowledge_ingest`** detaches any URL fetch / media transcription as a `spawn_work` job and returns a job id immediately; only a small local **text/Markdown file (≤64 KB)** ingests inline. Degrades to inline when no `background_mgr` is wired (`BACKGROUND_DISABLED`).

This is the deliberate exception to ADR 0050's "self-POST, not `create_task`" — that rationale is about *turns* needing the A2A task store; a deterministic pipeline needs only the registry + notification, which the store already gives. Documented in the ADR.

## Test
- `ruff` ✓ · `lint-imports` ✓ (3 kept, no new layering edges) · full `pytest` ✓ **2511 passed, 5 skipped** (+9) · `live_smoke` ✓ (boot + graph compile with new wiring + real A2A turn) · `vitepress build` ✓
- New: `test_background_work.py` (spawn_work complete/fail/cancel/reconcile + exactly-once notify); `test_knowledge_ingest_tool.py` (URL/media/large → background, small text → inline, no-mgr → inline, the detached coroutine actually ingests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)