### PR TITLE
feat(artifact): auto-mount React <App/> so the first-try render just works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (one machine-wide `host-config.yaml`, the layer's intent); shared commons stay shared; and the
   legacy `scope_leaf` scoping knob is removed. (ADR 0065; supersedes the path mechanics of ADR
   0004/0041 and re-amends the host-file location in ADR 0047.)
+- **React artifacts are more forgiving + the render loop is proactive** (artifact plugin 0.13.0) —
+  the most common first-try mistake (defining a component but never calling `render()`) now just
+  works: name your top-level component `App` and the harness **auto-mounts** `<App/>` when nothing
+  mounted itself (an explicit `render()` still wins; it never double-mounts). `check_artifact` now
+  waits briefly for the verdict when the panel is live (so an immediate post-render check returns
+  the real result), and the skill instructs the agent to **verify the render after every create/
+  edit** and iterate until it's clean.
 
 ### Fixed
 - **Docs reader: in-content cross-reference links route in-app instead of breaking the iframe**

--- a/plugins/artifact/__init__.py
+++ b/plugins/artifact/__init__.py
@@ -336,11 +336,15 @@ def show_artifact(kind: str, code: str, title: str = "") -> str:
     ``kind`` is one of: "html" (a full or partial HTML document), "svg" (inline SVG markup),
     "mermaid" (a Mermaid diagram definition), "markdown" (a Markdown document — rendered with
     design-system prose styling; ```mermaid fences become live diagrams), or "react" (a
-    self-contained React component script that renders into ``#root``; React, ReactDOM and Babel
-    are provided, and it can ``import`` from a curated offline set — ``d3``, ``chart.js``,
-    ``lucide``, and ``@pl/ui`` design-system components like ``Button``/``Card``/``Stat``/
-    ``Icon``). ``code`` is the source; ``title`` is an optional label. Runs sandboxed — it can't
-    access the console.
+    self-contained React component script; name your top-level component ``App`` and it
+    AUTO-MOUNTS into ``#root`` (no manual ``createRoot(...).render`` needed — though an explicit
+    render still works). React, ReactDOM and Babel are provided, and it can ``import`` from a
+    curated offline set — ``d3``, ``chart.js``, ``lucide``, and ``@pl/ui`` design-system
+    components like ``Button``/``Card``/``Stat``/``Icon``). ``code`` is the source; ``title`` is
+    an optional label. Runs sandboxed — it can't access the console.
+
+    After creating it, CHECK IT RENDERED: this reply carries the render verdict when the panel is
+    open; otherwise call ``check_artifact``. Fix any reported error before moving on.
 
     To EDIT what you just made, use ``update_artifact`` (a small targeted change) or
     ``rewrite_artifact`` (a full replacement) — they iterate the SAME artifact as a new
@@ -482,13 +486,18 @@ def check_artifact(artifact_id: str = "") -> str:
     Returns the render verdict: rendered cleanly, FAILED with the captured error message, or
     "no result yet" (the panel is closed / not showing this version — open the Artifact panel).
     Defaults to the current artifact; pass ``artifact_id`` (see ``list_artifacts``) to target
-    another. Read-only."""
+    another. Read-only.
+
+    Safe to call right after creating/editing: if a result isn't in yet but the panel is live,
+    it waits briefly for the verdict rather than returning "no result yet"."""
     store = _read_store()
     art = _find(store, artifact_id or store["current"])
     if art is None:
         return "No artifact to check. Use list_artifacts to see the ids, or show_artifact to create one."
     v = len(art["versions"])
-    r = _version_render(art, v)
+    # An already-recorded verdict reads instantly; otherwise wait briefly IFF a renderer is live
+    # (so an immediate post-render check returns the real result, not a premature "no result yet").
+    r = _version_render(art, v) or _await_render(art["id"], v)
     if r is None:
         return (
             f"Artifact {art['id']} v{v}: no render result yet — the Artifact panel may be "
@@ -905,18 +914,28 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
     if (kind === "markdown") return mdDoc(code);
     // `react`: import map + UMD react/react-dom/babel, compiled as a MODULE so `import` works
     // (no-import artifacts still run — they use the UMD React/ReactDOM globals as before).
+    // The artifact module + a forgiving AUTO-MOUNT epilogue (appended INSIDE the same babel
+    // module so it can see module-scoped `App`): the #1 first-try mistake is defining `App` but
+    // never calling render(). If #root is still empty a tick after the module runs and an `App`
+    // is in scope, mount <App/> for them. An explicit render() still wins — this fires ONLY when
+    // nothing mounted, so it never double-renders a self-mounting artifact.
     if (kind === "react") return '<!doctype html>' + dsLink() + base(kind) + '<body><div id="root"></div>' +
       '<script type="importmap">' + IMPORTMAP + '<\/script>' +
       cdn("react") + cdn("reactDom") + cdn("babel") +
-      '<script type="text/babel" data-type="module" data-presets="react">' + code + '<\/script>' +
-      // No-mount guard: a babel module that defines a component but never calls render() leaves
-      // #root empty with NO thrown error — the silent blank that reads as "stuck". Poll briefly;
-      // mount → report a clean render (#1458); if #root never gets a child and nothing else
-      // errored, surface an actionable message (which also reports the failure up).
+      '<script type="text/babel" data-type="module" data-presets="react">' + code
+      + '\n;(function(){var r=document.getElementById("root");if(!r)return;setTimeout(function(){'
+      + 'if(r.firstChild)return;'  // the artifact mounted itself — leave it alone
+      + 'try{if(typeof App!=="undefined"&&App){var R=window.ReactDOM;'
+      + 'if(R&&R.createRoot){R.createRoot(r).render(React.createElement(App));}'
+      + 'else if(R&&R.render){R.render(React.createElement(App),r);}}}'
+      + 'catch(e){if(window.__artErr)window.__artErr(String((e&&e.message)||e));}'
+      + '},0);})();<\/script>' +
+      // No-mount guard: if #root is STILL empty (no `App` to auto-mount, or it threw) after a few
+      // seconds and nothing else errored, surface an actionable message (also reported up, #1458).
       '<script>(function(){var n=0,t=setInterval(function(){var r=document.getElementById("root");'
       + 'if(r&&r.firstChild){clearInterval(t);if(window.__artOk)window.__artOk();return;}'
       + 'if(++n>=30){clearInterval(t);if(window.__artErr&&!document.getElementById("__arterr"))'
-      + 'window.__artErr("Nothing rendered into #root — a React artifact must MOUNT itself, e.g. createRoot(document.getElementById(\'root\')).render(<App/>). Defining a component is not enough; you must call render().");'
+      + 'window.__artErr("Nothing rendered into #root — name your top-level component `App` (it auto-mounts) or call createRoot(document.getElementById(\'root\')).render(<App/>) yourself.");'
       + '}},100);})();<\/script></body>';
     return '<!doctype html>' + base(kind) + '<body style="font-family:sans-serif;padding:16px">unsupported artifact kind</body>';
   }

--- a/plugins/artifact/protoagent.plugin.yaml
+++ b/plugins/artifact/protoagent.plugin.yaml
@@ -1,6 +1,6 @@
 id: artifact
 name: Artifact
-version: 0.12.0
+version: 0.13.0
 # Needs the host to serve the DS plugin-kit at /_ds/ (protoAgent #893, v0.34.0) —
 # the shell page links it for theming + the authed handshake, and artifacts inject it
 # so `.pl-*` design-system classes work inside the sandbox.

--- a/plugins/artifact/skills/rendering-artifacts/SKILL.md
+++ b/plugins/artifact/skills/rendering-artifacts/SKILL.md
@@ -26,8 +26,10 @@ the user files to wire up themselves — not what they asked for when they want 
 - `html` — a full or partial HTML document (with inline `<style>`/`<script>` as needed).
 - `svg` — inline SVG markup (icons, simple charts).
 - `react` — a self-contained component script that renders into `#root`; React, ReactDOM, and
-  Babel are provided. Write the component **and** the `ReactDOM.createRoot(...).render(...)` call.
-  React artifacts can also `import` from a curated **offline** set (see below).
+  Babel are provided. Easiest: **name your top-level component `App`** and it **auto-mounts** — you
+  don't have to write the mount call. (You still can: `ReactDOM.createRoot(...).render(...)`; an
+  explicit render always wins.) React artifacts can also `import` from a curated **offline** set
+  (see below).
 
 ## Richer React: charts, icons, and design-system components
 
@@ -85,19 +87,20 @@ Each edit is a **version** the user can step back through in the panel, so itera
 never destroying the previous version. Both default to the most-recent artifact; pass
 `artifact_id` to target another.
 
-## Did it render? (closing the loop)
+## Did it render? ALWAYS verify (closing the loop)
 
-A React artifact that throws at render time (a bad import, an undefined component, or defining a
-component but never calling `render()`) used to fail **silently** — you'd get "Created" and no hint
-it broke. Now the sandbox reports its render result back:
+A React artifact can throw at render time (a bad import, an undefined component, an export
+mismatch) even when the code looks right. **Verifying the render is a standard step, not an
+optional one** — confirm it worked before you tell the user it's done:
 
 - When the panel is open, `show_artifact` / `update_artifact` / `rewrite_artifact` wait briefly and
   **append the render verdict to their reply** — e.g. *"⚠ But it FAILED to render: Icon is not
-  defined"*. When that happens, **fix it** with `update_artifact` / `rewrite_artifact`; the artifact
-  still exists, so iterate on it (don't start over). A clean render says so too.
-- **`check_artifact(artifact_id?)`** — ask for the latest render verdict yourself (rendered cleanly
-  / failed with the error / no result yet). Useful when the create reply came back before the
-  render finished, or the panel was closed (open it to render).
+  defined"* or *"It rendered cleanly."* Read it.
+- If the reply didn't carry a clean verdict (it came back before the render finished, or said "no
+  result yet"), **call `check_artifact` to confirm** — it waits briefly for the verdict. Make this
+  your default after creating or editing an artifact.
+- On a failure, **fix it** with `update_artifact` / `rewrite_artifact` — the artifact still exists,
+  so iterate on it (don't start over), then verify again. Loop until it renders cleanly.
 
 Treat a render error as the signal to iterate — that's the code→render→fix loop. Don't apologise and
 guess; read the error and make the targeted edit.

--- a/tests/test_artifact_plugin.py
+++ b/tests/test_artifact_plugin.py
@@ -555,8 +555,9 @@ def test_harness_guards_against_silent_blank(monkeypatch, tmp_path):
     assert 'addEventListener("error"' in html
     assert 'addEventListener("unhandledrejection"' in html
     assert '"__arterr"' in html  # the overlay element id
-    # React no-mount guard: actionable message instead of a blank #root.
-    assert "must MOUNT itself" in html
+    # React no-mount guard: actionable message instead of a blank #root (now points at the
+    # `App` auto-mount convention, since defining `App` is enough).
+    assert "name your top-level component" in html
     assert "Nothing rendered into #root" in html
 
 
@@ -694,3 +695,32 @@ def test_history_poll_marks_a_renderer_live(monkeypatch, tmp_path):
     assert art._renderer_live() is False
     _client(art).get("/api/plugins/artifact/history")
     assert art._renderer_live() is True
+
+
+# ── react auto-mount + proactive verify (forgiving renderer) ────────────────────
+
+
+def test_react_srcdoc_auto_mounts_app(monkeypatch, tmp_path):
+    """The react harness auto-mounts a top-level `App` when the artifact defined it but never
+    called render() — the #1 first-try failure. Fires only if #root is still empty (an explicit
+    render wins), and routes any throw through __artErr."""
+    html = _load(monkeypatch, tmp_path)._SHELL_HTML
+    assert 'typeof App!=="undefined"' in html
+    assert "React.createElement(App)" in html
+    assert "if(r.firstChild)return;" in html  # never double-mounts a self-mounting artifact
+    # the no-mount guard now points at the App convention
+    assert "name your top-level component `App` (it auto-mounts)" in html
+
+
+def test_check_artifact_waits_for_a_live_render(monkeypatch, tmp_path):
+    """check_artifact returns a stored verdict regardless of live-ness, and (when nothing is
+    recorded yet) waits via _await_render only if a renderer is live."""
+    art = _load(monkeypatch, tmp_path)
+    art.show_artifact.invoke({"kind": "react", "code": "x"})
+    aid = art._read_store()["artifacts"][0]["id"]
+    # stored verdict is read even when no renderer is live
+    store = art._read_store()
+    store["artifacts"][0]["versions"][0]["render"] = {"ok": True, "error": "", "ts": art._now()}
+    art._write_store(store)
+    art._LAST_POLL_TS = 0
+    assert "rendered cleanly" in art.check_artifact.invoke({"artifact_id": aid})


### PR DESCRIPTION
## What

Makes the React artifact renderer **forgiving** — the fix for the failure every agent hit on its first try: defining a component but never calling `render()`, producing *"Nothing rendered into #root"*.

- **Auto-mount:** name your top-level component `App` and the harness mounts `<App/>` when nothing mounted itself after the module runs. An explicit `createRoot(...).render()` still wins; it never double-mounts; render errors route through the same reporting path as before.
- The no-mount guard message now teaches the `App`-name convention instead of demanding a manual `render()` call.
- **Proactive verification:** `check_artifact` waits briefly for the render verdict when the panel is live (an immediate post-render check returns the *real* result, not "no result yet"), and the `rendering-artifacts` skill instructs the agent to verify the render after every create/edit and iterate until clean — closing the code→render→fix loop.

Artifact plugin **0.13.0**.

## Context

This is the parked work from earlier this session (it was awaiting a live test). It builds on the render-error-feedback that already shipped (#1458/#1461) — that surfaced errors; this makes the common case *not error in the first place*. A stray `config/SOUL.md` edit that had leaked into the worktree (console persona-editing back when `write_soul` wrote the repo tree) was **excluded** — the template placeholder is untouched.

## Verification
`ruff` clean · artifact suite **52 passed** · full `pytest tests/` **2512 passed, 5 skipped**. Rebased onto current main (post store-tier migration); no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)