### PR TITLE
feat(palette): the ⌘K chat survives being closed mid-turn (durable reconnect)

### DIFF
--- a/apps/web/src/app/PaletteChat.tsx
+++ b/apps/web/src/app/PaletteChat.tsx
@@ -67,16 +67,68 @@ export function PaletteChat({ agentName }: { agentName: string }) {
   const abortRef = useRef<AbortController | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const contextRef = useRef(boot.contextId); // stable A2A contextId (= thread_id server-side)
+  const messagesRef = useRef(messages); // latest, for the unmount flush + self-heal
+  messagesRef.current = messages;
 
   // Focus the composer on open AND after each turn settles (streaming → false).
   useEffect(() => {
     if (!streaming) inputRef.current?.focus();
   }, [streaming]);
-  useEffect(() => () => abortRef.current?.abort(), []);
+  // On close (unmount) the palette abandons the live stream, but the backend turn keeps
+  // running (durable A2A task). Flush the transcript IMMEDIATELY so the in-flight
+  // assistant message + its taskId are on disk before the debounce would fire — the
+  // self-heal below reconnects to it on reopen. Abort last (it can't race the flush).
+  useEffect(
+    () => () => {
+      savePaletteThread({ contextId: contextRef.current, messages: messagesRef.current }, true);
+      abortRef.current?.abort();
+    },
+    [],
+  );
   // Preserve the thread (debounced) — survives close/reopen and reload.
   useEffect(() => {
     savePaletteThread({ contextId: contextRef.current, messages });
   }, [messages]);
+
+  // Reconnect an interrupted turn (ADR 0057 durability). Runs once per open: if the last
+  // assistant message is stuck "streaming" with a durable taskId — the palette was closed
+  // mid-turn — reconcile it against the server's A2A task (tasks/get), finalizing when
+  // terminal and polling briefly while it's genuinely still running. Mirrors ChatSurface's
+  // self-heal so a reopened palette shows the turn still running, or its finished result.
+  useEffect(() => {
+    if (abortRef.current) return; // a live turn in this session owns the stream
+    const last = messagesRef.current[messagesRef.current.length - 1];
+    if (!last || last.role !== "assistant" || last.status !== "streaming" || !last.taskId) return;
+    const taskId = last.taskId;
+    const TERMINAL = /completed|failed|canceled|cancelled/i;
+    let cancelled = false;
+    let polls = 0;
+    const MAX_POLLS = 40; // ~2 min at 3s, then unlock and let the next open re-poll
+    setStreaming(true); // lock the composer like a live turn while we reconcile
+    async function tick() {
+      if (cancelled) return;
+      let res: { state: string; text: string };
+      try {
+        res = await api.getTask(taskId);
+      } catch {
+        return; // best-effort — leave it for the next open to retry
+      }
+      if (cancelled) return;
+      if (!res.state || TERMINAL.test(res.state)) {
+        const failed = /fail|cancel/i.test(res.state);
+        update((m) => ({ ...finalize(m), content: res.text || m.content, status: failed ? "error" : "done" }));
+        setStreaming(false);
+        return;
+      }
+      if (++polls < MAX_POLLS) setTimeout(tick, 3000);
+      else setStreaming(false);
+    }
+    void tick();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const update = (fn: (m: ChatMessage) => ChatMessage) =>
     setMessages((ms) => {
@@ -121,6 +173,10 @@ export function PaletteChat({ agentName }: { agentName: string }) {
         contextRef.current,
         {
           signal: controller.signal,
+          // Pin the server task id to the streaming message so a palette closed mid-turn
+          // can reconnect to it on reopen (the self-heal above). Persisted via the messages
+          // effect + the unmount flush.
+          onTaskId: (id) => update((m) => ({ ...m, taskId: id })),
           onText: (t, append) =>
             update((m) => ({ ...m, content: append ? m.content + t : t, parts: appendText(m.parts, t, append) })),
           onReasoning: (d) =>

--- a/apps/web/src/app/paletteChatStore.test.ts
+++ b/apps/web/src/app/paletteChatStore.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { loadPaletteThread } from "./paletteChatStore";
+
+// jsdom path is "/" → the host (un-slugged) key.
+const KEY = "protoagent.palette.chat";
+
+describe("paletteChatStore load/sanitize", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("preserves a streaming message that has a taskId (reconnectable) and settles one without", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        contextId: "palette-x",
+        messages: [
+          { role: "user", content: "hi" },
+          // interrupted mid-turn but has a durable task id → kept streaming for self-heal
+          { role: "assistant", content: "partial", status: "streaming", taskId: "task-123" },
+          // stuck streaming with no task id → un-reconcilable, settle to done
+          { role: "assistant", content: "orphan", status: "streaming" },
+        ],
+      }),
+    );
+
+    const t = loadPaletteThread();
+    expect(t.contextId).toBe("palette-x");
+    expect(t.messages[1].status).toBe("streaming");
+    expect(t.messages[1].taskId).toBe("task-123");
+    expect(t.messages[2].status).toBe("done");
+  });
+
+  it("drops malformed messages but keeps well-formed ones", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        contextId: "palette-y",
+        messages: [{ role: "assistant", content: "ok" }, { role: "bogus" }, null, "nope"],
+      }),
+    );
+    const t = loadPaletteThread();
+    expect(t.messages).toHaveLength(1);
+    expect(t.messages[0].content).toBe("ok");
+  });
+
+  it("returns a fresh thread on corrupt storage", () => {
+    window.localStorage.setItem(KEY, "{not json");
+    const t = loadPaletteThread();
+    expect(t.contextId).toMatch(/^palette-/);
+    expect(t.messages).toEqual([]);
+  });
+});

--- a/apps/web/src/app/paletteChatStore.ts
+++ b/apps/web/src/app/paletteChatStore.ts
@@ -23,7 +23,10 @@ function newContextId(): string {
 }
 
 // A corrupt persisted message must not white-screen the chat (cf. chat-store #872) —
-// keep only well-formed ones, and never leave a message stuck "streaming" on reload.
+// keep only well-formed ones. A message stuck "streaming" is settled to "done" UNLESS it
+// carries a durable `taskId`: that one was interrupted mid-turn (palette closed), and
+// PaletteChat's self-heal reconnects it to the server task on reopen — so keep it
+// streaming for the reconnect to reconcile (mirrors the main chat, ChatSurface).
 function sanitize(messages: unknown): ChatMessage[] {
   if (!Array.isArray(messages)) return [];
   return messages
@@ -34,7 +37,7 @@ function sanitize(messages: unknown): ChatMessage[] {
         (x.role === "user" || x.role === "assistant" || x.role === "system") && typeof x.content === "string"
       );
     })
-    .map((m) => (m.status === "streaming" ? { ...m, status: "done" as const } : m));
+    .map((m) => (m.status === "streaming" && !m.taskId ? { ...m, status: "done" as const } : m));
 }
 
 export function loadPaletteThread(): PaletteThread {


### PR DESCRIPTION
**Draft** — console UX; needs a local open→send→close→reopen verification (CI can't judge the reconnect UX). Per the console-UX local-test gate.

## Problem
Run a turn in the ⌘K command-palette chat, close the palette mid-stream, reopen → the turn is **gone**. Two causes:
1. On unmount, `abortRef.current?.abort()` kills the fetch.
2. On reopen, `sanitize()` flips any `streaming` message to `done` — and there's **no `taskId`** persisted, so a turn that finished server-side while closed can't be recovered.

## Why not the background manager
(The natural first guess.) The background manager runs work **detached with no live token stream** — right for deterministic delegated work (ingestion), wrong for a foreground interactive chat you're watching stream. The console **already** has the correct machinery: the main `ChatSurface` persists a `taskId` and self-heals a stuck turn via `tasks/get` polling (the backend turn is durable in the A2A task store and keeps running after the client disconnects). This just gives the palette chat that same treatment.

## Change
- **`PaletteChat.tsx`** — capture the server task id (`onTaskId`) and pin it to the streaming message; **flush the transcript immediately on close** (before the 300ms debounce) so the id is durable; on reopen, **self-heal** — if the last assistant message is stuck `streaming` with a `taskId`, reconcile against the server task (`tasks/get`): finalize when terminal, poll ~2 min while still running, and lock the composer meanwhile so you can't start a concurrent turn on the same context. Mirrors `ChatSurface`'s self-heal.
- **`paletteChatStore.ts`** — `sanitize()` keeps a `streaming` message that carries a `taskId` (reconnectable) instead of settling it to `done`; a taskless orphan still settles (unchanged safety).
- **`paletteChatStore.test.ts`** — preserve-with-taskId / settle-without split + malformed / corrupt-storage guards.

## Result
Reopen the palette and you see the turn **still running** (spinner + it resolves live when done) or its **finished result** — exactly the ask.

## Test
`tsc --noEmit` (both configs) ✓ · `vitest run` ✓ (209 passed, +3). Manual UX check pending (that's why this is a draft).

## Verify locally
1. `scripts/dev.sh` (dev instance :7871), open the console, ⌘K.
2. Ask something slow (e.g. `knowledge_ingest` a URL, or a multi-tool task), then press Esc mid-turn.
3. Reopen ⌘K → the turn is still there, running; wait → it finalizes with the answer. Also try closing, waiting for it to finish, then reopening → shows the finished result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)