### PR TITLE
chore: release v0.77.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.77.0] - 2026-07-01
+
 ### Added
 - **Cross-machine fleet hardening — A2A federation is fault-transparent** (#1468, #1476) — a peer
   delegate (`delegate_to` over A2A) no longer cuts off a long-running task at a fixed 30s: the poll

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.76.0"
+version = "0.77.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,29 @@
 [
   {
+    "version": "v0.77.0",
+    "date": "2026-07-01",
+    "changes": [
+      "Cross-machine fleet hardening — A2A federation is fault-transparent",
+      "Remote fleet members surface their health immediately",
+      "Discovery auto-sweeps on hub boot",
+      "config explain diagnostic",
+      "Real multi-instance fleet test harness",
+      "Artifact is now a bundled core plugin, on by default",
+      "Artifact render errors feed back to the agent",
+      "Multi-step wizard + choice-card HITL forms",
+      "The agent can ingest documents & media into its knowledge base",
+      "Two-tier instance paths (box / instance) — one resolution rule, no more double-scoping",
+      "React artifacts are more forgiving + the render loop is proactive",
+      "Docs reader: in-content cross-reference links route in-app instead of breaking the iframe",
+      "A crashed co-located fleet member is now detected and restartable",
+      "Autonomous turns no longer deadlock on a human-input pause",
+      "HITL tools are hard-denied to subagents",
+      "Settings surfaces when the agent config shadows a host-scoped field",
+      "The ⌘K command-palette chat survives being closed mid-turn",
+      "Knowledge: fleet/commons sharing + the reusable background-job primitive"
+    ]
+  },
+  {
     "version": "v0.76.0",
     "date": "2026-06-30",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.77.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.77.0 -m 'Release v0.77.0' && git push origin v0.77.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release notes for version **v0.77.0** highlighting improvements across fleet management, discovery, testing, plugin behavior, rendering feedback, forms, knowledge ingestion, and command palette reliability.
* **Chores**
  * Bumped the package version from **0.76.0** to **0.77.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->