### PR TITLE
feat(goals): retire the goal-continuation XML for tools (update_goal_plan / abandon_goal)

### DIFF
--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -16,8 +16,8 @@ It's modelled on protocli's goal system but deliberately more rigorous for a lon
 | | protocli | protoAgent goal mode |
 |---|---|---|
 | Completion check | small-LLM judgment | **pluggable verifier** (command / test / CI / data), LLM only as fallback |
-| Drive-to-done | continuation prompt | continuation prompt **+ persisted `<goal_plan>` checklist** |
-| Give-up path | user sets "stop after N" in the text | **iteration budget + no-progress streak + model `<goal_unachievable>`** |
+| Drive-to-done | continuation prompt | continuation prompt **+ a persisted plan** (the `update_goal_plan` tool) |
+| Give-up path | user sets "stop after N" in the text | **iteration budget + no-progress streak + the `abandon_goal` tool** |
 | State | in-memory, per session | **disk-persisted** per session (survives restart/reload) |
 
 ## How it works
@@ -25,8 +25,8 @@ It's modelled on protocli's goal system but deliberately more rigorous for a lon
 1. You set a goal for a session (`/goal …`). Nothing else changes — the next message runs normally.
 2. When the agent produces a final answer (no more tool calls), the controller runs the goal's **verifier**.
 3. **Met** → the goal is marked `achieved` and the run ends.
-4. **Not met** → the controller extracts/refreshes the agent's `<goal_plan>` checklist, then re-invokes the agent on the same thread (history preserved) with a continuation prompt that includes the verifier's reason + evidence and the current plan.
-5. This repeats until met, the **iteration budget** (`goal.max_iterations`) is spent (`exhausted`), the verifier returns the **same evidence too many times** (`goal.no_progress_limit` → `unachievable`), or the agent itself emits `<goal_unachievable reason="…"/>` (`unachievable`).
+4. **Not met** → the agent records its running plan with the `update_goal_plan` tool, then the controller re-invokes it on the same thread (history preserved) with a continuation prompt that includes the verifier's reason + evidence and the current plan.
+5. This repeats until met, the **iteration budget** (`goal.max_iterations`) is spent (`exhausted`), the verifier returns the **same evidence too many times** (`goal.no_progress_limit` → `unachievable`), or the agent itself calls the `abandon_goal` tool with a reason (`unachievable`).
 
 The loop wraps graph invocation in `server/chat.py` (both the A2A streaming path and the non-streaming chat path); the graph itself is unchanged.
 
@@ -109,9 +109,9 @@ Examples:
 {"type": "data", "path": "/sandbox/state.json", "expr": "data['open_tickets'] == 0"}
 ```
 
-## The `<goal_plan>` checklist
+## The running plan (`update_goal_plan`)
 
-Continuation prompts ask the agent to keep a running plan inside a `<goal_plan>…</goal_plan>` block and update it each turn. The controller extracts that block, persists it with the goal state, and feeds it back into the next continuation — so the agent maintains a coherent plan across iterations instead of re-planning from scratch.
+Continuation prompts ask the agent to keep a running plan and record it each turn by calling the **`update_goal_plan`** tool. The controller persists that plan with the goal state (fresh-context goals write it to a durable plan artifact) and feeds it back into the next continuation — so the agent maintains a coherent plan across iterations instead of re-planning from scratch. To stop early when the goal is impossible or out of scope, the agent calls **`abandon_goal`** with a reason (honoured only after the verifier runs, so a goal the world already satisfies still finishes `achieved`). Both tools are bound whenever goal mode is on and are harmless no-ops outside a goal.
 
 ## Configuration
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -301,7 +301,7 @@ routing:
 
 ## `goal`
 
-**Goal mode** (`graph/goals/`) lets you give the agent a *testable outcome* it self-drives toward. After each terminal turn (the agent stops with a final answer), the goal's **verifier** decides whether it's met; if not, the agent is re-invoked with a continuation prompt — carrying the verifier's evidence and a running `<goal_plan>` checklist — until the verifier passes, the iteration budget runs out (`exhausted`), or the goal is flagged `unachievable` (a no-progress streak, or the model emitting `<goal_unachievable reason="…"/>`). Unlike a pure-LLM "are we done?" check, completion is backed by a real verifier.
+**Goal mode** (`graph/goals/`) lets you give the agent a *testable outcome* it self-drives toward. After each terminal turn (the agent stops with a final answer), the goal's **verifier** decides whether it's met; if not, the agent is re-invoked with a continuation prompt — carrying the verifier's evidence and the running plan the agent records with the `update_goal_plan` tool — until the verifier passes, the iteration budget runs out (`exhausted`), or the goal is flagged `unachievable` (a no-progress streak, or the agent calling the `abandon_goal` tool). Unlike a pure-LLM "are we done?" check, completion is backed by a real verifier.
 
 The machinery is wired when `enabled`, but **no goal is active until one is set** via the `/goal` control message (works over A2A / the React console / OpenAI-compat) or the `/api/goal/{session_id}` endpoints. State is persisted per session under `GOAL_PATH` → `/sandbox/goals` → `~/.protoagent/goals`.
 

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import re
 from dataclasses import dataclass
 
 from graph.goals.store import GoalStore
@@ -29,9 +28,6 @@ from graph.goals.verifiers import VerifyContext, run_verifier
 log = logging.getLogger(__name__)
 
 CLEAR_ALIASES = {"clear", "stop", "off", "reset", "none", "cancel"}
-
-_GOAL_PLAN_RE = re.compile(r"<goal_plan>(.*?)</goal_plan>", re.IGNORECASE | re.DOTALL)
-_GIVEUP_RE = re.compile(r"<goal_unachievable(?:\s+reason=\"([^\"]*)\")?\s*/?>", re.IGNORECASE)
 
 
 @dataclass
@@ -135,6 +131,39 @@ class GoalController:
         self._store.set(state)
         return (True, f"Goal set. {state.status_line()}")
 
+    # --- agent goal-loop tools (retired the <goal_plan>/<goal_unachievable> XML) ---
+
+    def record_plan(self, session_id: str, plan: str) -> tuple[bool, str]:
+        """Persist the agent's running plan for its active goal — called by the
+        ``update_goal_plan`` tool DURING a turn (replaces the old ``<goal_plan>`` tag).
+        Fresh-context goals write the durable plan artifact; same-session goals carry it
+        on the goal state. The next continuation prompt feeds it back. Returns (ok, msg)."""
+        state = self.active_goal(session_id)
+        if state is None:
+            return (False, "no active goal for this session.")
+        plan = (plan or "").strip()
+        if not plan:
+            return (False, "a plan is required.")
+        if state.fresh_context:
+            self._store.write_plan(state.session_id, plan)
+        else:
+            state.checklist = plan
+            self._store.set(state)
+        return (True, "plan recorded.")
+
+    def request_abandon(self, session_id: str, reason: str) -> tuple[bool, str]:
+        """Flag the active goal as unachievable at the agent's request — called by the
+        ``abandon_goal`` tool DURING a turn (replaces the old ``<goal_unachievable/>``
+        tag). Recorded on the goal state; the post-turn ``evaluate`` honours it AFTER the
+        verifier, so a goal the world already satisfies still finishes ``achieved``.
+        Returns (ok, msg)."""
+        state = self.active_goal(session_id)
+        if state is None:
+            return (False, "no active goal for this session.")
+        state.abandon_reason = (reason or "").strip() or "agent flagged the goal unachievable"
+        self._store.set(state)
+        return (True, "goal will stop after this turn (flagged unachievable).")
+
     def _parse_set(self, rest: str):
         """Return (verifier_spec, condition, max_iterations|None, no_progress_limit|None, mode, fresh_context)."""
         if rest.lstrip().startswith("{"):
@@ -163,7 +192,7 @@ class GoalController:
 
         # 1. Run the verifier first — ground truth overrides the model's
         # self-assessment. If the external world already satisfies the goal,
-        # a same-turn <goal_unachievable> give-up must not mask that.
+        # a same-turn abandon_goal give-up must not mask that.
         ctx = VerifyContext(
             config=self._config,
             condition=state.condition,
@@ -190,21 +219,15 @@ class GoalController:
             self._store.set(state)
             return None
 
-        # 2. Verifier not met — honour an explicit give-up from the agent.
-        giveup = _GIVEUP_RE.search(last_text or "")
-        if giveup:
-            reason = (giveup.group(1) or "agent flagged the goal unachievable").strip()
-            return await self._finish(state, "unachievable", reason)
+        # 2. Verifier not met — honour an explicit give-up. The agent records it
+        # DURING its turn via the `abandon_goal` tool (persisted to the goal state); we
+        # read it here, AFTER the verifier, so ground truth still wins over give-up.
+        if state.abandon_reason:
+            return await self._finish(state, "unachievable", state.abandon_reason)
 
-        # 3. Not met — refresh checklist, track progress, decide continue vs stop.
-        plan = _GOAL_PLAN_RE.search(last_text or "")
-        if plan:
-            plan_text = plan.group(1).strip()
-            if state.fresh_context:
-                self._store.write_plan(state.session_id, plan_text)
-            else:
-                state.checklist = plan_text
-
+        # 3. Not met — track progress, decide continue vs stop. The running plan is
+        # maintained by the agent's `update_goal_plan` tool (already persisted to the goal
+        # state / plan artifact), so there is nothing to extract from the text here.
         signature_unchanged = result.reason == state.last_reason and result.evidence == state.last_evidence
         state.no_progress_streak = (state.no_progress_streak + 1) if signature_unchanged else 0
         state.last_reason = result.reason
@@ -344,10 +367,10 @@ class GoalController:
                 + (evidence_block + "\n" if evidence_block else "\n")
                 + f"Plan from last iteration:\n{plan}\n\n"
                 f"Take ONE concrete step toward the goal. Read the plan — it records what's "
-                f"been tried, what's next, and what failed. Update your running checklist "
-                f"inside <goal_plan>...</goal_plan> at the end of your turn (it will be "
-                f"persisted for the next iteration). If you determine the goal is impossible "
-                f'or out of scope, emit <goal_unachievable reason="..."/> and stop.'
+                f"been tried, what's next, and what failed. Record your updated running plan "
+                f"by calling the `update_goal_plan` tool (it is persisted for the next "
+                f"iteration). If you determine the goal is impossible or out of scope, call "
+                f"the `abandon_goal` tool with a reason and stop."
             )
         evidence = (result.evidence or "").strip()
         evidence_block = f"\nEvidence:\n{evidence}\n" if evidence else "\n"
@@ -360,8 +383,8 @@ class GoalController:
             f"{evidence_block}\n"
             f"Current plan:\n{plan_block}\n\n"
             f'Keep working toward the goal: "{state.condition}".\n'
-            f"Maintain a running checklist inside a <goal_plan>...</goal_plan> block "
-            f"(update it every turn). If you determine the goal is impossible or out "
-            f'of scope, emit <goal_unachievable reason="..."/> and stop. '
-            f"Otherwise take the next concrete step now."
+            f"Record your running plan by calling the `update_goal_plan` tool (update it "
+            f"each turn — it is fed back to you here). If you determine the goal is "
+            f"impossible or out of scope, call the `abandon_goal` tool with a reason and "
+            f"stop. Otherwise take the next concrete step now."
         )

--- a/graph/goals/types.py
+++ b/graph/goals/types.py
@@ -41,8 +41,8 @@ class GoalState:
     ``verifier`` is a free-form spec dict whose ``type`` selects an entry in
     ``graph/goals/verifiers.VERIFIERS`` and whose other keys are that verifier's
     parameters (e.g. ``{"type": "command", "command": "pytest -q"}``).
-    ``checklist`` holds the model-authored ``<goal_plan>`` text, carried forward
-    across iterations so the agent keeps a running plan.
+    ``checklist`` holds the running plan the agent records with the
+    ``update_goal_plan`` tool, carried forward across iterations.
     """
 
     session_id: str
@@ -60,6 +60,9 @@ class GoalState:
     fresh_context: bool = False
     last_checked: float | None = None  # last out-of-band verifier check (monitor)
     checklist: str = ""
+    # Set by the agent's ``abandon_goal`` tool mid-turn; ``evaluate`` finishes the goal
+    # ``unachievable`` after the verifier runs (retired the ``<goal_unachievable/>`` tag).
+    abandon_reason: str = ""
     iteration: int = 0
     max_iterations: int = 8
     # Per-goal patience (ADR 0030 D4); None → the config goal_no_progress_limit.

--- a/tests/test_goal_controller.py
+++ b/tests/test_goal_controller.py
@@ -115,10 +115,12 @@ async def test_evaluate_no_progress_flags_unachievable(tmp_path):
 
 @pytest.mark.asyncio
 async def test_model_giveup_flags_unachievable(tmp_path):
-    # Verifier fails (exit 1), so the agent's give-up is honoured.
+    # Verifier fails (exit 1), so the agent's give-up (recorded mid-turn via the
+    # abandon_goal tool → request_abandon) is honoured.
     c = _ctrl(tmp_path)
     await c.parse_control('/goal {"condition": "done", "verifier": {"type": "command", "command": "exit 1"}}', "s")
-    decision = await c.evaluate("s", last_text='cannot do this <goal_unachievable reason="needs prod access"/>')
+    c.request_abandon("s", "needs prod access")
+    decision = await c.evaluate("s", last_text="cannot do this")
     assert decision.action == "done"
     assert decision.state.status == "unachievable"
     assert "prod access" in decision.state.last_reason
@@ -126,19 +128,23 @@ async def test_model_giveup_flags_unachievable(tmp_path):
 
 @pytest.mark.asyncio
 async def test_verifier_overrides_giveup(tmp_path):
-    # Ground truth wins: when the verifier passes, a same-turn give-up tag
+    # Ground truth wins: when the verifier passes, a same-turn give-up (abandon_goal)
     # must NOT mask the achievement.
     c = _ctrl(tmp_path)
     await c.parse_control('/goal {"condition": "done", "verifier": {"type": "command", "command": "exit 0"}}', "s")
-    decision = await c.evaluate("s", last_text='giving up <goal_unachievable reason="cannot proceed"/>')
+    c.request_abandon("s", "cannot proceed")
+    decision = await c.evaluate("s", last_text="giving up")
     assert decision.action == "done"
     assert decision.state.status == "achieved"
 
 
 @pytest.mark.asyncio
-async def test_checklist_extracted_and_carried(tmp_path):
+async def test_checklist_recorded_and_carried(tmp_path):
+    # The plan is recorded mid-turn via the update_goal_plan tool (→ record_plan),
+    # persisted, and fed back into the next continuation prompt.
     c = _ctrl(tmp_path)
     await c.parse_control('/goal {"condition": "done", "verifier": {"type": "command", "command": "exit 1"}}', "s")
-    decision = await c.evaluate("s", last_text="progress <goal_plan>1. do A\n2. do B</goal_plan> more")
+    c.record_plan("s", "1. do A\n2. do B")
+    decision = await c.evaluate("s", last_text="progress")
     assert "do A" in c.active_goal("s").checklist
     assert "do A" in decision.message

--- a/tests/test_goal_fresh_context.py
+++ b/tests/test_goal_fresh_context.py
@@ -108,7 +108,7 @@ def test_fresh_context_continuation_seeds_from_durable_plan(tmp_path):
     assert "make it green" in prompt  # the goal condition
     assert "2 tests still failing" in prompt  # the last verifier reason
     assert "ONE concrete step" in prompt
-    assert "<goal_plan>" in prompt
+    assert "update_goal_plan" in prompt
 
 
 def test_default_continuation_stays_same_session(tmp_path):

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -1092,6 +1092,66 @@ def _build_set_goal_tool():
     return set_goal
 
 
+def _build_goal_plan_tool():
+    """The agent records its running plan for the active goal (goal loop). Replaces the
+    retired ``<goal_plan>`` continuation tag — the plan is persisted to the goal state /
+    plan artifact and fed back into the next continuation prompt."""
+
+    @tool
+    def update_goal_plan(
+        plan: str,
+        state: Annotated[Any, InjectedState] = None,
+    ) -> str:
+        """Record/refresh your running plan for THIS session's active goal.
+
+        Call this during a goal continuation turn to carry a coherent plan across
+        iterations (what's done, what's next, what failed) — it is persisted and fed
+        back to you in the next continuation. Returns a message; it's a harmless no-op
+        when goal mode is off or no goal is active.
+        """
+        from runtime.state import STATE
+
+        if STATE.goal_controller is None:
+            return "Goal mode is not enabled."
+        session_id = _session_id_from(state)  # injected graph state, not the contextvar
+        if not session_id:
+            return "No active session — update_goal_plan can only run during a turn."
+        _ok, msg = STATE.goal_controller.record_plan(session_id, plan)
+        return msg
+
+    return update_goal_plan
+
+
+def _build_abandon_goal_tool():
+    """The agent explicitly gives up on the active goal (goal loop). Replaces the retired
+    ``<goal_unachievable/>`` tag — recorded on the goal state and honoured AFTER the
+    verifier runs, so a goal the world already satisfies still finishes ``achieved``."""
+
+    @tool
+    def abandon_goal(
+        reason: str,
+        state: Annotated[Any, InjectedState] = None,
+    ) -> str:
+        """Flag THIS session's active goal as unachievable and stop the goal loop.
+
+        Call this only when you determine the goal is impossible or out of scope, with a
+        one-line `reason`. The goal is finished ``unachievable`` after your turn — unless
+        the verifier finds it already met, which wins. Returns a message; it's a harmless
+        no-op when goal mode is off or no goal is active.
+        """
+        from runtime.state import STATE
+
+        if STATE.goal_controller is None:
+            return "Goal mode is not enabled."
+        session_id = _session_id_from(state)  # injected graph state, not the contextvar
+        if not session_id:
+            return "No active session — abandon_goal can only run during a turn."
+        _ok, msg = STATE.goal_controller.request_abandon(session_id, reason)
+        return msg
+
+    return abandon_goal
+
+
 @tool
 def load_skill(name: str) -> str:
     """Load the full step-by-step procedure for a skill.
@@ -1353,6 +1413,8 @@ def get_all_tools(
         tools.extend(_build_task_tools(tasks_store))
     if goal_enabled:
         tools.append(_build_set_goal_tool())  # ADR 0028 — agent owns a plugin-verified goal
+        tools.append(_build_goal_plan_tool())  # goal loop — record running plan (retired <goal_plan>)
+        tools.append(_build_abandon_goal_tool())  # goal loop — explicit give-up (retired <goal_unachievable>)
     # ADR 0054 — curation tools for the dream/distill subagents (read-only activity
     # + skill inventory + additive-only skill creation). Self-gate on STATE at call
     # time; present in the full set so the subagent allowlists can pick them up.


### PR DESCRIPTION
## What

Retires the last regex-parsed XML protocol in the goal system. The drive loop asked the model to wrap a running plan in `<goal_plan>…</goal_plan>` and signal give-up with `<goal_unachievable reason="…"/>`, both scraped out of the turn's final text by `GoalController`. That's the same brittle "emit XML we parse back" pattern the `<output>`/`<scratch_pad>` retirement (#1411/#1412) removed — so this replaces it with two agent tools, bound alongside `set_goal` whenever goal mode is on:

- **`update_goal_plan(plan)`** — records the running plan (fresh-context → durable plan artifact; same-session → goal state), fed back into the next continuation prompt.
- **`abandon_goal(reason)`** — flags the goal `unachievable`, honoured **after** the verifier runs so ground truth still wins (a goal the world already satisfies still finishes `achieved`).

## How

- `controller.evaluate` stops scraping `last_text`: it reads `state.abandon_reason` (set by the tool mid-turn, persisted to the goal store) and the plan the tool already persisted. New `GoalState.abandon_reason` field carries the give-up from the in-turn tool call to the post-turn evaluate.
- New `GoalController.record_plan` / `request_abandon` helpers back the tools.
- Continuation prompts, the goal-mode guide, and the configuration reference updated to reference the tools instead of the tags.
- `_GOAL_PLAN_RE` / `_GIVEUP_RE` (and the now-unused `import re`) deleted.

## Invariants preserved

Verifier-first ordering (ground truth over give-up), iteration budget/`exhausted`, and the no-progress streak are all unchanged. The two tools are harmless no-ops outside an active goal.

## Tests

`test_goal_controller.py` give-up + verifier-wins + plan-carry tests rewritten to drive via `request_abandon`/`record_plan`; `test_goal_fresh_context.py` prompt assertion updated. Full goal + tool-inventory suites pass (93 tests): `ruff` clean, `test_tools_tab_exactly_matches_the_bound_graph` absorbs the two new tools (inventory is derived from the bound graph, not hardcoded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)