### PR TITLE
fix(goals): gate /goal chat verifiers — close RCE-via-chat (#1407 Phase 1)

### DIFF
--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -38,10 +38,16 @@ Send a control message through any channel (A2A, the React console chat, OpenAI-
   ```
   /goal the README documents every config block
   ```
-- **Testable goal** (JSON spec):
+- **Testable goal** (JSON spec) — from a chat message you can use the *declarative*
+  verifiers (`plugin`, or `data` with a `contains` substring):
   ```
-  /goal {"condition": "unit tests pass", "verifier": {"type": "test", "command": "python -m pytest -q"}}
+  /goal {"condition": "migration recorded", "verifier": {"type": "data", "path": "/sandbox/state.json", "contains": "migration complete"}}
   ```
+
+  > **Shell/eval verifiers are operator-only.** `command`, `test`, `ci`, and `data`+`expr`
+  > execute on the host or hit a restricted-eval sink, so they are **refused from a `/goal`
+  > chat message** (a federation peer / API client shares the operator bearer today, #1407).
+  > A dedicated operator set-channel is the Phase 2 plan.
 - **Monitor goal** (ADR 0030) — for a metric driven by an *external* process (a
   background engine, a training run, a deployment), not the agent's turns. Add
   `"mode": "monitor"`: the agent **isn't** re-invoked, the goal **never exhausts**,

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -57,7 +57,10 @@ class GoalController:
 
     # --- control messages --------------------------------------------------
 
-    async def parse_control(self, message: str, session_id: str) -> str | None:
+    async def parse_control(self, message: str, session_id: str, *, trusted: bool = True) -> str | None:
+        # `trusted` gates which verifier types a SET may use (Phase 1 trust-gate, #1407).
+        # The server's chat entry points MUST pass trusted=False; the default stays True
+        # for the operator/programmatic path (and backward-compat) that Phase 2 re-enables.
         if not isinstance(message, str):
             return None
         stripped = message.strip()
@@ -83,6 +86,19 @@ class GoalController:
                 '`/goal {"condition": "...", "verifier": {"type": "command", '
                 '"command": "pytest -q"}}`.'
             )
+        # Phase 1 trust-gate (#1407): a /goal CHAT message is untrusted — both server call
+        # sites pass trusted=False, because a federation peer / API client shares the
+        # operator bearer today, so we can't tell them apart. Refuse the code-exec verifiers
+        # from chat for EVERYONE: command/test/ci shell out on the host, and a `data` `expr`
+        # is a restricted-eval sink + arbitrary file read (ADR 0028 D3). Only the declarative
+        # types pass — `plugin`, `llm` (fuzzy), and `data` with a plain `contains`.
+        if not trusted and not self._chat_verifier_allowed(spec):
+            return (
+                "For safety, a `command`, `test`, `ci`, or `data`+`expr` verifier can't be "
+                "set from a chat message. Use a fuzzy goal (`/goal <text>`), a `plugin` "
+                "verifier, or a `data` verifier with `contains`. (Shell/eval verifiers are "
+                "operator-only.)"
+            )
         state = GoalState(
             session_id=session_id,
             condition=condition,
@@ -94,6 +110,20 @@ class GoalController:
         )
         self._store.set(state)
         return f"Goal set. {state.status_line()}"
+
+    @staticmethod
+    def _chat_verifier_allowed(verifier: dict) -> bool:
+        """Allow-list for a verifier set from an (untrusted) /goal CHAT message (Phase 1,
+        #1407). Gate by the complement (R2): allow only the declarative, no-code-exec
+        types — `plugin`, `llm`, and `data` restricted to a plain `contains` substring.
+        Everything else (command/test/ci, and `data` carrying an `expr`) shells out or hits
+        a restricted-eval sink and stays operator-only."""
+        vtype = (verifier or {}).get("type", "llm")
+        if vtype in ("plugin", "llm"):
+            return True
+        if vtype == "data":
+            return "expr" not in verifier and "contains" in verifier
+        return False
 
     # Verifier types safe to set PROGRAMMATICALLY (agent / plugin / REST). Only
     # `plugin` qualifies (ADR 0028 D3): command/test/ci shell out, and `data`

--- a/server/chat.py
+++ b/server/chat.py
@@ -998,7 +998,7 @@ async def _chat_langgraph_stream(
             # Goal control messages (/goal ...) short-circuit the turn: set /
             # status / clear a goal and return the reply without running the graph.
             if STATE.goal_controller is not None:
-                reply = await STATE.goal_controller.parse_control(message, session_id)
+                reply = await STATE.goal_controller.parse_control(message, session_id, trusted=False)
                 if reply is not None:
                     yield ("done", reply)
                     return
@@ -1167,7 +1167,7 @@ async def _chat_langgraph(message: str, session_id: str, *, model: str | None = 
         try:
             # Goal control messages short-circuit (set / status / clear).
             if STATE.goal_controller is not None:
-                reply = await STATE.goal_controller.parse_control(message, session_id)
+                reply = await STATE.goal_controller.parse_control(message, session_id, trusted=False)
                 if reply is not None:
                     return [{"role": "assistant", "content": reply}]
 

--- a/tests/test_goal_controller.py
+++ b/tests/test_goal_controller.py
@@ -142,3 +142,62 @@ async def test_checklist_extracted_and_carried(tmp_path):
     decision = await c.evaluate("s", last_text="progress <goal_plan>1. do A\n2. do B</goal_plan> more")
     assert "do A" in c.active_goal("s").checklist
     assert "do A" in decision.message
+
+
+# --- Phase 1 chat trust-gate (#1407) ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_untrusted_chat_refuses_shell_and_eval_verifiers(tmp_path):
+    # command/test/ci shell out; data+expr is a restricted-eval sink — all refused from a
+    # chat message (trusted=False), and NOTHING is set.
+    c = _ctrl(tmp_path)
+    dangerous = [
+        '/goal {"condition": "x", "verifier": {"type": "command", "command": "rm -rf /"}}',
+        '/goal {"condition": "x", "verifier": {"type": "test", "command": "pytest"}}',
+        '/goal {"condition": "x", "verifier": {"type": "ci", "pr": 1}}',
+        '/goal {"condition": "x", "verifier": {"type": "data", "path": "/x", "expr": "1"}}',
+    ]
+    for msg in dangerous:
+        reply = await c.parse_control(msg, "s", trusted=False)
+        assert "can't be" in reply.lower(), msg
+        assert c.active_goal("s") is None, msg
+
+
+@pytest.mark.asyncio
+async def test_untrusted_chat_allows_declarative_verifiers(tmp_path):
+    c = _ctrl(tmp_path)
+    ok = [
+        "/goal make the build green",  # fuzzy → llm
+        '/goal {"condition": "x", "verifier": {"type": "plugin", "check": "p:v"}}',
+        '/goal {"condition": "x", "verifier": {"type": "data", "path": "/x", "contains": "ok"}}',
+    ]
+    for msg in ok:
+        reply = await c.parse_control(msg, "s", trusted=False)
+        assert "Goal set" in reply, msg
+        c._store.clear("s")
+
+
+@pytest.mark.asyncio
+async def test_trusted_default_keeps_full_verifier_access(tmp_path):
+    # The operator/programmatic path (trusted=True, the default) is unchanged — Phase 2
+    # threads a real trust signal into the chat call sites.
+    c = _ctrl(tmp_path)
+    reply = await c.parse_control(
+        '/goal {"condition": "x", "verifier": {"type": "command", "command": "exit 0"}}', "s"
+    )
+    assert "Goal set" in reply
+    assert c.active_goal("s").verifier["type"] == "command"
+
+
+def test_chat_verifier_allow_list():
+    allowed = GoalController._chat_verifier_allowed
+    assert allowed({"type": "plugin", "check": "p:v"})
+    assert allowed({"type": "llm"})
+    assert allowed({})  # no type → defaults to llm
+    assert allowed({"type": "data", "contains": "ok"})
+    assert not allowed({"type": "data", "expr": "1"})
+    assert not allowed({"type": "data", "contains": "ok", "expr": "1"})  # expr present → refused
+    assert not allowed({"type": "command", "command": "x"})
+    assert not allowed({"type": "test"})
+    assert not allowed({"type": "ci"})


### PR DESCRIPTION
## Security fix — RCE via a `/goal` chat message

A `/goal {"condition":"…","verifier":{"type":"command","command":"…"}}` chat message reached `GoalController.parse_control`, which set the goal and later ran a `command`/`test`/`ci` verifier that **shells out on the host** — remote code execution. Both the A2A stream handler and the console/`/v1` handler share the operator bearer with federation peers / API clients (ADR 0045 "A2A canonical"), so nothing distinguished a trusted operator from a semi-trusted caller. Surfaced by the goal trust-gate antagonistic review (2026-06-28); this is **Phase 1** of `docs/dev/notes/goal-trust-gate-token-model.md` — the mitigation that needs **no auth-model decision**.

## The fix (allow-list, gate the complement — R2)

- `parse_control(..., *, trusted: bool = True)`. **Both** server chat call sites (`server/chat.py` A2A + `/v1`) now pass `trusted=False`.
- An untrusted set may use only the **declarative, no-code-exec** verifiers: `plugin`, `llm` (fuzzy), and `data` with a plain `contains` substring. `command` / `test` / `ci` and `data`+`expr` are refused with a clear message; **nothing is set**.
- `trusted=True` (the default) preserves the operator/programmatic path byte-for-byte, so **Phase 2** can re-enable dangerous verifiers via a real token/channel *without re-touching the call sites*.
- Status / clear / `plugin` / fuzzy `/goal <text>` are unaffected.

## Design notes for review

- **Allow-list, not deny-list** (R2): a new verifier type is refused by default until explicitly allow-listed. `_chat_verifier_allowed` is the single source of truth.
- **`data`+`contains` residual:** it still reads an arbitrary `path` (a substring-existence **info-leak**, not code-exec). Allowed per the note's R2; trivially tightened to `{plugin, llm}` only if you'd rather not expose file reads to an untrusted caller — say the word.
- **Not in scope (Phase 2, task #6):** the R1 `/api` path-ceiling (a federation credential must be denied plugin-install/config-rewrite) and the two-token-vs-operator-channel decision. This PR is the standalone Phase 1 hole-closer.

## Tests

`test_goal_controller.py`: untrusted chat refuses command/test/ci/data-expr (asserts nothing is set) and allows plugin/llm/data-contains; trusted default keeps full access; `_chat_verifier_allowed` unit-tested. 25 pass (`ruff` clean; `test_goal_set_programmatic` still green — the programmatic gate is untouched).

Independent of #1491 (touches a different region of `controller.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)