### PR TITLE
fix(web): grant allow-pointer-lock to palette-morph plugin iframes

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -525,7 +525,7 @@ export function App() {
       icon: pluginViewIcon(v.icon),
       theme: consoleTheme(),
       token: authToken(),
-      sandbox: "allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox",
+      sandbox: "allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-pointer-lock",
     }));
   // Inline chat with the focused agent (ADR 0057) — ⌘K → a quick chat that streams via
   // api.streamChat (ephemeral context per open). Memoized so the transport (+ its

--- a/apps/web/src/app/Launcher.tsx
+++ b/apps/web/src/app/Launcher.tsx
@@ -64,7 +64,7 @@ export function Launcher() {
       icon: pluginIcon(),
       theme: consoleTheme(),
       token: authToken(),
-      sandbox: "allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox",
+      sandbox: "allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-pointer-lock",
     }));
 
   // Inline quick-chat with the focused agent (host, since the launcher loads /app/).


### PR DESCRIPTION
## What

Pointer lock is blocked unless **every** ancestor frame in the chain grants it. For a plugin artifact the chain is:

```
console document
 └─ plugin-view iframe        ← the sandboxed host frame
     └─ artifact #frame        ← generated code
```

The rail `PluginView` iframe (`PluginView.tsx`) and the artifact plugin's nested `#frame` already carry `allow-pointer-lock`, but the **two palette-morph iframes** were missed:

- `apps/web/src/app/App.tsx` — the in-app ⌘K palette morph
- `apps/web/src/app/Launcher.tsx` — the launcher palette morph

Any plugin view that opts into palette morphing (`views[].palette`) has pointer lock blocked by the sandboxed ancestor frame. This aligns all three sandbox strings by adding `allow-pointer-lock`.

## Why it surfaced

The artifact panel itself is rail-only (no `palette:` in its manifest), so it isn't hit today — the live "Blocked pointer lock … 'allow-pointer-lock' permission is not set" report was actually a **stale `apps/web/dist`** predating the committed `PluginView.tsx` fix (rebuilding the console resolves that). This PR closes the remaining *latent* gap so palette-morph views (or artifact, if it ever adds `palette:`) don't regress.

## Test

- `npm run build --workspace @protoagent/web` — clean; all three sandbox strings now include `allow-pointer-lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)