### PR TITLE
feat(goals): sdk.run_in_session — a goal-fire → follow-up-agent-turn primitive

### DIFF
--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -92,7 +92,26 @@ A terminal goal is a **trigger**, not just a checkbox. Every finish publishes on
 Two ways to react:
 
 - **No code (any plugin / the console).** Subscribe to the topic — `registry.on("goal.achieved", …)` in a plugin, or `protoagent:subscribe` from a sandboxed view. The built-in console toast is exactly this. Because it's the bus, **nobody imports the goal system** to listen.
-- **Plugin code (richer).** `register_goal_hook(on_achieved=…, on_failed=…)` hands your plugin the terminal `GoalState` to run arbitrary logic — set the next goal (phase progression), kick a follow-up agent turn via `host.invoke`, stop a background engine, alert. This is how a fork drives an autonomous loop: *set a monitor goal → external engine runs → the cadence tick verifies → the hook advances.*
+- **Plugin code (richer).** `register_goal_hook(on_achieved=…, on_failed=…)` hands your plugin the terminal `GoalState` to run arbitrary logic — set the next goal (phase progression), **prompt the agent with a follow-up turn** (`sdk.run_in_session`, below), stop a background engine, alert. This is how a fork drives an autonomous loop: *set a monitor goal → external engine runs → the cadence tick verifies → the hook advances.*
+
+### Goal fires → run a follow-up agent turn
+
+To have the agent *act* when a goal fires — not just record a status — call `sdk.run_in_session(session_id, prompt)` from a hook. It enqueues the prompt as a **one-shot agent turn in the goal's own session** (that session's memory + full tools), runs it on the normal scheduler fire path, and returns immediately — so it's safe to call from a hook or the monitor tick without blocking:
+
+```python
+from graph import sdk
+
+def register(registry):
+    async def on_achieved(goal):                # terminal GoalState
+        sdk.run_in_session(
+            goal.session_id,
+            f"The goal '{goal.condition}' just completed. Evidence: {goal.last_evidence}. "
+            f"Summarize the outcome and start the follow-up work.",
+        )
+    registry.register_goal_hook(on_achieved=on_achieved)
+```
+
+Pass `job_id=` to make the re-arm idempotent, or `delay_seconds=` to defer the turn. This is the *reaction* half of the self-improving loop: `sdk.start_goal_loop` **drives** a goal; a hook + `run_in_session` **reacts** when it lands.
 
 ## Verifier types
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -172,6 +172,12 @@ SDK** directly — `from graph.sdk import …`, the *stable* surface plugins cal
   completion (vs `host.invoke`, which runs a full lead-agent *chat turn*).
 - `subagent_types()` — the configured subagent ids.
 - `config()` — the live `LangGraphConfig`.
+- `run_in_session(session_id, prompt, *, delay_seconds=0, job_id=None)` — enqueue a
+  **non-blocking one-shot agent turn** in a session (that session's memory + full tools).
+  The primitive behind "when a goal fires, prompt the agent" — call it from a
+  `register_goal_hook` reaction. See [Goal mode ▸ Reacting to a goal](/guides/goal-mode#reacting-to-a-goal).
+- `start_goal_loop(...)` / `stop_goal_loop(...)` — declare/tear down a goal-driven recurring
+  loop (a goal + a scheduler tick) in one call.
 
 The **workflows plugin** (`plugins/workflows`) is the reference consumer: its engine
 injects `run_subagent` as the per-step runner. This is the pattern for plugins that tap

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -251,3 +251,67 @@ def stop_goal_loop(*, session_id: str, job_id: str | None = None) -> dict:
     if job_id and STATE.scheduler is not None:
         cancelled = STATE.scheduler.cancel_job(job_id)
     return {"ok": True, "goal_cleared": cleared, "job_cancelled": cancelled}
+
+
+def run_in_session(
+    session_id: str,
+    prompt: str,
+    *,
+    delay_seconds: float = 0.0,
+    job_id: str | None = None,
+) -> dict:
+    """Enqueue ``prompt`` as a one-shot agent turn in ``session_id`` — non-blocking.
+
+    This is the primitive behind "when a goal fires, prompt the agent." Call it from a
+    goal ``on_achieved`` / ``on_failed`` hook (``registry.register_goal_hook(...)``) — or
+    any plugin event handler — with a prompt built from the terminal ``GoalState`` (its
+    ``condition`` / ``last_reason`` / ``last_evidence``), and the agent runs a follow-up
+    turn (with that session's memory and full tool set) reacting to what just happened::
+
+        async def on_achieved(goal):
+            sdk.run_in_session(
+                goal.session_id,
+                f"The goal '{goal.condition}' just completed. Evidence: {goal.last_evidence}. "
+                f"Write up a summary and open the follow-up PR.",
+            )
+        registry.register_goal_hook(on_achieved=on_achieved)
+
+    Mechanics: it schedules a **one-shot** job (an ISO fire time, not a cron) into the
+    session's context via the scheduler, so the turn runs on the normal fire path (the
+    same loopback A2A call cron ticks use) and the caller returns immediately. It NEVER
+    runs the turn inline, so it is safe to call from a goal hook / monitor tick without
+    blocking it.
+
+    Args:
+        session_id: the A2A contextId to run the turn in (e.g. ``goal.session_id``).
+        prompt: the message the agent processes as a turn.
+        delay_seconds: fire at now + this delay (default 0 → the next poll tick, ~1s).
+        job_id: a stable id so a re-call REPLACES the pending one-shot (idempotent).
+
+    Returns ``{"ok", "job_id", "fires_at", "message"}``; ``ok=False`` with a readable
+    message when the scheduler is unavailable or the inputs are bad.
+    """
+    scheduler = STATE.scheduler
+    if scheduler is None:
+        return {"ok": False, "message": "scheduler unavailable — cannot enqueue a turn"}
+    if not (session_id or "").strip():
+        return {"ok": False, "message": "session_id is required"}
+    if not (prompt or "").strip():
+        return {"ok": False, "message": "prompt is required"}
+    from datetime import UTC, datetime, timedelta
+
+    fires_at = (datetime.now(UTC) + timedelta(seconds=max(0.0, delay_seconds))).isoformat()
+    # Idempotent replace: add_job RAISES on a duplicate id (it never overwrites), so drop
+    # any pending one-shot with this id first — a re-call re-arms rather than colliding.
+    if job_id:
+        scheduler.cancel_job(job_id)
+    try:
+        job = scheduler.add_job(prompt, fires_at, job_id=job_id, context_id=session_id)
+    except ValueError as e:
+        return {"ok": False, "message": f"could not enqueue turn: {e}"}
+    return {
+        "ok": True,
+        "job_id": job.id,
+        "fires_at": fires_at,
+        "message": f"turn enqueued in session {session_id!r} (fires {'now' if delay_seconds <= 0 else f'+{delay_seconds:g}s'})",
+    }

--- a/tests/test_goal_loop.py
+++ b/tests/test_goal_loop.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import pytest
 
 from graph import sdk
-from graph.sdk import _to_cron, start_goal_loop, stop_goal_loop
+from graph.sdk import _to_cron, run_in_session, start_goal_loop, stop_goal_loop
 from runtime.state import STATE
+from scheduler.interface import is_cron
 
 
 # ── _to_cron ─────────────────────────────────────────────────────────────────────────
@@ -168,3 +169,35 @@ def test_stop_goal_loop_without_job_id_just_clears(wired):
 
 def test_sdk_module_exposes_the_helpers():
     assert callable(sdk.start_goal_loop) and callable(sdk.stop_goal_loop)
+
+
+# ── run_in_session (goal fires → run a prompt as an agent turn) ───────────────────────
+def test_run_in_session_enqueues_a_one_shot_into_the_session(wired):
+    _ctrl, sched = wired
+    res = run_in_session("sess-9", "Summarize what just happened and open the next PR.")
+    assert res["ok"] and res["job_id"] == "job-1"
+    add = sched.added[0]
+    assert add["context_id"] == "sess-9"  # fires into the goal's OWN session
+    assert add["prompt"].startswith("Summarize")
+    assert not is_cron(add["schedule"])  # a one-shot ISO fire time, not a recurring cron
+
+
+def test_run_in_session_requires_scheduler_and_inputs(monkeypatch):
+    monkeypatch.setattr(STATE, "scheduler", None)
+    assert not run_in_session("s", "p")["ok"]  # no scheduler
+    sched = _Scheduler()
+    monkeypatch.setattr(STATE, "scheduler", sched)
+    assert not run_in_session("", "p")["ok"]  # empty session
+    assert not run_in_session("s", "  ")["ok"]  # empty prompt
+    assert sched.added == []  # nothing enqueued on bad input
+
+
+def test_run_in_session_job_id_replaces_the_pending_one_shot(wired):
+    _ctrl, sched = wired
+    run_in_session("s", "p", job_id="reaction-1")
+    assert sched.cancelled == ["reaction-1"]  # idempotent: drop any existing before re-adding
+    assert sched.added[0]["job_id"] == "reaction-1"
+
+
+def test_sdk_module_exposes_run_in_session():
+    assert callable(sdk.run_in_session)


### PR DESCRIPTION
## What

Makes "**when a goal fires, prompt the agent and run a turn**" a one-liner. The goal system could already *react* to a terminal goal (`register_goal_hook` / the `goal.achieved`/`goal.failed` bus events), but turning that reaction into an actual agent turn meant hand-rolling glue: `run_subagent` **blocks** the evaluate/monitor tick if called inline, and `scheduler.add_job` wants a cron for what is really a one-shot.

New consumption-SDK primitive:

```python
sdk.run_in_session(session_id, prompt, *, delay_seconds=0.0, job_id=None) -> dict
```

It enqueues a **one-shot agent turn** into the session (an ISO fire-time job, not a cron), so the turn runs on the scheduler's normal loopback-A2A fire path — **that session's memory + full tools** — and the caller **returns immediately**. It never runs inline, so it's safe to call from a goal hook or the monitor tick without blocking. `job_id` makes the re-arm idempotent (cancel-then-add, since `add_job` raises on a duplicate id); `delay_seconds` defers the fire.

## The pattern it unlocks

```python
from graph import sdk

def register(registry):
    async def on_achieved(goal):        # terminal GoalState
        sdk.run_in_session(
            goal.session_id,
            f"The goal '{goal.condition}' just completed. Evidence: {goal.last_evidence}. "
            f"Summarize the outcome and start the follow-up work.",
        )
    registry.register_goal_hook(on_achieved=on_achieved)
```

This is the **reaction** half of the self-improving loop: `sdk.start_goal_loop` *drives* a goal; a hook + `run_in_session` *reacts* when it lands. (Requested feature.)

## Design notes

- **Reuses the scheduler's turn path** (`_fire`'s loopback A2A: auth, contextId, retry, `scheduler.fired` bus event) rather than a parallel turn-runner. The one-shot is persisted (survives a restart until it fires) and visible in the scheduler surface.
- **Never inline** — the whole point is not to block the goal evaluate/monitor tick.
- Graceful `ok=False` (no scheduler / empty inputs); no new agent-facing tool (this is a plugin/SDK primitive, not an agent capability).

## Tests / docs

`test_goal_loop.py`: enqueue-into-session (asserts one-shot, not cron; fires into `context_id`), scheduler/input guards, idempotent replace, module export. 25 pass, `ruff` clean. Goal-mode guide gains a "Goal fires → run a follow-up agent turn" section; plugins guide lists the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)