### PR TITLE
refactor(goals): unify the drive-loop fresh-context continuation config

### DIFF
--- a/server/chat.py
+++ b/server/chat.py
@@ -93,6 +93,27 @@ def _resolve_thread_id(request_metadata: dict | None, session_id: str) -> str:
     return f"a2a:{session_id}"
 
 
+def _goal_continuation_config(config: dict, goal_state) -> dict:
+    """The LangGraph config for one goal *continuation* turn.
+
+    Same-session goals reuse ``config`` (the checkpointer keeps the transcript so the model
+    sees prior iterations). Fresh-context goals (Ralph loop) get a scoped, per-iteration
+    ``thread_id`` so the checkpointer starts clean each turn — derived from the CURRENT
+    ``config`` thread_id so the streaming (``a2a:…``) and non-streaming (``chat:…``) drive
+    loops build it identically instead of each hand-rolling it. (They had drifted: the two
+    paths re-derived the base thread_id differently and only the streaming one set
+    ``recursion_limit`` — this unifies both.) Durable state lives in the goal's plan
+    artifact on disk, not the thread.
+    """
+    if not (goal_state and getattr(goal_state, "fresh_context", False)):
+        return config
+    base_tid = (config.get("configurable") or {}).get("thread_id") or "goal"
+    return {
+        "configurable": {"thread_id": f"{base_tid}:goal-iter-{goal_state.iteration}"},
+        "recursion_limit": 200,
+    }
+
+
 # One ACP runtime per thread (the ACP session is stateful — the coding agent holds
 # history, so we reuse it across turns; ADR 0033 slice 4).
 _ACP_RUNTIMES: dict[str, Any] = {}
@@ -903,17 +924,9 @@ async def _run_native_turn(message, session_id, config, *, request_metadata=None
             yield ("tool_start", f"🎯 {decision.note}")
             if decision.action == "done":
                 break
-            # For fresh-context goals, create a scoped thread so the checkpointer starts
-            # clean — no accumulated transcript from prior iterations.
-            goal_state = decision.state
-            if goal_state and goal_state.fresh_context:
-                base_tid = _resolve_thread_id(request_metadata, session_id)
-                cont_config = {
-                    "configurable": {"thread_id": f"{base_tid}:goal-iter-{goal_state.iteration}"},
-                    "recursion_limit": 200,
-                }
-            else:
-                cont_config = config  # same-session (existing behavior)
+            # Fresh-context goals get a scoped per-iteration thread; same-session reuse
+            # `config`. Shared helper keeps the streaming + non-streaming loops in lockstep.
+            cont_config = _goal_continuation_config(config, decision.state)
 
             cont_raw = ""
             with goal_turn():
@@ -1250,15 +1263,9 @@ async def _chat_langgraph(message: str, session_id: str, *, model: str | None = 
                     note = decision.note
                     if decision.action == "done":
                         break
-                    # For fresh-context goals, create a scoped thread so the checkpointer
-                    # starts clean — no accumulated transcript from prior iterations.
-                    goal_state = decision.state
-                    if goal_state and goal_state.fresh_context:
-                        cont_config = {
-                            "configurable": {"thread_id": f"chat:{session_id}:goal-iter-{goal_state.iteration}"},
-                        }
-                    else:
-                        cont_config = config
+                    # Fresh-context goals get a scoped per-iteration thread; same-session
+                    # reuse `config`. Same shared helper as the streaming path (no drift).
+                    cont_config = _goal_continuation_config(config, decision.state)
 
                     with goal_turn():
                         result = await STATE.graph.ainvoke(

--- a/tests/test_thread_id_resolver.py
+++ b/tests/test_thread_id_resolver.py
@@ -6,8 +6,14 @@ server/chat.py. Unset ⇒ the template default `a2a:<session_id>`."""
 # Import the helper directly: the re-exported `chat` function shadows the
 # `server.chat` submodule on the package attribute, so `server.chat._resolve_...`
 # would resolve to the function. The symbol itself is unambiguous.
-from server.chat import _resolve_thread_id
+from types import SimpleNamespace
+
+from server.chat import _goal_continuation_config, _resolve_thread_id
 from runtime.state import STATE
+
+
+def _goal(fresh, iteration=3):
+    return SimpleNamespace(fresh_context=fresh, iteration=iteration)
 
 
 def test_default_when_no_resolver(monkeypatch):
@@ -61,3 +67,29 @@ def test_loader_last_plugin_wins(monkeypatch):
     result.thread_id_resolver = r1
     result.thread_id_resolver = r2  # later plugin overrides
     assert result.thread_id_resolver is r2
+
+
+# --- _goal_continuation_config (unify the drive-loop fresh-context thread-id) ---------
+
+
+def test_same_session_goal_reuses_config():
+    # Non-fresh-context: the checkpointer keeps history, so continuation reuses the config
+    # object as-is (identity — no new dict).
+    cfg = {"configurable": {"thread_id": "a2a:s1"}, "recursion_limit": 200}
+    assert _goal_continuation_config(cfg, _goal(False)) is cfg
+    assert _goal_continuation_config(cfg, None) is cfg  # no active goal state
+
+
+def test_fresh_context_scopes_thread_from_current_config():
+    # Streaming (a2a:) and non-streaming (chat:) bases both derive the SAME shape — the
+    # per-iteration sub-thread comes from the CURRENT thread_id (no drift), recursion_limit
+    # normalized on both.
+    a2a = _goal_continuation_config({"configurable": {"thread_id": "a2a:s1"}, "recursion_limit": 200}, _goal(True, 4))
+    assert a2a == {"configurable": {"thread_id": "a2a:s1:goal-iter-4"}, "recursion_limit": 200}
+    chat = _goal_continuation_config({"configurable": {"thread_id": "chat:s1"}}, _goal(True, 1))
+    assert chat == {"configurable": {"thread_id": "chat:s1:goal-iter-1"}, "recursion_limit": 200}
+
+
+def test_fresh_context_missing_thread_id_falls_back():
+    out = _goal_continuation_config({}, _goal(True, 2))
+    assert out["configurable"]["thread_id"] == "goal:goal-iter-2"


### PR DESCRIPTION
## What

The two goal drive loops in `server/chat.py` — the A2A streaming path (`_run_native_turn`) and the non-streaming console/`/v1` path (`_chat_langgraph`) — each hand-rolled the per-iteration **continuation config** for a fresh-context goal, and had **drifted**:

| | base thread_id | recursion_limit |
|---|---|---|
| streaming | `_resolve_thread_id(request_metadata, session_id)` | 200 |
| non-streaming | `chat:{session_id}` | *(none)* |

## The fix

Extract one helper, `_goal_continuation_config(config, goal_state)`:
- **same-session** goals → reuse the `config` object (checkpointer keeps the transcript);
- **fresh-context** goals → derive the scoped sub-thread `…:goal-iter-N` from the **current** `config`'s `thread_id`, and always set `recursion_limit: 200`.

Both loops now call it, so they build the continuation config identically — no drift.

## Behavior

- **Streaming: byte-for-byte identical.** In that path `config["configurable"]["thread_id"]` is already `_resolve_thread_id(request_metadata, session_id)` (set at the call site), so deriving from the current config yields the exact same `…:goal-iter-N`, and `recursion_limit` was already 200.
- **Non-streaming: one intentional normalization** — its fresh-context continuations now also get `recursion_limit: 200` (they previously fell back to the default and could trip the recursion cap on a deep continuation). Same-session behavior unchanged.

A full loop-body merge was considered and rejected: the two loops legitimately differ (one streams frames via `_run_turn_stream`, the other returns text via `graph.ainvoke`), so the continuation *config* is the real shared/drifted surface.

## Tests

`test_thread_id_resolver.py`: same-session identity reuse, fresh-context derivation for both `a2a:`/`chat:` bases, missing-thread_id fallback. Chat stream-finalization + non-streaming-robustness + goal + fresh-context suites all green (32 passed); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in goal-mode chat sessions so continuation threads now stay aligned across streaming and non-streaming interactions.
  * Fresh-context iterations now create a stable per-iteration continuation scope, helping prevent context mix-ups during multi-step conversations.
  * When no prior thread is available, chat continuations now fall back to a predictable default thread identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->