### PR TITLE
feat(goals): surface live goal.iteration progress in the Goals panel

### DIFF
--- a/apps/web/src/app/GoalsPanel.tsx
+++ b/apps/web/src/app/GoalsPanel.tsx
@@ -44,12 +44,15 @@ function GoalsList() {
     onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.goals }),
   });
 
-  // Live: the agent set/advanced/cleared a goal mid-turn — refresh off the `goal.changed`
-  // bus push instead of polling every 5s (#1310), the same pattern as the inbox panel.
-  useEffect(
-    () => onServerEvent("goal.changed", () => void queryClient.invalidateQueries({ queryKey: queryKeys.goals })),
-    [queryClient],
-  );
+  // Live: refresh off the goal bus instead of polling every 5s (#1310), the same pattern as
+  // the inbox panel. `goal.changed` fires when the agent set/advanced/cleared a goal mid-turn;
+  // `goal.iteration` fires on each drive-goal continuation (ADR 0051 Slice 3) so the row's
+  // `iter N/max` + last-reason updates live while the loop runs.
+  useEffect(() => {
+    const refresh = () => void queryClient.invalidateQueries({ queryKey: queryKeys.goals });
+    const offs = [onServerEvent("goal.changed", refresh), onServerEvent("goal.iteration", refresh)];
+    return () => offs.forEach((off) => off());
+  }, [queryClient]);
 
   if (!goals.length) {
     return (


### PR DESCRIPTION
## What

Subscribe the console Goals panel (`apps/web/src/app/GoalsPanel.tsx`) to the `goal.iteration` bus event, in addition to the existing `goal.changed` subscription. On each drive-goal continuation the panel now invalidates `queryKeys.goals`, so the already-rendered `iter N/max` progress + last-reason row refresh live while a drive goal loops.

The panel diff is minimal — the two subscriptions share one `refresh` callback in a single `useEffect` (mirrors the prior code style; no redesign, no new imports).

## Why / what I verified about SSE forwarding

- The backend already publishes `goal.iteration` `{session_id, condition, iteration, max_iterations, reason}` on the plugin bus for every drive-goal continuation — `graph/goals/controller.py`, the `HOST.publish("goal.iteration", …)` block in `evaluate` (ADR 0051 Slice 3).
- `HOST.publish` is wired directly to the in-process `EventBus.publish` (`server/agent_init.py`), and the SSE bridge `_sse_frames` in `operator_api/routes.py` streams **every** bus event as an unnamed SSE frame carrying `{topic, data, seq}` — there is **no** server-side topic allow-list. The client (`apps/web/src/lib/events.ts` `dispatch`) is what filters by topic. **So `goal.iteration` already reached the browser; nothing had to be added to any forward/allow-list.** The only gap was that the panel didn't subscribe to it.
- Note: `store.set(state)` (called in `evaluate` right after `iteration += 1`) already emits `goal.changed`, so the panel may already have refreshed on continuations via that path. This PR adds the semantically-explicit `goal.iteration` subscription so the live-progress path is intentional and robust to any future reordering/removal of that incidental `goal.changed`.
- The goals API (`_operator_goals_list` → `GoalState.to_dict()` = `asdict`) serializes `iteration` / `max_iterations` / `last_reason`, which the row already renders — so query invalidation surfaces the fresh values.

## Out of scope

The separate "POST /api/goals set-path form" was intentionally not touched.

## Gates

- No `lint` script exists in `@protoagent/web`; typecheck runs via `tsc --noEmit` inside `npm run build`. `node_modules` was absent (no hoisted root install), so a full install/build was skipped as too heavy. The change was reviewed for TS self-consistency instead: `onServerEvent` returns a `() => void` unsubscribe, `offs` is an array of those, the cleanup returns `() => void`, all imports/deps unchanged. **The full typecheck/build was NOT run.**

## DRAFT — visual verification needed

This is under the console local-test gate: CI can't judge the live UX. Opening as **DRAFT** for the user to verify visually (run a drive goal, watch the `iter N/max` + last-reason update as the loop continues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)