### PR TITLE
feat(goals): monitor-goal deadline + stall_after (ADR 0030 D5)

### DIFF
--- a/docs/adr/0030-monitor-goals.md
+++ b/docs/adr/0030-monitor-goals.md
@@ -107,12 +107,24 @@ Make it per-goal too (`GoalState.no_progress_limit`, defaulting to the config), 
 `drive` goal can widen its own patience without changing the global default. Tiny, additive,
 useful regardless of D1–D3.
 
-### D5 — stall signal (optional)
+### D5 — deadline + stall signal (BUILT)
 
-A monitor goal may set an optional `stall_after` (N checks with unchanged evidence) that
-fires an **`on_stalled`** hook — *without* ending the goal. This surfaces "the background
-engine stopped earning" as an actionable signal (notify, record a finding, set a remediation
-goal) while keeping the objective alive. Strictly optional; omit in the first slice.
+A monitor goal may set two optional plain-data fields:
+
+- **`deadline`** (ISO-8601 string or epoch seconds) — a hard stop. When an out-of-band
+  check finds the goal still unmet at/after the deadline, it finishes **`expired`** — a
+  *non-achieved* terminal, so it fires `on_failed` + the `goal.failed` bus event like
+  `exhausted`/`unachievable`.
+- **`stall_after`** (N checks with unchanged verifier evidence) — fires a new
+  **`on_stalled`** hook *without* ending the goal, surfacing "the background engine stopped
+  earning" as an actionable signal (notify, record a finding, set a remediation goal) while
+  keeping the objective alive. Fires **once per stall episode** (re-armed when the evidence
+  changes) and also publishes a best-effort `goal.stalled` bus event.
+
+Both live on `GoalState` (`deadline`, `stall_after`, plus the `stall_streak` /
+`stalled_notified` bookkeeping) and are handled in `controller.evaluate`'s monitor branch.
+Since they're data (not verifiers), the ADR-0028 D3 safe-programmatic-set gate and the
+Phase 1 chat trust-gate are unaffected.
 
 ## Consequences
 
@@ -152,7 +164,12 @@ goal) while keeping the objective alive. Strictly optional; omit in the first sl
 - **PR2** — the `monitor` disposition + the scheduler evaluate tick (D1, D2.1, D3). The core:
   makes long-horizon objectives work end-to-end via ADR-0028 hooks.
 - **PR3** — `controller.evaluate_now(session_id)` for prompt event-driven detection (D2.2).
-- **Future** — `on_stalled` / `deadline → expired` (D5).
+- **PR4 — BUILT** — the D5 slice: monitor-goal `deadline → expired` (a non-achieved
+  terminal firing `on_failed` + `goal.failed`) and `stall_after` → a new `on_stalled`
+  hook (fired once per stall episode without ending the goal; re-armed when the
+  verifier evidence changes; also emits a best-effort `goal.stalled` bus event).
+  Both are plain data fields on the goal spec (`deadline` ISO-8601/epoch, `stall_after`
+  int) — not verifiers, so the Phase 1 chat trust-gate is unaffected.
 
 ## Reference implementation
 

--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -57,6 +57,22 @@ Send a control message through any channel (A2A, the React console chat, OpenAI-
   /goal {"condition": "treasury ≥ 1,000,000", "mode": "monitor", "verifier": {"type": "plugin", "check": "spacetraders:credits", "args": {"min": 1000000}}}
   ```
   (Default is `"mode": "drive"` — the agent *is* the work, the bounded loop above.)
+  A monitor goal otherwise ends only on **achieved** or **cleared**; two optional
+  fields (ADR 0030 D5) bound it and surface trouble:
+  - `"deadline"` — an **ISO-8601 timestamp** (`"2026-07-01T00:00:00"`) or a raw
+    **epoch-seconds** number. If the goal isn't met by the deadline, the next
+    out-of-band check finishes it with terminal status **`expired`** — a
+    *non-achieved* terminal, so it fires `on_failed` + the `goal.failed` bus event
+    just like `exhausted`/`unachievable`.
+  - `"stall_after"` — an integer **N**. After N consecutive checks with **unchanged**
+    verifier evidence, a **`on_stalled`** hook fires (register it with
+    `register_goal_hook(on_stalled=…)`) — a signal that the external engine stopped
+    moving. It does **not** end the goal (the objective stays alive), fires **once per
+    stall episode**, and re-arms when the evidence changes. It also publishes a
+    best-effort `goal.stalled` bus event (`{session_id, condition, stall_streak, reason}`).
+  ```
+  /goal {"condition": "treasury ≥ 1,000,000", "mode": "monitor", "deadline": "2026-07-01T00:00:00", "stall_after": 5, "verifier": {"type": "plugin", "check": "spacetraders:credits", "args": {"min": 1000000}}}
+  ```
 - **Per-goal patience:** add `"no_progress_limit": N` to widen/narrow one goal's
   no-progress tolerance without changing the global default.
 - **Status:** `/goal`

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -75,7 +75,7 @@ class GoalController:
             return "Goal cleared." if existed else "No active goal to clear."
 
         # /goal {json}  or  /goal <free text>  → set
-        spec, condition, max_iters, no_progress, mode, fresh_context = self._parse_set(rest)
+        spec, condition, max_iters, no_progress, mode, fresh_context, deadline, stall_after = self._parse_set(rest)
         if condition is None:
             return (
                 "Could not parse goal. Use `/goal <text>` or "
@@ -103,6 +103,8 @@ class GoalController:
             fresh_context=fresh_context,
             max_iterations=max_iters or getattr(self._config, "goal_max_iterations", 8),
             no_progress_limit=no_progress,  # per-goal patience (ADR 0030 D4); None → config
+            deadline=deadline,  # monitor deadline → expired (ADR 0030 D5)
+            stall_after=stall_after,  # monitor stall signal → on_stalled (ADR 0030 D5)
         )
         self._store.set(state)
         return f"Goal set. {state.status_line()}"
@@ -134,6 +136,8 @@ class GoalController:
         max_iterations: int | None = None,
         no_progress_limit: int | None = None,
         mode: str = "drive",
+        deadline: float | None = None,
+        stall_after: int | None = None,
     ) -> tuple[bool, str]:
         """Set a goal from a NON-operator caller (an agent tool, a plugin, REST).
         Accepts ONLY a `plugin` verifier — refuses command/test/ci/data/llm so a
@@ -157,6 +161,8 @@ class GoalController:
             mode=("monitor" if mode == "monitor" else "drive"),  # ADR 0030 (still plugin-gated)
             max_iterations=max_iterations or getattr(self._config, "goal_max_iterations", 8),
             no_progress_limit=no_progress_limit,  # per-goal patience (ADR 0030 D4)
+            deadline=deadline,  # monitor deadline → expired (ADR 0030 D5)
+            stall_after=stall_after,  # monitor stall signal → on_stalled (ADR 0030 D5)
         )
         self._store.set(state)
         return (True, f"Goal set. {state.status_line()}")
@@ -195,23 +201,66 @@ class GoalController:
         return (True, "goal will stop after this turn (flagged unachievable).")
 
     def _parse_set(self, rest: str):
-        """Return (verifier_spec, condition, max_iterations|None, no_progress_limit|None, mode, fresh_context)."""
+        """Return (verifier_spec, condition, max_iterations|None, no_progress_limit|None,
+        mode, fresh_context, deadline|None, stall_after|None)."""
         if rest.lstrip().startswith("{"):
             try:
                 data = json.loads(rest)
             except json.JSONDecodeError:
-                return ({}, None, None, None, "drive", False)
+                return ({}, None, None, None, "drive", False, None, None)
             condition = data.get("condition")
             if not condition:
-                return ({}, None, None, None, "drive", False)
+                return ({}, None, None, None, "drive", False, None, None)
             verifier = data.get("verifier") or {"type": "llm"}
             if "type" not in verifier:
                 verifier["type"] = "llm"
             mode = "monitor" if data.get("mode") == "monitor" else "drive"
             fresh_context = bool(data.get("fresh_context", False))
-            return (verifier, condition, data.get("max_iterations"), data.get("no_progress_limit"), mode, fresh_context)
+            # Monitor termination + stall (ADR 0030 D5); plain data (not verifiers), so the
+            # Phase 1 trust-gate is unaffected.
+            deadline = self._parse_deadline(data.get("deadline"))
+            stall_after = self._parse_stall_after(data.get("stall_after"))
+            return (
+                verifier,
+                condition,
+                data.get("max_iterations"),
+                data.get("no_progress_limit"),
+                mode,
+                fresh_context,
+                deadline,
+                stall_after,
+            )
         # plain text → fuzzy goal judged by the llm verifier
-        return ({"type": "llm"}, rest, None, None, "drive", False)
+        return ({"type": "llm"}, rest, None, None, "drive", False, None, None)
+
+    @staticmethod
+    def _parse_deadline(value) -> float | None:
+        """A monitor-goal deadline: a number = epoch seconds, or an ISO-8601 string
+        (``datetime.fromisoformat``) → epoch seconds. Unparseable → None (no deadline)."""
+        if value is None:
+            return None
+        if isinstance(value, bool):  # bool is an int subclass — reject it explicitly
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        if isinstance(value, str):
+            from datetime import datetime
+
+            try:
+                return datetime.fromisoformat(value.strip()).timestamp()
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def _parse_stall_after(value) -> int | None:
+        """A monitor-goal stall threshold: a positive int (checks) or None."""
+        if value is None or isinstance(value, bool):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
     # --- evaluation --------------------------------------------------------
 
@@ -238,11 +287,52 @@ class GoalController:
         # Monitor goals (ADR 0030): an external process drives the metric, not the
         # agent's turns — so on not-met there's nothing for the agent to do. Record
         # the check and wait for the next one; no continuation, no iteration/no-
-        # progress bookkeeping, no exhaustion. It ends only on achieved / cleared
-        # (/ a future deadline). This is what closes ADR-0028 D6.
+        # progress bookkeeping, no exhaustion. It ends only on achieved / cleared /
+        # a deadline (→ expired), with an optional stall signal. This is what closes
+        # ADR-0028 D6 (and the ADR 0030 D5 slice).
         if state.mode == "monitor":
             from time import time
 
+            from graph.goals.hooks import fire_stall_hook
+
+            # (a) Deadline (ADR 0030 D5): a monitor goal that hasn't been met by its
+            # deadline finishes `expired` — a NON-achieved terminal, so it fires on_failed
+            # + the goal.failed bus event like exhausted/unachievable.
+            if state.deadline is not None and time() >= state.deadline:
+                return await self._finish(
+                    state, "expired", "deadline passed before the goal was met", evidence=result.evidence
+                )
+
+            # (b) Stall signal (ADR 0030 D5): after `stall_after` consecutive checks whose
+            # verifier reason+evidence didn't change, fire the on_stalled hook ONCE per stall
+            # episode — WITHOUT ending the goal (the external engine stopped moving, but the
+            # objective lives). Re-arm when the evidence changes.
+            unchanged = result.reason == state.last_reason and result.evidence == state.last_evidence
+            state.stall_streak = (state.stall_streak + 1) if unchanged else 0
+            if not unchanged:
+                state.stalled_notified = False
+            if state.stall_after and state.stall_streak >= state.stall_after and not state.stalled_notified:
+                state.stalled_notified = True
+                await fire_stall_hook(state)
+                # Best-effort bus signal (mirrors the goal.iteration publish below) so a
+                # console/plugin can react to a stalled monitor goal without a hook.
+                try:
+                    from graph.plugins.host import HOST
+
+                    if HOST.publish:
+                        HOST.publish(
+                            "goal.stalled",
+                            {
+                                "session_id": getattr(state, "session_id", "") or "",
+                                "condition": getattr(state, "condition", "") or "",
+                                "stall_streak": state.stall_streak,
+                                "reason": result.reason,
+                            },
+                        )
+                except Exception:  # noqa: BLE001 — a bus hiccup must never break the goal loop
+                    pass
+
+            # (c) Record the check and wait for the next one.
             state.last_reason = result.reason
             state.last_evidence = result.evidence
             state.last_checked = time()
@@ -381,7 +471,7 @@ class GoalController:
                 )
         except Exception:  # noqa: BLE001
             log.debug("[goals] goal.* bus emit failed", exc_info=True)
-        glyph = {"achieved": "✓", "exhausted": "⏳", "unachievable": "✗"}.get(status, "•")
+        glyph = {"achieved": "✓", "exhausted": "⏳", "unachievable": "✗", "expired": "⌛"}.get(status, "•")
         return Decision(action="done", state=state, note=f"{glyph} goal {status}: {reason}")
 
     def _continuation(self, state: GoalState, result) -> str:

--- a/graph/goals/hooks.py
+++ b/graph/goals/hooks.py
@@ -17,7 +17,7 @@ import logging
 
 log = logging.getLogger(__name__)
 
-# Each entry: {"plugin_id", "on_achieved": fn|None, "on_failed": fn|None}.
+# Each entry: {"plugin_id", "on_achieved": fn|None, "on_failed": fn|None, "on_stalled": fn|None}.
 _GOAL_HOOKS: list[dict] = []
 
 
@@ -40,3 +40,22 @@ async def fire_goal_hooks(status: str, state) -> None:
                 await result
         except Exception:  # noqa: BLE001 — a bad hook must not break the goal loop
             log.exception("[goal] %s hook (plugin %s) failed", key, hook.get("plugin_id"))
+
+
+async def fire_stall_hook(state) -> None:
+    """Fire the ``on_stalled`` hook for a monitor goal that stopped moving (ADR 0030 D5).
+
+    Unlike :func:`fire_goal_hooks`, this does **not** end the goal — it's a signal that the
+    external engine stopped earning (the verifier evidence hasn't changed for ``stall_after``
+    checks), fired once per stall episode so a plugin can notify / record a finding / set a
+    remediation goal while the objective stays alive. A hook that raises is logged and swallowed."""
+    for hook in _GOAL_HOOKS:
+        fn = hook.get("on_stalled")
+        if fn is None:
+            continue
+        try:
+            result = fn(state)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:  # noqa: BLE001 — a bad hook must not break the goal loop
+            log.exception("[goal] on_stalled hook (plugin %s) failed", hook.get("plugin_id"))

--- a/graph/goals/types.py
+++ b/graph/goals/types.py
@@ -22,7 +22,9 @@ from time import time
 #   exhausted     — ran out of iteration budget without meeting the goal
 #   unachievable  — flagged as not reachable (no-progress streak, or the model
 #                   explicitly gave up with a reason)
-TERMINAL_STATUSES = ("achieved", "exhausted", "unachievable")
+#   expired       — a monitor goal hit its deadline before the verifier passed
+#                   (a non-achieved terminal → fires on_failed / goal.failed)
+TERMINAL_STATUSES = ("achieved", "exhausted", "unachievable", "expired")
 
 
 @dataclass
@@ -59,6 +61,14 @@ class GoalState:
     # on disk. Opt-in only; short goals benefit from transcript continuity.
     fresh_context: bool = False
     last_checked: float | None = None  # last out-of-band verifier check (monitor)
+    # Monitor-goal termination + stall signal (ADR 0030 D5). A `monitor` goal
+    # otherwise ends only on achieved/cleared: `deadline` (epoch seconds) gives it
+    # a hard stop (→ `expired`), and `stall_after` fires the on_stalled hook after
+    # N consecutive checks with unchanged verifier evidence — WITHOUT ending it.
+    deadline: float | None = None
+    stall_after: int | None = None
+    stall_streak: int = 0
+    stalled_notified: bool = False  # one on_stalled fire per stall episode (re-armed on change)
     checklist: str = ""
     # Set by the agent's ``abandon_goal`` tool mid-turn; ``evaluate`` finishes the goal
     # ``unachievable`` after the verifier runs (retired the ``<goal_unachievable/>`` tag).

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -66,7 +66,7 @@ class PluginRegistry:
         self.mcp_servers: list = []  # factories: config -> entry dict | None
         self.thread_id_resolver = None  # (request_metadata, session_id) -> str (#571)
         self.goal_verifiers: dict = {}  # name -> async (spec, ctx) -> VerifyResult (ADR 0028)
-        self.goal_hooks: list = []  # {on_achieved, on_failed} terminal reactions (ADR 0028)
+        self.goal_hooks: list = []  # {on_achieved, on_failed, on_stalled} reactions (ADR 0028 + 0030 D5)
         self.knowledge_stores: dict = {}  # name -> (config) -> KnowledgeBackend (ADR 0031)
         self.embedders: dict = {}  # name -> (config) -> (text -> vector) embed_fn (ADR 0031)
         self.chat_commands: dict = {}  # token -> async (rest, session_id) -> str|None (user-only control commands)
@@ -218,19 +218,24 @@ class PluginRegistry:
         key = name if ":" in name else f"{self.plugin_id}:{name}"
         self.goal_verifiers[key] = fn
 
-    def register_goal_hook(self, *, on_achieved=None, on_failed=None) -> None:
-        """React when a goal reaches a terminal state (ADR 0028 D4). ``on_achieved``
-        / ``on_failed`` take the terminal ``GoalState`` (sync or async) — push a
-        notification, record a finding, or set the next goal. A raising hook is
-        logged + swallowed."""
-        if not (callable(on_achieved) or callable(on_failed)):
-            log.warning("[plugins] %s: register_goal_hook needs on_achieved and/or on_failed", self.plugin_id)
+    def register_goal_hook(self, *, on_achieved=None, on_failed=None, on_stalled=None) -> None:
+        """React when a goal reaches a terminal state (ADR 0028 D4) — or stalls (ADR 0030 D5).
+        ``on_achieved`` / ``on_failed`` take the terminal ``GoalState``; ``on_stalled`` (monitor
+        goals only) fires when the verifier evidence hasn't moved for ``stall_after`` checks —
+        WITHOUT ending the goal, once per stall episode. Each takes the ``GoalState`` (sync or
+        async) — push a notification, record a finding, or set the next goal. Provide ANY of the
+        three. A raising hook is logged + swallowed."""
+        if not (callable(on_achieved) or callable(on_failed) or callable(on_stalled)):
+            log.warning(
+                "[plugins] %s: register_goal_hook needs on_achieved, on_failed, and/or on_stalled", self.plugin_id
+            )
             return
         self.goal_hooks.append(
             {
                 "plugin_id": self.plugin_id,
                 "on_achieved": on_achieved if callable(on_achieved) else None,
                 "on_failed": on_failed if callable(on_failed) else None,
+                "on_stalled": on_stalled if callable(on_stalled) else None,
             }
         )
 

--- a/graph/plugins/testkit.py
+++ b/graph/plugins/testkit.py
@@ -220,8 +220,8 @@ class FakeRegistry:
     def register_goal_verifier(self, name: str, fn) -> None:
         self.verifiers[name] = fn
 
-    def register_goal_hook(self, *, on_achieved=None, on_failed=None) -> None:
-        self.goal_hooks.append((on_achieved, on_failed))
+    def register_goal_hook(self, *, on_achieved=None, on_failed=None, on_stalled=None) -> None:
+        self.goal_hooks.append((on_achieved, on_failed, on_stalled))
 
     def register_knowledge_store(self, name: str, factory) -> None:
         self.knowledge_stores[name] = factory

--- a/tests/test_goal_monitor.py
+++ b/tests/test_goal_monitor.py
@@ -94,3 +94,110 @@ async def test_parse_control_and_status_line_monitor(tmp_path):
     await c.parse_control('/goal {"condition":"x","mode":"monitor","verifier":{"type":"plugin","check":"a:b"}}', "s")
     g = c.active_goal("s")
     assert g.mode == "monitor" and "(monitor)" in g.status_line()
+
+
+# --- ADR 0030 D5: deadline → expired + stall_after → on_stalled ---------------
+
+
+@pytest.mark.asyncio
+async def test_monitor_past_deadline_expires_and_fires_on_failed(tmp_path):
+    from time import time
+
+    failed: list[str] = []
+    set_goal_hooks(
+        [{"plugin_id": "p", "on_achieved": None, "on_failed": lambda st: failed.append(st.status), "on_stalled": None}]
+    )
+
+    async def _no(spec, ctx):
+        return VerifyResult(False, "waiting", "42")
+
+    set_plugin_verifiers({"p:c": _no})
+    try:
+        c = _ctrl(tmp_path)
+        # deadline already in the past → the not-met monitor goal must finish `expired`.
+        c.set_goal_safe("s", "grow", {"type": "plugin", "check": "p:c"}, mode="monitor", deadline=time() - 1)
+        d = await c.evaluate("s", last_text="")
+        assert d is not None and d.action == "done"
+        assert d.state.status == "expired"
+        assert failed == ["expired"]  # a non-achieved terminal → on_failed fired
+        assert c.active_goal("s") is None  # terminal → no longer active
+    finally:
+        set_plugin_verifiers({})
+        set_goal_hooks([])
+
+
+@pytest.mark.asyncio
+async def test_monitor_future_deadline_stays_active(tmp_path):
+    from time import time
+
+    async def _no(spec, ctx):
+        return VerifyResult(False, "waiting", "42")
+
+    set_plugin_verifiers({"p:c": _no})
+    try:
+        c = _ctrl(tmp_path)
+        c.set_goal_safe("s", "grow", {"type": "plugin", "check": "p:c"}, mode="monitor", deadline=time() + 3600)
+        assert await c.evaluate("s", last_text="") is None  # not met, deadline not reached
+        assert c.active_goal("s").active  # stays active
+    finally:
+        set_plugin_verifiers({})
+
+
+@pytest.mark.asyncio
+async def test_monitor_stall_after_fires_on_stalled_without_ending(tmp_path):
+    stalled: list[int] = []
+    set_goal_hooks(
+        [
+            {
+                "plugin_id": "p",
+                "on_achieved": None,
+                "on_failed": None,
+                "on_stalled": lambda st: stalled.append(st.stall_streak),
+            }
+        ]
+    )
+
+    evidence = {"v": "e1"}
+
+    async def _no(spec, ctx):
+        return VerifyResult(False, "waiting", evidence["v"])  # identical evidence until we change it
+
+    set_plugin_verifiers({"p:c": _no})
+    try:
+        c = _ctrl(tmp_path)
+        c.set_goal_safe("s", "grow", {"type": "plugin", "check": "p:c"}, mode="monitor", stall_after=2)
+
+        await c.evaluate("s", last_text="")  # check 1: baseline (streak 0)
+        assert stalled == []
+        await c.evaluate("s", last_text="")  # check 2: 1st unchanged (streak 1)
+        assert stalled == []
+        await c.evaluate("s", last_text="")  # check 3: 2nd unchanged (streak 2 == stall_after) → fires
+        assert stalled == [2]
+        assert c.active_goal("s") and c.active_goal("s").active  # stall does NOT end the goal
+        await c.evaluate("s", last_text="")  # check 4: still unchanged → NOT re-fired (once per episode)
+        assert stalled == [2]
+
+        # Evidence changes → re-arm; two more unchanged checks fire on_stalled again.
+        evidence["v"] = "e2"
+        await c.evaluate("s", last_text="")  # changed → streak reset + notified cleared
+        await c.evaluate("s", last_text="")  # 1st unchanged (streak 1)
+        assert stalled == [2]
+        await c.evaluate("s", last_text="")  # 2nd unchanged (streak 2) → fires again
+        assert stalled == [2, 2]
+        assert c.active_goal("s").active
+    finally:
+        set_plugin_verifiers({})
+        set_goal_hooks([])
+
+
+@pytest.mark.asyncio
+async def test_parse_control_deadline_and_stall_after(tmp_path):
+    c = _ctrl(tmp_path)
+    await c.parse_control(
+        '/goal {"condition":"x","mode":"monitor","stall_after":3,'
+        '"deadline":"2999-01-01T00:00:00","verifier":{"type":"plugin","check":"a:b"}}',
+        "s",
+    )
+    g = c.active_goal("s")
+    assert g.stall_after == 3
+    assert g.deadline is not None and g.deadline > 0  # ISO-8601 parsed to epoch seconds


### PR DESCRIPTION
## What

Builds the previously-unbuilt **ADR 0030 D5** slice. Today a `monitor`-mode goal ends only on `achieved`/`cleared` — it ticks forever with no deadline and no stall signal. This adds both:

- **`deadline`** (ISO-8601 string or epoch seconds) → when a monitor goal isn't met by its deadline, the next out-of-band check finishes it with terminal status **`expired`** — a *non-achieved* terminal, so it fires `on_failed` + the `goal.failed` bus event just like `exhausted`/`unachievable`.
- **`stall_after`** (int N) → after N consecutive checks with **unchanged** verifier evidence, fire a new **`on_stalled`** hook **without ending the goal** (a signal that the external engine stopped moving). Fires **once per stall episode** and re-arms when evidence changes; also publishes a best-effort `goal.stalled` bus event.

Both are plain **data** fields on the goal spec (not verifiers), so the Phase 1 chat trust-gate (`_chat_verifier_allowed`) is unaffected.

## Changes

- `graph/goals/types.py` — `GoalState` gains `deadline`, `stall_after`, `stall_streak`, `stalled_notified`; `"expired"` added to `TERMINAL_STATUSES`.
- `graph/goals/controller.py` — monitor branch of `evaluate` now handles deadline → `_finish("expired", …)`, stall detection → `fire_stall_hook` (+ `goal.stalled` publish), then records the check. `_finish` glyph map gains `expired: ⌛`. `_parse_set`/`parse_control`/`set_goal_safe` accept `deadline` (number-or-ISO) + `stall_after`.
- `graph/goals/hooks.py` — new `fire_stall_hook(state)` mirroring `fire_goal_hooks` on `on_stalled` (log + swallow, does not end the goal).
- `graph/plugins/registry.py` + `graph/plugins/testkit.py` — `register_goal_hook` gains `on_stalled`.
- Tests + docs (`docs/guides/goal-mode.md`, `docs/adr/0030-monitor-goals.md`).

## Gates

- `uv run ruff check .` → **All checks passed!**
- `pytest tests/test_goal_monitor.py tests/test_goal_controller.py tests/test_goal_hooks.py tests/test_goal_set_programmatic.py -q` → **39 passed**

New tests cover: past deadline → `expired` + `on_failed` fires; future deadline → stays active; `stall_after=2` fires `on_stalled` after 2 unchanged checks, goal still active, no re-fire on the 3rd, re-arms after evidence changes; `/goal` JSON parse of `deadline`(ISO) + `stall_after`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)