### PR TITLE
fix(docs): make docs_search thread-safe (fixes float(None) TypeError on concurrent search)

### DIFF
--- a/plugins/docs/__init__.py
+++ b/plugins/docs/__init__.py
@@ -49,7 +49,14 @@ async def docs_search(query: str, k: int = 5) -> str:
     then call ``docs_read(path)`` on the best one or two.
     """
     k = max(1, min(int(k), 10))
-    results = await asyncio.to_thread(_index().search, query, k)
+    # The index is defensive (serialized + degrades to [] on any DB error), but never let an
+    # unexpected failure surface to the agent as a raw traceback / empty tool result — tell it
+    # the search errored so it can retry or fall back, rather than silently "nothing came back".
+    try:
+        results = await asyncio.to_thread(_index().search, query, k)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("[docs] docs_search failed: %s", exc)
+        return f"Docs search failed ({type(exc).__name__}). Try again, or rephrase/narrow the query."
     if not results:
         return "No matching docs."
     return "\n".join(f"[{r.section}] {r.title} — {r.path}" for r in results)

--- a/plugins/docs/docs_index.py
+++ b/plugins/docs/docs_index.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import re
 import sqlite3
+import threading
 from pathlib import Path
 from typing import NamedTuple
 
@@ -44,6 +45,14 @@ class DocsIndex:
         self._paths: set[str] = set()
         self._conn = sqlite3.connect(":memory:", check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
+        # One shared connection, but `docs_search` dispatches `search` onto thread-pool
+        # workers via `asyncio.to_thread` — and a single sqlite connection is NOT safe for
+        # concurrent use across threads (`check_same_thread=False` only silences the guard,
+        # it doesn't add locking). Two back-to-back searches racing on the connection
+        # corrupt cursor state → a NULL bm25 score → `float(None)`. Serialize every DB touch
+        # on this lock; the corpus is tiny + in-memory so contention is negligible. (A
+        # `:memory:` DB can't be shared via per-thread connections — each opens its own.)
+        self._lock = threading.Lock()
         try:
             self._conn.execute(
                 "CREATE VIRTUAL TABLE docs_fts USING fts5(path, title, section, content, preview UNINDEXED)"
@@ -62,11 +71,12 @@ class DocsIndex:
             rows.append((rel, doc_title(abs_path), rel.split("/", 1)[0], content, doc_preview(content)))
             self._paths.add(rel)
         if rows:
-            self._conn.executemany(
-                "INSERT INTO docs_fts (path, title, section, content, preview) VALUES (?, ?, ?, ?, ?)",
-                rows,
-            )
-            self._conn.commit()
+            with self._lock:
+                self._conn.executemany(
+                    "INSERT INTO docs_fts (path, title, section, content, preview) VALUES (?, ?, ?, ?, ?)",
+                    rows,
+                )
+                self._conn.commit()
         return len(rows)
 
     def search(self, query: str, k: int = 5) -> list[DocRecord]:
@@ -75,16 +85,20 @@ class DocsIndex:
         if not mq:
             return []
         try:
-            cur = self._conn.execute(
-                "SELECT path, title, section, preview, bm25(docs_fts) AS score "
-                "FROM docs_fts WHERE docs_fts MATCH ? ORDER BY score LIMIT ?",
-                (mq, max(1, int(k))),
-            )
+            with self._lock:
+                cur = self._conn.execute(
+                    "SELECT path, title, section, preview, bm25(docs_fts) AS score "
+                    "FROM docs_fts WHERE docs_fts MATCH ? ORDER BY score LIMIT ?",
+                    (mq, max(1, int(k))),
+                )
+                rows = cur.fetchall()
+            # `float(score or 0.0)`: defense in depth against a NULL bm25 (belt-and-braces
+            # with the lock above) so a stray None can never raise TypeError out of search.
             return [
-                DocRecord(r["path"], r["title"], r["section"], r["preview"] or "", float(r["score"]))
-                for r in cur.fetchall()
+                DocRecord(r["path"], r["title"], r["section"], r["preview"] or "", float(r["score"] or 0.0))
+                for r in rows
             ]
-        except sqlite3.OperationalError as exc:  # empty table / odd query
+        except Exception as exc:  # noqa: BLE001 — empty table / odd query / any sqlite hiccup: degrade to no-results, never raise into the tool
             log.debug("[docs] search error (returning empty): %s", exc)
             return []
 

--- a/tests/test_docs_plugin.py
+++ b/tests/test_docs_plugin.py
@@ -61,6 +61,40 @@ def test_index_seeds_and_ranks(tmp_path) -> None:
     assert idx.search("") == []
 
 
+def test_concurrent_search_is_thread_safe(tmp_path) -> None:
+    """`docs_search` runs `search` on `asyncio.to_thread` workers, so two back-to-back
+    searches hit the one shared in-memory sqlite connection from different threads. That
+    race used to corrupt cursor state → a NULL bm25 score → `float(None)` TypeError (and
+    InterfaceError/IndexError). Hammer it: every search must return cleanly, never raise."""
+    import threading
+
+    docs = _load_docs()
+    _corpus(tmp_path)
+    idx = docs.DocsIndex(root=tmp_path)
+    idx.seed()
+
+    errors: list[str] = []
+
+    def worker(q: str) -> None:
+        for _ in range(200):
+            try:
+                idx.search(q)
+            except Exception as exc:  # noqa: BLE001 — a raised search is the regression
+                errors.append(f"{type(exc).__name__}: {exc}")
+
+    queries = ["skills tools", "configuration schema", "langgraph option", "agent"]
+    threads = [threading.Thread(target=worker, args=(queries[i % len(queries)],)) for i in range(12)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent search raised: {errors[:3]}"
+    # Still returns real, correctly-typed results after the pounding.
+    hits = idx.search("skills tools")
+    assert hits and hits[0].path == "guides/skills.md" and isinstance(hits[0].score, float)
+
+
 def test_dev_dir_is_excluded(tmp_path) -> None:
     docs = _load_docs()
     _corpus(tmp_path)


### PR DESCRIPTION
## The bug

A user hit `TypeError: float() argument must be a string or a real number, not 'NoneType'` during a chat turn — specifically on the **second of two back-to-back `docs_search` calls**, which then returned nothing to the agent.

## Root cause (confirmed by repro)

`docs_search` runs `DocsIndex.search` on thread-pool workers via `asyncio.to_thread`, but `DocsIndex` holds **one** `sqlite3.connect(":memory:", check_same_thread=False)` connection shared across all of them. A single sqlite connection is **not safe for concurrent use across threads** — `check_same_thread=False` only silences the guard, it adds no locking.

When two searches race on the connection, cursor state corrupts and the computed `bm25(docs_fts)` column reads back as **NULL** → `float(None)` → the observed `TypeError`. It escaped the narrow `except sqlite3.OperationalError`, so the tool call failed and "nothing came back".

A concurrency stress harness reproduces it exactly:

```
16 threads × 200 searches on the shared connection:
  x172  TypeError: float() argument ... not 'NoneType'   ← the reported error
  x279  InterfaceError: bad parameter or other API misuse
  x87   IndexError: tuple index out of range
```

Single-threaded search of the same query always worked — which is why it looked intermittent and query-independent.

## Fix + hardening

- **Serialize** every connection touch (`seed` + `search`) on a `threading.Lock`. A `:memory:` DB can't be shared via per-thread connections (each opens its own empty DB), so a lock is the correct tool; the corpus is tiny and in-memory, so contention is negligible. → **540 errors → 0** under heavier load (24×300).
- **Defense in depth:** `float(score or 0.0)` guards a stray NULL; `search`'s `except` now catches any error and degrades to no-results instead of raising into the tool.
- **Tell the agent:** `docs_search` wraps the call and returns a graceful `Docs search failed (…)` message on any unexpected failure, rather than a raw traceback / silent empty result.
- **Regression test:** 12 threads × 200 concurrent searches must never raise. Verified it **fails on the pre-fix code** (float/InterfaceError) and **passes after**.

## Test

- `pytest tests/test_docs_plugin.py` — 10 passed (9 existing + new concurrency guard).
- `ruff check` — clean.

## Follow-up (not in this PR)

`graph/skills/index.py` mirrors the same shared-`check_same_thread=False`-connection pattern and is queried **every turn** (always-on skills index) — same latent race, worth a separate hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)