### PR TITLE
feat(security): federation token + /api operator ceiling; operator goal channel (ADR 0066)

### DIFF
--- a/a2a_impl/auth.py
+++ b/a2a_impl/auth.py
@@ -40,6 +40,9 @@ logger = logging.getLogger(__name__)
 
 # Live-updatable bearer token (None = open mode for bearer).
 _BEARER: list[str | None] = [None]
+# Optional federation token (ADR 0066) — a second credential confined to the /a2a + /v1
+# consumer surfaces and DENIED the /api operator surface. None = no federation tier.
+_FEDERATION: list[str | None] = [None]
 # X-API-Key (env-seeded at install; constant for the process).
 _API_KEY: list[str] = [""]
 # Allowed origins: None = verification disabled; list = allowlist.
@@ -133,12 +136,31 @@ def _is_public(path: str) -> bool:
     return False
 
 
+def _requires_operator(path: str) -> bool:
+    """Paths that require the OPERATOR credential (ADR 0066 R1 ceiling).
+
+    The ``/api`` operator/console surface — plugin install+enable (host code-exec),
+    config/SOUL rewrite, subagent runs, the operator goal set-path — is operator-only; a
+    configured federation token is denied it (403). ``/a2a`` + ``/v1`` are the
+    federation/consumer surfaces and are NOT operator-only. Public + SSE-token paths never
+    reach the ceiling (handled earlier in dispatch). The substring form also catches the
+    fleet-proxy variants (``/active/<slug>/api/…``, ``/agents/<slug>/api/…``)."""
+    return "/api/" in path or path == "/api" or path.endswith("/api")
+
+
 def set_bearer_token(token: str | None) -> None:
     """Update the active bearer token at runtime (wizard/drawer reload)."""
     _BEARER[0] = (token or "").strip() or None
 
 
-def configure(*, bearer_token: str | None, api_key: str, allowed_origins_raw: str) -> None:
+def set_federation_token(token: str | None) -> None:
+    """Update the federation token at runtime (wizard/drawer reload). None = no federation tier."""
+    _FEDERATION[0] = (token or "").strip() or None
+
+
+def configure(
+    *, bearer_token: str | None, api_key: str, allowed_origins_raw: str, federation_token: str | None = None
+) -> None:
     """Seed the guard at route-registration time.
 
     Args:
@@ -157,6 +179,14 @@ def configure(*, bearer_token: str | None, api_key: str, allowed_origins_raw: st
     _BEARER[0] = seed or None
     if _BEARER[0] is None:
         logger.warning("[a2a] A2A auth token not configured — endpoint is open")
+
+    # Federation token (ADR 0066) — same authoritative-vs-env-fallback rule as the bearer.
+    raw_fed = federation_token if federation_token is not None else os.environ.get("A2A_FEDERATION_TOKEN", "")
+    _FEDERATION[0] = (raw_fed or "").strip() or None
+    if _FEDERATION[0] is not None and _BEARER[0] is None:
+        logger.warning("[a2a] federation_token set but no operator bearer — federation tier is inert (open mode)")
+    if _FEDERATION[0] is not None and _FEDERATION[0] == _BEARER[0]:
+        logger.warning("[a2a] federation_token equals the operator token — federation tier collapses to operator")
 
     _API_KEY[0] = api_key or ""
 
@@ -251,14 +281,36 @@ class A2AAuthMiddleware(BaseHTTPMiddleware):
         if api_key and not hmac.compare_digest(request.headers.get("x-api-key", "") or "", api_key):
             return _unauthorized("Unauthorized")
 
-        # Bearer — enforced only when configured.
+        # Bearer — enforced only when configured. Classify which credential matched
+        # (ADR 0066): the operator token → full access; a configured federation token →
+        # the /a2a + /v1 consumer surfaces only (the /api ceiling below denies it the
+        # operator surface). Open mode + single-token mode resolve to operator (R3
+        # backward-compat: unset federation_token ⇒ this is the old single-token check).
         active = _BEARER[0]
+        fed = _FEDERATION[0]
+        tier = "operator"
         if active:
             header = request.headers.get("Authorization", "")
             if not header.startswith("Bearer "):
                 return _unauthorized("Unauthorized: expected 'Authorization: Bearer <token>'")
-            if not hmac.compare_digest(header[len("Bearer ") :], active):
+            token = header[len("Bearer ") :]
+            # Constant-time compare against each configured secret; classify by which
+            # matched. Trust = the matched secret, never the path/Origin/loopback (R5).
+            is_operator = hmac.compare_digest(token, active)
+            is_federation = fed is not None and hmac.compare_digest(token, fed)
+            if is_operator:
+                tier = "operator"
+            elif is_federation:
+                tier = "federation"
+            else:
                 return _unauthorized("Unauthorized: invalid bearer token")
+
+        # R1 path ceiling (ADR 0066): a federation credential is denied the /api operator
+        # surface — otherwise the token split is cosmetic (it has RCE via
+        # /api/plugins/install anyway). /a2a + /v1 stay open to either tier.
+        if tier == "federation" and _requires_operator(path):
+            return JSONResponse({"detail": "Forbidden: operator credential required"}, status_code=403)
+        request.state.trust_tier = tier
 
         # Origin — enforced only when an allowlist is set AND an Origin is
         # present. Origin is a browser-only header; server-to-server callers
@@ -273,12 +325,15 @@ class A2AAuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-def install(app, *, bearer_token: str | None, api_key: str, allowed_origins_raw: str) -> None:
+def install(
+    app, *, bearer_token: str | None, api_key: str, allowed_origins_raw: str, federation_token: str | None = None
+) -> None:
     """Configure the guard and add the middleware to ``app``."""
     configure(
         bearer_token=bearer_token,
         api_key=api_key,
         allowed_origins_raw=allowed_origins_raw,
+        federation_token=federation_token,
     )
     app.add_middleware(A2AAuthMiddleware)
 

--- a/docs/adr/0066-goal-trust-operator-channel.md
+++ b/docs/adr/0066-goal-trust-operator-channel.md
@@ -100,3 +100,7 @@ operational step.
 - **PR2** — a `protomaker`/CLI `goal set` command (thin client of `POST /api/goals`).
 - **PR3** — the console Goals set-form (DRAFT, local-test gate) — the set-path UI deferred from
   the goal.iteration work.
+
+**Operational follow-ups (the federation token itself)** — management UI, peer rotation + an
+optional `require_federation_token` enforce flag, fleet-member tokens, and `trust_tier`
+observability — are tracked in #1504.

--- a/docs/adr/0066-goal-trust-operator-channel.md
+++ b/docs/adr/0066-goal-trust-operator-channel.md
@@ -1,0 +1,102 @@
+# 0066 — Goal trust-gate Phase 2: federation token + operator `/api` channel
+
+Status: **Accepted** (Option B of the goal trust-gate design note, 2026-06-30)
+
+> Promotes `docs/dev/notes/goal-trust-gate-token-model.md` to an ADR. Phase 1 (#1492)
+> closed the RCE-via-chat hole by refusing `command`/`test`/`ci`/`data-expr` verifiers from a
+> `/goal` **chat** message for every caller. Phase 2 restores the *operator's* ability to set
+> those verifiers — safely — through a dedicated channel, and adds the path ceiling that makes
+> a federation token meaningful. **Chosen: Option B (dedicated operator channel).**
+
+## Context
+
+The goal verifiers `command`/`test`/`ci` shell out on the host and `data`+`expr` hits a
+restricted-eval sink — arming one is remote code execution. Phase 1 made all four
+**unsettable through any exposed door**: the `/goal` chat path refuses them (`trusted=False`
+from both server call sites) and the programmatic path (`set_goal_safe`) is `plugin`-only. That
+closed the hole but cost the *operator* a legitimate feature ("keep going until `pytest -q`
+passes").
+
+The crux (from the design note's red-team, R1/R5): protoAgent gates `/a2a`, `/api/*`, and
+`/v1/*` with a **single** bearer (`auth.token` / `A2A_AUTH_TOKEN`), default-deny — so a
+semi-trusted federation peer and the trusted operator are indistinguishable by code-path or
+token. And gating only the goal verifier is theatre while the same credential can `POST
+/api/plugins/install` (also host code-exec). The real control is **which surface a credential
+may reach**, not which verifier it may set.
+
+## Decision — Option B
+
+Keep chat **universally untrusted** (Phase 1 unchanged — the simplest, soundest model per both
+red-teams), and give the operator a **dedicated `/api` channel** for dangerous verifiers,
+protected by a real operator-vs-federation distinction.
+
+### D1 — A second credential: `auth.federation_token`
+
+Add an optional `federation_token` (YAML `auth.federation_token` / env `A2A_FEDERATION_TOKEN`),
+alongside the existing operator bearer. The middleware classifies each request by **which
+secret the inbound bearer matched** (constant-time `hmac.compare_digest`, server-side only —
+never by path, Origin, or loopback, all caller-forgeable; R5). Result: tier `operator` or
+`federation`.
+
+### D2 — The R1 path ceiling
+
+The **`/api/*` operator surface** (plugin install/enable = host code-exec, config/SOUL rewrite,
+subagent runs, the operator goal set-path) **requires the operator credential**. A federation
+token is denied it with `403`, even though it's a valid token. `/a2a` + `/v1` remain open to
+either tier (the consumer/federation surfaces). This is the whole point: without it, a
+federation credential has RCE via `/api/plugins/install` regardless of any goal gating.
+
+The ceiling lives **entirely in the auth middleware** — a request that *reaches* an `/api`
+handler is operator-tier by construction, so no per-request trust level has to be threaded into
+handlers or the streaming producer (this is why Option B avoids Option A's fragile
+`BaseHTTPMiddleware`→streaming-task propagation, R4).
+
+### D3 — The operator goal channel
+
+`POST /api/goals` (already routed) accepts **any** verifier type — `command`/`test`/`ci`/`data`
+included — via a new `GoalController.set_goal_operator`. It is safe because it sits under the
+`/api` ceiling: only the operator reaches it. (`set_goal_safe`, the *programmatic* agent/plugin
+path, stays `plugin`-only — unchanged.) A CLI and a console Goals set-form are thin clients of
+this endpoint (follow-up slices).
+
+### D4 — Backward compatibility (R3, fail-safe)
+
+When **no** `federation_token` is configured (the default), there is no federation tier: the
+bearer check is byte-for-byte the old single-token check and the ceiling never fires. Adding a
+federation token is **opt-in**. Note that in single-token mode any bearer holder already has
+host code-exec via `/api/plugins/install`, so allowing `/api/goals` to set a `command` verifier
+adds **no** new capability — the ceiling, not the goal endpoint, is the control. R6 caveat:
+existing peers hold the *operator* token until rotated onto the federation token; "adding a
+token protects nothing until peers rotate" is inherent to backward-compat and is a documented
+operational step.
+
+## Consequences
+
+- The operator sets dangerous verifiers again — from a dedicated, operator-tier channel, never
+  the chat box.
+- A configured federation token is confined to `/a2a` + `/v1`; it cannot install plugins,
+  rewrite config, run subagents, or set host-exec goals. The federation split stops being
+  cosmetic.
+- Trust model stays simple: chat is always untrusted; `/api` is always operator. No per-request
+  trust threading, no contextvar fragility.
+- Additive + opt-in: unset `federation_token` ⇒ zero behavior change.
+
+## Alternatives considered
+
+- **Option A — two-token + thread the tier into `parse_control`** so the operator arms shell
+  verifiers from the chat box. Preserves chat UX, but needs the tier to survive the
+  Starlette→streaming-producer hop (R4, fragile) and keeps chat trust-aware. Rejected: the chat
+  box was never a good place to arm a shell command, and B's "chat always untrusted" is the
+  sounder, simpler model.
+- **Loosen the chat gate for a "trusted" origin/loopback.** Rejected — Origin/loopback are
+  caller-forgeable (R5); trust must be the matched secret.
+- **Leave Phase 1 as the final state** (dangerous verifiers unsettable forever). Rejected — a
+  real operator use case (CI/test-driven goals) stays broken.
+
+## Slices
+
+- **PR1 (this ADR)** — D1 + D2 + D3: `federation_token` + middleware classification + `/api`
+  path ceiling + the `set_goal_operator` endpoint. Held for security review.
+- **PR2** — a `protomaker`/CLI `goal set` command (thin client of `POST /api/goals`).
+- **PR3** — the console Goals set-form (DRAFT, local-test gate) — the set-path UI deferred from
+  the goal.iteration work.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -70,9 +70,16 @@ model:
   api_key: sk-...
 auth:
   token: bearer-...
+  federation_token: fed-...   # optional (ADR 0066) — semi-trusted peers get THIS, not `token`
 ```
 
 `LangGraphConfig.from_yaml` overlays this file on top of the main config at load time. Precedence for each secret: **`secrets.yaml` → main YAML value → env var** (`OPENAI_API_KEY` / `A2A_AUTH_TOKEN`). So env-injected deployments (e.g. `infisical run`) work unchanged — just leave `secrets.yaml` absent. Every config save also strips any secret keys the main YAML might still carry, so a checkout converges to secret-free. The `/api/config` endpoint redacts both fields to `""`; runtime status reports only whether a key is set (`model.api_key_configured`), never the value.
+
+### Federation token — operator vs peer (ADR 0066)
+
+A deployment that hands its `/a2a` endpoint to **semi-trusted A2A peers** (a fleet hub, a partner agent) can issue them a **second** credential instead of the operator bearer: set `auth.federation_token` (secret; env fallback `A2A_FEDERATION_TOKEN`). A request authenticated with the federation token reaches only the **`/a2a` + `/v1` consumer surfaces** — it is **denied the whole `/api` operator surface** (plugin install/enable = host code-exec, config/SOUL rewrite, subagent runs, the operator goal set-path) with a `403`. The operator bearer keeps full access. Leaving `federation_token` blank is **single-token mode** (unchanged behavior): every bearer holder is the operator. Rotate existing peers onto the federation token — until they do, they still hold the operator credential.
+
+This is the R1 path ceiling behind the goal trust-gate: the dangerous goal verifiers (`command`/`test`/`ci`, `data`+`expr`) are refused from a `/goal` **chat** message for everyone (Phase 1), and the operator sets them through the operator-tier **`POST /api/goals`** endpoint — safe precisely because the `/api` ceiling confines that endpoint to the operator.
 
 ## `subagents`
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -637,6 +637,14 @@ class LangGraphConfig:
     # Kept in YAML rather than env so the drawer can manage it.
     auth_token: str = ""
 
+    # Optional federation token (ADR 0066) — a SECOND credential handed to
+    # semi-trusted A2A peers. It reaches only the /a2a + /v1 consumer surfaces;
+    # the /api operator surface (plugin install, config rewrite, subagent runs,
+    # the operator goal set-path) is denied it. Blank = no federation tier
+    # (single-token mode; every bearer holder is the operator). Env fallback:
+    # A2A_FEDERATION_TOKEN.
+    federation_token: str = ""
+
     # OS-level autostart — ``True`` means the server launches on user
     # login (macOS LaunchAgent today; Linux/Windows TBD). Managed by
     # ``autostart.py``; the field here is the source of truth for
@@ -817,6 +825,7 @@ class LangGraphConfig:
         # value still lets create_llm / set_a2a_token fall back to env.
         secret_api_key = secrets.get("model", {}).get("api_key")
         secret_auth_token = secrets.get("auth", {}).get("token")
+        secret_federation_token = secrets.get("auth", {}).get("federation_token")
 
         config = cls(
             model_provider=model.get("provider", cls.model_provider),
@@ -944,6 +953,7 @@ class LangGraphConfig:
             a2a_require_routable_url=bool(a2a.get("require_routable_url", False)),
             instance_id=data.get("instance", {}).get("id", "") or data.get("instance_id", cls.instance_id),
             auth_token=secret_auth_token or auth.get("token", cls.auth_token),
+            federation_token=secret_federation_token or auth.get("federation_token", cls.federation_token),
             autostart_on_boot=runtime.get("autostart_on_boot", cls.autostart_on_boot),
             # Box runtime (Host layer, ADR 0047 D8) — file > env > default. The env
             # fallback only fires when the merged dict omits the key (zero-migration).

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -167,6 +167,44 @@ class GoalController:
         self._store.set(state)
         return (True, f"Goal set. {state.status_line()}")
 
+    def set_goal_operator(
+        self,
+        session_id: str,
+        condition: str,
+        verifier: dict,
+        max_iterations: int | None = None,
+        no_progress_limit: int | None = None,
+        mode: str = "drive",
+        deadline: float | None = None,
+        stall_after: int | None = None,
+    ) -> tuple[bool, str]:
+        """Set a goal from the TRUSTED OPERATOR surface — ``POST /api/goals``, gated to
+        operator-tier by the ADR 0066 ``/api`` path ceiling. Unlike ``set_goal_safe``
+        (agent/plugin/programmatic → ``plugin``-verifier only), this accepts ANY verifier
+        type (command/test/ci/data included) because the caller is the authenticated
+        operator — the same power the operator ``/goal`` chat path had before Phase 1.
+        Returns (ok, message)."""
+        from graph.goals.verifiers import VERIFIERS
+
+        if not condition:
+            return (False, "a goal condition is required.")
+        verifier = verifier or {"type": "llm"}
+        vtype = verifier.get("type", "llm")
+        if vtype not in VERIFIERS:
+            return (False, f"unknown verifier type {vtype!r}; known: {', '.join(sorted(VERIFIERS))}.")
+        state = GoalState(
+            session_id=session_id,
+            condition=condition,
+            verifier=verifier,
+            mode=("monitor" if mode == "monitor" else "drive"),
+            max_iterations=max_iterations or getattr(self._config, "goal_max_iterations", 8),
+            no_progress_limit=no_progress_limit,
+            deadline=deadline,
+            stall_after=stall_after,
+        )
+        self._store.set(state)
+        return (True, f"Goal set. {state.status_line()}")
+
     # --- agent goal-loop tools (retired the <goal_plan>/<goal_unachievable> XML) ---
 
     def record_plan(self, session_id: str, plan: str) -> tuple[bool, str]:

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -354,18 +354,27 @@ async def _operator_goals_clear(session_id: str) -> dict:
 
 
 async def _operator_goals_set(body: dict) -> dict:
-    """Programmatic goal-set (ADR 0028 D3) — plugin-verifier goals only; the route
-    maps ok=False to 400."""
+    """Operator goal-set (ADR 0066) — the trusted operator channel. This route lives on the
+    ``/api`` operator surface, which the auth path ceiling restricts to the operator
+    credential, so it accepts ANY verifier type (command/test/ci/data included) — unlike the
+    plugin-only programmatic ``set_goal_safe``. The route maps ok=False to 400."""
     if STATE.goal_controller is None:
         return {"ok": False, "error": "goal mode is not enabled"}
-    sid = str((body or {}).get("session_id") or "").strip()
+    body = body or {}
+    sid = str(body.get("session_id") or "").strip()
     if not sid:
         return {"ok": False, "error": "session_id is required"}
-    ok, msg = STATE.goal_controller.set_goal_safe(
+    from graph.goals.controller import GoalController
+
+    ok, msg = STATE.goal_controller.set_goal_operator(
         sid,
-        (body or {}).get("condition"),
-        (body or {}).get("verifier") or {},
-        (body or {}).get("max_iterations"),
+        body.get("condition"),
+        body.get("verifier") or {},
+        max_iterations=body.get("max_iterations"),
+        no_progress_limit=body.get("no_progress_limit"),
+        mode="monitor" if body.get("mode") == "monitor" else "drive",
+        deadline=GoalController._parse_deadline(body.get("deadline")),
+        stall_after=GoalController._parse_stall_after(body.get("stall_after")),
     )
     return {"ok": ok, "message": msg} if ok else {"ok": False, "error": msg}
 

--- a/plugins/docs/nav.json
+++ b/plugins/docs/nav.json
@@ -605,6 +605,10 @@
           "title": "0065 — Two-tier instance paths (box / instance) + single resolution rule"
         },
         {
+          "path": "adr/0066-goal-trust-operator-channel.md",
+          "title": "0066 — Goal trust-gate Phase 2: federation token + operator `/api` channel"
+        },
+        {
           "path": "adr/index.md",
           "title": "Architecture Decision Records"
         }

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -733,6 +733,7 @@ def _main():
         bearer_token=((STATE.graph_config.auth_token if STATE.graph_config else "") or None),
         api_key=os.environ.get(f"{AGENT_NAME_ENV.upper()}_API_KEY", ""),
         allowed_origins_raw=os.environ.get("A2A_ALLOWED_ORIGINS", ""),
+        federation_token=((STATE.graph_config.federation_token if STATE.graph_config else "") or None),
     )
 
     # Short-lived SSE token endpoint (Part 3 of auth inversion): the React

--- a/tests/test_a2a_auth.py
+++ b/tests/test_a2a_auth.py
@@ -24,10 +24,12 @@ from a2a_impl import auth
 def _reset_guard():
     """Each test seeds the guard itself; reset module state around it."""
     auth._BEARER[0] = None
+    auth._FEDERATION[0] = None
     auth._API_KEY[0] = ""
     auth._ALLOWED_ORIGINS[0] = None
     yield
     auth._BEARER[0] = None
+    auth._FEDERATION[0] = None
     auth._API_KEY[0] = ""
     auth._ALLOWED_ORIGINS[0] = None
 
@@ -485,6 +487,87 @@ def test_open_bind_optin_allowed_with_warning():
 
 
 # ── 7. _is_public coverage ───────────────────────────────────────────────────
+
+
+# ── 8. federation token + /api path ceiling (ADR 0066) ───────────────────────
+
+
+def _fed_configured():
+    auth.configure(bearer_token="op-secret", api_key="", allowed_origins_raw="", federation_token="fed-secret")
+
+
+def test_federation_token_denied_api_operator_surface():
+    _fed_configured()
+    c = _client_multi()
+    fed = {"Authorization": "Bearer fed-secret"}
+    # The /api operator surface (+ fleet-proxied variants) is 403 for a federation credential —
+    # even though the token itself is valid (the R1 path ceiling).
+    assert c.post("/api/config", headers=fed).status_code == 403
+    assert c.post("/api/subagents/run", headers=fed).status_code == 403
+    assert c.get("/active/foo/api/config", headers=fed).status_code == 403
+    assert c.get("/agents/slug/api/config", headers=fed).status_code == 403
+
+
+def test_federation_token_allowed_consumer_surface():
+    _fed_configured()
+    c = _client_multi()
+    fed = {"Authorization": "Bearer fed-secret"}
+    # /a2a + /v1 are the federation/consumer surfaces — a federation token passes.
+    assert c.post("/a2a", headers=fed).status_code == 200
+    assert c.post("/v1/chat/completions", headers=fed).status_code == 200
+
+
+def test_operator_token_reaches_everything():
+    _fed_configured()
+    c = _client_multi()
+    op = {"Authorization": "Bearer op-secret"}
+    assert c.post("/api/config", headers=op).status_code == 200
+    assert c.post("/api/subagents/run", headers=op).status_code == 200
+    assert c.post("/a2a", headers=op).status_code == 200
+    assert c.post("/v1/chat/completions", headers=op).status_code == 200
+
+
+def test_federation_invalid_token_still_401():
+    _fed_configured()
+    c = _client_multi()
+    bad = {"Authorization": "Bearer nope"}
+    assert c.post("/api/config", headers=bad).status_code == 401  # neither token → 401, not 403
+    assert c.post("/a2a", headers=bad).status_code == 401
+
+
+def test_single_token_mode_unchanged_no_ceiling():
+    # No federation token → the bearer holder is the operator everywhere (backward-compat).
+    auth.configure(bearer_token="op-secret", api_key="", allowed_origins_raw="")
+    c = _client_multi()
+    op = {"Authorization": "Bearer op-secret"}
+    assert c.post("/api/config", headers=op).status_code == 200
+    assert c.post("/a2a", headers=op).status_code == 200
+    # The would-be federation token is simply invalid in single-token mode.
+    assert c.post("/api/config", headers={"Authorization": "Bearer fed-secret"}).status_code == 401
+
+
+def test_federation_inert_in_open_mode():
+    # federation_token set but no operator bearer → open mode; the tier is inert.
+    auth.configure(bearer_token=None, api_key="", allowed_origins_raw="", federation_token="fed-secret")
+    assert auth._BEARER[0] is None
+    assert _client_multi().post("/api/config").status_code == 200  # open — no 403
+
+
+@pytest.mark.parametrize(
+    "path,operator",
+    [
+        ("/api/config", True),
+        ("/api/goals", True),
+        ("/api/plugins/install", True),
+        ("/active/slug/api/config", True),
+        ("/agents/x/api/events", True),
+        ("/a2a", False),
+        ("/v1/chat/completions", False),
+        ("/healthz", False),
+    ],
+)
+def test_requires_operator_classification(path, operator):
+    assert auth._requires_operator(path) is operator
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -180,7 +180,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
 }
 
 # Fields handled by their own dedicated assertions, not the golden map.
-_GOLDEN_EXEMPT = {"api_key", "auth_token", "plugin_config"}
+_GOLDEN_EXEMPT = {"api_key", "auth_token", "federation_token", "plugin_config"}
 
 # config_to_dict(from_yaml(example)) exact output — freezes the now-FIELDS-
 # complete emitted surface (B1 PR-3) so a later change shows up as a reviewable
@@ -486,6 +486,7 @@ def test_from_yaml_example_golden():
     # Redacted / unpinned fields get dedicated assertions.
     assert cfg.api_key == ""
     assert cfg.auth_token == ""
+    assert cfg.federation_token == ""  # ADR 0066 secret — redacted, no example value
     assert isinstance(cfg.plugin_config, dict)
 
     # Every other dataclass field must match the captured golden exactly.

--- a/tests/test_goal_controller.py
+++ b/tests/test_goal_controller.py
@@ -207,3 +207,27 @@ def test_chat_verifier_allow_list():
     assert not allowed({"type": "command", "command": "x"})
     assert not allowed({"type": "test"})
     assert not allowed({"type": "ci"})
+
+
+# --- operator goal channel (ADR 0066 — POST /api/goals, operator-tier gated) -----------
+
+
+def test_set_goal_operator_accepts_dangerous_verifiers(tmp_path):
+    # The operator /api channel accepts command/test/ci/data — unlike set_goal_safe
+    # (plugin-only) — because it's reachable only under the /api operator-tier ceiling.
+    c = _ctrl(tmp_path)
+    ok, msg = c.set_goal_operator("s", "tests pass", {"type": "command", "command": "pytest -q"})
+    assert ok and "Goal set" in msg
+    assert c.active_goal("s").verifier["type"] == "command"
+
+
+def test_set_goal_operator_rejects_unknown_verifier(tmp_path):
+    c = _ctrl(tmp_path)
+    ok, msg = c.set_goal_operator("s", "x", {"type": "bogus"})
+    assert not ok and "unknown verifier type" in msg
+
+
+def test_set_goal_operator_requires_condition(tmp_path):
+    c = _ctrl(tmp_path)
+    ok, msg = c.set_goal_operator("s", "", {"type": "command", "command": "true"})
+    assert not ok and "condition is required" in msg

--- a/tests/test_goal_set_programmatic.py
+++ b/tests/test_goal_set_programmatic.py
@@ -41,21 +41,26 @@ def test_requires_condition_and_check(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_rest_handler_gates_non_plugin(tmp_path, monkeypatch):
+async def test_rest_handler_is_the_operator_channel(tmp_path, monkeypatch):
+    # ADR 0066: POST /api/goals is the OPERATOR channel — gated to operator-tier by the
+    # /api auth path ceiling, not by the handler — so it accepts ANY verifier type
+    # (command/test/ci/data included), unlike the plugin-only agent/SDK path (set_goal_safe).
     from operator_api import console_handlers
     from runtime.state import STATE
 
     monkeypatch.setattr(STATE, "goal_controller", _ctrl(tmp_path))
 
-    good = await console_handlers._operator_goals_set(
+    plugin_goal = await console_handlers._operator_goals_set(
         {"session_id": "s", "condition": "c", "verifier": {"type": "plugin", "check": "x:y"}}
     )
-    assert good["ok"] is True
+    assert plugin_goal["ok"] is True
 
-    bad = await console_handlers._operator_goals_set(
-        {"session_id": "s", "condition": "c", "verifier": {"type": "command", "command": "x"}}
+    # A command verifier now SUCCEEDS via the operator channel (was rejected pre-0066) —
+    # the security control is the /api operator-tier ceiling, not this handler.
+    command_goal = await console_handlers._operator_goals_set(
+        {"session_id": "s2", "condition": "c", "verifier": {"type": "command", "command": "true"}}
     )
-    assert bad["ok"] is False and "error" in bad
+    assert command_goal["ok"] is True
 
     nosession = await console_handlers._operator_goals_set(
         {"condition": "c", "verifier": {"type": "plugin", "check": "x:y"}}


### PR DESCRIPTION
> **🔒 Security-critical — held as DRAFT for your review before merge.** Touches the auth middleware.

## What & why

Goal trust-gate **Phase 2, Option B** (the one you picked). Phase 1 (#1492) closed the RCE-via-chat hole by refusing `command`/`test`/`ci`/`data`+`expr` goal verifiers from a `/goal` **chat** message for *everyone* — including the operator, who lost a legitimate feature ("keep going until `pytest -q` passes"). Phase 2 gives that power back through a **dedicated operator channel**, and adds the **path ceiling** that makes a federation token real. Full design: `docs/adr/0066-goal-trust-operator-channel.md`.

## The mechanism

- **`auth.federation_token`** (optional; env `A2A_FEDERATION_TOKEN`). The middleware classifies each request by **which secret matched** (constant-time `hmac.compare_digest`) → `operator` | `federation`.
- **R1 path ceiling:** a federation credential is **denied the whole `/api` operator surface** (plugin install/enable = host code-exec, config/SOUL rewrite, subagent runs, the operator goal set-path) with `403`. `/a2a` + `/v1` stay open to either tier. **The ceiling lives entirely in the middleware** — a request that *reaches* an `/api` handler is operator-tier by construction, so no per-request trust has to be threaded into handlers or the streaming producer (this is Option B's simplification over A's fragile propagation).
- **Operator goal channel:** `GoalController.set_goal_operator` accepts **any** verifier type; `POST /api/goals` routes to it (was plugin-only). Safe because `/api` is operator-tier by the ceiling. `set_goal_safe` (agent/SDK/plugin) stays `plugin`-only.

## Backward compatibility (opt-in, fail-safe)

No `federation_token` configured ⇒ **single-token mode**, byte-for-byte unchanged: the bearer check is exactly the old one and the ceiling never fires.

**The one judgement call to sanity-check (ADR D4):** loosening `POST /api/goals` to accept `command` verifiers is safe because in single-token mode any bearer holder *already* has host code-exec via `/api/plugins/install` — so the goal endpoint adds no new capability; the **ceiling** (not the goal handler) is the real control. If you'd rather keep defense-in-depth and only accept dangerous verifiers when a federation token is actually configured, that's a ~2-line guard I can add — flag it in review.

## Tests

`test_a2a_auth.py`: federation denied `/api` (+ `/active/<slug>/api`, `/agents/<slug>/api` proxied variants) / allowed `/a2a`+`/v1`; operator full access; invalid token still 401 (not 403); single-token + open-mode unchanged; `_requires_operator` classification. `test_goal_controller.py`: `set_goal_operator` accepts dangerous verifiers, rejects unknown, requires condition. Config-roundtrip golden + REST-handler contract updated. **379 passed, ruff clean.**

## Follow-up slices (ADR 0066)
- PR2 — CLI `goal set` (thin client of `POST /api/goals`).
- PR3 — console Goals set-form (DRAFT, local-test gate) — the set-path UI deferred from the goal.iteration work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)