### PR TITLE
feat(watches): standalone watch primitive — many concurrent supervised watches (ADR 0067)

### DIFF
--- a/docs/adr/0067-standalone-watch-primitive.md
+++ b/docs/adr/0067-standalone-watch-primitive.md
@@ -1,0 +1,110 @@
+# 0067 — Standalone `watch` primitive (many concurrent watches)
+
+Status: **Accepted**
+
+> Resolves the fork-in-the-road ADR 0030 left open ("a separate watch primitive … open to
+> the inverse call in review"). A supervisor agent needs to babysit **many** external
+> processes **at once**; the monitor-goal *disposition* can't, because a goal is keyed
+> one-per-session. This adds a first-class `watch` primitive and ties it to
+> `sdk.run_in_session` (ADR/#1494) so a met watch can run a follow-up agent turn.
+
+## Context
+
+ADR 0030 gave goals a `monitor` disposition: an out-of-band, verifier-only objective the
+agent *supervises* rather than *drives*. It was the right shape for **one** standing
+watch, but it lives inside `GoalState` and `GoalStore`, which key **one goal per session**.
+That imposes two limits that a supervisor agent hits immediately:
+
+1. **One watch per session.** You can't watch a deploy *and* CI *and* a treasury *and* a
+   backlog concurrently from one context.
+2. **Session-coupling.** ADR 0030 D2 itself notes monitor evaluation is *"decoupled from
+   sessions and turns"* — it polls global state — so keying it by `session_id` is an
+   impedance mismatch.
+
+`GoalState` also became a union type: half its fields are drive-only
+(`iteration`/`max_iterations`/`no_progress_streak`/`checklist`/`abandon_reason`), half
+monitor-only (`deadline`/`stall_after`/`stall_streak`/`last_checked`) — dead weight either
+way.
+
+## Decision
+
+Add a standalone `watch` primitive. A **goal** stays what it is best at — the agent
+*drives* a bounded loop toward it (`drive` mode). A **watch** is the passive counterpart:
+*poll a condition on a cadence; when it trips, react* — and you can hold as many as you
+like.
+
+### D1 — `Watch` + `WatchStore` (keyed by watch id, many per instance)
+
+```
+Watch = { id, condition, verifier, interval_s, status,
+          deadline?, stall_after?,                       # termination / stall (as ADR 0030 D5)
+          run_prompt?, run_session?,                     # reaction: enqueue a turn (D3)
+          created_at, last_checked, last_reason, last_evidence, stall_streak, ... }
+```
+
+`WatchStore` writes one JSON per **watch id** (not session), `PROTOAGENT_INSTANCE`-scoped
+exactly like `GoalStore`. So an agent/instance holds N concurrent watches; `list()` returns
+them all. Verifiers are **reused verbatim** from `graph/goals/verifiers.py` (plugin /
+command / test / ci / data / llm) — no new verification surface.
+
+### D2 — Out-of-band tick
+
+A `_watch_loop` (mirroring `_monitor_goals_loop`) evaluates every active watch on a cadence
+(`watch_interval` default 30s; a watch may set a shorter per-watch `interval_s`), verifier
+only, no agent turn. Met → finish + react; deadline passed → `expired` (fires `on_expired`);
+`stall_after` consecutive unchanged checks → `on_stalled` once per episode (watch stays
+active).
+
+### D3 — Reaction = `run_in_session` + hooks (the supervision payoff)
+
+When a watch is **met**, two reactions fire, either/both:
+
+- **Run a follow-up turn.** If the watch carries `run_prompt`, the controller enqueues it as
+  a one-shot agent turn via `sdk.run_in_session(run_session, run_prompt)` (ADR/#1494) — the
+  agent *acts* on the trip ("deploy finished → run the smoke test"), non-blocking.
+- **Fire hooks.** `register_watch_hook(on_met=…, on_stalled=…, on_expired=…)` lets a plugin
+  react in-process (notify, record, set the next watch).
+
+This is the parallel-supervision engine: N watches, each with its own trip-action.
+
+### D4 — Set-paths mirror the goal trust model
+
+- **Agent tool** `create_watch(condition, check, …)` / `list_watches` / `clear_watch` —
+  `plugin`-verifier only (same posture as `set_goal`, ADR 0028 D3): the agent can't open a
+  shell/eval watch.
+- **Operator** `POST/GET/DELETE /api/watches` — accepts **any** verifier type, safe because
+  `/api` is operator-tier by the ADR 0066 path ceiling (the operator channel).
+- **SDK** `sdk.create_watch(...)` + `register_watch_hook(...)` for plugins.
+
+### D5 — Relationship to the monitor-goal disposition
+
+Watches **supersede** ADR 0030's `monitor` mode. Monitor-goal mode keeps working
+(back-compat: `sdk.start_goal_loop(mode="monitor")`, existing forks) but is **deprecated**;
+a follow-up can reimplement `start_goal_loop`'s monitor path over watches and eventually
+drop the `mode` field, leaving `GoalState` drive-only (shedding the union fields). No
+breaking change here.
+
+## Consequences
+
+- A supervisor agent holds **many** concurrent, independently-reacting watches.
+- `watch` + `run_in_session` compose into event→action supervision without bespoke glue.
+- `GoalState` can shrink to drive-only once monitor mode is retired (follow-up).
+- Additive: goals, `run_goal_loop`, and existing monitor goals are untouched.
+
+## Alternatives considered
+
+- **Keep the disposition, lift the one-per-session limit inside `GoalStore`.** Rejected:
+  it drags the whole drive-loop union type along and keeps session-coupling; the concept is
+  cleaner as its own primitive.
+- **Reuse the scheduler directly (a cron job whose prompt is "check X").** That's the ADR
+  0028 anti-pattern ("storms the loop") and has no verifier/terminal/stall model — a watch
+  is verifier-first with typed termination.
+
+## Slices
+
+- **PR1 (this ADR)** — the engine: `Watch` + `WatchStore` + `WatchController`
+  (create/list/clear/evaluate/tick) + hooks + the `_watch_loop` tick + agent tools + tests.
+- **PR2** — operator `/api/watches` + `sdk.create_watch`.
+- **PR3** — console **Watches** panel (list/status/clear; DRAFT, local-test gate).
+- **Follow-up** — migrate `start_goal_loop` monitor path onto watches; deprecate the goal
+  `monitor` mode.

--- a/graph/watches/__init__.py
+++ b/graph/watches/__init__.py
@@ -1,0 +1,7 @@
+"""Watch primitive (ADR 0067) — many concurrent, out-of-band, verifier-backed watches."""
+
+from graph.watches.controller import WatchController
+from graph.watches.store import WatchStore
+from graph.watches.types import TERMINAL_STATUSES, Watch
+
+__all__ = ["WatchController", "WatchStore", "Watch", "TERMINAL_STATUSES"]

--- a/graph/watches/controller.py
+++ b/graph/watches/controller.py
@@ -1,0 +1,198 @@
+"""WatchController — create/list/clear + the out-of-band evaluate/tick (ADR 0067).
+
+Pure of graph calls so it's unit-testable. Verifiers are reused verbatim from
+``graph/goals/verifiers.py``. On *met* the optional ``run_prompt`` is enqueued as a one-shot
+agent turn via ``sdk.run_in_session`` (ADR/#1494) and ``on_met`` hooks fire; a passed
+``deadline`` finishes the watch ``expired``; ``stall_after`` unchanged checks fire
+``on_stalled`` (the watch stays active).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+
+from graph.goals.verifiers import VERIFIERS, VerifyContext, run_verifier
+from graph.watches.store import WatchStore
+from graph.watches.types import Watch
+
+log = logging.getLogger(__name__)
+
+# Verifier types safe to create PROGRAMMATICALLY (agent tool / plugin / SDK). Only `plugin`
+# — command/test/ci shell out and `data` eval()s a spec expr; those stay operator-only (the
+# /api/watches channel, gated to operator-tier by the ADR 0066 path ceiling). Mirrors
+# GoalController.SAFE_PROGRAMMATIC_VERIFIERS.
+SAFE_PROGRAMMATIC_VERIFIERS = frozenset({"plugin"})
+
+
+class WatchController:
+    def __init__(self, config, store: WatchStore | None = None):
+        self._config = config
+        self._store = store or WatchStore()
+
+    @property
+    def store(self) -> WatchStore:
+        return self._store
+
+    def active_watches(self) -> list[Watch]:
+        return [w for w in self._store.all() if w.active]
+
+    def list_watches(self) -> list[Watch]:
+        return self._store.all()
+
+    def clear(self, watch_id: str) -> bool:
+        return self._store.clear(watch_id)
+
+    # --- create ------------------------------------------------------------
+
+    def create(
+        self,
+        *,
+        condition: str,
+        verifier: dict,
+        watch_id: str | None = None,
+        interval_s: float | None = None,
+        deadline: float | None = None,
+        stall_after: int | None = None,
+        run_prompt: str = "",
+        run_session: str = "",
+        trusted: bool = False,
+    ) -> tuple[bool, str, Watch | None]:
+        """Create a watch. ``trusted=False`` (agent/plugin/SDK) allows ONLY a ``plugin``
+        verifier (like ``set_goal_safe``); ``trusted=True`` (operator ``/api/watches``,
+        gated to operator-tier by the ADR 0066 ceiling) accepts any verifier type. A blank
+        ``watch_id`` is derived from the condition (idempotent: same condition → same id,
+        replaced). Returns ``(ok, message, watch|None)``."""
+        if not condition:
+            return (False, "a watch condition is required.", None)
+        verifier = verifier or {"type": "llm"}
+        vtype = verifier.get("type", "llm")
+        if vtype not in VERIFIERS:
+            return (False, f"unknown verifier type {vtype!r}; known: {', '.join(sorted(VERIFIERS))}.", None)
+        if not trusted and vtype not in SAFE_PROGRAMMATIC_VERIFIERS:
+            return (
+                False,
+                f"programmatic watches must use a 'plugin' verifier (got {vtype!r}); "
+                "command/test/ci/data verifiers are operator-only — create them via POST /api/watches.",
+                None,
+            )
+        if vtype == "plugin" and not verifier.get("check"):
+            return (False, "a plugin verifier needs a 'check' (the <plugin-id>:<name>).", None)
+        wid = (watch_id or "").strip() or self._derive_id(condition)
+        watch = Watch(
+            id=wid,
+            condition=condition,
+            verifier=verifier,
+            interval_s=interval_s,
+            deadline=deadline,
+            stall_after=stall_after,
+            run_prompt=run_prompt or "",
+            run_session=run_session or "",
+        )
+        self._store.set(watch)
+        return (True, f"Watch created. {watch.status_line()}", watch)
+
+    @staticmethod
+    def _derive_id(condition: str) -> str:
+        """A stable id from the condition — slug + short hash, so re-creating the same
+        condition replaces it (idempotent) while distinct conditions get distinct ids. Pass an
+        explicit ``watch_id`` to hold two watches on the identical condition."""
+        slug = "".join(c if c.isalnum() else "-" for c in (condition or "watch").lower()).strip("-")[:24].strip("-")
+        h = hashlib.sha1((condition or "").encode()).hexdigest()[:6]
+        return f"{slug or 'watch'}-{h}"
+
+    # --- evaluation --------------------------------------------------------
+
+    async def evaluate(self, watch_id: str) -> str | None:
+        """Run one watch's verifier out-of-band. Met → finish+react; deadline passed →
+        ``expired``; ``stall_after`` unchanged checks → ``on_stalled`` (stays active). Returns
+        the terminal status, or ``None`` while still active."""
+        watch = self._store.get(watch_id)
+        if watch is None or not watch.active:
+            return None
+        ctx = VerifyContext(
+            config=self._config, condition=watch.condition, last_text="", tool_summary="", cwd=os.getcwd()
+        )
+        result = await run_verifier(watch.verifier, ctx)
+        from time import time
+
+        now = time()
+        if result.met:
+            return await self._finish(watch, "met", result.reason or "verifier passed", result.evidence)
+        if watch.deadline is not None and now >= watch.deadline:
+            return await self._finish(watch, "expired", "deadline passed before the watch met", result.evidence)
+
+        unchanged = result.reason == watch.last_reason and result.evidence == watch.last_evidence
+        watch.stall_streak = (watch.stall_streak + 1) if unchanged else 0
+        if not unchanged:
+            watch.stalled_notified = False
+        if watch.stall_after and watch.stall_streak >= watch.stall_after and not watch.stalled_notified:
+            watch.stalled_notified = True
+            from graph.watches.hooks import fire_watch_hook
+
+            await fire_watch_hook("on_stalled", watch)
+            self._publish("watch.stalled", watch, result.reason)
+        watch.last_reason = result.reason
+        watch.last_evidence = result.evidence
+        watch.last_checked = now
+        self._store.set(watch)
+        return None
+
+    async def evaluate_now(self, watch_id: str) -> str | None:
+        """Event-driven fast path — a plugin calls this from its own state-change path so a
+        met watch is caught promptly instead of at the next tick. Same semantics as evaluate."""
+        return await self.evaluate(watch_id)
+
+    async def tick_all(self) -> int:
+        """Evaluate every active watch out-of-band (verifier-only, no agent turn). The server
+        runs this on a cadence. Returns how many reached a terminal state this tick."""
+        finished = 0
+        for watch in self.active_watches():
+            try:
+                status = await self.evaluate(watch.id)
+            except Exception:  # noqa: BLE001 — one bad watch must not stop the tick
+                log.exception("[watch] tick failed for %s", watch.id)
+                continue
+            if status is not None:
+                finished += 1
+        return finished
+
+    async def _finish(self, watch: Watch, status: str, reason: str, evidence: str = "") -> str:
+        from time import time
+
+        from graph.watches.hooks import fire_watch_hook
+
+        watch.status = status
+        watch.last_reason = reason
+        if evidence:
+            watch.last_evidence = evidence
+        watch.finished_at = time()
+        self._store.set(watch)
+
+        # Reaction (ADR 0067 D3): on MET, enqueue the follow-up prompt as a one-shot agent
+        # turn in the watch's target session — non-blocking, reuses the tested run_in_session
+        # primitive. Skipped when there's no prompt or no target session (hooks still fire).
+        if status == "met" and (watch.run_prompt or "").strip() and (watch.run_session or "").strip():
+            try:
+                from graph.sdk import run_in_session
+
+                run_in_session(watch.run_session, watch.run_prompt, job_id=f"watch-{watch.id}")
+            except Exception:  # noqa: BLE001 — a reaction failure must not break the tick
+                log.exception("[watch] run_in_session reaction failed for %s", watch.id)
+
+        await fire_watch_hook("on_met" if status == "met" else "on_expired", watch)
+        self._publish("watch.met" if status == "met" else "watch.expired", watch, reason)
+        return status
+
+    def _publish(self, topic: str, watch: Watch, reason: str = "") -> None:
+        try:
+            from graph.plugins.host import HOST
+
+            if HOST.publish:
+                HOST.publish(
+                    topic,
+                    {"id": watch.id, "condition": watch.condition, "status": watch.status, "reason": reason},
+                )
+        except Exception:  # noqa: BLE001
+            pass

--- a/graph/watches/hooks.py
+++ b/graph/watches/hooks.py
@@ -1,0 +1,37 @@
+"""Watch lifecycle hooks (ADR 0067 D3).
+
+A plugin reacts when a watch trips — ``on_met`` (verifier passed), ``on_expired`` (deadline
+passed), ``on_stalled`` (unchanged evidence for ``stall_after`` checks; the watch stays
+active). Populated by the loader at graph build via ``set_watch_hooks`` (re-set on reload),
+fired from ``WatchController``. A hook fn takes the ``Watch``; sync or async. A hook that
+raises is logged and swallowed — a bad hook must never break the tick.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+
+log = logging.getLogger(__name__)
+
+# Each entry: {"plugin_id", "on_met": fn|None, "on_expired": fn|None, "on_stalled": fn|None}.
+_WATCH_HOOKS: list[dict] = []
+
+
+def set_watch_hooks(hooks: list[dict] | None) -> None:
+    """Replace the registered watch hooks (called at build + reload)."""
+    _WATCH_HOOKS[:] = list(hooks or [])
+
+
+async def fire_watch_hook(event: str, watch) -> None:
+    """Fire the matching hook for ``event`` (``on_met`` | ``on_expired`` | ``on_stalled``)."""
+    for hook in _WATCH_HOOKS:
+        fn = hook.get(event)
+        if fn is None:
+            continue
+        try:
+            result = fn(watch)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:  # noqa: BLE001 — a bad hook must not break the tick
+            log.exception("[watch] %s hook (plugin %s) failed", event, hook.get("plugin_id"))

--- a/graph/watches/store.py
+++ b/graph/watches/store.py
@@ -1,0 +1,121 @@
+"""WatchStore — per-watch persistence on disk (ADR 0067).
+
+Mirrors ``GoalStore``, but keyed by **watch id** (not session) so an instance holds MANY
+concurrent watches. Path resolution mirrors the goal/memory subsystems: ``WATCH_PATH`` env →
+``/sandbox/watches`` → ``~/.protoagent/watches``, all ``PROTOAGENT_INSTANCE``-scoped.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from graph.watches.types import Watch
+
+log = logging.getLogger(__name__)
+
+
+def _publish(topic: str, data: dict) -> None:
+    """Best-effort bus push so a console Watches panel can invalidate live. No-op when the
+    host hasn't wired a publisher (unit tests); a bus hiccup must never break a write."""
+    try:
+        from graph.plugins.host import HOST
+
+        if HOST.publish:
+            HOST.publish(topic, data)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _resolve_base() -> Path:
+    # Per-instance scoping (ADR 0004), mirroring GoalStore.
+    from infra.paths import scope_leaf
+
+    candidates: list[Path] = []
+    env = os.environ.get("WATCH_PATH", "").strip()
+    if env:
+        candidates.append(Path(env))
+    candidates.append(Path("/sandbox/watches"))
+    candidates.append(Path.home() / ".protoagent" / "watches")
+    for raw in candidates:
+        path = scope_leaf(raw)
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+            probe = path / ".write_probe"
+            probe.touch()
+            probe.unlink()
+            return path
+        except OSError:
+            continue
+    fallback = scope_leaf(Path(tempfile.gettempdir()) / "protoagent_watches")
+    fallback.mkdir(parents=True, exist_ok=True)
+    return fallback
+
+
+def _safe_name(watch_id: str) -> str:
+    return "".join(c if c.isalnum() or c in "-_." else "_" for c in watch_id) or "watch"
+
+
+class WatchStore:
+    def __init__(self, base_dir: str | os.PathLike | None = None):
+        self._base = Path(base_dir) if base_dir else _resolve_base()
+        log.info("[watch] store path: %s", self._base)
+
+    def _path(self, watch_id: str) -> Path:
+        return self._base / f"{_safe_name(watch_id)}.json"
+
+    def get(self, watch_id: str) -> Watch | None:
+        path = self._path(watch_id)
+        if not path.exists():
+            return None
+        try:
+            with open(path, encoding="utf-8") as fh:
+                return Watch.from_dict(json.load(fh))
+        except (OSError, json.JSONDecodeError, ValueError, TypeError) as exc:
+            log.warning("[watch] failed to read %s: %s", path, exc)
+            return None
+
+    def set(self, watch: Watch) -> None:
+        path = self._path(watch.id)
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=self._base, suffix=".tmp")
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                json.dump(watch.to_dict(), fh, indent=2, default=str)
+            os.rename(tmp_path, path)
+            tmp_path = None
+            _publish("watch.changed", {"id": watch.id})
+        except OSError as exc:
+            log.error("[watch] write failed for %s: %s", watch.id, exc)
+        finally:
+            if tmp_path is not None:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+    def clear(self, watch_id: str) -> bool:
+        path = self._path(watch_id)
+        try:
+            path.unlink()
+            _publish("watch.changed", {"id": watch_id})
+            return True
+        except FileNotFoundError:
+            return False
+        except OSError as exc:
+            log.warning("[watch] clear failed for %s: %s", watch_id, exc)
+            return False
+
+    def all(self) -> list[Watch]:
+        """Every persisted watch, newest-created first. Unreadable files are skipped+logged."""
+        watches: list[Watch] = []
+        for path in self._base.glob("*.json"):
+            try:
+                with open(path, encoding="utf-8") as fh:
+                    watches.append(Watch.from_dict(json.load(fh)))
+            except (OSError, json.JSONDecodeError, ValueError, TypeError) as exc:
+                log.warning("[watch] skipping %s: %s", path, exc)
+        watches.sort(key=lambda w: getattr(w, "created_at", 0) or 0, reverse=True)
+        return watches

--- a/graph/watches/store.py
+++ b/graph/watches/store.py
@@ -31,26 +31,28 @@ def _publish(topic: str, data: dict) -> None:
 
 
 def _resolve_base() -> Path:
-    # Per-instance scoping (ADR 0004), mirroring GoalStore.
-    from infra.paths import scope_leaf
+    # Per-instance (ADR 0004/0065), mirroring GoalStore: the default sits at
+    # ``instance_root/watches`` so two agents on one machine don't share a watch dir.
+    # ``WATCH_PATH`` env overrides verbatim.
+    from infra.paths import instance_paths
 
-    candidates: list[Path] = []
+    candidates = []
     env = os.environ.get("WATCH_PATH", "").strip()
     if env:
-        candidates.append(Path(env))
-    candidates.append(Path("/sandbox/watches"))
-    candidates.append(Path.home() / ".protoagent" / "watches")
-    for raw in candidates:
-        path = scope_leaf(raw)
+        candidates.append(Path(env).expanduser())
+    candidates.append(instance_paths().store("watches"))
+    for path in candidates:
         try:
             path.mkdir(parents=True, exist_ok=True)
+            # confirm writable
             probe = path / ".write_probe"
             probe.touch()
             probe.unlink()
             return path
         except OSError:
             continue
-    fallback = scope_leaf(Path(tempfile.gettempdir()) / "protoagent_watches")
+    # Last resort: a temp dir (keeps the server alive even if nothing is writable).
+    fallback = Path(tempfile.gettempdir()) / "protoagent_watches"
     fallback.mkdir(parents=True, exist_ok=True)
     return fallback
 

--- a/graph/watches/types.py
+++ b/graph/watches/types.py
@@ -1,0 +1,71 @@
+"""Watch-mode data types (ADR 0067).
+
+A *watch* is a passive, out-of-band objective: poll a condition on a cadence, and when it
+trips, react (run a follow-up agent turn and/or fire hooks). Unlike a *goal* — which the
+agent DRIVES via a bounded continuation loop, one per session — a watch is verifier-only and
+you can hold MANY at once (keyed by its own id, not the session). It's the parallel-
+supervision counterpart to goal-drive.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from time import time
+
+# Watch lifecycle:
+#   active   — being polled on a cadence
+#   met      — the verifier passed (reaction fired)
+#   expired  — a deadline passed before it met (on_expired fired)
+#   cleared  — removed by an operator/agent/plugin
+TERMINAL_STATUSES = ("met", "expired", "cleared")
+
+
+@dataclass
+class Watch:
+    """A persisted watch, keyed by ``id`` (many per instance).
+
+    ``verifier`` is the same free-form spec dict goals use (``type`` selects an entry in
+    ``graph/goals/verifiers.VERIFIERS``). On *met*, the optional ``run_prompt`` is enqueued
+    as a one-shot agent turn in ``run_session`` (via ``sdk.run_in_session``); registered
+    hooks fire regardless.
+    """
+
+    id: str
+    condition: str
+    verifier: dict = field(default_factory=lambda: {"type": "llm"})
+    status: str = "active"
+    interval_s: float | None = None  # per-watch cadence override; None → config watch_interval
+    deadline: float | None = None  # epoch seconds; past → expired (fires on_expired)
+    stall_after: int | None = None  # N unchanged checks → on_stalled (watch stays active)
+    # Reaction (ADR 0067 D3): on met, enqueue this prompt as a one-shot agent turn in
+    # ``run_session`` via sdk.run_in_session. Both empty → the watch reacts via hooks only.
+    run_prompt: str = ""
+    run_session: str = ""
+    created_at: float = field(default_factory=time)
+    last_checked: float | None = None
+    last_reason: str = ""
+    last_evidence: str = ""
+    stall_streak: int = 0
+    stalled_notified: bool = False
+    finished_at: float | None = None
+
+    @property
+    def active(self) -> bool:
+        return self.status == "active"
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Watch":
+        # Tolerate unknown/missing keys so older files load forward-compatibly.
+        known = {f for f in cls.__dataclass_fields__}  # type: ignore[attr-defined]
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+    def status_line(self) -> str:
+        """One-line human summary for list output + status."""
+        vt = self.verifier.get("type", "llm")
+        base = f"watch [{self.status}] ({self.id}) via {vt}: {self.condition!r}"
+        if self.last_reason:
+            base += f" — {self.last_reason}"
+        return base

--- a/plugins/docs/nav.json
+++ b/plugins/docs/nav.json
@@ -609,6 +609,10 @@
           "title": "0066 — Goal trust-gate Phase 2: federation token + operator `/api` channel"
         },
         {
+          "path": "adr/0067-standalone-watch-primitive.md",
+          "title": "0067 — Standalone `watch` primitive (many concurrent watches)"
+        },
+        {
           "path": "adr/index.md",
           "title": "Architecture Decision Records"
         }

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -23,6 +23,7 @@ class AppState:
     checkpoint_path: Any = None
     checkpoint_prune_task: Any = None
     monitor_goals_task: Any = None  # ADR 0030 monitor-goal cadence loop
+    watch_task: Any = None  # ADR 0067 watch cadence loop
     # Stores / registries bound into the active graph.
     knowledge_store: Any = None
     skills_index: Any = None
@@ -68,6 +69,7 @@ class AppState:
     background_mgr: Any = None  # ADR 0050 — detached background subagent jobs
     cache_warmer: Any = None
     goal_controller: Any = None
+    watch_controller: Any = None  # ADR 0067 — standalone watch primitive
     main_loop: Any = None
     # The port this process actually bound to (populated by _main).
     active_port: int = 7870

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -238,6 +238,7 @@ from server.agent_init import (  # noqa: E402,F401 — re-export of the extracte
     _checkpoint_prune_loop,
     _init_langgraph_agent,
     _monitor_goals_loop,
+    _watch_loop,
     _mount_plugin_routers,
     _plugin_agent_invoke,
     _populate_plugin_host,
@@ -522,6 +523,7 @@ def _main():
             import asyncio
 
             STATE.monitor_goals_task = asyncio.create_task(_monitor_goals_loop())
+            STATE.watch_task = asyncio.create_task(_watch_loop())
 
         # (The inbound Discord gateway now starts as the discord plugin's surface,
         # below — ADR 0018/0019.)
@@ -640,6 +642,8 @@ def _main():
             STATE.checkpoint_prune_task.cancel()
         if STATE.monitor_goals_task is not None:
             STATE.monitor_goals_task.cancel()
+        if STATE.watch_task is not None:
+            STATE.watch_task.cancel()
         # Close the long-lived A2A push-notification client (created below in
         # _main) so its connection pool doesn't leak on shutdown/reload — matters
         # in the desktop-sidecar restart loop. Best-effort; NameError if boot

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -282,6 +282,11 @@ def _init_langgraph_agent(headless_setup: bool = False):
         STATE.goal_controller = GoalController(STATE.graph_config, GoalStore())
     else:
         STATE.goal_controller = None
+    # Watch primitive (ADR 0067) — many concurrent, out-of-band watches. Machinery only; no
+    # watch runs until one is created, so it's always on (cheap when idle).
+    from graph.watches import WatchController, WatchStore
+
+    STATE.watch_controller = WatchController(STATE.graph_config, WatchStore())
     log.info(
         "LangGraph agent initialized (model: %s, knowledge_db: %s, scheduler: %s)",
         STATE.graph_config.model_name,
@@ -816,6 +821,25 @@ async def _monitor_goals_loop() -> None:
                     log.info("[goal-monitor] %d monitor goal(s) reached a terminal state", n)
             except Exception:
                 log.exception("[goal-monitor] tick failed")
+        await asyncio.sleep(max(5, interval))
+
+
+async def _watch_loop() -> None:
+    """Out-of-band cadence for watches (ADR 0067): periodically run each active watch's
+    verifier — no agent turn — so a met watch reacts (run_in_session + hooks) without waiting
+    for a session turn. Many watches tick together; verifier-only."""
+    await asyncio.sleep(15)  # let boot settle before the first tick
+    while True:
+        ctrl = STATE.watch_controller
+        cfg = STATE.graph_config
+        interval = getattr(cfg, "watch_interval", 30) if cfg else 30
+        if ctrl is not None:
+            try:
+                n = await ctrl.tick_all()
+                if n:
+                    log.info("[watch] %d watch(es) reached a terminal state", n)
+            except Exception:
+                log.exception("[watch] tick failed")
         await asyncio.sleep(max(5, interval))
 
 

--- a/tests/test_watch_controller.py
+++ b/tests/test_watch_controller.py
@@ -1,0 +1,174 @@
+"""WatchController — create / trust-gate / evaluate / tick, and the many-concurrent-watches
+property that motivated the primitive (ADR 0067)."""
+
+import pytest
+
+from graph.config import LangGraphConfig
+from graph.watches.controller import WatchController
+from graph.watches.store import WatchStore
+
+
+def _ctrl(tmp_path, **overrides):
+    cfg = LangGraphConfig(**overrides)
+    return WatchController(cfg, WatchStore(tmp_path))
+
+
+# --- create + trust gate ---------------------------------------------------
+
+
+def test_create_plugin_verifier_untrusted_ok(tmp_path):
+    c = _ctrl(tmp_path)
+    ok, msg, w = c.create(condition="reach 1M", verifier={"type": "plugin", "check": "p:v"})
+    assert ok and w is not None and "Watch created" in msg
+    assert w.verifier["type"] == "plugin"
+
+
+def test_create_untrusted_rejects_dangerous_verifiers(tmp_path):
+    c = _ctrl(tmp_path)
+    for spec in ({"type": "command", "command": "x"}, {"type": "test"}, {"type": "data", "path": "/x", "expr": "1"}):
+        ok, msg, w = c.create(condition="c", verifier=spec)
+        assert not ok and w is None and "operator-only" in msg
+
+
+def test_create_trusted_accepts_dangerous_verifier(tmp_path):
+    # The operator channel (trusted=True, gated to operator-tier by the ADR 0066 /api ceiling)
+    # accepts any verifier type.
+    c = _ctrl(tmp_path)
+    ok, _msg, w = c.create(condition="tests pass", verifier={"type": "command", "command": "true"}, trusted=True)
+    assert ok and w.verifier["type"] == "command"
+
+
+def test_create_rejects_unknown_verifier(tmp_path):
+    c = _ctrl(tmp_path)
+    ok, msg, w = c.create(condition="c", verifier={"type": "bogus"}, trusted=True)
+    assert not ok and "unknown verifier type" in msg
+
+
+def test_create_requires_condition(tmp_path):
+    c = _ctrl(tmp_path)
+    ok, msg, _w = c.create(condition="", verifier={"type": "plugin", "check": "p:v"})
+    assert not ok and "condition is required" in msg
+
+
+# --- MANY concurrent watches (the whole point of the primitive) ------------
+
+
+def test_many_concurrent_watches(tmp_path):
+    c = _ctrl(tmp_path)
+    for cond in ("watch deploy", "watch CI", "watch treasury", "watch backlog"):
+        ok, _m, _w = c.create(condition=cond, verifier={"type": "plugin", "check": "p:v"})
+        assert ok
+    watches = c.list_watches()
+    assert len(watches) == 4  # a goal could only hold ONE per session — a watch holds many
+    assert {w.condition for w in watches} == {"watch deploy", "watch CI", "watch treasury", "watch backlog"}
+    assert len({w.id for w in watches}) == 4  # distinct ids
+
+
+def test_same_condition_idempotent_explicit_id_opts_in(tmp_path):
+    c = _ctrl(tmp_path)
+    c.create(condition="watch deploy", verifier={"type": "plugin", "check": "p:v"})
+    c.create(condition="watch deploy", verifier={"type": "plugin", "check": "p:v"})  # same condition → same id
+    assert len(c.list_watches()) == 1
+    c.create(condition="watch deploy", verifier={"type": "plugin", "check": "p:v"}, watch_id="deploy-2")
+    assert len(c.list_watches()) == 2  # explicit id → a second, distinct watch
+
+
+# --- evaluate: met / not-met / expired / stall / tick ----------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_met_finishes(tmp_path):
+    c = _ctrl(tmp_path)
+    _ok, _m, w = c.create(condition="done", verifier={"type": "command", "command": "exit 0"}, trusted=True)
+    assert await c.evaluate(w.id) == "met"
+    assert c.store.get(w.id).status == "met"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_not_met_stays_active(tmp_path):
+    c = _ctrl(tmp_path)
+    _ok, _m, w = c.create(condition="pending", verifier={"type": "command", "command": "exit 1"}, trusted=True)
+    assert await c.evaluate(w.id) is None
+    assert c.store.get(w.id).active
+
+
+@pytest.mark.asyncio
+async def test_evaluate_deadline_expires(tmp_path):
+    c = _ctrl(tmp_path)
+    _ok, _m, w = c.create(
+        condition="deploy", verifier={"type": "command", "command": "exit 1"}, deadline=1.0, trusted=True
+    )  # deadline epoch 1.0 = long past
+    assert await c.evaluate(w.id) == "expired"
+
+
+@pytest.mark.asyncio
+async def test_stall_fires_on_stalled_without_ending(tmp_path):
+    from graph.watches import hooks as watch_hooks
+
+    fired: list[str] = []
+    watch_hooks.set_watch_hooks([{"plugin_id": "t", "on_stalled": lambda w: fired.append(w.id)}])
+    try:
+        c = _ctrl(tmp_path)
+        _ok, _m, w = c.create(
+            condition="stuck", verifier={"type": "command", "command": "exit 1"}, stall_after=2, trusted=True
+        )
+        await c.evaluate(w.id)  # baseline (streak 0)
+        await c.evaluate(w.id)  # streak 1
+        assert fired == []
+        await c.evaluate(w.id)  # streak 2 → fire once
+        assert fired == [w.id]
+        assert c.store.get(w.id).active  # signal, NOT terminal
+        await c.evaluate(w.id)  # streak 3 → no re-fire
+        assert fired == [w.id]
+    finally:
+        watch_hooks.set_watch_hooks([])
+
+
+@pytest.mark.asyncio
+async def test_tick_all_counts_terminal(tmp_path):
+    c = _ctrl(tmp_path)
+    c.create(condition="a", verifier={"type": "command", "command": "exit 0"}, trusted=True)  # met
+    c.create(condition="b", verifier={"type": "command", "command": "exit 1"}, trusted=True)  # active
+    assert await c.tick_all() == 1
+
+
+# --- the run_in_session reaction on met (the supervision payoff) ------------
+
+
+@pytest.mark.asyncio
+async def test_met_enqueues_followup_turn_in_session(tmp_path, monkeypatch):
+    from runtime.state import STATE
+
+    added: list[dict] = []
+
+    class _Sched:
+        def add_job(self, prompt, schedule, *, job_id=None, timezone=None, context_id=None):
+            added.append({"prompt": prompt, "context_id": context_id, "job_id": job_id})
+
+            class _J:
+                id = job_id or "j"
+
+            return _J()
+
+        def cancel_job(self, job_id):
+            return True
+
+    monkeypatch.setattr(STATE, "scheduler", _Sched())
+    c = _ctrl(tmp_path)
+    _ok, _m, w = c.create(
+        condition="deploy done",
+        verifier={"type": "command", "command": "exit 0"},
+        run_prompt="Run the smoke test.",
+        run_session="sess-7",
+        trusted=True,
+    )
+    assert await c.evaluate(w.id) == "met"
+    assert added and added[0]["context_id"] == "sess-7"  # follow-up turn fired into the target session
+    assert added[0]["prompt"] == "Run the smoke test."
+
+
+def test_clear(tmp_path):
+    c = _ctrl(tmp_path)
+    _ok, _m, w = c.create(condition="c", verifier={"type": "plugin", "check": "p:v"})
+    assert c.clear(w.id) is True
+    assert c.clear(w.id) is False

--- a/tests/test_watch_controller.py
+++ b/tests/test_watch_controller.py
@@ -172,3 +172,12 @@ def test_clear(tmp_path):
     _ok, _m, w = c.create(condition="c", verifier={"type": "plugin", "check": "p:v"})
     assert c.clear(w.id) is True
     assert c.clear(w.id) is False
+
+
+def test_store_resolves_base_without_args(tmp_path, monkeypatch):
+    # Exercises the REAL _resolve_base (the infra.paths API) — the path a base_dir-injecting
+    # test skips, and that live-smoke caught (a stale scope_leaf import). WATCH_PATH keeps it
+    # off the shared instance dir.
+    monkeypatch.setenv("WATCH_PATH", str(tmp_path / "w"))
+    s = WatchStore()
+    assert s._base == (tmp_path / "w")

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -1152,6 +1152,72 @@ def _build_abandon_goal_tool():
     return abandon_goal
 
 
+def _build_watch_tools():
+    """Watch primitive (ADR 0067) — the agent supervises MANY external conditions at once.
+    Each watch is polled out-of-band; on met it can run a follow-up prompt back in this
+    session. Plugin-verifier only (like set_goal): the agent can't open a shell/eval watch."""
+
+    @tool
+    def create_watch(
+        condition: str,
+        check: str,
+        check_args: dict | None = None,
+        run_prompt: str = "",
+        watch_id: str | None = None,
+        state: Annotated[Any, InjectedState] = None,
+    ) -> str:
+        """Create a WATCH: poll `condition` on a cadence (ground-truthed by the plugin verifier
+        `check`), and when it's met run `run_prompt` (if given) as a follow-up turn in THIS
+        session. Use watches to supervise many things at once (a deploy, CI, a metric) — each a
+        separate watch, all polled in parallel. Only plugin verifiers are allowed; shell/test/
+        data watches are operator-only. `watch_id` defaults to a slug of the condition (pass one
+        to hold two watches on the same condition). Returns the watch status, or an error.
+        """
+        from runtime.state import STATE
+
+        if STATE.watch_controller is None:
+            return "Watch mode is not available."
+        session_id = _session_id_from(state)  # injected graph state, not the contextvar
+        from graph.goals.verifiers import plugin_verifier_names
+
+        known = plugin_verifier_names()
+        if check not in known:
+            avail = ", ".join(known) if known else "(none registered — enable a plugin that contributes a verifier)"
+            return f"Error: unknown plugin verifier {check!r}. Available verifiers: {avail}."
+        ok, msg, _w = STATE.watch_controller.create(
+            condition=condition,
+            verifier={"type": "plugin", "check": check, "args": check_args or {}},
+            watch_id=watch_id,
+            run_prompt=run_prompt or "",
+            run_session=session_id or "",
+            trusted=False,
+        )
+        return msg
+
+    @tool
+    def list_watches() -> str:
+        """List every watch for this agent (id · status · condition · verifier). Returns a
+        human-readable summary, or a note when there are none."""
+        from runtime.state import STATE
+
+        if STATE.watch_controller is None:
+            return "Watch mode is not available."
+        watches = STATE.watch_controller.list_watches()
+        return "\n".join(w.status_line() for w in watches) if watches else "No watches."
+
+    @tool
+    def clear_watch(watch_id: str) -> str:
+        """Remove a watch by its id (from list_watches). Returns whether it existed."""
+        from runtime.state import STATE
+
+        if STATE.watch_controller is None:
+            return "Watch mode is not available."
+        cleared = STATE.watch_controller.clear(watch_id)
+        return f"Watch {watch_id!r} cleared." if cleared else f"No watch {watch_id!r} to clear."
+
+    return [create_watch, list_watches, clear_watch]
+
+
 @tool
 def load_skill(name: str) -> str:
     """Load the full step-by-step procedure for a skill.
@@ -1415,6 +1481,7 @@ def get_all_tools(
         tools.append(_build_set_goal_tool())  # ADR 0028 — agent owns a plugin-verified goal
         tools.append(_build_goal_plan_tool())  # goal loop — record running plan (retired <goal_plan>)
         tools.append(_build_abandon_goal_tool())  # goal loop — explicit give-up (retired <goal_unachievable>)
+        tools.extend(_build_watch_tools())  # ADR 0067 — many concurrent supervised watches
     # ADR 0054 — curation tools for the dream/distill subagents (read-only activity
     # + skill inventory + additive-only skill creation). Self-gate on STATE at call
     # time; present in the full set so the subagent allowlists can pick them up.

--- a/uv.lock
+++ b/uv.lock
@@ -1539,7 +1539,7 @@ wheels = [
 
 [[package]]
 name = "protoagent"
-version = "0.52.0"
+version = "0.77.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["fastapi", "http-server", "sqlite"] },


### PR DESCRIPTION
## What & why

You decided #7: a supervisor agent needs to babysit **many** external processes **at once** — the monitor-goal *disposition* can't, because a goal is stored **one-per-session**. This adds a first-class **`watch`** primitive (the passive counterpart to goal-drive) that you can hold as many of as you like, and wires it to `sdk.run_in_session` (#1494) so a tripped watch runs a follow-up agent turn. Design: `docs/adr/0067-standalone-watch-primitive.md`.

A **watch** = *poll a condition on a cadence; when it trips, react.* Examples: "watch the deploy → run the smoke test", "watch CI → merge", "watch the treasury → stop trading" — all at once.

## What's in this slice (the engine)

- **`graph/watches/`** — `Watch` type + `WatchStore` (keyed by **watch id**, many-per-instance, `PROTOAGENT_INSTANCE`-scoped) + `WatchController` (create / list / clear / evaluate / `tick_all`). Verifiers are **reused verbatim** from `graph/goals/verifiers.py` — no new verification surface.
- **Out-of-band tick** — `_watch_loop` (mirrors `_monitor_goals_loop`), evaluates every active watch on a cadence (30s default, per-watch `interval_s` override), verifier-only, no agent turn. `deadline` → `expired` (`on_expired`); `stall_after` unchanged checks → `on_stalled` once per episode (watch stays active).
- **Reaction (the payoff)** — on **met**, an optional `run_prompt` is enqueued as a one-shot agent turn in `run_session` via `sdk.run_in_session`, plus `on_met` hooks fire. `watch + run_in_session` = the parallel-supervision engine.
- **Agent tools** — `create_watch` / `list_watches` / `clear_watch`, **plugin-verifier only** (same posture as `set_goal`); shell/test/data watches are operator-only (the `trusted=True` path, wired in the next slice).

## Notes for review

- **Additive + non-breaking.** Goals, `run_goal_loop`, and existing monitor goals are untouched. Watches **supersede** ADR 0030's `monitor` mode, which stays working but is now deprecated (a follow-up migrates `start_goal_loop`'s monitor path onto watches and can then shed the `GoalState` union fields).
- No config fields added (interval is a constant + per-watch override) — deliberately, to keep the change small.

## Follow-up slices (ADR 0067)
- **PR2** — operator `POST/GET/DELETE /api/watches` (any verifier, gated by the ADR 0066 `/api` ceiling) + `sdk.create_watch` + `register_watch_hook` (registry/loader/testkit seam).
- **PR3** — console **Watches** panel (DRAFT, local-test gate).

## Tests
`test_watch_controller.py`: trust gate (untrusted → plugin-only, trusted → any), **many concurrent watches** (the motivating property), met / not-met / expired / stall (fires once, stays active) / `tick_all`, and the `run_in_session` reaction fires into the target session. 15 pass (incl. docs-nav sync); ruff + tool-inventory + import-layering clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple concurrent watches with creation, listing, and clearing.
  * Introduced watch lifecycle behavior, including automatic checks, expiration, stall detection, and completion handling.
  * Added user-facing tools to create and manage watches, plus follow-up actions when a watch is met.
  * Included watch lifecycle events in the documentation navigation.

* **Bug Fixes**
  * Improved persistence and recovery for watch state, with safer handling of invalid or incomplete saved data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->