### PR TITLE
feat(watches): console Watches panel (ADR 0067 PR3)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -421,7 +421,16 @@ export function App() {
         title: "Goal failed",
         message: `${String(d.condition || "the goal")}${d.reason ? ` — ${String(d.reason)}` : ""}`,
       }));
-    return () => { offDone(); offFail(); };
+    // Watch transitions (ADR 0067) surface the same way — watch.met / watch.expired on the bus.
+    const offMet = onServerEvent("watch.met", (d) =>
+      toast({ tone: "success", title: "Watch met", message: String(d.condition || "the watch") }));
+    const offExpired = onServerEvent("watch.expired", (d) =>
+      toast({
+        tone: "error",
+        title: "Watch expired",
+        message: `${String(d.condition || "the watch")}${d.reason ? ` — ${String(d.reason)}` : ""}`,
+      }));
+    return () => { offDone(); offFail(); offMet(); offExpired(); };
   }, [toast]);
 
   // Resize + collapse are now the DS AppShell's (controlled via rightWidth/onRightWidthChange +

--- a/apps/web/src/app/WatchesPanel.tsx
+++ b/apps/web/src/app/WatchesPanel.tsx
@@ -1,0 +1,120 @@
+import "../watches/watches.css";
+
+import { Button, Empty } from "@protolabsai/ui/primitives";
+import {
+  QueryErrorResetBoundary,
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { Trash2 } from "lucide-react";
+import { Suspense, useEffect } from "react";
+
+import { api } from "../lib/api";
+import { onServerEvent } from "../lib/events";
+import { PanelHeader } from "@protolabsai/ui/navigation";
+import { watchesQuery, queryKeys } from "../lib/queries";
+import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
+import { ScrollArea } from "@protolabsai/ui/data";
+import { StatusPill } from "./StatusPill";
+
+// The agent's watches (ADR 0067 passive-supervision layer), in the Work hub. Mirrors
+// GoalsPanel on the TanStack Query + Suspense + ErrorBoundary data layer (ADR 0013): the read
+// is a `useSuspenseQuery` (loading → <Suspense>, failure → <ErrorBoundary>), and clearing a
+// watch is a `useMutation` that invalidates the watches query. Unlike goals (one per session,
+// keyed by session_id), a watch is verifier-only and keyed by its own `id` — many at once.
+
+function watchTone(status: string) {
+  if (status === "met") return "success" as const;
+  if (status === "active") return "warning" as const;
+  if (status === "expired") return "error" as const;
+  return "muted" as const;
+}
+
+const trunc = (t: string, n = 80) => (t.length > n ? `${t.slice(0, n)}…` : t);
+
+function WatchesList() {
+  const { data } = useSuspenseQuery(watchesQuery());
+  const watches = data.watches;
+  const queryClient = useQueryClient();
+  const clear = useMutation({
+    mutationFn: (id: string) => api.clearWatch(id),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.watches }),
+  });
+
+  // Live: refresh off the watch bus instead of polling, the same pattern as GoalsPanel.
+  // `watch.changed` fires on create/check/clear; `watch.met`/`watch.expired`/`watch.stalled`
+  // fire on the terminal/stall transitions — any of them re-reads the list.
+  useEffect(() => {
+    const refresh = () => void queryClient.invalidateQueries({ queryKey: queryKeys.watches });
+    const offs = [
+      onServerEvent("watch.changed", refresh),
+      onServerEvent("watch.met", refresh),
+      onServerEvent("watch.expired", refresh),
+      onServerEvent("watch.stalled", refresh),
+    ];
+    return () => offs.forEach((off) => off());
+  }, [queryClient]);
+
+  if (!watches.length) {
+    return (
+      <Empty
+        title="No watches"
+        description={
+          <>
+            an agent or plugin creates them (or <code>POST /api/watches</code>)
+          </>
+        }
+      />
+    );
+  }
+
+  return (
+    <>
+      {watches.map((watch) => (
+        <div className="watch-row" key={watch.id}>
+          <div className="watch-row-head">
+            <strong>{watch.condition || watch.id}</strong>
+            <StatusPill label={watch.status} tone={watchTone(watch.status)} />
+          </div>
+          <span className="watch-row-meta">
+            {watch.id} · {watch.verifier?.type || "llm"}
+            {watch.last_reason ? ` · ${trunc(watch.last_reason)}` : ""}
+          </span>
+          <Button
+            icon variant="ghost" className="watch-row-clear"
+            type="button"
+            onClick={() => clear.mutate(watch.id)}
+            disabled={clear.isPending}
+            title="Clear watch"
+          >
+            <Trash2 size={15} />
+          </Button>
+        </div>
+      ))}
+    </>
+  );
+}
+
+export function WatchesPanel() {
+  return (
+    <section className="panel side-panel watches-panel">
+      <PanelHeader
+        compact
+        title="Watches"
+        kicker={<>passive verifier-only objectives · created by an agent or plugin</>}
+      />
+      <ScrollArea className="watches-list" role="region" aria-label="Watches" tabIndex={0}>
+        <QueryErrorResetBoundary>
+          {({ reset }: { reset: () => void }) => (
+            <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="watches" />}>
+              <Suspense fallback={<PanelSkeleton label="Loading watches…" />}>
+                <WatchesList />
+              </Suspense>
+            </ErrorBoundary>
+          )}
+        </QueryErrorResetBoundary>
+      </ScrollArea>
+    </section>
+  );
+}

--- a/apps/web/src/app/WorkPanel.tsx
+++ b/apps/web/src/app/WorkPanel.tsx
@@ -1,11 +1,12 @@
 import { useState, type ComponentProps, type ReactNode } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Tabs } from "@protolabsai/ui/navigation";
-import { Boxes, CalendarClock, ChevronRight, LayoutDashboard, Target } from "lucide-react";
+import { Boxes, CalendarClock, ChevronRight, Eye, LayoutDashboard, Target } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 import { StagePanel } from "./ErrorBoundary";
 import { GoalsPanel } from "./GoalsPanel";
+import { WatchesPanel } from "./WatchesPanel";
 import { TasksPanel } from "./TasksPanel";
 import { SchedulePanel } from "../schedule/SchedulePanel";
 import { tasksQuery, goalsQuery, schedulesQuery } from "../lib/queries";
@@ -13,12 +14,13 @@ import type { Task, GoalState, ScheduledJob } from "../lib/types";
 
 import "./work.css";
 
-type WorkTab = "overview" | "goals" | "tasks" | "schedule";
+type WorkTab = "overview" | "goals" | "watches" | "tasks" | "schedule";
 type Confirm = ComponentProps<typeof TasksPanel>["confirm"];
 
 const TABS: { id: WorkTab; label: string; icon: LucideIcon }[] = [
   { id: "overview", label: "Overview", icon: LayoutDashboard },
   { id: "goals", label: "Goals", icon: Target },
+  { id: "watches", label: "Watches", icon: Eye },
   { id: "tasks", label: "Tasks", icon: Boxes },
   { id: "schedule", label: "Schedule", icon: CalendarClock },
 ];
@@ -45,6 +47,8 @@ export function WorkPanel({ confirm }: { confirm: Confirm }) {
         </StagePanel>
       ) : tab === "goals" ? (
         <GoalsPanel />
+      ) : tab === "watches" ? (
+        <WatchesPanel />
       ) : tab === "tasks" ? (
         <TasksPanel confirm={confirm} />
       ) : (

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -37,6 +37,7 @@ import type {
   TelemetryTurn,
   ToolEvent,
   TurnUsage,
+  WatchState,
   WorkflowRunResult,
   WorkflowSummary,
 } from "./types";
@@ -969,6 +970,19 @@ export const api = {
 
   clearGoal(sessionId: string) {
     return request<{ cleared: boolean }>(`/api/goals/${encodeURIComponent(sessionId)}`, {
+      method: "DELETE",
+    });
+  },
+
+  // Watches (ADR 0067) — passive verifier-only objectives, many at once, keyed by id. The
+  // panel invalidates this on the `watch.*` bus pushes (created/checked/met/expired/stalled)
+  // instead of polling — same pattern as goals.
+  watches() {
+    return request<{ watches: WatchState[]; enabled: boolean }>("/api/watches");
+  },
+
+  clearWatch(id: string) {
+    return request<{ cleared: boolean }>(`/api/watches/${encodeURIComponent(id)}`, {
       method: "DELETE",
     });
   },

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -7,6 +7,7 @@ import { api } from "./api";
 // stable and hierarchical so a mutation can invalidate a whole subtree.
 export const queryKeys = {
   goals: ["goals"] as const,
+  watches: ["watches"] as const,
   tasks: ["tasks", "issues"] as const,
   workflows: ["workflows"] as const,
   subagents: ["subagents"] as const,
@@ -50,6 +51,15 @@ export const goalsQuery = () =>
   queryOptions({
     queryKey: queryKeys.goals,
     queryFn: () => api.goals(),
+  });
+
+// Passive watches (ADR 0067) — verifier-only objectives polled out-of-band. Lives in the
+// Work hub; the panel invalidates this on the `watch.*` bus pushes (created/checked/met/
+// expired/stalled) instead of a poll — same pattern as goals.
+export const watchesQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.watches,
+    queryFn: () => api.watches(),
   });
 
 // The agent's task board (in-process tasks store — always available). The panel

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -342,6 +342,25 @@ export type GoalState = {
   finished_at?: number | null;
 };
 
+// A passive watch (ADR 0067) — a verifier-only objective polled out-of-band. Unlike a goal
+// (driven via a bounded continuation loop, one per session), you can hold MANY watches at
+// once, keyed by their own `id`. Mirrors the backend `Watch` (graph/watches/types.py).
+export type WatchState = {
+  id: string;
+  condition: string;
+  status: string; // active | met | expired | cleared
+  verifier?: { type?: string } & Record<string, unknown>;
+  interval_s?: number | null; // per-watch cadence override; null → config watch_interval
+  deadline?: number | null; // epoch seconds; past → expired
+  stall_after?: number | null; // N unchanged checks → on_stalled
+  run_prompt?: string; // on met, enqueued as a one-shot turn in run_session
+  run_session?: string;
+  last_reason?: string;
+  last_evidence?: string;
+  last_checked?: number | null; // last out-of-band verifier check (epoch seconds)
+  created_at?: number;
+};
+
 export type ScheduledJob = {
   id: string;
   prompt: string;

--- a/apps/web/src/watches/watches.css
+++ b/apps/web/src/watches/watches.css
@@ -1,0 +1,49 @@
+/* Watches side-panel (ADR 0067 passive-supervision layer) — mirrors goals.css. */
+.watches-list {
+  display: grid;
+  align-content: start;
+  height: 100%;
+}
+
+.watch-row {
+  position: relative;
+  display: grid;
+  gap: 4px;
+  padding: 10px 34px 10px 12px;
+  border-bottom: 1px solid var(--border);
+  min-width: 0;
+}
+
+.watch-row:last-child {
+  border-bottom: 0;
+}
+
+.watch-row-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.watch-row-head strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+.watch-row-meta {
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.watch-row-clear {
+  position: absolute;
+  top: 8px;
+  right: 6px;
+}


### PR DESCRIPTION
## Console Watches panel (ADR 0067)

Adds a **Watches** panel to the operator console, mirroring the existing Goals panel structure/patterns exactly. Watches are the passive, verifier-only supervision counterpart to goals (ADR 0067): polled out-of-band on a cadence, held **many at once** keyed by their own `id` (not the session).

### What it does
- New **Watches** tab in the Work hub right-rail (`WorkPanel`, icon `Eye`), rendering `<WatchesPanel/>` alongside Goals/Tasks/Schedule.
- Lists watch rows: title = `condition`, a status pill toned by `status` (met→success, active→warning, expired→error, else muted), a meta line `id · verifier.type · last_reason`, and a `Trash2` **Clear watch** button.
- Empty state: "No watches — an agent or plugin creates them (or POST /api/watches)."
- Same TanStack Query + Suspense + ErrorBoundary data layer as GoalsPanel (ADR 0013).

### Wire
- Consumes **`GET /api/watches`** → `{watches: Watch[], enabled: boolean}` and **`DELETE /api/watches/{id}`** → `{cleared: boolean}` (from backend PR #1507).
- `WatchState` type mirrors the backend `Watch` (`graph/watches/types.py`): `id, condition, status, verifier?:{type?}, interval_s?, deadline?, stall_after?, run_prompt?, run_session?, last_reason?, last_evidence?, last_checked?, created_at?`.
- Live-refreshes off the bus via a single `useEffect` subscribing to `watch.changed`, `watch.met`, `watch.expired`, `watch.stalled` (each invalidates `queryKeys.watches`) — no polling, mirroring how GoalsPanel subscribes to `goal.changed`.
- Adds `watch.met` / `watch.expired` toasts in `App.tsx`, mirroring the `goal.achieved` / `goal.failed` toasts.

### Files
- `apps/web/src/lib/types.ts` — `WatchState` type.
- `apps/web/src/lib/api.ts` — `watches()` + `clearWatch(id)`.
- `apps/web/src/lib/queries.ts` — `queryKeys.watches` + `watchesQuery()`.
- `apps/web/src/app/WatchesPanel.tsx` (new) + `apps/web/src/watches/watches.css` (new, mirrors `goals.css`).
- `apps/web/src/app/WorkPanel.tsx` — Watches tab.
- `apps/web/src/app/App.tsx` — watch toasts.

### Status
**DRAFT** — this is UI under the local-test gate (CI can't judge UX; verify visually). Depends on **#1507**'s `/api/watches` endpoint; against a server without it, the panel degrades to the ErrorBoundary card (same as any disabled-surface). Typecheck via `tsc` was **not run** (web `node_modules` absent; DS `@protolabsai/*` packages would need a registry-authed install) — changes were verified by careful review against the Goals equivalents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)