### PR TITLE
fix(watches): serialize evaluate per watch + disambiguate store filenames (CodeRabbit #1505)

### DIFF
--- a/graph/watches/controller.py
+++ b/graph/watches/controller.py
@@ -9,6 +9,7 @@ agent turn via ``sdk.run_in_session`` (ADR/#1494) and ``on_met`` hooks fire; a p
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import os
@@ -30,6 +31,13 @@ class WatchController:
     def __init__(self, config, store: WatchStore | None = None):
         self._config = config
         self._store = store or WatchStore()
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def _lock_for(self, watch_id: str) -> asyncio.Lock:
+        lock = self._locks.get(watch_id)
+        if lock is None:
+            lock = self._locks[watch_id] = asyncio.Lock()
+        return lock
 
     @property
     def store(self) -> WatchStore:
@@ -42,6 +50,7 @@ class WatchController:
         return self._store.all()
 
     def clear(self, watch_id: str) -> bool:
+        self._locks.pop(watch_id, None)
         return self._store.clear(watch_id)
 
     # --- create ------------------------------------------------------------
@@ -107,7 +116,16 @@ class WatchController:
     async def evaluate(self, watch_id: str) -> str | None:
         """Run one watch's verifier out-of-band. Met → finish+react; deadline passed →
         ``expired``; ``stall_after`` unchanged checks → ``on_stalled`` (stays active). Returns
-        the terminal status, or ``None`` while still active."""
+        the terminal status, or ``None`` while still active.
+
+        Serialized per watch id (an ``asyncio.Lock``) so the cadence ``tick_all`` and an
+        event-driven ``evaluate_now`` can't interleave a read-mutate-write on the SAME watch —
+        which would drop a stall increment or re-activate a just-finished watch. Distinct watch
+        ids never block each other."""
+        async with self._lock_for(watch_id):
+            return await self._evaluate_unlocked(watch_id)
+
+    async def _evaluate_unlocked(self, watch_id: str) -> str | None:
         watch = self._store.get(watch_id)
         if watch is None or not watch.active:
             return None

--- a/graph/watches/store.py
+++ b/graph/watches/store.py
@@ -58,7 +58,14 @@ def _resolve_base() -> Path:
 
 
 def _safe_name(watch_id: str) -> str:
-    return "".join(c if c.isalnum() or c in "-_." else "_" for c in watch_id) or "watch"
+    safe = "".join(c if c.isalnum() or c in "-_." else "_" for c in watch_id) or "watch"
+    # Distinct ids that sanitize to the same string (e.g. "a/b" vs "a_b") must not share a
+    # file — disambiguate with a short hash of the RAW id whenever sanitization changed it.
+    if safe != watch_id:
+        import hashlib
+
+        safe = f"{safe[:48]}-{hashlib.sha1(watch_id.encode()).hexdigest()[:8]}"
+    return safe
 
 
 class WatchStore:

--- a/tests/test_watch_controller.py
+++ b/tests/test_watch_controller.py
@@ -181,3 +181,48 @@ def test_store_resolves_base_without_args(tmp_path, monkeypatch):
     monkeypatch.setenv("WATCH_PATH", str(tmp_path / "w"))
     s = WatchStore()
     assert s._base == (tmp_path / "w")
+
+
+def test_safe_name_no_collision_across_sanitized_ids():
+    # CodeRabbit #1505: distinct raw ids that sanitize to the same string used to collide on
+    # one file. Now they get distinct filenames; an already-safe id stays human-readable.
+    from graph.watches.store import _safe_name
+
+    assert _safe_name("abc/def") != _safe_name("abc_def")
+    assert _safe_name("a/b") != _safe_name("a\\b")
+    assert _safe_name("deploy-1a2b3c") == "deploy-1a2b3c"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_evaluate_finishes_once(tmp_path, monkeypatch):
+    # CodeRabbit #1505: the per-watch lock serializes tick_all vs evaluate_now on the SAME
+    # watch, so a met watch finishes (and fires its run_in_session reaction) exactly once.
+    import asyncio
+
+    from runtime.state import STATE
+
+    calls: list[str] = []
+
+    class _Sched:
+        def add_job(self, prompt, schedule, *, job_id=None, timezone=None, context_id=None):
+            calls.append(job_id)
+
+            class _J:
+                id = job_id or "j"
+
+            return _J()
+
+        def cancel_job(self, job_id):
+            return True
+
+    monkeypatch.setattr(STATE, "scheduler", _Sched())
+    c = _ctrl(tmp_path)
+    _ok, _m, w = c.create(
+        condition="done",
+        verifier={"type": "command", "command": "exit 0"},
+        run_prompt="go",
+        run_session="s",
+        trusted=True,
+    )
+    await asyncio.gather(c.evaluate(w.id), c.evaluate(w.id))
+    assert calls.count(f"watch-{w.id}") == 1  # not 2 — the lock prevented a double-finish


### PR DESCRIPTION
Addresses the two CodeRabbit findings on #1505 (the watch engine).

- **Race (Major)** — `WatchController.evaluate` did an unlocked read-mutate-write, so the cadence `tick_all` and an event-driven `evaluate_now` on the **same** watch could interleave: a dropped stall increment, or a just-finished watch re-activated / its `run_in_session` reaction double-fired. Now serialized per watch id with an `asyncio.Lock` (`evaluate` → `_evaluate_unlocked`); distinct watch ids never block each other. Lock is dropped on `clear`.
- **Filename collision (Minor)** — `_safe_name` mapped every unsafe char (incl. `/`, `\`) to `_`, so `"a/b"` and `"a_b"` shared one JSON file. Now appends a short hash of the **raw** id whenever sanitization changed it; already-safe ids stay human-readable/backward-compatible.

Tests: `test_concurrent_evaluate_finishes_once` (fails without the lock — asserts the reaction fires exactly once), `test_safe_name_no_collision_across_sanitized_ids`. 25 pass, ruff clean.

Note: `GoalController`/`GoalStore` share the same latent read-mutate-write + `_safe_name` pattern — out of scope for this fix, flagged for a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)