### PR TITLE
feat(goals): console set-goal form (ADR 0066 follow-up)

### DIFF
--- a/apps/web/src/app/GoalsPanel.tsx
+++ b/apps/web/src/app/GoalsPanel.tsx
@@ -1,6 +1,8 @@
 import "../goals/goals.css";
 
+import { Input, Textarea } from "@protolabsai/ui/forms";
 import { Button, Empty } from "@protolabsai/ui/primitives";
+import { useToast } from "@protolabsai/ui/overlays";
 import {
 
   QueryErrorResetBoundary,
@@ -9,10 +11,10 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { Trash2 } from "lucide-react";
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useState, type FormEvent } from "react";
 
 import { api } from "../lib/api";
-import { ago } from "../lib/format";
+import { ago, errMsg } from "../lib/format";
 import { onServerEvent } from "../lib/events";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { goalsQuery, queryKeys } from "../lib/queries";
@@ -100,6 +102,93 @@ function GoalsList() {
   );
 }
 
+// Compact operator "set a goal" form, above the list. Collapsed by default (a <details>
+// disclosure) so it stays out of the way — the primary surface is still the goal list. POSTs
+// to the operator `/api/goals` (ADR 0066), which accepts any verifier type; the verifier is a
+// small JSON textarea (default `{"type":"llm"}`) parsed on submit — invalid JSON shows an
+// inline error and doesn't submit. Result is surfaced via the shared DS toast, and the goals
+// query is invalidated so the list picks up the new goal.
+function NewGoalForm() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const [sessionId, setSessionId] = useState("operator");
+  const [condition, setCondition] = useState("");
+  const [verifier, setVerifier] = useState('{"type":"llm"}');
+  const [jsonError, setJsonError] = useState<string | null>(null);
+
+  const set = useMutation({
+    mutationFn: (body: { session_id: string; condition: string; verifier: unknown }) =>
+      api.setGoal(body),
+    onSuccess: (res) => {
+      setCondition("");
+      toast({ tone: "success", title: "Goal set", message: res.message || "The agent has a new goal." });
+    },
+    // A rejected verifier / disabled goal mode comes back as HTTP 400 → request() throws here.
+    onError: (e) => toast({ tone: "error", title: "Couldn't set goal", message: errMsg(e) }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.goals }),
+  });
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    const cond = condition.trim();
+    if (!cond) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(verifier.trim() || "{}");
+    } catch {
+      setJsonError("Verifier must be valid JSON");
+      return;
+    }
+    setJsonError(null);
+    set.mutate({ session_id: sessionId.trim() || "operator", condition: cond, verifier: parsed });
+  };
+
+  return (
+    <details className="goal-new">
+      <summary>New goal</summary>
+      <form className="goal-new-form" onSubmit={submit}>
+        <label className="field">
+          <span>Session</span>
+          <Input value={sessionId} onChange={(e) => setSessionId(e.target.value)} placeholder="operator" />
+        </label>
+        <label className="field">
+          <span>Condition</span>
+          <Input
+            value={condition}
+            onChange={(e) => setCondition(e.target.value)}
+            placeholder="What the agent should achieve"
+            required
+          />
+        </label>
+        <label className="field">
+          <span>Verifier (JSON)</span>
+          <Textarea
+            value={verifier}
+            rows={2}
+            spellCheck={false}
+            aria-invalid={jsonError ? true : undefined}
+            onChange={(e) => {
+              setVerifier(e.target.value);
+              if (jsonError) setJsonError(null);
+            }}
+          />
+        </label>
+        {jsonError ? (
+          <p className="goal-new-error field-warn" role="alert">{jsonError}</p>
+        ) : null}
+        <Button
+          type="submit"
+          variant="primary"
+          loading={set.isPending}
+          disabled={!condition.trim() || set.isPending}
+        >
+          Set goal
+        </Button>
+      </form>
+    </details>
+  );
+}
+
 export function GoalsPanel() {
   return (
     <section className="panel side-panel goals-panel">
@@ -108,6 +197,7 @@ export function GoalsPanel() {
         title="Goals"
         kicker={<>the agent's standing goals · set with <code>/goal</code> in chat</>}
       />
+      <NewGoalForm />
       <ScrollArea className="goals-list" role="region" aria-label="Goals" tabIndex={0}>
         <QueryErrorResetBoundary>
           {({ reset }: { reset: () => void }) => (

--- a/apps/web/src/goals/goals.css
+++ b/apps/web/src/goals/goals.css
@@ -47,3 +47,32 @@
   top: 8px;
   right: 6px;
 }
+
+/* Compact operator "New goal" form above the list — collapsed <details> by default. */
+.goal-new {
+  border-bottom: 1px solid var(--border);
+}
+
+.goal-new > summary {
+  cursor: pointer;
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--fg-muted);
+  user-select: none;
+}
+
+.goal-new[open] > summary {
+  color: var(--fg);
+}
+
+.goal-new-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 4px 12px 12px;
+}
+
+.goal-new-error {
+  margin: 0;
+  font-size: 11px;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -974,6 +974,17 @@ export const api = {
     });
   },
 
+  // Operator goal-set (ADR 0066) — the trusted operator channel. `/api` is operator-tier by
+  // the ADR 0066 path ceiling, so this accepts ANY verifier type (unlike the plugin-only SDK
+  // path). A rejected verifier / disabled goal mode comes back as HTTP 400 (request() throws,
+  // so the caller's onError surfaces the reason); the happy path returns {ok:true, message}.
+  setGoal(body: { session_id: string; condition: string; verifier: unknown }) {
+    return request<{ ok: boolean; message?: string; error?: string }>("/api/goals", {
+      method: "POST",
+      body,
+    });
+  },
+
   // Watches (ADR 0067) — passive verifier-only objectives, many at once, keyed by id. The
   // panel invalidates this on the `watch.*` bus pushes (created/checked/met/expired/stalled)
   // instead of polling — same pattern as goals.


### PR DESCRIPTION
## What

Adds a minimal, unobtrusive **"New goal"** form to the console's Goals panel — the first UI-driven way to create a goal (previously only the `/goal` chat command could).

The form is a **collapsed-by-default `<details>` disclosure** at the top of the panel, above the goal list, so it stays out of the way. Fields:

- **Session** — text, defaults to `operator`
- **Condition** — text, required
- **Verifier** — small JSON textarea, defaults to `{"type":"llm"}`, parsed as JSON on submit. Invalid JSON shows an inline error and does **not** submit.

On submit it POSTs to the **operator `/api/goals`** endpoint (ADR 0066, `_operator_goals_set`), which accepts any verifier type behind the `/api` operator auth ceiling. The result is surfaced through the existing DS `useToast` (`success`/`error`), the `queryKeys.goals` query is invalidated so the list refreshes, and the condition field is cleared on success.

## Changes

- `apps/web/src/lib/api.ts` — new `api.setGoal({session_id, condition, verifier})` → `POST /api/goals`, mirroring the existing `clearGoal` / `request()` POST patterns. Returns `{ok, message?, error?}`; a rejected verifier / disabled goal mode comes back as HTTP 400, so `request()` throws and the caller's `onError` surfaces the reason.
- `apps/web/src/app/GoalsPanel.tsx` — new `NewGoalForm` component (reuses the DS `Input`, `Textarea`, `Button`, `useToast` primitives already used across the app + the shared `.field` class), rendered between the panel header and the list.
- `apps/web/src/goals/goals.css` — minimal styling for the collapsible form.

Reuses DS primitives and existing panel conventions; no panel restructuring, no new heavy components.

## Gates

Frontend under the local-test gate. `node_modules` is not installed in this worktree, so the `tsc`/`npm run build` typecheck was **skipped** — verified by careful review instead (imports resolve, types line up with sibling panels, `JSON.parse` is guarded, toast/mutation usage matches `TasksPanel`). **DRAFT** for visual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)