### PR TITLE
feat(artifact): pan & zoom for mermaid + svg diagrams (#1495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Artifact panel: pan & zoom for diagrams** (#1495, artifact plugin v0.14.0). Mermaid **and** SVG
+  artifacts now render into a transform-driven viewport — scroll-wheel / pinch to zoom (cursor-anchored),
+  click-drag to pan, and a **Reset** control that re-fits the diagram. Large flowcharts and architecture
+  views are finally explorable; mermaid re-fits automatically after its async render.
 - **Watch primitive — supervise many external conditions at once** (#1505, #1507, #1508, ADR 0067). A
   *watch* polls a condition on a cadence and, when it trips, runs a follow-up agent turn (via
   `run_in_session`) and/or fires hooks — the passive counterpart to a goal (which the agent *drives*).

--- a/plugins/artifact/__init__.py
+++ b/plugins/artifact/__init__.py
@@ -905,12 +905,63 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
     + '#md blockquote{margin:1em 0;padding-left:1em;border-left:3px solid var(--pl-color-border,rgba(255,255,255,.2));color:var(--pl-color-fg-muted,#9aa0aa)}'
     + '#md img{max-width:100%}#md .mermaid{background:none;border:0;padding:0}';
 
+  // Pan/zoom viewport for the GRAPHIC kinds (svg + mermaid — #1495). Both render an <svg>
+  // into the sandboxed frame; wrap it in a transform-driven viewport so large diagrams can be
+  // explored: scroll-wheel / pinch to zoom (cursor-anchored), click-drag to pan, Reset to re-fit.
+  // Self-contained (needs no DS stylesheet) — styled off the base() token carry.
+  var VP_CSS = '<style>html,body{margin:0;height:100%;overflow:hidden}'
+    + '#__vp{position:absolute;inset:0;overflow:hidden;cursor:grab;touch-action:none}'
+    + '#__vp.__drag{cursor:grabbing}'
+    + '#__cv{position:absolute;top:0;left:0;transform-origin:0 0;will-change:transform}'
+    + '#__zb{position:fixed;top:8px;right:8px;display:flex;gap:4px;z-index:2147483646;opacity:.4;transition:opacity .12s}'
+    + '#__zb:hover{opacity:1}'
+    + '#__zb button{height:26px;min-width:26px;padding:0 7px;font:13px/1 ui-sans-serif,system-ui,sans-serif;cursor:pointer;'
+    + 'color:var(--pl-color-fg,#ededed);background:var(--pl-color-bg,#18181b);'
+    + 'border:1px solid var(--pl-color-border,rgba(255,255,255,.16));border-radius:6px}'
+    + '#__zb button:hover{border-color:var(--pl-color-accent,#9b87f2)}</style>';
+  var ZBAR = '<div id="__zb"><button id="__zi" title="Zoom in" aria-label="Zoom in">+</button>'
+    + '<button id="__zo" title="Zoom out" aria-label="Zoom out">−</button>'
+    + '<button id="__zr" title="Reset view" aria-label="Reset view">Reset</button></div>';
+  // Transforms #__cv; exposes window.__artFit so an ASYNC renderer (mermaid) can re-fit once its
+  // <svg> exists. Cursor-anchored zoom keeps the point under the pointer fixed; fit() re-centers.
+  var PANZOOM = '<script>(function(){'
+    + 'var vp=document.getElementById("__vp"),cv=document.getElementById("__cv");if(!vp||!cv)return;'
+    + 'var k=1,x=0,y=0,MIN=0.05,MAX=40;'
+    + 'function apply(){cv.style.transform="translate("+x+"px,"+y+"px) scale("+k+")";}'
+    + 'function clamp(v){return v<MIN?MIN:(v>MAX?MAX:v);}'
+    + 'function fit(){cv.style.transform="none";'
+    + 'var r=cv.getBoundingClientRect(),cw=r.width,ch=r.height,vw=vp.clientWidth,vh=vp.clientHeight;'
+    + 'if(!cw||!ch){k=1;x=0;y=0;return apply();}'
+    + 'var s=Math.min((vw-24)/cw,(vh-24)/ch);if(!(s>0)||s>1)s=1;'
+    + 'k=s;x=(vw-cw*s)/2;y=(vh-ch*s)/2;apply();}'
+    + 'function zoomAt(px,py,f){var nk=clamp(k*f);f=nk/k;x=px-f*(px-x);y=py-f*(py-y);k=nk;apply();}'
+    + 'vp.addEventListener("wheel",function(e){e.preventDefault();var rc=vp.getBoundingClientRect();'
+    + 'zoomAt(e.clientX-rc.left,e.clientY-rc.top,Math.exp(-e.deltaY*0.0015));},{passive:false});'
+    + 'var dn=false,lx=0,ly=0;'
+    + 'vp.addEventListener("pointerdown",function(e){if(e.button!==0)return;dn=true;lx=e.clientX;ly=e.clientY;'
+    + 'vp.classList.add("__drag");try{vp.setPointerCapture(e.pointerId);}catch(_){}});'
+    + 'vp.addEventListener("pointermove",function(e){if(!dn)return;x+=e.clientX-lx;y+=e.clientY-ly;lx=e.clientX;ly=e.clientY;apply();});'
+    + 'function up(){dn=false;vp.classList.remove("__drag");}'
+    + 'vp.addEventListener("pointerup",up);vp.addEventListener("pointercancel",up);'
+    + 'function cz(f){var rc=vp.getBoundingClientRect();zoomAt(rc.width/2,rc.height/2,f);}'
+    + 'var zi=document.getElementById("__zi"),zo=document.getElementById("__zo"),zr=document.getElementById("__zr");'
+    + 'if(zi)zi.addEventListener("click",function(){cz(1.25);});'
+    + 'if(zo)zo.addEventListener("click",function(){cz(0.8);});'
+    + 'if(zr)zr.addEventListener("click",fit);'
+    + 'window.__artFit=fit;window.addEventListener("resize",fit);requestAnimationFrame(fit);'
+    + '})();<\/script>';
+  // Wrap graphic content in the viewport + controls (svg + mermaid share this).
+  function viewport(inner){ return VP_CSS + '<body><div id="__vp"><div id="__cv">' + inner + '</div></div>' + ZBAR + PANZOOM; }
+
   function srcdoc(kind, code) {
     if (kind === "html") return dsLink() + base(kind) + code;
-    if (kind === "svg") return '<!doctype html>' + base(kind) + '<body style="display:grid;place-items:center;min-height:100vh">' + code + '</body>';
-    if (kind === "mermaid") return '<!doctype html>' + base(kind) + '<body><pre class="mermaid">' + esc(code) + '</pre>' +
+    if (kind === "svg") return '<!doctype html>' + base(kind) + viewport(code) + '</body>';
+    if (kind === "mermaid") return '<!doctype html>' + base(kind) + viewport('<pre class="mermaid">' + esc(code) + '</pre>') +
       cdn("mermaid") +
-      '<script>mermaid.initialize({startOnLoad:false,theme:"dark"});mermaid.run();<\/script></body>';
+      '<script>mermaid.initialize({startOnLoad:false,theme:"dark"});'
+      + 'try{var __p=mermaid.run();if(__p&&__p.then)__p.then(function(){if(window.__artFit)window.__artFit();});}catch(_){}'
+      + 'setTimeout(function(){if(window.__artFit)window.__artFit();},80);'
+      + 'setTimeout(function(){if(window.__artFit)window.__artFit();},400);<\/script></body>';
     if (kind === "markdown") return mdDoc(code);
     // `react`: import map + UMD react/react-dom/babel, compiled as a MODULE so `import` works
     // (no-import artifacts still run — they use the UMD React/ReactDOM globals as before).

--- a/plugins/artifact/protoagent.plugin.yaml
+++ b/plugins/artifact/protoagent.plugin.yaml
@@ -1,6 +1,6 @@
 id: artifact
 name: Artifact
-version: 0.13.0
+version: 0.14.0
 # Needs the host to serve the DS plugin-kit at /_ds/ (protoAgent #893, v0.34.0) —
 # the shell page links it for theming + the authed handshake, and artifacts inject it
 # so `.pl-*` design-system classes work inside the sandbox.

--- a/tests/test_artifact_plugin.py
+++ b/tests/test_artifact_plugin.py
@@ -473,6 +473,25 @@ def test_ask_bridge_is_wired(monkeypatch, tmp_path):
     assert "e.source!==$frame.contentWindow" in html
 
 
+def test_graphic_kinds_get_a_panzoom_viewport(monkeypatch, tmp_path):
+    """svg + mermaid render into a transform-driven pan/zoom viewport (#1495): scroll-wheel
+    zoom (cursor-anchored), click-drag pan, and a Reset-to-fit control. Both kinds share the
+    one `viewport(...)` wrapper; mermaid re-fits after its async render via window.__artFit."""
+    html = _load(monkeypatch, tmp_path)._SHELL_HTML
+    # the viewport scaffold + controls exist.
+    assert 'id="__vp"' in html and 'id="__cv"' in html
+    assert 'id="__zi"' in html and 'id="__zo"' in html and 'id="__zr"' in html  # zoom in/out/reset
+    # wheel-to-zoom (cursor-anchored) + drag-to-pan wiring.
+    assert 'addEventListener("wheel"' in html and "{passive:false}" in html
+    assert 'addEventListener("pointerdown"' in html and 'addEventListener("pointermove"' in html
+    assert "transform-origin:0 0" in html  # transform applied to #__cv
+    # both graphic kinds route through the shared wrapper; the old bare-centering is gone.
+    assert "function viewport(inner)" in html
+    assert "place-items:center" not in html  # svg no longer just centers a static graphic
+    # mermaid's async render re-fits the freshly-drawn <svg>.
+    assert "window.__artFit" in html
+
+
 def test_libs_are_vendored_same_origin_not_cdn(monkeypatch, tmp_path):
     """react/mermaid load from the same-origin vendor route — NO cdnjs (so artifacts
     work offline), every lib still SRI-pinned (sha512 of the vendored bytes)."""


### PR DESCRIPTION
Closes #1495.

## What

Mermaid **and** SVG artifacts now render into a shared transform-driven **pan/zoom viewport** instead of a static, centered graphic:

- **Zoom** — scroll-wheel / trackpad-pinch, cursor-anchored (the point under the pointer stays fixed)
- **Pan** — click-drag
- **Reset** — a control that re-fits the diagram to the panel
- Mermaid **re-fits automatically** after its async render (`window.__artFit`)

Large flowcharts / sequence / architecture diagrams are finally explorable.

## A note on the premise

The issue framed this as "copy how the SVG renderer already supports zoom/pan." It turns out **SVG had none either** — the `svg` branch only did `place-items:center`. Neither kind had zoom/pan. Since both render an `<svg>` into the sandboxed frame, I built **one** `viewport(...)` wrapper and applied it to both `svg` and `mermaid` — which also makes SVG behave the way the issue assumed, rather than leaving it the odd one out.

## Implementation

- `plugins/artifact/__init__.py` — new `VP_CSS` / `ZBAR` / `PANZOOM` shell constants + a `viewport(inner)` wrapper; `srcdoc()`'s `svg` and `mermaid` branches route through it. Self-contained JS/CSS styled off the existing `base()` `--pl-*` token carry — no DS stylesheet pulled into the graphic frames.
- Injected scripts escape their close as `<\/script>` (the existing "exactly 2 `</script>`" shell guard confirms this).
- Artifact plugin **v0.13.0 → v0.14.0**; CHANGELOG entry.
- New regression test `test_graphic_kinds_get_a_panzoom_viewport`.

## Tests

`uv run pytest tests/test_artifact_plugin.py -q` → **53 passed**. `ruff` clean.

## ⚠ Needs a visual check before merge

CI can't judge the interaction. Recommend a quick look in the artifact panel (render a large mermaid diagram → wheel-zoom, drag-pan, Reset). **I did not enable auto-merge** — this is UI behavior under the local-test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)