### PR TITLE
feat(web): open Knowledge Upload/Add in a dialog, not inline (#1502)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Console set-goal form** (#1510) and **live `goal.iteration` progress** in the Goals panel (#1498).
 
 ### Changed
+- **Knowledge panel: Upload / Add now open in a dialog** (#1502) instead of expanding inline in the
+  narrow sidebar. The source-ingest and add-entry forms get room to breathe and the knowledge list
+  stays in view behind the modal; per-row edit stays inline where it belongs.
 - **Goal mode is now drive-only; the `monitor` disposition is retired** (#1511, ADR 0030 superseded by
   ADR 0067) — watching a metric an external process moves is a **watch**, not a goal. **BREAKING:**
   `sdk.start_goal_loop` / `stop_goal_loop` are removed (use `sdk.create_watch`), `register_goal_hook` no

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -1,6 +1,6 @@
 import { Input, Textarea } from "@protolabsai/ui/forms";
 import { Alert } from "@protolabsai/ui/data";
-import { ConfirmDialog, useToast } from "@protolabsai/ui/overlays";
+import { ConfirmDialog, Dialog, useToast } from "@protolabsai/ui/overlays";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowDownFromLine, ArrowUpToLine, Database, FileUp, Library, Pencil, Plus, Trash2 } from "lucide-react";
@@ -338,23 +338,40 @@ export function KnowledgeStore() {
           <Alert status="error">Couldn't search the knowledge base — {errMsg(error)}</Alert>
         ) : null}
 
+        {/* Upload + Add open in a centered dialog (not inline) so the source/entry form has
+            room and the knowledge list underneath stays in view (#1502). Per-row EDIT below
+            stays inline — it belongs next to the chunk it edits. */}
         {ingesting ? (
-          <IngestForm
-            onDone={invalidate}
-            onError={onError}
+          <Dialog
+            open
             onClose={() => setIngesting(false)}
-          />
+            title={<><FileUp size={16} /> Add a source</>}
+            width="min(680px, 94vw)"
+          >
+            <IngestForm
+              onDone={invalidate}
+              onError={onError}
+              onClose={() => setIngesting(false)}
+            />
+          </Dialog>
         ) : null}
 
         {adding ? (
-          <ChunkForm
-            draft={draft}
-            setDraft={setDraft}
-            onSave={() => save.mutate()}
-            onCancel={() => { setAdding(false); setDraft(EMPTY_DRAFT); }}
-            saving={save.isPending}
-            saveLabel="Add entry"
-          />
+          <Dialog
+            open
+            onClose={() => { setAdding(false); setDraft(EMPTY_DRAFT); }}
+            title={<><Plus size={16} /> Add a knowledge entry</>}
+            width="min(680px, 94vw)"
+          >
+            <ChunkForm
+              draft={draft}
+              setDraft={setDraft}
+              onSave={() => save.mutate()}
+              onCancel={() => { setAdding(false); setDraft(EMPTY_DRAFT); }}
+              saving={save.isPending}
+              saveLabel="Add entry"
+            />
+          </Dialog>
         ) : null}
 
         {!enabled ? (


### PR DESCRIPTION
Closes #1502.

## What

The Knowledge panel's **Upload** (source ingest) and **Add** (typed entry) buttons expanded a form **inline** inside the narrow sidebar panel — cramped for the file picker / URL + domain fields, and it pushed the knowledge list out of view.

Both now open in a centered DS **`Dialog`** (`width="min(680px, 94vw)"`), so the forms have room and the list stays visible behind the overlay — matching how the rest of the console (settings, MCP catalog, schedule) handles these actions.

## Scope

- Wrapped the `ingesting` (`IngestForm`) and `adding` (`ChunkForm`) branches in `<Dialog>`. **The form bodies are untouched** (issue non-goal: don't redesign the form).
- **Per-row edit stays inline** — it belongs next to the chunk it edits, and isn't one of the two header buttons the issue targets.
- UI-only. No Knowledge API / ingestion-pipeline change.

## Tests

- `tsc --noEmit` (web) → clean
- `vitest run` → **209 passed**
- `knowledge.spec.ts` e2e covers listing / search / share-unshare — not the add/ingest flow — so it's unaffected.

## ⚠ Needs a visual check before merge

Under the console UI local-test gate — CI can't judge the modal layout. Recommend a quick look: open Knowledge → click Upload and Add, confirm the dialogs center, size well, and the list stays behind. **Auto-merge NOT enabled.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)