### PR TITLE
feat(web): expose registerKeybinding on the fork extension seam (#1457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   artifacts now render into a transform-driven viewport — scroll-wheel / pinch to zoom (cursor-anchored),
   click-drag to pan, and a **Reset** control that re-fits the diagram. Large flowcharts and architecture
   views are finally explorable; mermaid re-fits automatically after its async render.
+- **`registerKeybinding` on the fork extension seam** (#1457, ADR 0063) — the keybinding registry is
+  now re-exported from `src/ext/index.ts` alongside `registerSlashCommand` / `registerComposerAction` /
+  `registerPaletteCommand`, so a fork binds its own default shortcut through the same seam core uses.
+  Registered binds already appear in **Settings ▸ Keyboard** (rebindable, with conflict detection) and
+  fire through the global host — this just completes the discoverable public surface, with a README example.
 - **Watch primitive — supervise many external conditions at once** (#1505, #1507, #1508, ADR 0067). A
   *watch* polls a condition on a cadence and, when it trips, runs a follow-up agent turn (via
   `run_in_session`) and/or fires hooks — the passive counterpart to a goal (which the agent *drives*).

--- a/apps/web/src/ext/README.md
+++ b/apps/web/src/ext/README.md
@@ -30,3 +30,25 @@ registerContextMenu({
 ```
 
 That's it — rebuild and your surface appears in the rail. No core files touched.
+
+## Example — add a keybinding (ADR 0063)
+
+`registerKeybinding` is a peer of the registries above: a fork/plugin binds its own default
+shortcut through the same seam core uses. Every registered binding automatically appears in
+**Settings ▸ Keyboard** (rebindable, with conflict detection) and fires through the global host.
+
+```tsx
+import { registerKeybinding } from "./index";
+
+registerKeybinding({
+  id: "my-dashboard.toggle",     // stable id — the key for user overrides + dedup
+  label: "Toggle Dashboard",
+  group: "My fork",              // its own section in Settings ▸ Keyboard
+  defaultKeys: "mod+shift+d",    // normalized combo (mod = ⌘ on mac, ctrl elsewhere)
+  scope: "my-dashboard",         // optional: fire only within a `data-kb-scope` panel
+  run: () => { /* … open/focus the surface … */ },
+});
+```
+
+A user can rebind it in Settings; if the combo collides with another binding in an overlapping
+scope, the rebind UI blocks it and names the conflict.

--- a/apps/web/src/ext/index.ts
+++ b/apps/web/src/ext/index.ts
@@ -16,6 +16,8 @@ export { registerChatComponent, registeredChatComponents } from "./componentRegi
 export type { ChatComponentRenderer } from "./componentRegistry";
 export { registerPaletteCommand, registeredPaletteCommands } from "./paletteRegistry";
 export type { PaletteCommand, PaletteCommandContext } from "./paletteRegistry";
+export { registerKeybinding, registeredKeybindings } from "./keybindingRegistry";
+export type { Keybinding } from "./keybindingRegistry";
 export { createUISlice, registeredUISlices } from "./uiStateRegistry";
 export { registerContextMenu, openContextMenu } from "../contextMenu";
 export type { MenuItem, MenuEntry, ContextType } from "../contextMenu";

--- a/docs/adr/0061-frontend-extension-registries.md
+++ b/docs/adr/0061-frontend-extension-registries.md
@@ -79,6 +79,12 @@ menu from `registeredSlashCommands()` + the server list, and `runClientSlash` di
   bypass). Handler context: `{ close }`. (Distinct from plugin manifest `palette` views,
   ADR 0057, which morph the palette body into a plugin iframe — these RUN trusted in-process
   code.)
+- **`registerKeybinding`** (`apps/web/src/ext/keybindingRegistry.ts`, ADR 0063) — binds a
+  default keyboard shortcut (optionally focus-scoped to a `data-kb-scope` panel). Every
+  registered binding auto-appears in **Settings ▸ Keyboard** (user-rebindable, with conflict
+  detection) and fires through the one global keydown host. **Dogfooded:** core's own shortcuts
+  (`keybindings/coreKeybindings.ts`) register through this same seam. Re-exported from
+  `src/ext/index.ts` alongside the seams above (#1457) so a fork reaches it the same way.
 
 ### UI-state slices (shipped, `createUISlice`)
 


### PR DESCRIPTION
Re: #1457 — clears the `needs-info` scope by landing the one concrete, verifiable gap.

## Context: most of #1457 already shipped in #1364

The keybinding system (ADR 0063, #1364) already delivers the substance of this request:

- **Conflict detection** — the rebind UI (`KeybindingsPanel.onRecordKey`) already blocks a combo that clashes with another binding in an overlapping scope and names the conflict ("Already bound to '…' — pick another").
- **Binds shown in a settings UI** — **Settings ▸ Keyboard** auto-enumerates `registeredKeybindings()`, grouped, rebindable, resettable.
- **Host fires every registered bind** — `useKeybindings` resolves against the same registry, so a fork/plugin bind works like a core one.

## The actual gap this PR closes

`registerKeybinding` lives in `src/ext/keybindingRegistry.ts` and its own header calls it *"the fork/plugin seam, mirroring the other src/ext/ registries"* — but it was the **only** `register*` **not** re-exported from `src/ext/index.ts`. A fork following `src/ext/README.md` would expect `import { registerKeybinding } from "./index"` (as it does for `registerSurface` / `registerSlashCommand` / `registerComposerAction` / `registerPaletteCommand`) and not find it.

- Re-export `registerKeybinding`, `registeredKeybindings`, and the `Keybinding` type from the seam index.
- Add a keybinding example to the ext README.

So the fork path now literally satisfies "plugins should be able to register default keybinds for their actions **via the seam**."

## What remains (needs design — recommend splitting out)

The issue's example — an **installed, sandboxed iframe plugin** binding a **host** shortcut (⌘⇧D to toggle its rail panel) — is *not* a small delta. `src/ext/` is the trusted build-time **fork** path; installed plugins render as sandboxed iframe views. A host-level keybind registered from inside a sandboxed iframe needs a postMessage/host-bridge design (and a trust decision about letting an iframe claim global chords). I'll note this on #1457 as the remaining, design-gated piece.

## Tests
`tsc --noEmit` clean; `vitest run src/ext` → 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)