### PR TITLE
feat(web): terminal-style input history in the chat composer (#1496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Chat composer: terminal-style input history** (#1496). Press **↑** to recall previously-sent
+  messages into the composer (newest first), **↓** to walk back toward your in-progress draft — just
+  like a shell. Recalled messages are editable before resending; history only triggers at the top/bottom
+  line so multi-line editing keeps normal caret movement. The last 100 messages persist across reloads
+  (localStorage), shared across chat slots.
 - **Artifact panel: pan & zoom for diagrams** (#1495, artifact plugin v0.14.0). Mermaid **and** SVG
   artifacts now render into a transform-driven viewport — scroll-wheel / pinch to zoom (cursor-anchored),
   click-drag to pan, and a **Reset** control that re-fits the diagram. Large flowcharts and architecture

--- a/apps/web/e2e/chat-input-history.spec.ts
+++ b/apps/web/e2e/chat-input-history.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+// Terminal-style input history (#1496): ↑ recalls previously-submitted messages into the
+// composer, ↓ walks back toward the live draft. Fresh browser context per test → clean
+// localStorage-backed history.
+
+test("↑/↓ recalls and walks submitted-message history", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.waitFor({ state: "visible" });
+
+  // Submit two messages.
+  await composer.fill("first message");
+  await composer.press("Enter");
+  await expect(page.locator(".pl-message--user").filter({ hasText: "first message" })).toBeVisible();
+  await composer.fill("second message");
+  await composer.press("Enter");
+  await expect(page.locator(".pl-message--user").filter({ hasText: "second message" })).toBeVisible();
+  await expect(composer).toHaveValue(""); // cleared on send
+
+  // ↑ recalls newest-first; a second ↑ walks further back.
+  await composer.press("ArrowUp");
+  await expect(composer).toHaveValue("second message");
+  await composer.press("ArrowUp");
+  await expect(composer).toHaveValue("first message");
+  await composer.press("ArrowUp"); // already at oldest → stays put
+  await expect(composer).toHaveValue("first message");
+
+  // ↓ walks forward; past the newest restores the (empty) draft we started from.
+  await composer.press("ArrowDown");
+  await expect(composer).toHaveValue("second message");
+  await composer.press("ArrowDown");
+  await expect(composer).toHaveValue("");
+});
+
+test("a recalled message is editable and resends the edited text", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.waitFor({ state: "visible" });
+
+  await composer.fill("draft one");
+  await composer.press("Enter");
+  await expect(page.locator(".pl-message--user").filter({ hasText: "draft one" })).toBeVisible();
+
+  // Recall, append, resend → the EDITED text is what's sent (and the newest history entry).
+  await composer.press("ArrowUp");
+  await expect(composer).toHaveValue("draft one");
+  await composer.type(" edited");
+  await composer.press("Enter");
+  await expect(page.locator(".pl-message--user").filter({ hasText: "draft one edited" })).toBeVisible();
+
+  await composer.press("ArrowUp");
+  await expect(composer).toHaveValue("draft one edited");
+});

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -28,6 +28,7 @@ import { registeredComposerActions } from "../ext/composerRegistry";
 import { ChatMessageView } from "./ChatMessageView";
 import { ComposerModelSelect } from "./ComposerModelSelect";
 import { filesFromTransfer, isLargePaste, pastedTextFile } from "./paste";
+import { inputHistory, pushInputHistory } from "./inputHistory";
 import { addComponent, addToolRef, appendReasoning, appendText } from "./parts";
 
 function messageId() {
@@ -289,6 +290,11 @@ function ChatSessionSlot({
   // Forwarded into the DS PromptInput (inputRef) — for slash-completion focus and
   // the Ctrl/⌘+Enter caret insert. The DS component owns the auto-grow.
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  // Terminal-style ↑/↓ history nav (#1496): position in the shared submitted-message ring
+  // (null = not navigating), and the live draft stashed when nav began (restored on ↓ past
+  // the newest). Refs, not state — they change alongside a setDraft, no separate re-render.
+  const histIndexRef = useRef<number | null>(null);
+  const histStashRef = useRef<string>("");
   // Autofocus the composer when this becomes the active session AND the chat surface is
   // the active rail surface — so clicking the Chat rail item (or switching tabs) lands
   // focus in the composer without a click. (`visible` alone is the active tab, which
@@ -483,6 +489,53 @@ function ChatSessionSlot({
         return;
       }
     }
+    // Terminal-style input history (#1496): ↑ recalls the previous submitted message when the
+    // caret is on the FIRST line; ↓ walks back toward the live draft when on the LAST line — so
+    // multi-line editing keeps normal caret movement and history only triggers at the edges.
+    // (Bare arrows only — a modifier means a tab-jump / caret combo, not history.)
+    if (
+      (event.key === "ArrowUp" || event.key === "ArrowDown") &&
+      !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey
+    ) {
+      const ta = textareaRef.current;
+      const hist = inputHistory();
+      if (ta && hist.length) {
+        const caret = ta.selectionStart ?? 0;
+        const onFirstLine = draft.slice(0, caret).indexOf("\n") === -1;
+        const onLastLine = draft.slice(ta.selectionEnd ?? caret).indexOf("\n") === -1;
+        const recall = (val: string) => {
+          setDraft(val);
+          // caret to end so the next keystroke edits the recalled text (readline behaviour)
+          requestAnimationFrame(() => {
+            const t = textareaRef.current;
+            if (t) t.selectionStart = t.selectionEnd = val.length;
+          });
+        };
+        if (event.key === "ArrowUp" && onFirstLine) {
+          event.preventDefault();
+          if (histIndexRef.current === null) {
+            histStashRef.current = draft; // remember the in-progress draft
+            histIndexRef.current = hist.length - 1;
+          } else if (histIndexRef.current > 0) {
+            histIndexRef.current -= 1;
+          }
+          recall(hist[histIndexRef.current]);
+          return;
+        }
+        if (event.key === "ArrowDown" && histIndexRef.current !== null && onLastLine) {
+          event.preventDefault();
+          histIndexRef.current += 1;
+          if (histIndexRef.current > hist.length - 1) {
+            histIndexRef.current = null; // walked past the newest → restore the stashed draft
+            recall(histStashRef.current);
+            histStashRef.current = "";
+          } else {
+            recall(hist[histIndexRef.current]);
+          }
+          return;
+        }
+      }
+    }
     if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
       // ⌘/Ctrl+Enter → newline at the caret (the textarea wouldn't on its own).
       event.preventDefault();
@@ -579,6 +632,9 @@ function ChatSessionSlot({
   async function send() {
     if (!session || !canSend) return;
     const text = draft.trim();
+    pushInputHistory(text); // record for ↑/↓ recall, then reset nav to the newest
+    histIndexRef.current = null;
+    histStashRef.current = "";
     setDraft("");
     // Deterministic client-side slash commands (ADR 0057) — handled locally, not sent.
     if (text.startsWith("/") && runClientSlash(text.slice(1).trim())) return;
@@ -606,6 +662,9 @@ function ChatSessionSlot({
   async function queueSteer() {
     const text = draft.trim();
     if (!session || !text) return;
+    pushInputHistory(text); // steered messages join the same recall ring
+    histIndexRef.current = null;
+    histStashRef.current = "";
     const id = messageId();
     setDraft("");
     setSteerQueue([...steerQueueRef.current, { id, text }]);
@@ -1201,6 +1260,7 @@ function ChatSessionSlot({
           onChange={(v) => {
             setDraft(v);
             setSlashDismissed(false); // re-open the menu when the input changes
+            histIndexRef.current = null; // typing detaches from history nav (readline)
           }}
           // Idle → send. While a turn streams (`busy`), the field stays live: Enter
           // queues a steer into the running turn (onQueue) without stopping it, and
@@ -1212,7 +1272,7 @@ function ChatSessionSlot({
           placeholder={
             status === "streaming"
               ? "Steer the agent — your message folds into its work at the next step (Enter to queue)"
-              : "Message protoAgent  (/ for commands · Enter to send · ⌘/Ctrl+Enter for newline)"
+              : "Message protoAgent  (/ for commands · Enter to send · ↑ history · ⌘/Ctrl+Enter for newline)"
           }
           inputRef={textareaRef}
           onKeyDown={onComposerKeyDown}

--- a/apps/web/src/chat/inputHistory.test.ts
+++ b/apps/web/src/chat/inputHistory.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { _resetInputHistoryCache, inputHistory, pushInputHistory } from "./inputHistory";
+
+const KEY = "protoagent.chat.inputHistory";
+
+beforeEach(() => {
+  localStorage.clear();
+  _resetInputHistoryCache();
+});
+
+describe("inputHistory", () => {
+  it("starts empty and records submitted messages oldest → newest", () => {
+    expect(inputHistory()).toEqual([]);
+    pushInputHistory("first");
+    pushInputHistory("second");
+    expect(inputHistory()).toEqual(["first", "second"]);
+  });
+
+  it("trims and ignores blank / whitespace-only input", () => {
+    pushInputHistory("   ");
+    pushInputHistory("");
+    pushInputHistory("  keep me  ");
+    expect(inputHistory()).toEqual(["keep me"]); // trimmed, blanks dropped
+  });
+
+  it("de-dupes only CONSECUTIVE repeats (like a shell)", () => {
+    pushInputHistory("a");
+    pushInputHistory("a"); // consecutive repeat → ignored
+    pushInputHistory("b");
+    pushInputHistory("a"); // not consecutive → recorded again
+    expect(inputHistory()).toEqual(["a", "b", "a"]);
+  });
+
+  it("caps the ring at 100, dropping the oldest", () => {
+    for (let i = 0; i < 130; i++) pushInputHistory(`m${i}`);
+    const hist = inputHistory();
+    expect(hist.length).toBe(100);
+    expect(hist[0]).toBe("m30"); // 0–29 rotated out
+    expect(hist[hist.length - 1]).toBe("m129");
+  });
+
+  it("persists across a cache reset (localStorage-backed)", () => {
+    pushInputHistory("survives");
+    _resetInputHistoryCache(); // simulate a fresh page load
+    expect(inputHistory()).toEqual(["survives"]);
+    expect(JSON.parse(localStorage.getItem(KEY) as string)).toEqual(["survives"]);
+  });
+
+  it("reads corrupt storage as empty instead of throwing", () => {
+    localStorage.setItem(KEY, "{not json");
+    _resetInputHistoryCache();
+    expect(inputHistory()).toEqual([]);
+  });
+});

--- a/apps/web/src/chat/inputHistory.ts
+++ b/apps/web/src/chat/inputHistory.ts
@@ -1,0 +1,55 @@
+// Terminal-style chat input history (#1496) — the last N submitted messages, so the
+// composer can recall/edit/resend them with ↑/↓ like a shell (readline). Persisted in
+// localStorage and shared across chat slots (one ring, like a terminal's history file);
+// nav state (where you are in the ring) is per-composer and lives in ChatSurface.
+//
+// Read `inputHistory()` for the current ring (oldest → newest); call `pushInputHistory()`
+// when a message is submitted. The in-memory cache avoids re-parsing localStorage on every
+// arrow press; it stays in sync because pushes go through here.
+
+const KEY = "protoagent.chat.inputHistory";
+const MAX = 100; // cap the ring — plenty for recall, bounded localStorage footprint
+
+let _cache: string[] | null = null;
+
+function read(): string[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw) as unknown;
+    return Array.isArray(arr) ? arr.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return []; // corrupt/absent/blocked storage → empty history, never throw
+  }
+}
+
+/** The history ring, oldest → newest. Cached in memory after the first read. */
+export function inputHistory(): string[] {
+  if (_cache === null) _cache = read();
+  return _cache;
+}
+
+/**
+ * Record a submitted message as the newest history entry. No-ops on blank input and on a
+ * repeat of the most-recent entry (consecutive dedupe, like a shell), so hammering the same
+ * message doesn't flood the ring. Trims to the last MAX entries. Best-effort persistence —
+ * a storage failure (quota / private mode) leaves the in-memory ring intact.
+ */
+export function pushInputHistory(entry: string): void {
+  const e = entry.trim();
+  if (!e) return;
+  const hist = inputHistory();
+  if (hist[hist.length - 1] === e) return; // consecutive dedupe
+  hist.push(e);
+  while (hist.length > MAX) hist.shift();
+  try {
+    localStorage.setItem(KEY, JSON.stringify(hist));
+  } catch {
+    /* quota / disabled storage — keep the in-memory ring, don't throw */
+  }
+}
+
+/** Test-only: drop the in-memory cache so a fresh read hits localStorage again. */
+export function _resetInputHistoryCache(): void {
+  _cache = null;
+}


### PR DESCRIPTION
Closes #1496.

## What

The chat composer now has **terminal-style input history**:

- **↑** recalls previously-submitted messages into the composer (newest first); repeated presses walk further back.
- **↓** walks forward toward the most recent, then restores whatever you'd typed before you started navigating.
- Recalled messages are **editable before resending** — the edited text is what's sent, and becomes the newest history entry.
- **Edge-triggered:** ↑ recalls only when the caret is on the **first** line, ↓ only on the **last** line — so multi-line editing keeps normal caret movement. Bare arrows only (a modifier = tab-jump/caret combo).
- The last **100** submitted messages persist in **localStorage** (one ring shared across chat slots, consecutive-deduped), surviving reloads.

## Implementation

- New `apps/web/src/chat/inputHistory.ts` — a small cached, crash-safe localStorage-backed ring (`inputHistory()` / `pushInputHistory()`).
- `ChatSurface.tsx` — ↑/↓ handling in the existing `onComposerKeyDown` seam (runs before the DS `PromptInput`); nav position + stashed draft in refs; typing detaches from nav (`onChange`); recording on both `send()` and the mid-turn `queueSteer()` path.
- Composer placeholder gains a `· ↑ history` hint.

## Tests — all green locally

- **Unit** (`inputHistory.test.ts`, 6): empty/record order, blank-skip + trim, consecutive-dedupe, 100-cap rotation, persistence round-trip, corrupt-storage tolerance. Full web unit suite **215 passed**.
- **E2E** (`chat-input-history.spec.ts`, 2): ↑/↓ recall-and-walk incl. draft restore; recall→edit→resend. **Built the app and ran them locally → 2 passed.**
- `tsc --noEmit` clean.

## Notes
Out of scope per the issue: cross-session server-side history and search/filter. Sits on the composer (a hot surface) — the edge-trigger + bare-arrow guards keep it out of the way of slash-menu nav (which already owns ↑/↓ while open) and ⌘/Ctrl+Enter newline. A quick manual sanity check in-app is still worth it before merge; **auto-merge not enabled.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)