### PR TITLE
docs(portfolio): add 'spinning up teams on demand' + gateway inheritance

### DIFF
--- a/docs/guides/portfolio.md
+++ b/docs/guides/portfolio.md
@@ -117,6 +117,29 @@ schedule it with `schedule_task` and the PM dispatches each held feature the mom
 dependency lands — no polling, no jumping the gun. See
 [ADR 0055 P3](../adr/0055-multi-team-orchestration-federated-boards.md#phasing).
 
+## Spinning up teams on demand
+
+The Setup above assumes standing team-agents you register as remotes. A PM can also spin
+teams up **ephemerally** — one per project, disposed when its board drains:
+
+```python
+portfolio_spinup_team(name="docs-team", repo="/abs/path/to/repo")  # clone a team config into a
+                                                                   # scoped workspace, boot it,
+                                                                   # register it as a board
+portfolio_dispatch(board="docs-team", title=…, spec=…)             # send it work over A2A
+portfolio_autodispose()                                            # dispose teams whose board is drained
+# also: portfolio_teardown_team(name) to dispose one now, portfolio_teams() to list them
+```
+
+**Gateway inheritance (v0.14+): no creds prep.** A spawned team inherits the PM's own
+resolved model gateway — the PM's `model.api_base` (resolved through the ADR 0047
+App→Host→Agent cascade, so a box-level gateway counts) plus its `OPENAI_API_KEY`, which
+reaches the team via its environment. So `portfolio_spinup_team` runs real turns out of the
+box with **no `team_template`**. Pass `template=`/`portfolio.team_template` only for a team on
+a *different* gateway than the PM's; spinup preflights the assembled config and fails loudly
+(rolling the workspace back) if a team couldn't reach a model, rather than booting a mute one.
+The host needs the `br` (beads) CLI for the team's board.
+
 ## Notes
 
 - A board id **is** the team-agent's fleet name — no separate registry.


### PR DESCRIPTION
## What

The portfolio guide (`docs/guides/portfolio.md`) documented only the **federated** model (register standing team-agents as remotes) and **omitted team spawning entirely** — `portfolio_spinup_team` wasn't even mentioned.

Adds a **"Spinning up teams on demand"** section covering the ephemeral-team lifecycle (`spinup_team` / `dispatch` / `autodispose` / `teardown_team` / `teams`), and documents **v0.14 gateway inheritance**: a spawned team inherits the PM's resolved `model.api_base` (through the ADR 0047 cascade, so a box-level gateway counts) + its `OPENAI_API_KEY` via the team's environment — so spinup runs real turns with **no `team_template` / creds prep**. Also notes the spawn preflight (fails loudly + rolls back on an unreachable model) and the `br` host prereq.

Part of the portfolio-manager onboarding pass — pairs with [portfolio-plugin #17](https://github.com/protoLabsAI/portfolio-plugin/pull/17) (the inheritance feature) and pm-stack #14 (bundle docs). Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for spinning up portfolio teams on demand.
  * Documented the ephemeral team workflow, including setup, dispatch, teardown, and listing steps.
  * Added notes about gateway inheritance, including how spawned teams use the resolved model gateway and API key, plus preflight and failure behavior when connectivity is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->