### PR TITLE
feat(flags): developer-flags backend foundation (#1506, ADR 0068 slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Developer flags — backend foundation** (#1506, ADR 0068, slice 1). A small local/static
+  feature-flag system to gate pre-release functionality: `runtime/flags.py` with a `Flag` registry
+  (`off`·`dev`·`beta`·`on` tiers) and `flag_enabled(id)` / `resolved_flags()`. Enablement resolves
+  a flag's tier against a runtime **channel** (`prod ⊂ beta ⊂ dev`) — derived from the dev sandbox
+  instance, a `PROTOAGENT_CHANNEL` env, or the new **`developer.channel`** setting — with a
+  `PROTOAGENT_FLAG_<ID>` env override on top. No flags ship yet; the `/api/flags` route and the
+  Developer panel are later slices.
 - **Chat composer: terminal-style input history** (#1496). Press **↑** to recall previously-sent
   messages into the composer (newest first), **↓** to walk back toward your in-progress draft — just
   like a shell. Recalled messages are editable before resending; history only triggers at the top/bottom

--- a/graph/config.py
+++ b/graph/config.py
@@ -570,6 +570,11 @@ class LangGraphConfig:
     # LangGraph loop (default). "acp:<agent>" (e.g. "acp:codex", "acp:claude") = an
     # external coding agent drives the turn over ACP, mounting the operator MCP bus.
     agent_runtime: str = "native"
+    # Developer channel (ADR 0068) — which pre-release feature tier this instance exposes:
+    # "prod" (released only) | "beta" (opt-in previews) | "dev" (everything, incl. in-progress).
+    # The dev sandbox instance defaults to "dev"; env fallback PROTOAGENT_CHANNEL. Read by
+    # ``runtime.flags`` to resolve developer flags.
+    developer_channel: str = "prod"
     # ACP launch overrides (ADR 0033) — per-agent ``{command, args}`` from the YAML
     # ``acp.agents`` block, e.g. ``acp: {agents: {claude: {command: claude-agent-acp}}}``.
     # ``runtime.acp_runtime.adapter_for`` reads this to override the built-in default
@@ -938,6 +943,7 @@ class LangGraphConfig:
             operator_mcp_enabled=operator_mcp.get("enabled", cls.operator_mcp_enabled),
             operator_mcp_tools=list(operator_mcp.get("tools", []) or []),
             agent_runtime=str(data.get("agent_runtime", cls.agent_runtime) or "native"),
+            developer_channel=str((data.get("developer", {}) or {}).get("channel", cls.developer_channel) or "prod"),
             acp_agents=dict(acp.get("agents", {}) or {}),
             plugins_enabled=list(plugins.get("enabled", []) or []),
             plugins_disabled=list(plugins.get("disabled", []) or []),

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -684,6 +684,17 @@ FIELDS: list[Field] = [
         minimum=0,
         scope="host",
     ),
+    Field(
+        "developer.channel",
+        "developer_channel",
+        "Developer channel",
+        "select",
+        "Developer",
+        "Which pre-release features this instance exposes (ADR 0068). `prod` = released "
+        "features only; `beta` = opt-in previews; `dev` = everything, incl. in-progress "
+        "work. The dev sandbox instance defaults to `dev`. Env fallback: PROTOAGENT_CHANNEL.",
+        options=["prod", "beta", "dev"],
+    ),
 ]
 
 # Knowledge domain sub-sections (console grouping). The Knowledge fields are declared with
@@ -807,6 +818,9 @@ _SECTION_CATEGORY = {
     "Network": "Box",
     "Discovery": "Box",
     "Keep-warm": "Box",
+    # Developer — pre-release feature gating (ADR 0068). The channel this instance runs on;
+    # the flags themselves live in a device-local Developer panel, not the schema.
+    "Developer": "Behavior",
     # Discord / Google / GitHub / other plugin sections → "Plugins" (the default), the
     # Integrations surface.
 }

--- a/runtime/flags.py
+++ b/runtime/flags.py
@@ -1,0 +1,133 @@
+"""Developer flags (ADR 0068) — a small, local/static feature-flag system that gates
+pre-release functionality behind tiers (``off`` < ``dev`` < ``beta`` < ``on``), measured
+against a runtime *channel* (``prod`` ⊂ ``beta`` ⊂ ``dev``).
+
+A flag is a **temporary** gate on a core code path, meant to be deleted when the feature
+graduates — *not* a plugin (a permanent capability toggle) and *not* a setting (permanent
+user config). See ``docs/adr/0068-developer-flags-and-panel.md``.
+
+This module is slice 1 (backend core): the registry + resolution. ``flag_enabled(id)`` is
+the check core code wraps a pre-release path in; ``resolved_flags()`` is the payload the
+``/api/flags`` route (slice 2) serves and the Developer panel (slice 4) renders.
+
+Resolution precedence (ADR 0068 D3, backend half):
+    ``PROTOAGENT_FLAG_<ID>`` env override  >  the flag's tier vs. the runtime channel  >  off
+(The query-param and panel-toggle override layers are frontend, slices 3–4.)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+Tier = Literal["off", "dev", "beta", "on"]
+Channel = Literal["prod", "beta", "dev"]
+
+# Channel openness — higher sees more. A flag at tier T is enabled when the channel's rank
+# meets the tier's requirement. ``off`` requires more than any channel can offer (never on);
+# ``on`` requires nothing (always on).
+_CHANNEL_RANK: dict[str, int] = {"prod": 0, "beta": 1, "dev": 2}
+_TIER_REQUIRES: dict[str, int] = {"on": 0, "beta": 1, "dev": 2, "off": 99}
+
+
+@dataclass(frozen=True)
+class Flag:
+    """One pre-release feature gate. Declared once in ``FLAGS`` — the single source of truth."""
+
+    id: str  # dotted, stable — the override + lookup key, e.g. "chat.new_dashboard"
+    description: str  # what it gates (shown in the Developer panel)
+    tier: Tier = "off"  # rollout stage: off (nobody) · dev · beta · on (everybody)
+    owner: str = ""  # who to ask — makes a stale flag actionable
+    remove_by: str = ""  # a version or ISO date; a staleness test (slice 5) will guard it
+
+
+# The registry — the SINGLE source of truth. Add a flag here; check it with ``flag_enabled``.
+# Empty until a real pre-release feature needs gating (slice 6 dogfoods the first one).
+FLAGS: list[Flag] = []
+
+
+def _registry() -> dict[str, Flag]:
+    """Flags keyed by id (built fresh so tests can monkeypatch ``FLAGS``)."""
+    return {f.id: f for f in FLAGS}
+
+
+def _env_key(flag_id: str) -> str:
+    """``PROTOAGENT_FLAG_<ID>`` — the id upper-cased with every non-alphanumeric run → ``_``
+    (``chat.new_dashboard`` → ``PROTOAGENT_FLAG_CHAT_NEW_DASHBOARD``)."""
+    return "PROTOAGENT_FLAG_" + "".join(c if c.isalnum() else "_" for c in flag_id).upper()
+
+
+def _env_override(flag_id: str) -> bool | None:
+    """The forced state from ``PROTOAGENT_FLAG_<ID>`` (headless / CI / deployment escape
+    hatch), or ``None`` when the var is unset."""
+    raw = os.environ.get(_env_key(flag_id))
+    if raw is None:
+        return None
+    return raw.strip().lower() in ("1", "true", "on", "yes")
+
+
+def current_channel() -> Channel:
+    """The runtime's openness. Explicit ``PROTOAGENT_CHANNEL`` wins; else the dev sandbox
+    instance (``PROTOAGENT_INSTANCE=dev``, ADR 0065) is ``dev``; else the ``developer.channel``
+    config field; else ``prod``.
+
+    Read live (like plugin config) so a Settings save applies without a restart, and degrades
+    to env/default when there's no graph state (ACP / headless / import-time)."""
+    explicit = os.environ.get("PROTOAGENT_CHANNEL", "").strip().lower()
+    if explicit in _CHANNEL_RANK:
+        return explicit  # type: ignore[return-value]
+    try:
+        from infra.paths import instance_id
+
+        if instance_id() == "dev":
+            return "dev"
+    except Exception:
+        pass
+    try:
+        from graph.sdk import config
+
+        configured = str(getattr(config(), "developer_channel", "") or "").strip().lower()
+        if configured in _CHANNEL_RANK:
+            return configured  # type: ignore[return-value]
+    except Exception:
+        pass
+    return "prod"
+
+
+def _tier_enabled(tier: str, channel: str) -> bool:
+    return _CHANNEL_RANK.get(channel, 0) >= _TIER_REQUIRES.get(tier, 99)
+
+
+def flag_enabled(flag_id: str, *, channel: Channel | None = None) -> bool:
+    """Is ``flag_id`` enabled in the current process? Env override > tier-vs-channel > off.
+    An unregistered id is always off (fail-closed). Pass ``channel`` to resolve against a
+    specific channel instead of the live one (used by ``resolved_flags`` and tests)."""
+    override = _env_override(flag_id)
+    if override is not None:
+        return override
+    flag = _registry().get(flag_id)
+    if flag is None:
+        return False
+    return _tier_enabled(flag.tier, channel or current_channel())
+
+
+def resolved_flags(*, channel: Channel | None = None) -> dict:
+    """Every registered flag with its metadata + resolved state, plus the active channel —
+    the payload for ``GET /api/flags`` (slice 2) and the Developer panel (slice 4)."""
+    resolved_channel = channel or current_channel()
+    flags = []
+    for f in FLAGS:
+        override = _env_override(f.id)
+        flags.append(
+            {
+                "id": f.id,
+                "description": f.description,
+                "tier": f.tier,
+                "owner": f.owner,
+                "remove_by": f.remove_by,
+                "enabled": override if override is not None else _tier_enabled(f.tier, resolved_channel),
+                "source": "env" if override is not None else "channel",
+            }
+        )
+    return {"channel": resolved_channel, "flags": flags}

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -143,6 +143,8 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
         "runtime",
         "operator",
         "agent_runtime",
+        # Developer channel (ADR 0068) — the pre-release feature tier this instance exposes.
+        "developer",
         "checkpoint",
         "compaction",
         "goal",

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -52,6 +52,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "a2a_skills": [],
     "acp_agents": {},
     "agent_runtime": "native",
+    "developer_channel": "prod",
     "api_base": "http://gateway:4000/v1",
     "audit_middleware": True,
     "autostart_on_boot": False,
@@ -189,6 +190,7 @@ _GOLDEN_EXEMPT = {"api_key", "auth_token", "federation_token", "plugin_config"}
 # prompt_cache / routing / telemetry appeared; no pre-existing value changed.
 CONFIG_TO_DICT_GOLDEN = {
     "agent_runtime": "native",
+    "developer": {"channel": "prod"},
     "auth": {
         "token": "",
     },

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,0 +1,128 @@
+"""Developer flags (ADR 0068, slice 1) — the registry + resolution.
+
+Freezes the tier-vs-channel matrix, the env-override precedence, and channel derivation.
+Tests monkeypatch ``flags.FLAGS`` to a hermetic registry and wipe flag/channel env vars."""
+
+from __future__ import annotations
+
+import os
+import types
+
+import pytest
+
+from runtime import flags
+from runtime.flags import Flag
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_env(monkeypatch):
+    """Wipe any real flag/channel/instance env so resolution is deterministic per test."""
+    for k in list(os.environ):
+        if k.startswith("PROTOAGENT_FLAG_") or k in (
+            "PROTOAGENT_CHANNEL",
+            "PROTOAGENT_INSTANCE",
+            "PROTOAGENT_AUTO_SCOPE",
+        ):
+            monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def _use(monkeypatch, *registry: Flag) -> None:
+    monkeypatch.setattr(flags, "FLAGS", list(registry))
+
+
+# ── tier vs channel ─────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "tier,channel,expected",
+    [
+        ("on", "prod", True), ("on", "beta", True), ("on", "dev", True),
+        ("beta", "prod", False), ("beta", "beta", True), ("beta", "dev", True),
+        ("dev", "prod", False), ("dev", "beta", False), ("dev", "dev", True),
+        ("off", "prod", False), ("off", "beta", False), ("off", "dev", False),
+    ],
+)
+def test_tier_vs_channel(monkeypatch, tier, channel, expected):
+    _use(monkeypatch, Flag("x", "d", tier=tier))
+    assert flags.flag_enabled("x", channel=channel) is expected
+
+
+def test_unregistered_flag_is_off(monkeypatch):
+    _use(monkeypatch)  # empty registry
+    assert flags.flag_enabled("nope", channel="dev") is False
+
+
+# ── env override precedence ─────────────────────────────────────────────────────
+
+def test_env_override_forces_state(monkeypatch):
+    _use(monkeypatch, Flag("chat.new", "d", tier="off"))
+    monkeypatch.setenv("PROTOAGENT_FLAG_CHAT_NEW", "on")
+    assert flags.flag_enabled("chat.new", channel="prod") is True  # off tier, env forces on
+    monkeypatch.setenv("PROTOAGENT_FLAG_CHAT_NEW", "0")
+    assert flags.flag_enabled("chat.new", channel="dev") is False  # on-in-dev, env forces off
+
+
+def test_env_key_derivation():
+    assert flags._env_key("chat.new_dashboard") == "PROTOAGENT_FLAG_CHAT_NEW_DASHBOARD"
+
+
+# ── channel derivation ──────────────────────────────────────────────────────────
+
+def test_channel_explicit_env_wins(monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_CHANNEL", "beta")
+    assert flags.current_channel() == "beta"
+
+
+def test_channel_dev_sandbox_instance(monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "dev")  # the dev sandbox (ADR 0065)
+    assert flags.current_channel() == "dev"
+
+
+def test_channel_from_config_field(monkeypatch):
+    import graph.sdk
+
+    monkeypatch.setattr(graph.sdk, "config", lambda: types.SimpleNamespace(developer_channel="beta"))
+    assert flags.current_channel() == "beta"
+
+
+def test_channel_defaults_to_prod(monkeypatch):
+    import graph.sdk
+
+    monkeypatch.setattr(graph.sdk, "config", lambda: types.SimpleNamespace(developer_channel=""))
+    assert flags.current_channel() == "prod"
+
+
+def test_bad_channel_value_ignored(monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_CHANNEL", "banana")  # not a real channel → ignored
+    import graph.sdk
+
+    monkeypatch.setattr(graph.sdk, "config", lambda: types.SimpleNamespace(developer_channel=""))
+    assert flags.current_channel() == "prod"
+
+
+# ── the API payload ─────────────────────────────────────────────────────────────
+
+def test_resolved_flags_payload(monkeypatch):
+    _use(monkeypatch, Flag("a.b", "desc", tier="beta", owner="me", remove_by="v1.0"))
+    out = flags.resolved_flags(channel="beta")
+    assert out["channel"] == "beta"
+    assert out["flags"] == [
+        {
+            "id": "a.b", "description": "desc", "tier": "beta", "owner": "me",
+            "remove_by": "v1.0", "enabled": True, "source": "channel",
+        }
+    ]
+    # an env override flips enabled + tags the source.
+    monkeypatch.setenv("PROTOAGENT_FLAG_A_B", "off")
+    flipped = flags.resolved_flags(channel="dev")["flags"][0]
+    assert flipped["enabled"] is False and flipped["source"] == "env"
+
+
+# ── registry hygiene (guards the real FLAGS as it grows) ────────────────────────
+
+def test_real_registry_is_well_formed():
+    ids = [f.id for f in flags.FLAGS]
+    assert len(ids) == len(set(ids)), "duplicate flag id in FLAGS"
+    for f in flags.FLAGS:
+        assert f.tier in ("off", "dev", "beta", "on"), f"{f.id}: invalid tier {f.tier!r}"
+        assert f.id and f.description, "every flag needs an id + description"


### PR DESCRIPTION
Slice 1 of the developer-flags system designed in **ADR 0068** (#1506). Backend core only — the registry + resolution.

## What lands

- **`runtime/flags.py`** — the whole slice-1 surface:
  - `Flag` (frozen: `id`, `description`, `tier`, `owner`, `remove_by`) + the `FLAGS` registry (single source of truth, **empty for now**).
  - `flag_enabled(id)` — the check core code wraps a pre-release path in. Precedence: **`PROTOAGENT_FLAG_<ID>` env override > the flag's tier vs. the runtime channel > off** (unregistered id → off, fail-closed).
  - `current_channel()` — `prod ⊂ beta ⊂ dev`, derived from explicit `PROTOAGENT_CHANNEL` > the **dev sandbox instance** (`PROTOAGENT_INSTANCE=dev`, ADR 0065) > the `developer.channel` config field > `prod`. Read live (via `graph.sdk.config`, imported lazily to dodge cycles) so a Settings save applies without a restart; degrades to env/default under ACP/headless.
  - `resolved_flags()` — `{channel, flags:[…]}` with each flag's resolved state + source; the payload `GET /api/flags` (slice 2) and the Developer panel (slice 4) will serve/render.
- **`developer.channel`** config field — added to `LangGraphConfig` + the settings schema (`select` prod/beta/dev, new "Developer" section → Behavior domain). Config-roundtrip goldens updated.

## Design fidelity

Matches ADR 0068 D1–D3 (single backend registry, tier-vs-channel, the precedence ladder). A flag is deliberately **neither a plugin** (load-time capability) **nor a setting** (permanent user config) — see D7.

## Tests / gates (all green locally)

- `tests/test_flags.py` — **22 passed**: the full tier×channel matrix, env-override precedence, env-key derivation, channel derivation (explicit / dev-instance / config-field / default / bad-value), the `resolved_flags` payload, and a registry-hygiene guard.
- `tests/test_config_roundtrip.py` + the full `test_config_*` / `test_settings_*` suite — **green** (goldens updated for `developer.channel`).
- `ruff` clean; **import contracts kept** (`runtime → graph.sdk` / `infra.paths` is allowed; the module imports them lazily).

## Not in this PR
Slices 2–6 (the `/api/flags` route, the frontend `useFlag` + query-param/panel overrides, the `CONSOLE_SECTIONS` Developer panel, the `remove_by` staleness test, and dogfooding a first real flag). Happy to take slice 2 next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)