### PR TITLE
feat(flags): GET /api/flags operator route (#1506, ADR 0068 slice 2)

### DIFF
--- a/operator_api/flags_routes.py
+++ b/operator_api/flags_routes.py
@@ -1,0 +1,26 @@
+"""Developer flags (ADR 0068) — ``GET /api/flags``.
+
+Serves the resolved flag list (registry metadata + each flag's enabled state for the
+current channel) so the console **Developer panel** (slice 4) can render and toggle them.
+Read-only; gated by the ``/api/*`` operator bearer (a2a_impl/auth.py) like every operator
+route. The registry + resolution live in ``runtime.flags`` (slice 1).
+"""
+
+from __future__ import annotations
+
+
+def register_flags_routes(app) -> None:
+    from fastapi import APIRouter
+
+    router = APIRouter()
+
+    @router.get("/api/flags")
+    async def _flags() -> dict:
+        """The active channel + every registered developer flag with its resolved state
+        (ADR 0068). Shape: ``{"channel": "prod|beta|dev", "flags": [{id, description, tier,
+        owner, remove_by, enabled, source}]}``. See ``runtime.flags.resolved_flags``."""
+        from runtime.flags import resolved_flags
+
+        return resolved_flags()
+
+    app.include_router(router)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -674,6 +674,12 @@ def _main():
 
     register_fleet_routes(fastapi_app)
 
+    # Developer flags (ADR 0068) — /api/flags serves the resolved flag states the
+    # console Developer panel renders + toggles.
+    from operator_api.flags_routes import register_flags_routes
+
+    register_flags_routes(fastapi_app)
+
     # Per-agent theme (ADR 0042) — each agent saves its own look; the console repaints
     # to the focused agent's theme (proxied via /agents/<slug>/api/theme, slug routing).
     from operator_api.theme_routes import register_theme_routes

--- a/tests/test_flags_routes.py
+++ b/tests/test_flags_routes.py
@@ -1,0 +1,62 @@
+"""Developer flags API (ADR 0068, slice 2) — GET /api/flags serves resolved_flags()."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from operator_api.flags_routes import register_flags_routes
+from runtime import flags
+from runtime.flags import Flag
+
+
+@pytest.fixture(autouse=True)
+def _hermetic_env(monkeypatch):
+    for k in list(os.environ):
+        if k.startswith("PROTOAGENT_FLAG_") or k in ("PROTOAGENT_CHANNEL", "PROTOAGENT_INSTANCE", "PROTOAGENT_AUTO_SCOPE"):
+            monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    register_flags_routes(app)
+    return TestClient(app)
+
+
+def test_flags_route_serves_resolved_payload(monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_CHANNEL", "beta")
+    monkeypatch.setattr(flags, "FLAGS", [Flag("chat.new", "A new thing", tier="beta", owner="kj", remove_by="v2")])
+
+    r = _client().get("/api/flags")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["channel"] == "beta"
+    assert body["flags"] == [
+        {
+            "id": "chat.new", "description": "A new thing", "tier": "beta",
+            "owner": "kj", "remove_by": "v2", "enabled": True, "source": "channel",
+        }
+    ]
+
+
+def test_flags_route_reflects_env_override_and_channel(monkeypatch):
+    # prod channel: a dev-tier flag is off…
+    monkeypatch.setenv("PROTOAGENT_CHANNEL", "prod")
+    monkeypatch.setattr(flags, "FLAGS", [Flag("x.y", "d", tier="dev")])
+    off = _client().get("/api/flags").json()["flags"][0]
+    assert off["enabled"] is False and off["source"] == "channel"
+
+    # …until an env override forces it on (source flips to "env").
+    monkeypatch.setenv("PROTOAGENT_FLAG_X_Y", "on")
+    on = _client().get("/api/flags").json()["flags"][0]
+    assert on["enabled"] is True and on["source"] == "env"
+
+
+def test_flags_route_empty_registry(monkeypatch):
+    monkeypatch.setattr(flags, "FLAGS", [])
+    body = _client().get("/api/flags").json()
+    assert body["flags"] == [] and body["channel"] in ("prod", "beta", "dev")


### PR DESCRIPTION
Slice 2 of ADR 0068 (dev-flags), building on slice 1 (#1533).

## What
`GET /api/flags` serves `runtime.flags.resolved_flags()` — the active channel plus every registered developer flag with its resolved `enabled` state + `source` (`channel` vs `env`):

```json
{"channel": "prod", "flags": [{"id": "...", "description": "...", "tier": "dev",
  "owner": "...", "remove_by": "...", "enabled": false, "source": "channel"}]}
```

The console **Developer panel** (slice 4) consumes this to render + toggle flags.

- `operator_api/flags_routes.py` (`register_flags_routes`), wired into the server bootstrap next to the fleet/theme registrars.
- Read-only; gated by the `/api/*` operator bearer like every operator route.

## Tests
`tests/test_flags_routes.py` — 3: the resolved payload, env-override-flips-source, empty-registry. Full suite **2577 passed**; ruff clean; import contracts kept (`operator_api → runtime.flags` is allowed).

No CHANGELOG entry — internal plumbing with no user-facing surface yet; slice 1's entry already forward-references this route, and the user-facing entry will land with the panel (slice 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)