### PR TITLE
feat(flags): Developer panel + useFlag hook (#1506, ADR 0068 slices 3–4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Developer panel — view & toggle developer flags** (#1506, ADR 0068). A new **Settings ▸ Developer**
+  section (surfaced only off prod — a dev build, a non-prod `developer.channel`, or a `?dev` reveal —
+  so production operators never see it) lists every registered flag with its tier + resolved state and
+  lets you flip it **per-device** (device-local overrides, *Reset* to clear). Backed by `GET /api/flags`;
+  `useFlag(id)` gates console UI, and `?flag:<id>=on|off` gives a shareable per-load override.
 - **Developer flags — backend foundation** (#1506, ADR 0068, slice 1). A small local/static
   feature-flag system to gate pre-release functionality: `runtime/flags.py` with a `Flag` registry
   (`off`·`dev`·`beta`·`on` tiers) and `flag_enabled(id)` / `resolved_flags()`. Enablement resolves

--- a/apps/web/e2e/developer-flags.spec.ts
+++ b/apps/web/e2e/developer-flags.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+// Developer flags panel (ADR 0068). The mock serves channel "dev", so the Developer section
+// appears under Settings ▸ This console; toggling a flag persists a device-local override that
+// a Reset clears.
+
+test("Developer panel lists flags and a toggle persists as an override", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("settings-widget").click();
+  await expect(page.locator(".settings-overlay")).toBeVisible();
+
+  // Off prod (mock channel = dev) the Developer section is present.
+  await page.locator(".settings-overlay .pl-sidenav").getByRole("tab", { name: "Developer", exact: true }).click();
+  const panel = page.getByTestId("developer-panel");
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText("chat.new_dashboard")).toBeVisible();
+  await expect(panel.getByText("chat.experimental_widget")).toBeVisible();
+
+  // Toggle the beta flag → an "overridden" badge + a Reset appear.
+  const row = panel.locator('[data-key="flag.chat.new_dashboard"]');
+  await expect(row.getByText("overridden")).toHaveCount(0);
+  await row.locator(".pl-switch").click();
+  await expect(row.getByText("overridden")).toBeVisible();
+
+  // Reset → the override clears.
+  await row.getByRole("button", { name: "Reset" }).click();
+  await expect(row.getByText("overridden")).toHaveCount(0);
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -256,6 +256,15 @@ function handleApiGet(pathname, fleet = FLEET) {
           commons: knowledgeChunks.filter((c) => c.tier === "commons").length,
         },
       };
+    case "/api/flags":
+      // Developer flags (ADR 0068). channel "dev" so the Developer panel is visible in e2e.
+      return {
+        channel: "dev",
+        flags: [
+          { id: "chat.new_dashboard", description: "Preview of the redesigned dashboard.", tier: "beta", owner: "kj", remove_by: "v1.0", enabled: true, source: "channel" },
+          { id: "chat.experimental_widget", description: "An in-progress widget.", tier: "dev", owner: "kj", remove_by: "", enabled: true, source: "channel" },
+        ],
+      };
     default:
       return null;
   }

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -72,6 +72,7 @@ test("the settings dialog lists the domain groups (host, no scope toggle)", asyn
     "Theme",
     "Chat",
     "Keyboard",
+    "Developer", // ADR 0068 — shown off prod (the mock serves channel "dev")
   ]);
   await section(page, "Behavior");
   await expect(page.locator(".pl-accordion__title").first()).toBeVisible();

--- a/apps/web/src/flags/flags.test.ts
+++ b/apps/web/src/flags/flags.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { clearFlagOverride, resetFlagOverrides, setFlagOverride, useFlagOverrides } from "./flags";
+
+// The device-local override store (ADR 0068) — the Developer panel's toggles. The useFlag /
+// channel hooks are exercised end-to-end in e2e/developer-flags.spec.ts (they need the query).
+
+describe("flag overrides store", () => {
+  beforeEach(() => resetFlagOverrides());
+
+  it("sets, clears, and resets device-local overrides", () => {
+    expect(useFlagOverrides.getState().overrides).toEqual({});
+
+    setFlagOverride("chat.new", true);
+    setFlagOverride("chat.old", false);
+    expect(useFlagOverrides.getState().overrides).toEqual({ "chat.new": true, "chat.old": false });
+
+    clearFlagOverride("chat.new");
+    expect(useFlagOverrides.getState().overrides).toEqual({ "chat.old": false });
+
+    resetFlagOverrides();
+    expect(useFlagOverrides.getState().overrides).toEqual({});
+  });
+
+  it("re-setting an override replaces its value", () => {
+    setFlagOverride("x.y", true);
+    setFlagOverride("x.y", false);
+    expect(useFlagOverrides.getState().overrides["x.y"]).toBe(false);
+  });
+});

--- a/apps/web/src/flags/flags.ts
+++ b/apps/web/src/flags/flags.ts
@@ -1,0 +1,79 @@
+// Developer flags (ADR 0068) — the console half. The backend (runtime/flags.py) resolves
+// each flag's tier against the runtime channel and serves it at /api/flags; here we add the
+// two frontend override layers (a shareable ?flag:<id>= query param, and a device-local
+// panel toggle) on top, and expose `useFlag(id)` for gating console UI.
+//
+// Effective state precedence (ADR 0068 D3, frontend half):
+//   ?flag:<id>= query param  >  device-local panel toggle  >  server channel-resolved state
+// (The server has already applied the PROTOAGENT_FLAG_<ID> env override beneath that.)
+
+import { useQuery } from "@tanstack/react-query";
+
+import { createUISlice } from "../ext/uiStateRegistry";
+import { flagsQuery } from "../lib/queries";
+import type { FlagChannel } from "../lib/types";
+
+// Device-local panel overrides — persisted per-agent (like the other UI slices), so a
+// developer's toggles never leak into shared config. `undefined` = follow the server state.
+type OverrideState = { overrides: Record<string, boolean> };
+export const useFlagOverrides = createUISlice<OverrideState>("dev-flags", { overrides: {} });
+
+export function setFlagOverride(id: string, on: boolean): void {
+  useFlagOverrides.setState((s) => ({ overrides: { ...s.overrides, [id]: on } }));
+}
+export function clearFlagOverride(id: string): void {
+  useFlagOverrides.setState((s) => {
+    const next = { ...s.overrides };
+    delete next[id];
+    return { overrides: next };
+  });
+}
+export function resetFlagOverrides(): void {
+  useFlagOverrides.setState({ overrides: {} });
+}
+
+// Transient, shareable overrides parsed ONCE from ?flag:<id>=on|off (a "try this build"
+// link). Not persisted — they last only for the current page load.
+const TRUEY = new Set(["1", "on", "true", "yes"]);
+const _queryOverrides: Record<string, boolean> = (() => {
+  const out: Record<string, boolean> = {};
+  try {
+    new URLSearchParams(window.location.search).forEach((value, key) => {
+      if (key.startsWith("flag:")) out[key.slice(5)] = TRUEY.has(value.trim().toLowerCase());
+    });
+  } catch {
+    /* no location (SSR/tests) — no query overrides */
+  }
+  return out;
+})();
+
+export function useFlags() {
+  return useQuery(flagsQuery());
+}
+
+/** Is a developer flag ON for this session? Fail-closed: an unknown/loading flag is off. */
+export function useFlag(id: string): boolean {
+  const { data } = useFlags();
+  const override = useFlagOverrides((s) => s.overrides[id]);
+  if (id in _queryOverrides) return _queryOverrides[id];
+  if (override !== undefined) return override;
+  return data?.flags.find((f) => f.id === id)?.enabled ?? false;
+}
+
+/** The runtime channel this instance runs on (prod | beta | dev). */
+export function useDeveloperChannel(): FlagChannel {
+  return useFlags().data?.channel ?? "prod";
+}
+
+/** Whether to surface the Developer panel: a dev build, a non-prod channel, or an explicit
+ *  `?dev` / `?flag:` reveal — so production users never see it, but a developer always can. */
+export function developerPanelVisible(channel: FlagChannel): boolean {
+  let revealed = false;
+  try {
+    const q = new URLSearchParams(window.location.search);
+    revealed = q.has("dev") || [...q.keys()].some((k) => k.startsWith("flag:"));
+  } catch {
+    /* no location */
+  }
+  return import.meta.env.DEV || channel !== "prod" || revealed;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   DiscoveredAgent,
   FleetAgent,
   FleetStatus,
+  FlagsPayload,
   GoalState,
   HitlPayload,
   InboxItem,
@@ -1069,6 +1070,9 @@ export const api = {
   // --- Fleet (ADR 0042) — many workspace agents on one host ------------------
   fleet() {
     return request<FleetStatus>("/api/fleet");
+  },
+  flags() {
+    return request<FlagsPayload>("/api/flags");
   },
   discoverAgents() {
     return request<{ discovered: DiscoveredAgent[] }>("/api/fleet/discover");

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -26,6 +26,7 @@ export const queryKeys = {
   archetypes: ["archetypes"] as const,
   playbooks: ["playbooks"] as const,
   knowledge: ["knowledge"] as const,
+  flags: ["flags"] as const,
 };
 
 // The fleet of workspace agents (ADR 0042). `running` is a live-pid probe, so poll
@@ -35,6 +36,15 @@ export const fleetQuery = () =>
     queryKey: queryKeys.fleet,
     queryFn: () => api.fleet(),
     refetchInterval: 3_000,
+  });
+
+// Developer flags (ADR 0068) — the active channel + resolved flag states. Static per
+// process (channel + registry don't change without a config edit / restart), so no poll.
+export const flagsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.flags,
+    queryFn: () => api.flags(),
+    staleTime: 5 * 60_000,
   });
 
 // Archetypes for the new-agent picker (Basic + installed bundles) — config, not live.

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -776,3 +776,17 @@ export type Archetype = {
   bundle: string | null; // null = Basic; else the bundle git URL
   soul: string; // base SOUL.md the wizard seeds when this archetype is picked ("" = none)
 };
+
+// Developer flags (ADR 0068) — the /api/flags payload the Developer panel renders.
+export type FlagTier = "off" | "dev" | "beta" | "on";
+export type FlagChannel = "prod" | "beta" | "dev";
+export type FlagInfo = {
+  id: string;
+  description: string;
+  tier: FlagTier;
+  owner: string;
+  remove_by: string;
+  enabled: boolean; // channel-resolved (before any device-local override)
+  source: "channel" | "env";
+};
+export type FlagsPayload = { channel: FlagChannel; flags: FlagInfo[] };

--- a/apps/web/src/settings/DeveloperPanel.tsx
+++ b/apps/web/src/settings/DeveloperPanel.tsx
@@ -1,0 +1,88 @@
+import { Switch } from "@protolabsai/ui/forms";
+import { PanelHeader } from "@protolabsai/ui/navigation";
+import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
+
+import {
+  clearFlagOverride,
+  resetFlagOverrides,
+  setFlagOverride,
+  useFlag,
+  useFlagOverrides,
+  useFlags,
+} from "../flags/flags";
+import type { FlagInfo, FlagTier } from "../lib/types";
+
+// Settings → Developer (ADR 0068) — view + toggle pre-release feature flags for THIS
+// device/session. Only surfaced off prod (a dev build / a non-prod channel / ?dev), so
+// production users never see it. Toggles are device-local (they never touch shared config);
+// the channel + tiers come from the server (/api/flags).
+
+const TIER_STATUS: Record<FlagTier, "neutral" | "warning" | "info" | "success"> = {
+  off: "neutral",
+  dev: "warning",
+  beta: "info",
+  on: "success",
+};
+
+function FlagRow({ flag }: { flag: FlagInfo }) {
+  const effective = useFlag(flag.id);
+  const override = useFlagOverrides((s) => s.overrides[flag.id]);
+  const overridden = override !== undefined;
+  return (
+    <div className="setting-row" data-key={`flag.${flag.id}`}>
+      <div className="setting-meta">
+        <span className="setting-label">
+          <code>{flag.id}</code> <Badge status={TIER_STATUS[flag.tier]}>{flag.tier}</Badge>
+          {overridden ? <Badge status="info">overridden</Badge> : null}
+        </span>
+        <p className="setting-desc">
+          {flag.description}
+          {flag.owner ? <span className="muted"> · owner {flag.owner}</span> : null}
+          {flag.remove_by ? <span className="muted"> · remove by {flag.remove_by}</span> : null}
+        </p>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Switch
+          id={`flag-${flag.id}`}
+          checked={effective}
+          onCheckedChange={(on) => setFlagOverride(flag.id, on)}
+          label={effective ? "on" : "off"}
+        />
+        {overridden ? (
+          <Button variant="ghost" size="sm" onClick={() => clearFlagOverride(flag.id)} title="Reset to the channel default">
+            Reset
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function DeveloperPanel() {
+  const { data } = useFlags();
+  const overrideCount = useFlagOverrides((s) => Object.keys(s.overrides).length);
+  const flags = data?.flags ?? [];
+  const channel = data?.channel ?? "prod";
+  return (
+    <section className="panel stage-panel" data-testid="developer-panel">
+      <PanelHeader
+        title="Developer"
+        kicker={`pre-release feature flags · channel ${channel} · toggles saved on this device`}
+        actions={
+          <Button variant="ghost" size="sm" onClick={resetFlagOverrides} disabled={overrideCount === 0}>
+            Reset all
+          </Button>
+        }
+      />
+      <div className="stage-body">
+        {flags.length === 0 ? (
+          <Empty>
+            No developer flags are registered. Add one in <code>runtime/flags.py</code>.
+          </Empty>
+        ) : (
+          flags.map((f) => <FlagRow key={f.id} flag={f} />)
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Bot, BookMarked, Boxes, Brain, Cpu, Database, Gauge, Keyboard, KeyRound, MessageSquare, Network, Palette, Plug, Puzzle, Server, Sparkles, Store, Wrench } from "lucide-react";
+import { BarChart3, Bot, BookMarked, Boxes, Brain, Cpu, Database, FlaskConical, Gauge, Keyboard, KeyRound, MessageSquare, Network, Palette, Plug, Puzzle, Server, Sparkles, Store, Wrench } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useEffect, type ReactNode } from "react";
 
@@ -17,6 +17,8 @@ import { DelegatesSection } from "./DelegatesSection";
 import { FleetSurface } from "./FleetSurface";
 import { KeybindingsPanel } from "./KeybindingsPanel";
 import { ChatSettingsPanel } from "./ChatSettingsPanel";
+import { DeveloperPanel } from "./DeveloperPanel";
+import { developerPanelVisible, useDeveloperChannel } from "../flags/flags";
 import { OverviewPanel } from "./OverviewPanel";
 import { SettingsCategoryPanel } from "./SettingsCategory";
 import { ThemeSurface } from "./ThemeSurface";
@@ -111,11 +113,18 @@ export function SettingsSurface({ initialSection }: { only?: "host" | "workspace
     if (initialSection) setSection(initialSection);
   }, [initialSection, setSection]);
 
+  // The Developer panel (ADR 0068) joins "This console" only off prod — a dev build, a
+  // non-prod channel, or an explicit ?dev/?flag: reveal — so production operators never see it.
+  const channel = useDeveloperChannel();
+  const consoleSections: Section[] = developerPanelVisible(channel)
+    ? [...CONSOLE_SECTIONS, { id: "developer", label: "Developer", icon: FlaskConical, render: () => <DeveloperPanel /> }]
+    : CONSOLE_SECTIONS;
+
   const sections = [
     ...AGENT_SECTIONS,
     ...CAPABILITY_SECTIONS,
     ...(onHost ? BOX_SECTIONS : []),
-    ...CONSOLE_SECTIONS,
+    ...consoleSections,
   ];
   const active = sections.find((s) => s.id === persistedSection) ?? sections[0];
   const toItem = (s: Section) => ({ id: s.id, label: s.label, icon: <s.icon size={15} /> });
@@ -123,7 +132,7 @@ export function SettingsSurface({ initialSection }: { only?: "host" | "workspace
     { label: "Agent", items: AGENT_SECTIONS.map(toItem) },
     { label: "Capabilities", items: CAPABILITY_SECTIONS.map(toItem) },
     ...(onHost ? [{ label: "Box", items: BOX_SECTIONS.map(toItem) }] : []),
-    { label: "This console", items: CONSOLE_SECTIONS.map(toItem) },
+    { label: "This console", items: consoleSections.map(toItem) },
   ];
 
   return (


### PR DESCRIPTION
The console half of developer flags (ADR 0068), on top of the `/api/flags` route (#1539). Ships the user-visible surface.

## What

- **`useFlag(id)`** (`flags/flags.ts`) — gates console UI, fail-closed while loading. `useFlags()` / `useDeveloperChannel()` read `/api/flags`.
- **Two frontend override layers** on top of the server's channel resolution (ADR 0068 D3, frontend half):
  - a **device-local panel toggle** (`createUISlice`, persisted per-agent — never touches shared config)
  - a shareable **`?flag:<id>=on|off`** query param (per-load)
  - precedence: `?flag:` > panel toggle > server channel-resolved state
- **`Settings ▸ Developer`** (`DeveloperPanel.tsx`) — each registered flag with its **tier** badge, **resolved state**, a per-device **Switch**, and **Reset**; plus **Reset all**.
- **Gated to non-prod** — `SettingsSurface` adds the section only when `developerPanelVisible`: a dev build (`import.meta.env.DEV`), a non-prod `developer.channel`, or a `?dev` / `?flag:` reveal. Production operators never see it.

## Tests (all green locally)

- `tsc --noEmit` clean.
- **vitest** — the override store + full web unit suite (**217 passed**).
- **e2e** — new `developer-flags.spec.ts` (panel lists the mock flags, toggling persists an "overridden" state, Reset clears it), **run against the built app**. `settings.spec` section-list updated for the new panel; settings + navigation e2e pass.

## Slice status
This completes ADR 0068 slices 3–4. Remaining: slice 5 (`remove_by` staleness test) and slice 6 (dogfood a first real flag). The registry is still empty, so the panel currently shows "no flags registered" in prod builds (and the mock's fixtures in e2e).

⚠ Console UX under the local-test gate — a quick manual look is worth it, but the e2e exercises the real interaction. Merging on green per the session's autonomous directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)