### PR TITLE
test(flags): fail CI on a flag past its remove_by (#1506, ADR 0068 slice 5)

### DIFF
--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -126,3 +126,23 @@ def test_real_registry_is_well_formed():
     for f in flags.FLAGS:
         assert f.tier in ("off", "dev", "beta", "on"), f"{f.id}: invalid tier {f.tier!r}"
         assert f.id and f.description, "every flag needs an id + description"
+
+
+def test_no_flag_is_past_its_remove_by():
+    """The cleanup contract (ADR 0068 D6): a flag whose ISO-date `remove_by` has passed is
+    overdue debt — graduate it to `on` and delete the flag + the old code path. This guard
+    fails CI so a stale gate is visible instead of accreting. `remove_by` values that aren't
+    ISO dates (e.g. a version like "v2.0") can't be auto-compared, so they're skipped."""
+    import datetime
+
+    today = datetime.date.today().isoformat()
+    overdue = []
+    for f in flags.FLAGS:
+        rb = (f.remove_by or "").strip()
+        try:
+            datetime.date.fromisoformat(rb)  # only date-form remove_by is auto-checked
+        except ValueError:
+            continue
+        if rb < today:  # ISO dates sort chronologically as strings
+            overdue.append(f"{f.id} (remove_by {rb}, owner {f.owner or '?'})")
+    assert not overdue, "overdue developer flags — graduate to `on` and delete: " + ", ".join(overdue)


### PR DESCRIPTION
Slice 5 of ADR 0068 — the **cleanup contract** (D6).

A developer flag with an ISO-date `remove_by` in the past is overdue debt: the feature has graduated and the flag + its old code path should have been deleted. `test_no_flag_is_past_its_remove_by` **fails CI** when that happens, so a stale gate is visible instead of accreting forever.

- Only ISO-date `remove_by` values are auto-checked; a version-form value (e.g. `v2.0`) can't be compared to a running version, so it's skipped.
- No-op today (the `FLAGS` registry is empty) — a guard for as flags are added.

23 flag tests pass; ruff clean. No CHANGELOG (internal test guard).

Remaining: **slice 6** (dogfood a first real flag) — that needs an actual pre-release feature to gate, so I'll surface it for a call rather than gate something artificial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)