### PR TITLE
fix(chat): disable streamdown line numbers — they render as a broken gutter

### DIFF
--- a/apps/web/src/chat/Markdown.tsx
+++ b/apps/web/src/chat/Markdown.tsx
@@ -10,7 +10,18 @@ import { Markdown as DSMarkdown } from "@protolabsai/ui/markdown";
  *
  * `className="markdown"` rides the same element the DS scopes as `.pl-markdown`, so existing
  * `.markdown` selectors (e2e + message-layout) keep matching.
+ *
+ * `lineNumbers={false}`: streamdown defaults line numbers ON, but renders them purely via
+ * `before:` Tailwind utilities with NO `data-streamdown` hook — so the DS's attribute-selector
+ * theming can't reach them and the console (which purges streamdown's inert Tailwind by design)
+ * leaves a broken, unstyled gutter that pushes code sideways. Code reads clean without them.
+ * (DS gap — the DS `<Markdown>` should default this off since it can't theme the gutter;
+ * file on protoContent.)
  */
 export function Markdown({ children }: { children: string }) {
-  return <DSMarkdown className="markdown">{children}</DSMarkdown>;
+  return (
+    <DSMarkdown className="markdown" lineNumbers={false}>
+      {children}
+    </DSMarkdown>
+  );
 }


### PR DESCRIPTION
## Symptom

Chat code blocks render wonky — a huge left gutter shoving code sideways, no visible line numbers, not responsive. (Screenshot: the code content starts ~30% in with empty space to its left.)

## Root cause

streamdown 2.5.0 defaults **`lineNumbers: true`**, and the DS `<Markdown>` (`@protolabsai/ui/markdown`) passes it straight through. streamdown renders the line-number gutter **purely via `before:` Tailwind utility classes** (`before:content-[counter(line)]`, `before:w-6`, `before:mr-4`, …) on each line `<span>` — with **no `data-streamdown` attribute** to hook.

The console styles streamdown via the DS's **attribute-selector** CSS (`[data-streamdown="code-block-body"]` etc.) and **deliberately purges streamdown's inert Tailwind classes** (the config comment says so). Every part of the code block *with* a `data-streamdown` hook is themed fine — border, header, body, copy button, shiki colors. But the line-number gutter has **no hook**, so it can be neither themed by the DS nor generated by Tailwind → an unstyled, half-broken gutter that pushes the code sideways.

## Fix

Line numbers are architecturally unthemeable in the DS's inert-Tailwind model, so disable them: `lineNumbers={false}` on the chat `<Markdown>`. Code reads clean without them; the rest of the block was already themed.

## Test

- `npm run build --workspace @protoagent/web` — clean (the `lineNumbers` prop typechecks via the DS's Streamdown-props passthrough).

## Follow-up

The DS `<Markdown>` should default `lineNumbers` off since it can't theme the gutter — I'll file that on protoContent so every consumer benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)