### PR TITLE
feat(web): adopt @protolabsai/ui 0.53.0 — drop 3 DS workarounds

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.52.0",
+    "@protolabsai/ui": "^0.53.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -489,21 +489,10 @@ export function App() {
   }
 
   // Right-click the EMPTY rail background (not an icon) → the "Hidden views" restore menu
-  // (ADR 0035/0036). The DS AppShell only fires onRailContextMenu on icons, so we catch the
-  // rail-container right-click here via event delegation (the DS classnames are the contract)
-  // and hand the resolved hidden-surface labels to the `rail-background` menu. An icon click
-  // is handled by its own `rail-surface` menu, so bail when the target is a rail button.
-  const onShellContextMenu = (e: ReactMouseEvent) => {
-    const t = e.target as HTMLElement;
-    if (t.closest(".pl-rail__btn")) return; // an icon — its own menu handles it
-    const railEl = t.closest(".pl-rail") as HTMLElement | null;
-    if (!railEl) return; // not the rail — leave the default menu
-    // Which rail was right-clicked → restore a hidden view to THIS dock (not its default).
-    const side: "left" | "right" | "bottom" = railEl.classList.contains("pl-rail--right")
-      ? "right"
-      : railEl.classList.contains("pl-rail--bottom")
-        ? "bottom"
-        : "left";
+  // (ADR 0035/0036). The DS AppShell's `onRailBackgroundContextMenu` (@protolabsai/ui@0.53.0)
+  // fires on empty rail space with the resolved side — no more DOM/classname delegation.
+  // Icon right-clicks go to `onRailContextMenu` (the `rail-surface` menu) instead.
+  const onRailBackgroundContextMenu = (side: "left" | "right" | "bottom", e: ReactMouseEvent) => {
     const hidden = (railOrder.hidden ?? []).map((id) => ({ id, label: metaFor(id)?.label ?? id }));
     openContextMenu("rail-background", e, { side, hidden });
   };
@@ -695,7 +684,7 @@ export function App() {
     {/* Command palette (⌘K, ADR 0057) — portals over the shell; the same component
         backs the desktop quick-command (step 4). */}
     <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} registry={paletteRegistry} />
-    <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`} onContextMenu={onShellContextMenu}>
+    <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`}>
       {/* protoLabs.studio brand bumper — DS Splash (@protolabsai/ui/splash). Holds
           2.5s then hands off via the View Transitions API cross-fade (the
           protoAgent path); shows once per tab session (sessionStorage
@@ -847,6 +836,7 @@ export function App() {
             else { setBottomPanel(id); setBottomCollapsed(false); }
           }
         }}
+        onRailBackgroundContextMenu={onRailBackgroundContextMenu}
         onRailContextMenu={(side, e, id) => {
           // A plugin view's rail id is `plugin:<pluginId>:<viewId>` — resolve the owning
           // plugin's id + display name so the menu can offer "Configure…" (ADR 0036/0059).

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -155,25 +155,26 @@ export function ChatSurface({
     closeSession(session.id, false); // false = no knowledge harvest
   }
 
-  // Right-click a chat tab → context menu (ADR 0036). The DS TabBar exposes no per-tab
-  // context-menu hook, so we delegate from the tab-bar wrapper and map the clicked tab to its
-  // session by sibling index (DOM order tracks the `items` = sessions order). Close reuses the
-  // confirm dialog; Rename fires the TabBar's inline editor via a synthetic dblclick on the tab.
-  function onTabBarContextMenu(e: ReactMouseEvent) {
+  // Right-click a chat tab → context menu (ADR 0036). The DS TabBar's `onTabContextMenu`
+  // (@protolabsai/ui@0.53.0) hands us the session id directly — no sibling-index DOM sniffing.
+  // Rename opens the TabBar's inline editor via a synthetic dblclick on the tab element (the DS
+  // exposes no start-rename API); we grab that element off the event, not to recover WHICH tab
+  // (the hook gives us the id) but only to fire the editor.
+  function onTabContextMenu(id: string, e: ReactMouseEvent) {
     const tabEl = (e.target as HTMLElement).closest(".pl-tabbar__tab") as HTMLElement | null;
-    if (!tabEl) {
-      openContextMenu("chat-tab", e, { onNew: () => chatStore.createSession() });
-      return;
-    }
-    const tabs = Array.from((e.currentTarget as HTMLElement).querySelectorAll(".pl-tabbar__tab"));
-    const session = chat.sessions[tabs.indexOf(tabEl)];
-    if (!session) return;
     openContextMenu("chat-tab", e, {
-      sessionId: session.id,
+      sessionId: id,
       onNew: () => chatStore.createSession(),
-      onRename: () => tabEl.dispatchEvent(new MouseEvent("dblclick", { bubbles: true })),
-      onClose: () => setPendingClose(session.id),
+      onRename: () => tabEl?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true })),
+      onClose: () => setPendingClose(id),
     });
+  }
+
+  // Right-click EMPTY tab-bar space (not a tab) → just the "New chat" affordance. onTabContextMenu
+  // owns per-tab; this catches the background only, and bails on tab hits so the two never both fire.
+  function onTabBarBackgroundContextMenu(e: ReactMouseEvent) {
+    if ((e.target as HTMLElement).closest(".pl-tabbar__tab")) return; // a tab — onTabContextMenu owns it
+    openContextMenu("chat-tab", e, { onNew: () => chatStore.createSession() });
   }
 
   return (
@@ -185,7 +186,7 @@ export function ChatSurface({
           the collapsed <option> can't host markup, matching the old behavior. */}
       <div
         className={`chat-tabbar-wrap${shiftDel ? " chat-tabbar-wrap--del" : ""}`}
-        onContextMenu={onTabBarContextMenu}
+        onContextMenu={onTabBarBackgroundContextMenu}
         onClickCapture={onTabBarClickCapture}
       >
         <TabBar
@@ -205,6 +206,7 @@ export function ChatSurface({
           onRename={(id, label) => chatStore.renameSession(id, label)}
           onReorder={(next) => chatStore.reorderSessions(next.map((t) => t.id))}
           onAdd={() => chatStore.createSession()}
+          onTabContextMenu={onTabContextMenu}
           addLabel="New chat"
         />
       </div>

--- a/apps/web/src/chat/Markdown.tsx
+++ b/apps/web/src/chat/Markdown.tsx
@@ -11,17 +11,11 @@ import { Markdown as DSMarkdown } from "@protolabsai/ui/markdown";
  * `className="markdown"` rides the same element the DS scopes as `.pl-markdown`, so existing
  * `.markdown` selectors (e2e + message-layout) keep matching.
  *
- * `lineNumbers={false}`: streamdown defaults line numbers ON, but renders them purely via
- * `before:` Tailwind utilities with NO `data-streamdown` hook — so the DS's attribute-selector
- * theming can't reach them and the console (which purges streamdown's inert Tailwind by design)
- * leaves a broken, unstyled gutter that pushes code sideways. Code reads clean without them.
- * (DS gap — the DS `<Markdown>` should default this off since it can't theme the gutter;
- * file on protoContent.)
+ * Code-block line numbers default OFF in the DS `<Markdown>` as of `@protolabsai/ui@0.52.1`
+ * (protoContent#376) — the DS themes the gutter for Tailwind-purging consumers and no longer
+ * needs the console to force `lineNumbers={false}`. Pass an explicit `lineNumbers` prop to opt
+ * a numbered code well back in.
  */
 export function Markdown({ children }: { children: string }) {
-  return (
-    <DSMarkdown className="markdown" lineNumbers={false}>
-      {children}
-    </DSMarkdown>
-  );
+  return <DSMarkdown className="markdown">{children}</DSMarkdown>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.52.0",
+        "@protolabsai/ui": "^0.53.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -70,9 +70,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.52.0.tgz",
-      "integrity": "sha512-Rqc5dVXUhdJKTMQTd/CQtFqQ7OgBx2OZjWbyYXRwOEZuXZ6ZTuSTEO2ponSsDkEMj7911ZKpj9Mt/7ThHKmtuA==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.53.0.tgz",
+      "integrity": "sha512-ZxzXaITxvGCX3UHgQBwz6X4y4a3u0Vzwi/uv258v8afLVus1l9dAH2V7zYWf13IwjkILF0SxJHRnZbosyFks9w==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Bumps the DS **0.52.0 → 0.53.0** and removes the three console workarounds it makes unnecessary.

## What lands

| DS release | New API | Console workaround dropped |
|---|---|---|
| **0.52.1** ([protoContent#376](https://github.com/protoLabsAI/protoContent/issues/376)) | `<Markdown>` defaults `lineNumbers` off + themes the gutter for Tailwind-purging consumers | the `lineNumbers={false}` markdown workaround (#1542) |
| **0.53.0** | `AppShell` `onRailBackgroundContextMenu(side, e)` | the shell-level `onContextMenu` that recovered the rail side via `closest(".pl-rail")` + `classList` |
| **0.53.0** | `TabBar` `onTabContextMenu(id, e)` | the tab-bar delegation that mapped a right-clicked tab to its session by **DOM sibling index** |

A minimal background-only wrapper remains on the tab bar for the empty-space "New chat" affordance (the per-tab hook doesn't fire for background) — it bails on tab hits so the two never double-fire.

## Verify

- `npm ci` installs 0.53.0 clean (lockfile bump is minimal — 0.53.0 has identical deps to 0.52.0).
- `tsc` build green — the new props + dropped `lineNumbers` all typecheck.
- **217 unit tests pass.**

## ⚠ Needs a click-test

The context-menu wiring typechecks and builds, but I can't click-test right-click menus. Worth a quick smoke before/after merge: right-click a **rail icon**, **empty rail space**, a **chat tab**, and **empty tab-bar space**; and exercise **Rename / Close / New** from the tab menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Right-click menus now open more reliably from the app’s rail and chat tabs, including background areas and individual tabs.
* **Bug Fixes**
  * Improved tab context menu behavior so the correct chat is targeted when using tab actions.
  * Updated markdown rendering to match the default code-block appearance, keeping line numbers off unless enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->