### PR TITLE
ci(desktop): build on manual dispatch only, not every tag

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -19,26 +19,35 @@ name: Desktop Build
 # updater bundles, and the updater-manifest fan-in job composes latest.json
 # (the manifest the in-app updater polls) onto the release — uploaded last.
 #
-# Fires on EVERY semver tag push (patch included) alongside release.yml's Docker build,
-# and on manual dispatch. Patches used to be skipped to save CI minutes, but this repo is
-# public so GitHub-hosted runners (incl. the 10×/2× macOS/Windows legs) are free +
-# unlimited — so every release, patch or minor, ships fresh desktop binaries and an
-# updated latest.json (no more hand-attaching a patch's binaries). macOS builds are signed
-# only when the full Apple secret set is present; Linux/Windows are always unsigned. See
-# ADR 0010 (UI tiers / desktop).
+# Runs on MANUAL DISPATCH ONLY (workflow_dispatch) — deliberately NOT on tag pushes.
+# The macOS (10×) and Windows (2×) legs are this repo's only paid CI, and building the
+# full matrix on EVERY semver tag (dozens/month at current release cadence) was the
+# dominant cost — so desktop drops are now on-demand instead of per-release. Tag pushes
+# still ship the Docker image + a (non-Latest) GitHub Release via release.yml; only the
+# desktop binaries wait for a dispatch.
+#
+# Two dispatch modes, keyed off the `tag` input:
+#   • WITH a `tag` (a vX.Y.Z) → a real desktop RELEASE: binaries attach to that GitHub
+#     Release, the fan-in composes latest.json, and the release is promoted to 'Latest'
+#     (release.yml creates releases --latest=false; the promotion happens here). This is
+#     how a desktop update reaches users' in-app updater.
+#   • WITHOUT a tag (dispatched from a branch) → a TEST build: bundles upload as workflow
+#     artifacts only; no release, no latest.json, no 'Latest' change.
+#
+# macOS builds are signed only when the full Apple secret set is present; Linux/Windows
+# are always unsigned. The repo guard keeps forks from running the matrix. See ADR 0010
+# (UI tiers / desktop) and docs/guides/releasing.md § Desktop.
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag/ref to build against (blank = current ref)'
+        description: 'Tag to publish a desktop release for (vX.Y.Z). Blank = test build (artifacts only, no release).'
         required: false
 
 concurrency:
-  group: desktop-build-${{ github.ref }}
+  # Keyed on the dispatched tag (or ref) so two release dispatches don't collide.
+  group: desktop-build-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -47,11 +56,9 @@ permissions:
 jobs:
   build:
     name: ${{ matrix.target }}
-    # Build on every semver tag push (patch included) + any manual dispatch. The old
-    # patch-skip was a CI-cost guard; it's unnecessary on a public repo where GH-hosted
-    # runners are free, and it meant patch desktop fixes never reached users (their
-    # binaries weren't attached and latest.json kept pointing at the last minor). The
-    # repo guard keeps forks from running the matrix.
+    # Manual dispatch only (see the `on:` block) — the tag-push trigger was retired
+    # because the macOS/Windows matrix on every release was the repo's dominant CI cost.
+    # The repo guard keeps forks from running the matrix.
     if: github.repository == 'protoLabsAI/protoAgent'
     # Per-leg runner, overridable by repo variable so the expensive macOS/Windows
     # legs can move off GitHub-hosted runners (10×/2× billing multipliers) onto
@@ -199,8 +206,8 @@ jobs:
           SIGNED="unsigned (dev)"
           if [ "${RUNNER_OS}" = "macOS" ]; then
             # tauri-bundler signs as soon as *any* Apple secret is set, then fails
-            # if the set is incomplete. Require the full set; otherwise unset all so
-            # a dispatch build falls back cleanly to unsigned.
+            # if the set is incomplete. Require the full set for a tagged (publish)
+            # dispatch; a test build (no tag) unsets all and falls back to unsigned.
             if [ -n "${APPLE_CERTIFICATE}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD}" ] \
                && [ -n "${APPLE_SIGNING_IDENTITY}" ] && [ -n "${APPLE_API_ISSUER}" ] \
                && [ -n "${APPLE_API_KEY}" ] && [ -n "${APPLE_API_KEY_BASE64}" ] \
@@ -210,8 +217,8 @@ jobs:
               python3 -c 'import base64,os,sys; open(sys.argv[1],"wb").write(base64.b64decode(os.environ["APPLE_API_KEY_BASE64"]))' "$KEYFILE"
               export APPLE_API_KEY_PATH="${KEYFILE}"
               SIGNED="Developer ID (signed + notarized)"
-            elif [ "${{ github.event_name }}" = "push" ]; then
-              echo "::error::Semver-tag desktop releases require the full Apple signing secret set."
+            elif [ -n "${{ inputs.tag }}" ]; then
+              echo "::error::A tagged desktop release (tag=${{ inputs.tag }}) requires the full Apple signing secret set."
               exit 2
             else
               unset APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY \
@@ -335,15 +342,17 @@ jobs:
           if [ "${{ steps.build.outputs.signed }}" = "true" ]; then FLAG="--require-signed"; fi
           scripts/verify-macos-desktop.sh $FLAG dist-desktop/*.dmg
 
-      - name: Upload dispatch artifact
-        if: github.event_name == 'workflow_dispatch'
+      - name: Upload test-build artifact
+        # No tag → a test build: bundles are downloadable workflow artifacts only.
+        if: inputs.tag == ''
         uses: actions/upload-artifact@v6
         with:
           name: protoAgent-${{ steps.version.outputs.version }}-${{ matrix.target }}
           path: dist-desktop/*
 
       - name: Attach to release
-        if: github.event_name == 'push'
+        # A tag → publish: attach binaries to that GitHub Release (fan-in adds latest.json).
+        if: inputs.tag != ''
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -351,29 +360,27 @@ jobs:
 
   # Fan-in: compose latest.json from every leg's signed updater bundle and
   # upload it LAST, so the manifest never points at assets that don't exist
-  # yet. Runs only on semver tags, and only once ALL legs succeeded (a partial
-  # manifest would skew versions across platforms). If the release carries no
-  # updater bundles (key wasn't present), it skips — in-app updates are simply
-  # disabled for that release.
+  # yet. Runs only for a tagged (publish) dispatch, and only once ALL legs
+  # succeeded (a partial manifest would skew versions across platforms). If the
+  # release carries no updater bundles (key wasn't present), it skips — in-app
+  # updates are simply disabled for that release.
   updater-manifest:
     name: updater manifest (latest.json)
     needs: build
-    # Runs on every tag push (patch included) so the in-app updater's latest.json is
-    # refreshed for every release. Gated to `push` so a manual dispatch (which builds
-    # artifacts, with no release to attach to) doesn't try to compose a manifest;
-    # `needs: build` ties it to a successful matrix.
+    # Only for a publish dispatch (a `tag` was supplied) — a test build (no tag) has no
+    # release to attach a manifest to. `needs: build` ties it to a successful matrix.
     if: >-
-      github.event_name == 'push' && github.repository == 'protoLabsAI/protoAgent'
+      inputs.tag != '' && github.repository == 'protoLabsAI/protoAgent'
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 10
     steps:
       # Checkout at the tag so we can read the rolled CHANGELOG.md section for the
-      # in-app updater notes (below). By tag-push time CHANGELOG.md already holds the
+      # in-app updater notes (below). By publish time CHANGELOG.md already holds the
       # dated `## [VERSION]` section — the bump PR (prepare-release.yml) merged before
       # the tag. Without this the job has no working tree (it only `gh release`s).
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ inputs.tag }}
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -386,7 +393,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          TAG="${{ github.ref_name }}"
+          TAG="${{ inputs.tag }}"
           VERSION="${TAG#v}"
           mkdir -p updater-dist
           gh release download "$TAG" --repo "${{ github.repository }}" --dir updater-dist \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,13 +145,14 @@ jobs:
           NOTES: ${{ steps.notes.outputs.notes }}
         run: |
           printf '%s' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
-          # --latest=false: do NOT promote to 'Latest' yet. The in-app updater fetches
+          # --latest=false: do NOT promote to 'Latest'. The in-app updater fetches
           # releases/latest/download/latest.json, so a release must not become 'Latest'
-          # until its latest.json exists — otherwise update checks 404 in the window
-          # before the desktop build's fan-in uploads it. The desktop fan-in flips this
-          # release to 'Latest' once latest.json is up (desktop-build.yml). Patch tags
-          # skip the desktop build entirely, so they stay non-Latest and 'Latest'
-          # correctly remains on the last .0 (the one carrying latest.json).
+          # until its latest.json exists — otherwise update checks 404. Desktop builds
+          # are now MANUAL (desktop-build.yml runs on workflow_dispatch, not on tags), so
+          # every tagged release stays non-Latest here; it's promoted to 'Latest' only
+          # when someone dispatches a desktop build for that tag and its fan-in uploads
+          # latest.json. 'Latest' therefore tracks the last DESKTOP release (the one the
+          # updater can actually use), not the newest tag.
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
             --notes-file "$RUNNER_TEMP/release-notes.md" \

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -54,8 +54,13 @@ relaunches — agent data (`PROTOAGENT_CONFIG_DIR`, workspaces) is untouched.
 
 ## Platforms & CI
 
-`.github/workflows/desktop-build.yml` builds all three platforms on semver tags
-(and on manual dispatch, which uploads workflow artifacts instead):
+`.github/workflows/desktop-build.yml` builds all three platforms on **manual dispatch
+only** (`workflow_dispatch`) — the tag-push trigger was retired because the macOS (10×)
+and Windows (2×) legs were the repo's dominant CI cost. Dispatch **with** a `tag` input
+(`gh workflow run desktop-build.yml -f tag=vX.Y.Z`) publishes a real release: binaries
+attach to that GitHub Release, `latest.json` is composed, and the release is promoted to
+`Latest`. Dispatch **without** a tag is a test build (workflow artifacts only). See
+`docs/guides/releasing.md` § Desktop.
 
 | Platform | Artifact | Signing |
 |---|---|---|

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -126,7 +126,9 @@ PyInstaller-freezes the headless server (`binaries/protoagent-server-<triple>`),
 frozen build bundles the `plugins/` tree and `--collect-all`s `tools`/`websockets`/`mcp`
 (plugins load by file path, which PyInstaller's scan misses; a runtime-installed comms
 plugin, ADR 0058, can only import what's bundled). Signed macOS DMG / Linux AppImage+deb /
-Windows NSIS artifacts + an in-app updater ship from the desktop-build CI on release tags.
+Windows NSIS artifacts + an in-app updater ship from the desktop-build CI, dispatched
+manually per release (`gh workflow run desktop-build.yml -f tag=vX.Y.Z`) — see
+`docs/guides/releasing.md` § Desktop.
 
 On macOS, `spawn_sidecar` augments the sidecar's `PATH` with the user's login-shell `PATH`
 (via `$SHELL -ilc`, plus the Homebrew/local fallbacks) before spawning. A Finder/Dock launch

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -22,21 +22,37 @@ you merge the PR (CI green)  ──▶  you push tag vX.Y.Z  ──▶  Release 
 `latest` Docker tag is pushed on every `main` merge by `docker-publish.yml` —
 independent of releases.
 
-**Every** semver tag push (patch included) also triggers `desktop-build.yml`, which
-builds the desktop app on a three-platform matrix and attaches the artifacts to the
-same GitHub Release: the macOS `.dmg` (signed + notarized — requires the full Apple
-secret set, the leg fails otherwise), the Linux `.AppImage` + `.deb`, and the Windows
-NSIS `-setup.exe` (both unsigned). See `apps/desktop/README.md` § Platforms & CI.
+### Desktop
 
-> **Patches ship desktop binaries too** (changed 2026-06-19). They used to skip the
-> desktop build to save CI minutes, but this repo is public so GitHub-hosted runners
-> (incl. the 10×/2× macOS/Windows legs) are free + unlimited — so every release, patch
-> or minor, publishes fresh desktop binaries and refreshes `latest.json`. (The old
-> skip also meant a patch's desktop fix never reached users — binaries weren't attached
-> and the in-app updater stayed on the last minor.)
-When the org updater signing key is present, the legs also attach signed updater
-bundles and a fan-in job uploads `latest.json` — the manifest the desktop app's
-in-app updater polls. See `apps/desktop/README.md` § Updates.
+Desktop builds are **manual** — `desktop-build.yml` runs on `workflow_dispatch` only,
+**not** on tag pushes. The macOS (10×) and Windows (2×) legs are the repo's only paid
+CI, and building the full matrix on every tag (dozens/month) was the dominant cost, so
+desktop drops are on-demand. A normal `git push` of a tag still ships the Docker image
+and a GitHub Release (via `release.yml`); only the desktop binaries wait for a dispatch.
+
+To cut a desktop release, dispatch `desktop-build.yml` with the **tag** input set to the
+release tag (`vX.Y.Z`):
+
+```sh
+gh workflow run desktop-build.yml -f tag=vX.Y.Z
+```
+
+That builds the three-platform matrix and attaches the artifacts to that GitHub Release:
+the macOS `.dmg` (signed + notarized — requires the full Apple secret set, the leg fails
+otherwise), the Linux `.AppImage` + `.deb`, and the Windows NSIS `-setup.exe` (both
+unsigned). When the org updater signing key is present, the legs also attach signed
+updater bundles and a fan-in job uploads `latest.json` (the manifest the in-app updater
+polls) and promotes the release to **Latest**. See `apps/desktop/README.md` §§ Platforms
+& CI / Updates.
+
+> **Dispatching without a tag** (from a branch) is a **test build**: bundles upload as
+> workflow artifacts only — no release, no `latest.json`, no `Latest` change.
+
+> **`Latest` tracks the last desktop release, not the newest tag.** `release.yml` creates
+> every release `--latest=false`; a release is promoted to `Latest` only when its desktop
+> build's fan-in has uploaded `latest.json`, so the in-app updater never 404s on a release
+> that has no manifest. Tags you never build desktop for stay non-Latest (their Docker
+> image and notes are still published).
 
 > **Runner cost.** Every other workflow runs on Namespace; the desktop matrix is
 > the only GitHub-hosted usage (macOS bills at 10×, Windows 2×). To move a leg onto


### PR DESCRIPTION
## Why

Desktop builds were the repo's dominant CI cost. `desktop-build.yml` fired the full three-platform matrix — including the **macOS 10×** and **Windows 2×** billing runners — on **every** semver tag. At current cadence that's ~**99 tag pushes in the last 30 days** (74 minors + 25 patches; up to 15 in a single day), so ~99 macOS builds/month. The old rationale ("public repo → GH-hosted runners are free/unlimited") no longer holds — it's costing real money.

## What

Retire the `push: tags` trigger. Desktop builds now run on **`workflow_dispatch` only**, with two modes keyed off the existing `tag` input:

| Dispatch | Result |
|---|---|
| **with `tag=vX.Y.Z`** | Real desktop **release** — binaries attach to that GitHub Release, fan-in composes `latest.json`, release promoted to **Latest**. This is what reaches users' in-app updater. |
| **no tag** (from a branch) | **Test build** — bundles upload as workflow artifacts only; no release, no `latest.json`, no Latest change. |

Tag pushes still ship the **Docker image + a (non-Latest) GitHub Release** via `release.yml` — only the *desktop binaries* wait for a dispatch.

To cut a desktop release:
```sh
gh workflow run desktop-build.yml -f tag=vX.Y.Z
```

## Coupling handled

- `release.yml` already creates releases `--latest=false`; the desktop fan-in is what flips **Latest**. With manual desktop builds, **Latest now tracks the last *desktop* release** (the one carrying `latest.json`), so the in-app updater never 404s on a manifest-less release. Comment updated (no logic change).
- The "unsigned release must fail" guard now keys on `inputs.tag` — a **tagged publish still requires the full Apple signing secret set**; a test build falls back to unsigned.
- Fan-in checkout/`TAG` read from `inputs.tag` instead of `github.ref_name`.
- Fork guard (`github.repository == …`) preserved.

## Docs

`docs/guides/releasing.md` § Desktop (new), `apps/desktop/README.md` § Platforms & CI, `docs/guides/react-tauri-ui.md`.

## Note / verification

This workflow only runs on dispatch, so PR CI can't exercise it. YAML validated locally. **First verification after merge:** dispatch a real desktop release for the next tag and confirm binaries + `latest.json` attach and the release flips to Latest. Adjacent to #1534 (CI hygiene) but scoped to cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)