### PR TITLE
fix(wait): humanize wait/yield tool output so agents don't echo raw system text (#1536)

### DIFF
--- a/server/chat.py
+++ b/server/chat.py
@@ -389,8 +389,8 @@ async def _clear_pending_interrupt(config: dict) -> None:
 
 def _last_tool_text(result) -> str:
     """The last tool result's text in a turn — the fallback when a turn produced
-    no assistant text (e.g. a ``wait`` yield, whose 'Yielding…' confirmation is a
-    ToolMessage, not an AIMessage)."""
+    no assistant text (e.g. a ``wait`` yield, whose 'Wait scheduled…' confirmation
+    is a ToolMessage, not an AIMessage)."""
     from langchain_core.messages import ToolMessage
 
     for msg in reversed((result or {}).get("messages", [])):

--- a/tests/test_chat_nonstreaming_robustness.py
+++ b/tests/test_chat_nonstreaming_robustness.py
@@ -107,4 +107,4 @@ async def test_wait_yield_turn_falls_back_to_tool_text(monkeypatch):
     )
     out = await chat("wait a bit then resume", "sessC")
     content = out[0]["content"]
-    assert content and "Yielding" in content  # not a blank reply
+    assert content and "Wait scheduled" in content  # not a blank reply

--- a/tests/test_wait_yield.py
+++ b/tests/test_wait_yield.py
@@ -25,14 +25,14 @@ def _tool_msg(name: str, content: str = "ok", status: str | None = None) -> Tool
 
 
 def test_just_waited_true_after_successful_wait():
-    msgs = [HumanMessage("go"), AIMessage("…"), _tool_msg("wait", "Yielding for 40s …")]
+    msgs = [HumanMessage("go"), AIMessage("…"), _tool_msg("wait", "Wait scheduled: 40 seconds …")]
     assert _just_waited(msgs) is True
 
 
 def test_just_waited_false_on_fresh_turn():
     # A new stimulus is the trailing message — wait may be deep in history but
     # didn't just run.
-    msgs = [_tool_msg("wait", "Yielding …"), AIMessage("done"), HumanMessage("new task")]
+    msgs = [_tool_msg("wait", "Wait scheduled: …"), AIMessage("done"), HumanMessage("new task")]
     assert _just_waited(msgs) is False
 
 
@@ -43,7 +43,7 @@ def test_just_waited_false_for_other_tools():
 
 def test_just_waited_true_with_parallel_tools():
     # wait alongside another tool in the same step still yields.
-    msgs = [AIMessage("…"), _tool_msg("st_ship", "ok"), _tool_msg("wait", "Yielding …")]
+    msgs = [AIMessage("…"), _tool_msg("st_ship", "ok"), _tool_msg("wait", "Wait scheduled: …")]
     assert _just_waited(msgs) is True
 
 
@@ -56,7 +56,7 @@ def test_just_waited_false_when_wait_errored():
 
 def test_middleware_jumps_to_end_only_after_wait():
     mw = WaitYieldMiddleware()
-    waited = {"messages": [AIMessage("…"), _tool_msg("wait", "Yielding …")]}
+    waited = {"messages": [AIMessage("…"), _tool_msg("wait", "Wait scheduled: …")]}
     assert mw.before_model(waited, None) == {"jump_to": "end"}
 
     fresh = {"messages": [HumanMessage("hello")]}
@@ -101,7 +101,7 @@ async def test_wait_schedules_a_one_shot_in_the_future():
     fire = datetime.fromisoformat(schedule)  # parses ISO-8601 (one-shot)
     delta = (fire - datetime.now(UTC)).total_seconds()
     assert 30 < delta <= 41  # ~40s out
-    assert "Dock and sell ore." in out and "re-invoked" in out
+    assert "Dock and sell ore." in out and "resume" in out.lower()
 
 
 @pytest.mark.asyncio

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -806,6 +806,27 @@ def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None)
 # instances on the same machine never see each other's jobs.
 
 
+def _humanize_duration(seconds: int) -> str:
+    """Turn a raw second count into a short, human phrase (300 -> "5 minutes").
+
+    Keeps the ``wait`` confirmation conversational so the agent can relay it
+    naturally instead of parroting a machine-y "300s / ISO timestamp"."""
+    s = max(1, int(seconds))
+    if s < 60:
+        return f"{s} second{'s' if s != 1 else ''}"
+    mins, secs = divmod(s, 60)
+    if mins < 60:
+        parts = [f"{mins} minute{'s' if mins != 1 else ''}"]
+        if secs:
+            parts.append(f"{secs} second{'s' if secs != 1 else ''}")
+        return " ".join(parts)
+    hours, mins = divmod(mins, 60)
+    parts = [f"{hours} hour{'s' if hours != 1 else ''}"]
+    if mins:
+        parts.append(f"{mins} minute{'s' if mins != 1 else ''}")
+    return " ".join(parts)
+
+
 def _build_scheduler_tools(scheduler) -> list:
     """Bind scheduler tools to a ``SchedulerBackend``. Returns a list."""
 
@@ -930,9 +951,13 @@ def _build_scheduler_tools(scheduler) -> list:
                 contract." This is your only context when you wake, so be
                 specific about what to do and which entities are involved.
 
-        Returns a confirmation with the resume time. For an absolute time or a
-        recurring schedule use ``schedule_task`` instead — ``wait`` is for
-        "yield for a bit, then pick this back up".
+        Returns a short confirmation of the scheduled wait. Do NOT echo this
+        return value verbatim into chat — it's a status line for you, not a reply
+        to the user. If you say anything, paraphrase it conversationally and
+        briefly (e.g. "Okay, I'll check back in about 5 minutes."); never paste
+        the raw string or an ISO timestamp. For an absolute time or a recurring
+        schedule use ``schedule_task`` instead — ``wait`` is for "yield for a
+        bit, then pick this back up".
         """
         if not (then or "").strip():
             return "Error: `then` is required — describe what to do on resume."
@@ -949,10 +974,14 @@ def _build_scheduler_tools(scheduler) -> list:
         # LangGraph, which silently dropped this resume to the Activity thread.
         ctx = _session_id_from(state) or None
         try:
-            job = await asyncio.to_thread(scheduler.add_job, then, when, context_id=ctx)
+            await asyncio.to_thread(scheduler.add_job, then, when, context_id=ctx)
         except Exception as exc:  # noqa: BLE001
             return f"Error: couldn't schedule the wake-up: {exc}"
-        return f"Yielding for {secs}s — turn ending now. You'll be re-invoked at {job.next_fire or when} to: {then}"
+        # Concise, human-friendly summary — the agent should paraphrase this, not
+        # echo it (the old ISO timestamp / "re-invoked at" phrasing read as raw
+        # system text when parroted into chat). Machine-relevant facts stay intact:
+        # the humanized duration and the resume instruction.
+        return f"Wait scheduled: {_humanize_duration(secs)}. Will resume to: {then}"
 
     return [schedule_task, list_schedules, cancel_schedule, wait]
 


### PR DESCRIPTION
Closes #1536.

## Problem
The `wait` tool returned raw text — `Yielding for 300s — turn ending now. You'll be re-invoked at 2026-07-01T06:56:36.281559+00:00 to: …` — which agents recited verbatim, reading as a raw system/engineering message instead of a natural reply.

## Fix
- Return a concise, human-friendly summary: **`Wait scheduled: 5 minutes. Will resume to: <then>.`** (new `_humanize_duration` helper, 300s → "5 minutes"), dropping the ISO timestamp / "you'll be re-invoked at" phrasing while keeping the facts the agent needs.
- Docstring now explicitly tells the agent **not to echo** the return value verbatim and to paraphrase conversationally.
- The load-bearing fix is the wording: `WaitYieldMiddleware` jumps to `end` after `wait`, so the model is never re-invoked with the result and `server/chat.py::_last_tool_text` surfaces the tool's raw string as the reply — the new wording fixes that path directly.
- Yield/re-invoke scheduling is unchanged (middleware keys on tool name + `Error:` prefix, which the new success string doesn't trip).

## Tests
`ruff` clean; `pytest tests/test_wait_yield.py tests/test_chat_nonstreaming_robustness.py` → 16 passed. Independent review verdict: **ship**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)