### PR TITLE
feat(chat): slash-command UX — mid-input trigger, auto-scroll, command bubbles (#1530, #1528, #1529)

### DIFF
--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -5,6 +5,7 @@ import { Spinner } from "@protolabsai/ui/data";
 import { ArrowDownToLine, Check, Clock, Coins, Copy, GitBranch, Gauge, Maximize2, RotateCcw } from "lucide-react";
 
 import { openDocument } from "../docviewer";
+import { slashCommandName } from "../ext/slashRegistry";
 import { api } from "../lib/api";
 import { useUI } from "../state/uiStore";
 import type { ChatMessage, ChatPart, ContextWindow, TurnUsage } from "../lib/types";
@@ -43,6 +44,24 @@ export function ChatMessageView({
   const streaming = message.status === "streaming";
   // Per-turn token/cost footer is an opt-out display pref (Settings ▸ Chat, #1372).
   const showChatUsage = useUI((s) => s.showChatUsage);
+  // An issued slash command (/goal …) renders as a distinct user bubble (subtle tint /
+  // monospace / "/" badge) so it reads as a command in history, to operator and agent (#1529).
+  const userSlashCmd = message.role === "user" ? slashCommandName(message.content) : null;
+  // Literal user text — a monospace "/command" chip when it's a slash command, else plain
+  // whitespace-preserving text. Shared by the ordered-parts and history render paths.
+  const renderUserText = (text: string, key?: string) =>
+    slashCommandName(text) ? (
+      <span className="chat-user-text chat-slash-cmd" key={key}>
+        <span className="chat-slash-badge" aria-hidden>
+          /
+        </span>
+        <span className="chat-slash-body">{text.replace(/^\s*\//, "")}</span>
+      </span>
+    ) : (
+      <span className="chat-user-text" key={key}>
+        {text}
+      </span>
+    );
   return (
     <Message
       role={message.role}
@@ -54,7 +73,10 @@ export function ChatMessageView({
             // tone modifier is appended only when set, so neutral notes still get the styling.
             message.role === "system"
             ? `chat-note${message.noteTone ? ` chat-note--${message.noteTone}` : ""}`
-            : undefined
+            : // An issued slash command → distinct .chat-slash-msg user bubble (#1529).
+              userSlashCmd
+              ? "chat-slash-msg"
+              : undefined
       }
     >
       {message.reasoning && !(message.parts && message.parts.length) ? (
@@ -78,7 +100,7 @@ export function ChatMessageView({
           const { fold, workParts, answerParts } = foldPlan(parts, streaming);
           const renderText = (part: ChatPart, key: string) =>
             part.kind !== "text" || !part.text.trim() ? null : message.role === "user" ? (
-              <span className="chat-user-text" key={key}>{part.text}</span>
+              renderUserText(part.text, key)
             ) : (
               <Markdown key={key}>{part.text}</Markdown>
             );
@@ -117,7 +139,7 @@ export function ChatMessageView({
           ) : null}
           {message.content ? (
             message.role === "user" ? (
-              <span className="chat-user-text">{message.content}</span>
+              renderUserText(message.content)
             ) : (
               <Markdown>{message.content}</Markdown>
             )

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -4,7 +4,7 @@ import { Switch } from "@protolabsai/ui/forms";
 import { Conversation, Message, PromptInput } from "@protolabsai/ui/ai";
 import { TabBar } from "@protolabsai/ui/navigation";
 import { Check, TerminalSquare } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent } from "react";
 import { useQuery } from "@tanstack/react-query";
 
@@ -23,7 +23,7 @@ import {
   effectiveReasoningEffort,
 } from "./chat-store";
 import "./coreSlashCommands"; // registers /new, /clear, /effort via the slash-command seam (ADR 0061)
-import { findSlashCommand, registeredSlashCommands } from "../ext/slashRegistry";
+import { findSlashCommand, registeredSlashCommands, slashTokenAt } from "../ext/slashRegistry";
 import { registeredComposerActions } from "../ext/composerRegistry";
 import { ChatMessageView } from "./ChatMessageView";
 import { ComposerModelSelect } from "./ComposerModelSelect";
@@ -382,20 +382,48 @@ function ChatSessionSlot({
   }
 
   // Slash-command autocomplete. Commands the server handles (e.g. /goal) are
-  // fetched once; the dropdown is active while typing "/name" (before a space).
+  // fetched once; the dropdown is active while typing a "/name" token (before a space).
   const [commands, setCommands] = useState<SlashCommand[]>([]);
   const [slashIndex, setSlashIndex] = useState(0);
   const [slashDismissed, setSlashDismissed] = useState(false);
+  // The "/name" token the caret currently sits in ({query, start}), or null. Recomputed
+  // from the LIVE textarea caret (not just the draft) so the popover triggers MID-INPUT —
+  // typing "/" at any cursor position opens it, not only when "/" is char 0 (#1530).
+  const [slashCtx, setSlashCtx] = useState<{ query: string; start: number; end: number } | null>(null);
+  // Keeps the keyboard-selected item scrolled into view during ↑/↓ nav (#1528).
+  const activeSlashRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     api.chatCommands().then((r) => setCommands(r.commands)).catch(() => {});
   }, []);
 
-  const slashQuery = useMemo(() => {
-    if (slashDismissed || !draft.startsWith("/")) return null;
-    const after = draft.slice(1);
-    return after.includes(" ") ? null : after; // closes once a space is typed
-  }, [draft, slashDismissed]);
+  // Re-parse the slash token from the textarea's current value + caret. Called on input,
+  // on caret moves (native keyup/click/select/focus listeners below), and after any
+  // programmatic caret change — so the popover state tracks the caret wherever it is.
+  const refreshSlash = useCallback(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    setSlashCtx(slashTokenAt(ta.value, ta.selectionStart ?? ta.value.length));
+  }, []);
+
+  // Caret moves that don't fire onChange (arrow keys, clicks, selection, focus) still need
+  // to re-evaluate the popover so "/" mid-input opens/closes as the caret enters/leaves a token.
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.addEventListener("keyup", refreshSlash);
+    ta.addEventListener("click", refreshSlash);
+    ta.addEventListener("select", refreshSlash);
+    ta.addEventListener("focus", refreshSlash);
+    return () => {
+      ta.removeEventListener("keyup", refreshSlash);
+      ta.removeEventListener("click", refreshSlash);
+      ta.removeEventListener("select", refreshSlash);
+      ta.removeEventListener("focus", refreshSlash);
+    };
+  }, [refreshSlash]);
+
+  const slashQuery = slashDismissed ? null : slashCtx?.query ?? null;
 
   const slashMatches = useMemo(() => {
     if (slashQuery === null) return [];
@@ -414,6 +442,12 @@ function ChatSessionSlot({
 
   const slashActive = slashMatches.length > 0;
   const slashSel = slashActive ? Math.min(slashIndex, slashMatches.length - 1) : 0;
+
+  // Auto-scroll the keyboard-selected item into view during ↑/↓ nav so it never hides
+  // below the popover's scroll edge (standard listbox behavior, #1528).
+  useEffect(() => {
+    if (slashActive) activeSlashRef.current?.scrollIntoView({ block: "nearest" });
+  }, [slashSel, slashActive]);
 
   // Post a local SYSTEM NOTE to the thread (e.g. a /effort confirmation, a status line, a
   // warning) — never sent to the agent, just shown so the operator sees a local action took
@@ -450,17 +484,38 @@ function ChatSessionSlot({
   }
 
   function completeCommand(cmd: SlashCommand) {
-    // A client command runs on pick; a server skill fills the draft to edit + send.
+    // Replace ONLY the "/name" token the caret is in — surrounding text is preserved so a
+    // command can be completed at the start, middle, or end of the draft (#1530). Fall back
+    // to the whole draft if the token is somehow unknown (defensive).
+    const token = slashCtx;
+    const start = token ? token.start : 0;
+    const end = token ? token.end : draft.length;
+    // Place the caret + re-sync the popover after React commits the new value.
+    const settleCaret = (pos: number) => {
+      requestAnimationFrame(() => {
+        const ta = textareaRef.current;
+        if (!ta) return;
+        ta.focus();
+        ta.selectionStart = ta.selectionEnd = pos;
+        refreshSlash();
+      });
+    };
+    // A client command runs on pick — drop just its token from the draft (keeping any
+    // surrounding text); a server skill inserts "/name " to edit + send.
     if (runClientSlash(cmd.name)) {
-      setDraft("");
+      setDraft(draft.slice(0, start) + draft.slice(end));
       setSlashIndex(0);
       setSlashDismissed(true);
+      setSlashCtx(null);
+      settleCaret(start);
       return;
     }
-    setDraft(`/${cmd.name} `);
+    const insert = `/${cmd.name} `;
+    setDraft(draft.slice(0, start) + insert + draft.slice(end));
     setSlashIndex(0);
     setSlashDismissed(true); // a space follows, so it would close anyway
-    textareaRef.current?.focus();
+    setSlashCtx(null);
+    settleCaret(start + insert.length);
   }
 
   // Runs BEFORE the DS PromptInput's Enter-to-submit (via its onKeyDown seam):
@@ -508,7 +563,10 @@ function ChatSessionSlot({
           // caret to end so the next keystroke edits the recalled text (readline behaviour)
           requestAnimationFrame(() => {
             const t = textareaRef.current;
-            if (t) t.selectionStart = t.selectionEnd = val.length;
+            if (t) {
+              t.selectionStart = t.selectionEnd = val.length;
+              refreshSlash(); // keep the slash popover in sync with the moved caret
+            }
           });
         };
         if (event.key === "ArrowUp" && onFirstLine) {
@@ -546,6 +604,7 @@ function ChatSessionSlot({
         setDraft(`${draft.slice(0, start)}\n${draft.slice(end)}`);
         requestAnimationFrame(() => {
           ta.selectionStart = ta.selectionEnd = start + 1;
+          refreshSlash(); // keep the slash popover in sync with the moved caret
         });
       }
     }
@@ -1261,6 +1320,7 @@ function ChatSessionSlot({
             setDraft(v);
             setSlashDismissed(false); // re-open the menu when the input changes
             histIndexRef.current = null; // typing detaches from history nav (readline)
+            refreshSlash(); // re-parse the "/name" token at the (post-input) caret (#1530)
           }}
           // Idle → send. While a turn streams (`busy`), the field stays live: Enter
           // queues a steer into the running turn (onQueue) without stopping it, and
@@ -1351,6 +1411,7 @@ function ChatSessionSlot({
                 <button
                   type="button"
                   key={cmd.name}
+                  ref={index === slashSel ? activeSlashRef : undefined}
                   role="option"
                   aria-selected={index === slashSel}
                   className={`slash-item${index === slashSel ? " active" : ""}`}

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -193,6 +193,41 @@
   word-break: break-word;
 }
 
+/* An issued slash command rendered as a distinct USER bubble (#1529): a subtle accent
+   tint + monospace body + a small "/" badge, so a command sent to the agent reads as a
+   command in history — to operator and agent — not as prose. `.chat-slash-msg` sits ON
+   .pl-message--user (anchored under .chat-session-slot), so it outranks the DS base
+   user-bubble rule regardless of import order. */
+.chat-session-slot .pl-message--user.chat-slash-msg .pl-message__content {
+  background: color-mix(in srgb, var(--brand-violet) 12%, var(--bg-raised));
+  border-color: color-mix(in srgb, var(--brand-violet) 40%, var(--border-strong));
+}
+.chat-user-text.chat-slash-cmd {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+.chat-slash-badge {
+  flex-shrink: 0;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.2em;
+  height: 1.2em;
+  border-radius: 4px;
+  background: var(--brand-violet);
+  color: #fff;
+  font-weight: 600;
+  line-height: 1;
+}
+.chat-slash-body {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* Our only `role:"system"` chat messages are background-agent completion
    notifications (ADR 0050) — full markdown reports (a lede + tables/lists), not
    a one-line notice. The DS styles system messages as a terse CENTERED 100px

--- a/apps/web/src/ext/slashRegistry.test.ts
+++ b/apps/web/src/ext/slashRegistry.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { findSlashCommand, registerSlashCommand, registeredSlashCommands } from "./slashRegistry";
+import {
+  findSlashCommand,
+  registerSlashCommand,
+  registeredSlashCommands,
+  slashCommandName,
+  slashTokenAt,
+} from "./slashRegistry";
 
 describe("slash-command registry (ADR 0061)", () => {
   it("registers and finds a command, case-insensitively", () => {
@@ -43,5 +49,57 @@ describe("slash-command registry (ADR 0061)", () => {
     });
     expect(handled).toBe(true);
     expect(got).toBe("hello world");
+  });
+});
+
+describe("slashTokenAt — MID-INPUT popover parsing (#1530)", () => {
+  it("parses a token at the start of the input", () => {
+    expect(slashTokenAt("/eff", 4)).toEqual({ query: "eff", start: 0, end: 4 });
+  });
+
+  it("parses a token MID-INPUT (after whitespace), not only at char 0", () => {
+    // caret right after "/eff" inside "hey /eff"
+    expect(slashTokenAt("hey /eff", 8)).toEqual({ query: "eff", start: 4, end: 8 });
+  });
+
+  it("uses the caret for query, but end runs to the token's end (mid-token completion)", () => {
+    // caret after "/ne" in "/newthing": query is the text BEFORE the caret ("ne"), but end
+    // spans the WHOLE token (index 9), so completing replaces "/newthing" with no tail left.
+    expect(slashTokenAt("/newthing", 3)).toEqual({ query: "ne", start: 0, end: 9 });
+  });
+
+  it("returns the bare token ('/') so the empty query opens the full list", () => {
+    expect(slashTokenAt("/", 1)).toEqual({ query: "", start: 0, end: 1 });
+    expect(slashTokenAt("hi /", 4)).toEqual({ query: "", start: 3, end: 4 });
+  });
+
+  it("is null when the caret is not inside a slash token", () => {
+    expect(slashTokenAt("hello", 5)).toBeNull(); // no slash
+    expect(slashTokenAt("/eff done", 9)).toBeNull(); // caret past the space → token closed
+    expect(slashTokenAt("path/to/file", 12)).toBeNull(); // mid-word slash, not a token start
+  });
+
+  it("clamps an out-of-range caret", () => {
+    expect(slashTokenAt("/eff", 99)).toEqual({ query: "eff", start: 0, end: 4 });
+    expect(slashTokenAt("/eff", -1)).toEqual({ query: "", start: 0, end: 4 });
+  });
+});
+
+describe("slashCommandName — distinct command bubble detection (#1529)", () => {
+  it("names a bare command and a command with args", () => {
+    expect(slashCommandName("/goal")).toBe("goal");
+    expect(slashCommandName("/goal ship it")).toBe("goal");
+    expect(slashCommandName("/effort high")).toBe("effort");
+  });
+
+  it("is case-insensitive and tolerates surrounding whitespace", () => {
+    expect(slashCommandName("  /New  ")).toBe("New");
+  });
+
+  it("does NOT treat a file path or non-command as a command", () => {
+    expect(slashCommandName("/home/user/notes.md is here")).toBeNull();
+    expect(slashCommandName("just a message")).toBeNull();
+    expect(slashCommandName("/")).toBeNull(); // no letter-led word
+    expect(slashCommandName("/123")).toBeNull(); // must start with a letter
   });
 });

--- a/apps/web/src/ext/slashRegistry.ts
+++ b/apps/web/src/ext/slashRegistry.ts
@@ -64,3 +64,35 @@ export function findSlashCommand(token: string): ClientSlashCommand | undefined 
   const t = (token || "").trim().toLowerCase();
   return _commands.find((c) => c.name === t);
 }
+
+/** Parse the slash-command token the caret currently sits in — powers the MID-INPUT
+ *  popover (#1530), so typing "/" opens the menu at ANY cursor position, not only when
+ *  "/" is the first character. A token is a "/" at the start of the input OR immediately
+ *  after whitespace, running up to the caret with no intervening whitespace. Returns the
+ *  `query` (the text after the "/", up to the caret — what filters the popover), the token's
+ *  `start` index, and its `end` index (the token runs to the next whitespace, which may be
+ *  PAST the caret when completing mid-token — both bound a caret-anchored replace that
+ *  preserves surrounding text), or null when the caret is not inside a token. */
+export function slashTokenAt(
+  text: string,
+  caret: number,
+): { query: string; start: number; end: number } | null {
+  const pos = Math.max(0, Math.min(caret, text.length));
+  let start = pos;
+  while (start > 0 && !/\s/.test(text[start - 1])) start -= 1;
+  if (text[start] !== "/") return null;
+  // End of the token = next whitespace at/after the caret, so completing with the caret in
+  // the MIDDLE of "/token" replaces the whole token, not just up to the caret (no tail left).
+  let end = pos;
+  while (end < text.length && !/\s/.test(text[end])) end += 1;
+  return { query: text.slice(start + 1, pos), start, end };
+}
+
+/** The command name of a user message that IS a slash command (e.g. "/goal ship it" →
+ *  "goal"), or null. Used to render an issued command as a distinct user bubble (#1529).
+ *  Anchored at the start and requiring a letter-led word that ends at whitespace or EOL, so
+ *  a file path like "/home/user" (a "/" followed by more path) is NOT mistaken for one. */
+export function slashCommandName(content: string): string | null {
+  const m = /^\/([a-z][\w-]*)(?=\s|$)/i.exec(content.trim());
+  return m ? m[1] : null;
+}


### PR DESCRIPTION
Closes #1530, #1528, #1529.

**Draft for local UX testing** — CI validates typecheck/tests, but the popover feel + bubble styling need a human eye.

## What
- **#1530** — slash popover triggers **mid-input** at any caret position (Discord/Slack/Notion behavior), not only when `/` is the first char. Caret-aware `slashTokenAt` + native keyup/click/select/focus listeners; completion inserts at the cursor and preserves surrounding text at start/middle/end.
- **#1528** — keyboard nav **auto-scrolls** the focused item into view (`scrollIntoView({block:'nearest'})` tied to the active index).
- **#1529** — an issued (sent) slash command renders as a **distinct user bubble** (subtle violet tint, monospace, `/` badge); `slashCommandName` excludes file paths like `/home/user`.

## Review fixes applied
- **[med, fixed]** `slashTokenAt` returned the token end as the *caret* position, so completing mid-token left a garbage suffix (`/goalX`, caret after `/go`, pick `/goal` → `/goal alX`). Now returns the token's true end (scan to next whitespace); added unit coverage.

## Known tradeoff (your call on local test)
- `slashCommandName` is a regex heuristic unaware of the registered command set, so a `/word`-shaped message that isn't a real command (a typo, or prose like `/s means seconds`) still gets the command-bubble styling. Matching the real command list would couple `ChatMessageView` to the server-command fetch — left as-is; flagging for your review.
- Client commands (`/new`, `/clear`, …) short-circuit before send, so they never produce a bubble; #1529 applies to sent server commands (e.g. `/goal`).

## Gates
typecheck ✓ (both tsconfigs); `vitest` slashRegistry 13/13. e2e not run (draft; will run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)