### PR TITLE
feat(console): header brand settings menu + unified settings sub-panel container (#1544, #1545)

### DIFF
--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -13,8 +13,10 @@ async function openIntegrations(page) {
 
 test("lists configured delegates with type + secret badges", async ({ page }) => {
   await openIntegrations(page);
+  // The panel title now renders in the shared SettingsSubPanel header (#1545) as a DS
+  // PanelHeader heading (outside .delegates-section); the rows stay inside it.
+  await expect(page.getByRole("heading", { name: "Delegates" })).toBeVisible();
   const panel = page.locator(".delegates-section");
-  await expect(panel.getByText("Delegates", { exact: true })).toBeVisible();
   const row = panel.locator(".subagent-row", { hasText: "opus" });
   await expect(row).toBeVisible();
   await expect(row.getByText("openai", { exact: true })).toBeVisible(); // DS Badge (#832)

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -82,6 +82,7 @@ import { PluginSettingsDialog } from "../plugins/PluginSettingsDialog";
 import { AppDrawer } from "./AppDrawer";
 import { HamburgerMenu } from "./HamburgerMenu";
 import { FleetSwitcher } from "./FleetSwitcher";
+import { BrandMenu } from "./BrandMenu";
 import {
   useUI,
   type RightPanel,
@@ -782,7 +783,9 @@ export function App() {
       <div className="app-topbar">
       <Header
         dragRegion
-        logo={<ProtoLabsIcon variant="outline" tone="accent" size={22} decorative />}
+        // The brand mark is a compact settings menu (#1544): click/right-click → Agent · Fleet ·
+        // Theme deep-links. The DS Header has no brand-slot onClick, so we wrap the logo ourselves.
+        logo={<BrandMenu logo={<ProtoLabsIcon variant="outline" tone="accent" size={22} decorative />} />}
         name={
           <FleetSwitcher
             fallbackName={brandName(runtime?.identity?.name)}

--- a/apps/web/src/app/BrandMenu.tsx
+++ b/apps/web/src/app/BrandMenu.tsx
@@ -1,0 +1,54 @@
+import { useRef } from "react";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+
+import { Menu, MenuItem, type MenuHandle } from "@protolabsai/ui/menu";
+import { Bot, ChevronDown, Palette, Server } from "lucide-react";
+
+import { useUI } from "../state/uiStore";
+
+// Compact settings menu anchored to the header brand mark (#1544). Click — or right-click —
+// the logo to open a short list of settings deep-links; each opens the settings overlay on
+// that section. The DS Menu (Radix) owns keyboard access (Enter/Space open, arrows move, Esc
+// close), focus management, and outside-click dismissal.
+//
+// DS gap: @protolabsai/ui/app-shell `Header` exposes no onClick/hook for its brand slot, so we
+// pass the logo through our own trigger button (the Header renders it inside `.pl-header__brand`)
+// and anchor the menu to that button.
+export function BrandMenu({ logo }: { logo: ReactNode }) {
+  const openGlobalSettings = useUI((s) => s.openGlobalSettings);
+  const menuRef = useRef<MenuHandle>(null);
+
+  // Right-click opens the same menu (anchored to the mark) instead of the browser's context menu.
+  const onContextMenu = (e: ReactMouseEvent) => {
+    e.preventDefault();
+    menuRef.current?.open();
+  };
+
+  return (
+    <Menu
+      ref={menuRef}
+      trigger={
+        <button
+          type="button"
+          className="brand-menu-trigger"
+          aria-label="Settings menu"
+          data-testid="brand-menu"
+          onContextMenu={onContextMenu}
+        >
+          {logo}
+          <ChevronDown size={12} className="brand-menu-chevron" aria-hidden />
+        </button>
+      }
+    >
+      <MenuItem icon={<Bot size={14} />} onSelect={() => openGlobalSettings("identity")}>
+        Agent settings
+      </MenuItem>
+      <MenuItem icon={<Server size={14} />} onSelect={() => openGlobalSettings("fleet")}>
+        Fleet settings
+      </MenuItem>
+      <MenuItem icon={<Palette size={14} />} onSelect={() => openGlobalSettings("theme")}>
+        Theme
+      </MenuItem>
+    </Menu>
+  );
+}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -2019,6 +2019,36 @@ textarea {
 .fleet-switcher-trigger:hover {
   background: var(--bg-hover);
 }
+
+/* Header brand mark = a compact settings menu trigger (#1544). The logo + a subtle chevron
+   that fades in on hover/focus/open; the whole mark is a button (pointer cursor, hover tint).
+   The dropdown itself is the DS Menu (.pl-menu), portaled to <body>. */
+.brand-menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  margin: -2px -4px;
+  border-radius: var(--radius);
+  color: inherit;
+  line-height: 0;
+  cursor: pointer;
+}
+.brand-menu-trigger:hover {
+  background: var(--bg-hover);
+}
+.brand-menu-chevron {
+  color: var(--fg-muted);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.brand-menu-trigger:hover .brand-menu-chevron,
+.brand-menu-trigger:focus-visible .brand-menu-chevron,
+.brand-menu-trigger[data-state="open"] .brand-menu-chevron {
+  opacity: 1;
+}
 .fleet-switcher-name {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -17,6 +17,7 @@ import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { acpAgentsQuery, delegatesQuery, delegateTypesQuery, queryKeys } from "../lib/queries";
 import type { DelegateFieldSpec, DelegateProbe, DelegateTypeSpec, DelegateView } from "../lib/types";
+import { SettingsSubPanel } from "./SettingsSubPanel";
 
 // Delegates panel (ADR 0025, PR3) — manage the agents & endpoints the agent can
 // talk to via delegate_to, under Settings → Integrations. Hot-swappable: create/
@@ -92,14 +93,13 @@ export function DelegatesSection() {
   // an error.
   if (list.isError) {
     return (
-      <section className="settings-group">
-        <p className="settings-group-title">Delegates</p>
+      <SettingsSubPanel label="delegates" title="Delegates">
         <p className="setting-desc">
           Couldn't reach the delegate registry for this agent — manage the agents and
           endpoints it can talk to once it's available.{" "}
           <HelpLink href={DELEGATES_GUIDE_URL}>Guide</HelpLink>
         </p>
-      </section>
+      </SettingsSubPanel>
     );
   }
 
@@ -107,76 +107,77 @@ export function DelegatesSection() {
   const typeSpecs = types.data?.types ?? [];
 
   return (
-    <section className="settings-group delegates-section">
-      <p className="settings-group-title">Delegates</p>
-      <p className="setting-desc">
-        Agents &amp; endpoints this agent can reach via <code>delegate_to</code> — changes apply on the next turn.
-      </p>
+    <SettingsSubPanel label="delegates" title="Delegates">
+      <div className="delegates-section">
+        <p className="setting-desc">
+          Agents &amp; endpoints this agent can reach via <code>delegate_to</code> — changes apply on the next turn.
+        </p>
 
-      <div className="subagent-list">
-        {delegates.map((d) => {
-          const p = probes[d.name];
-          return (
-            <div className="subagent-row" key={d.name}>
-              <div>
-                <strong>
-                  {d.health ? (
-                    <span
-                      title={d.health.ok
-                        ? `${d.health.detail || "reachable"}${d.health.latency_ms != null ? ` (${d.health.latency_ms} ms)` : ""}`
-                        : d.health.error || "unreachable"}
-                    >
-                      <StatusDot status={d.health.ok ? "success" : d.health.ok === false ? "error" : "neutral"} />
-                    </span>
-                  ) : null}
-                  {d.name} <Badge status="neutral">{d.type}</Badge>
-                  {!d.configured ? <StatusPill label="unconfigured" tone="warning" /> : null}
-                  {d.has_secret ? <StatusPill label="secret set" tone="muted" /> : null}
-                </strong>
-                <span>{p ? probeLine(p) : d.description || d.error || ""}</span>
+        <div className="subagent-list">
+          {delegates.map((d) => {
+            const p = probes[d.name];
+            return (
+              <div className="subagent-row" key={d.name}>
+                <div>
+                  <strong>
+                    {d.health ? (
+                      <span
+                        title={d.health.ok
+                          ? `${d.health.detail || "reachable"}${d.health.latency_ms != null ? ` (${d.health.latency_ms} ms)` : ""}`
+                          : d.health.error || "unreachable"}
+                      >
+                        <StatusDot status={d.health.ok ? "success" : d.health.ok === false ? "error" : "neutral"} />
+                      </span>
+                    ) : null}
+                    {d.name} <Badge status="neutral">{d.type}</Badge>
+                    {!d.configured ? <StatusPill label="unconfigured" tone="warning" /> : null}
+                    {d.has_secret ? <StatusPill label="secret set" tone="muted" /> : null}
+                  </strong>
+                  <span>{p ? probeLine(p) : d.description || d.error || ""}</span>
+                </div>
+                <div className="issue-actions">
+                  <Button icon variant="ghost" title="Test" onClick={() => testRow.mutate(d)} loading={testRow.isPending && testRow.variables?.name === d.name} disabled={testRow.isPending}>
+                    <ShieldCheck size={15} />
+                  </Button>
+                  <Button icon variant="ghost" title="Edit" onClick={() => { setEditing(d); setAdding(false); }}>
+                    <Pencil size={15} />
+                  </Button>
+                  <Button icon variant="ghost" title="Delete" onClick={() => remove.mutate(d.name)} disabled={remove.isPending}>
+                    <Trash2 size={15} />
+                  </Button>
+                </div>
               </div>
-              <div className="issue-actions">
-                <Button icon variant="ghost" title="Test" onClick={() => testRow.mutate(d)} loading={testRow.isPending && testRow.variables?.name === d.name} disabled={testRow.isPending}>
-                  <ShieldCheck size={15} />
-                </Button>
-                <Button icon variant="ghost" title="Edit" onClick={() => { setEditing(d); setAdding(false); }}>
-                  <Pencil size={15} />
-                </Button>
-                <Button icon variant="ghost" title="Delete" onClick={() => remove.mutate(d.name)} disabled={remove.isPending}>
-                  <Trash2 size={15} />
-                </Button>
-              </div>
-            </div>
-          );
-        })}
-        {!delegates.length ? <p className="setting-desc">No delegates yet — add one below.</p> : null}
-      </div>
+            );
+          })}
+          {!delegates.length ? <p className="setting-desc">No delegates yet — add one below.</p> : null}
+        </div>
 
-      <div className="settings-group-actions">
-        <Button type="button" onClick={() => { setEditing(null); setAdding(true); }} disabled={!typeSpecs.length}>
-          <Plus size={15} /> Add delegate
-        </Button>
-      </div>
+        <div className="settings-group-actions">
+          <Button type="button" onClick={() => { setEditing(null); setAdding(true); }} disabled={!typeSpecs.length}>
+            <Plus size={15} /> Add delegate
+          </Button>
+        </div>
 
-      {/* Add / edit happen in a dialog (the form used to render inline and push the
-          panel down). The DS Dialog supplies the header + close, so DelegateForm
-          carries only the fields + actions. */}
-      <Dialog
-        open={adding || editing != null}
-        onClose={closeForm}
-        title={editing ? `Edit ${editing.name}` : "Add a delegate"}
-        width="min(560px, 94vw)"
-        className="delegate-dialog"
-      >
-        <DelegateForm
-          key={editing?.name ?? "_new"}
-          spec={typeSpecs}
-          initial={editing}
+        {/* Add / edit happen in a dialog (the form used to render inline and push the
+            panel down). The DS Dialog supplies the header + close, so DelegateForm
+            carries only the fields + actions. */}
+        <Dialog
+          open={adding || editing != null}
           onClose={closeForm}
-          onSaved={(msg) => { closeForm(); toast({ tone: "success", title: "Delegate saved", message: msg }); void invalidate(); }}
-        />
-      </Dialog>
-    </section>
+          title={editing ? `Edit ${editing.name}` : "Add a delegate"}
+          width="min(560px, 94vw)"
+          className="delegate-dialog"
+        >
+          <DelegateForm
+            key={editing?.name ?? "_new"}
+            spec={typeSpecs}
+            initial={editing}
+            onClose={closeForm}
+            onSaved={(msg) => { closeForm(); toast({ tone: "success", title: "Delegate saved", message: msg }); void invalidate(); }}
+          />
+        </Dialog>
+      </div>
+    </SettingsSubPanel>
   );
 }
 

--- a/apps/web/src/settings/KeybindingsPanel.tsx
+++ b/apps/web/src/settings/KeybindingsPanel.tsx
@@ -9,6 +9,7 @@ import type { Keybinding } from "../ext/keybindingRegistry";
 import { eventToCombo, formatCombo } from "../keybindings/combo";
 import { useKbIntents } from "../keybindings/intents";
 import { effectiveCombo, useKeybindingOverrides } from "../keybindings/overrides";
+import { SettingsSubPanel } from "./SettingsSubPanel";
 
 // Settings ▸ Keyboard (ADR 0063) — view + rebind every registered keybinding. Click a
 // shortcut to record a new combo; conflicts (same combo in an overlapping scope) are
@@ -65,63 +66,69 @@ export function KeybindingsPanel() {
   const overrideCount = Object.keys(overrides).length;
 
   return (
-    <div className="kb-panel">
-      <div className="kb-panel__head">
+    <SettingsSubPanel
+      label="keyboard"
+      title="Keyboard"
+      kicker="rebind any registered shortcut — saved on this device"
+      actions={
+        <Button variant="ghost" size="sm" onClick={resetAll} disabled={overrideCount === 0}>
+          Reset all
+        </Button>
+      }
+    >
+      <div className="kb-panel">
         <p className="muted kb-panel__hint">
           Click a shortcut to rebind it. Note: <Kbd>⌘T</Kbd>, <Kbd>⌘1–9</Kbd> and <Kbd>⌃Tab</Kbd> are
           reserved by the browser — they work in the desktop app; in a browser, rebind to a free combo.
         </p>
-        <Button variant="ghost" size="sm" onClick={resetAll} disabled={overrideCount === 0}>
-          Reset all
-        </Button>
-      </div>
 
-      {groups.map((g) => (
-        <div className="kb-group" key={g}>
-          <div className="kb-group__label">{g}</div>
-          {bindings
-            .filter((b) => (b.group || "Other") === g)
-            .map((b) => {
-              const recording = recordingId === b.id;
-              const overridden = b.id in overrides;
-              return (
-                <div className="kb-row" key={b.id}>
-                  <div className="kb-row__label">
-                    {b.label}
-                    {b.scope ? <span className="kb-row__scope">{b.scope}</span> : null}
-                  </div>
-                  <div className="kb-row__keys">
-                    <button
-                      type="button"
-                      className={`kb-key${recording ? " kb-key--recording" : ""}`}
-                      onClick={() => (recording ? stopRecording() : startRecording(b.id))}
-                      onKeyDown={recording ? (e) => onRecordKey(b, e) : undefined}
-                      onBlur={recording ? stopRecording : undefined}
-                    >
-                      {recording ? "Press keys… (Esc to cancel)" : formatCombo(effectiveCombo(b))}
-                    </button>
-                    {overridden ? (
+        {groups.map((g) => (
+          <div className="kb-group" key={g}>
+            <div className="kb-group__label">{g}</div>
+            {bindings
+              .filter((b) => (b.group || "Other") === g)
+              .map((b) => {
+                const recording = recordingId === b.id;
+                const overridden = b.id in overrides;
+                return (
+                  <div className="kb-row" key={b.id}>
+                    <div className="kb-row__label">
+                      {b.label}
+                      {b.scope ? <span className="kb-row__scope">{b.scope}</span> : null}
+                    </div>
+                    <div className="kb-row__keys">
                       <button
                         type="button"
-                        className="kb-reset"
-                        title="Reset to default"
-                        aria-label={`Reset ${b.label} to default`}
-                        onClick={() => resetBinding(b.id)}
+                        className={`kb-key${recording ? " kb-key--recording" : ""}`}
+                        onClick={() => (recording ? stopRecording() : startRecording(b.id))}
+                        onKeyDown={recording ? (e) => onRecordKey(b, e) : undefined}
+                        onBlur={recording ? stopRecording : undefined}
                       >
-                        ↺
+                        {recording ? "Press keys… (Esc to cancel)" : formatCombo(effectiveCombo(b))}
                       </button>
+                      {overridden ? (
+                        <button
+                          type="button"
+                          className="kb-reset"
+                          title="Reset to default"
+                          aria-label={`Reset ${b.label} to default`}
+                          onClick={() => resetBinding(b.id)}
+                        >
+                          ↺
+                        </button>
+                      ) : null}
+                    </div>
+                    {conflict?.id === b.id ? (
+                      <div className="kb-row__conflict" role="alert">
+                        Already bound to “{conflict.with}” — pick another.
+                      </div>
                     ) : null}
                   </div>
-                  {conflict?.id === b.id ? (
-                    <div className="kb-row__conflict" role="alert">
-                      Already bound to “{conflict.with}” — pick another.
-                    </div>
-                  ) : null}
-                </div>
-              );
-            })}
-        </div>
-      ))}
-    </div>
+                );
+              })}
+          </div>
+        ))}
+      </div>
+    </SettingsSubPanel>
   );
 }

--- a/apps/web/src/settings/SettingsSubPanel.tsx
+++ b/apps/web/src/settings/SettingsSubPanel.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+
+import { PanelHeader } from "@protolabsai/ui/navigation";
+
+import { StagePanel } from "../app/ErrorBoundary";
+
+// Shared chrome for a bespoke Settings sub-panel (#1545). Wraps content in the canonical
+// StagePanel scaffold (ADR 0013 — ErrorBoundary + Suspense) plus the DS PanelHeader title bar
+// and the scrolling `stage-body`, so hand-built panels (Keyboard, Delegates) match the
+// schema-driven ones (SettingsCategoryPanel) and the other bespoke panels (Theme, Chat).
+// One container → the header/padding/scroll treatment can't drift per panel.
+export function SettingsSubPanel({
+  label,
+  title,
+  kicker,
+  actions,
+  children,
+}: {
+  /** Error/loading label for the StagePanel scaffold. */
+  label: string;
+  title: ReactNode;
+  kicker?: ReactNode;
+  actions?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <StagePanel label={label}>
+      <PanelHeader title={title} kicker={kicker} actions={actions} />
+      <div className="stage-body">{children}</div>
+    </StagePanel>
+  );
+}

--- a/apps/web/src/settings/keybindings.css
+++ b/apps/web/src/settings/keybindings.css
@@ -4,12 +4,6 @@
   flex-direction: column;
   gap: 18px;
 }
-.kb-panel__head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-}
 .kb-panel__hint {
   margin: 0;
   font-size: 12px;

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -113,9 +113,6 @@
   border-radius: 0;
   background: transparent;
 }
-.settings-group {
-  margin-bottom: 40px;
-}
 /* Per-group action row (e.g. the Discord "Test connection" + help link). */
 .settings-group-actions {
   display: flex;
@@ -126,15 +123,6 @@
 .settings-inline-status {
   font-size: 0.8rem;
   color: var(--fg-muted);
-}
-.settings-group-title {
-  margin: 0 0 4px;
-  font-size: 0.72rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--brand-violet-light);
-  border-bottom: 1px solid var(--border);
-  padding-bottom: 8px;
 }
 .setting-row {
   display: grid;


### PR DESCRIPTION
Closes #1544, #1545.

**Draft for local UX testing** — independent review ran the full e2e suite (40 tests pass) and verdict was **ship**, but the menu placement/feel + panel chrome want a human eye per the UI local-test gate.

## What
- **#1544** — the header **brand mark is a compact settings menu**: click or right-click opens a DS Menu (Radix) with **Agent settings** (identity), **Fleet settings** (fleet), **Theme** (theme), each deep-linking the settings overlay. Keyboard-accessible (Enter/Space/arrows/Esc), hover/focus chevron affordance, pointer cursor. New `BrandMenu` wraps the logo; the name slot keeps the existing FleetSwitcher so they don't collide.
- **#1545** — Keybinds + Delegate panels now render through a new shared **`SettingsSubPanel`** (StagePanel scaffold + DS `PanelHeader` + scrolling body), matching the sibling panels so header/padding/scroll chrome can't drift again. Panel content unchanged.

## Review fixes applied
- **[low, fixed]** removed dead `.settings-group` / `.settings-group-title` CSS (unreferenced after DelegatesSection moved to the shared container — matches the "so it doesn't drift again" intent).

## DS gap (noted, not blocking)
`@protolabsai/ui/app-shell` `Header` v0.52.0 exposes no `onClick`/interactive hook for its brand slot — worked around by anchoring the DS Menu to a local trigger. Contribute-back candidate: an optional `onBrandClick`/`brandMenu` slot.

## Remaining low-severity polish (your call)
- "Fleet settings" on a non-host console falls back to the first section (matches the FleetSwitcher "New agent" precedent); could gate on `isHostConsole()`.
- Right-click opens anchored to the trigger, not at the cursor (DS Menu supports `open({x,y})`).

## Gates
typecheck ✓; `vitest` 217/217; css-comments ✓; reviewer also ran build + e2e (keybindings/settings/quick-settings/model/navigation/fleet, 40 tests) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)