### PR TITLE
feat(chat): Cmd/Ctrl+O toggles the latest tool-call block (#1526)

### DIFF
--- a/apps/web/src/chat/toolCollapse.test.ts
+++ b/apps/web/src/chat/toolCollapse.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __resetToolCollapseWalk,
+  resolveToggle,
+  toggleLatestToolBlock,
+  topLevelToggles,
+} from "./toolCollapse";
+
+describe("resolveToggle", () => {
+  it("no-ops when there are no tool blocks", () => {
+    expect(resolveToggle([], null)).toBeNull();
+  });
+
+  it("idle → targets the latest (last) block and expands it", () => {
+    expect(resolveToggle([false, false, false], null)).toEqual({
+      index: 2,
+      expand: true,
+      nextCursor: 2,
+    });
+  });
+
+  it("an out-of-range cursor is treated as idle (→ latest)", () => {
+    expect(resolveToggle([false, false], 9)).toEqual({ index: 1, expand: true, nextCursor: 1 });
+    expect(resolveToggle([false, false], -5)).toEqual({ index: 1, expand: true, nextCursor: 1 });
+  });
+
+  it("expanded target → collapses it and walks the cursor upward", () => {
+    // Latest is open → collapse it, cursor moves up to the previous block.
+    expect(resolveToggle([false, false, true], 2)).toEqual({
+      index: 2,
+      expand: false,
+      nextCursor: 1,
+    });
+  });
+
+  it("after collapsing, the walked-to previous block is expanded", () => {
+    expect(resolveToggle([false, false, false], 1)).toEqual({
+      index: 1,
+      expand: true,
+      nextCursor: 1,
+    });
+  });
+
+  it("collapsing the topmost block wraps the cursor out of range (next press → latest)", () => {
+    const collapseTop = resolveToggle([true, false, false], 0);
+    expect(collapseTop).toEqual({ index: 0, expand: false, nextCursor: -1 });
+    // Next press: -1 is out of range → idle → latest again.
+    expect(resolveToggle([false, false, false], collapseTop!.nextCursor)).toEqual({
+      index: 2,
+      expand: true,
+      nextCursor: 2,
+    });
+  });
+
+  it("drives the full toggle-latest → walk-upward sequence", () => {
+    // Three collapsed blocks; simulate presses by threading the cursor + flipping state.
+    const expanded = [false, false, false];
+    let cursor: number | null = null;
+    const press = () => {
+      const plan = resolveToggle(expanded, cursor)!;
+      expanded[plan.index] = plan.expand;
+      cursor = plan.nextCursor;
+      return plan;
+    };
+    expect(press()).toMatchObject({ index: 2, expand: true }); // expand latest
+    expect(press()).toMatchObject({ index: 2, expand: false }); // collapse latest
+    expect(press()).toMatchObject({ index: 1, expand: true }); // walk up → expand prev
+    expect(press()).toMatchObject({ index: 1, expand: false }); // collapse prev
+    expect(press()).toMatchObject({ index: 0, expand: true }); // walk up → expand oldest
+    expect(expanded).toEqual([true, false, false]);
+  });
+});
+
+// ── DOM integration (jsdom): the walk over the rendered chat DOM ────────────────────────────
+
+// A minimal stand-in for a DS ToolCard head: a button whose aria-expanded flips on click,
+// matching the DS `ToolCard` disclosure the real action clicks.
+function toolCard(open = false): HTMLElement {
+  const card = document.createElement("div");
+  card.className = "pl-toolcard";
+  const row = document.createElement("div");
+  row.className = "pl-toolcard__head-row";
+  const head = document.createElement("button");
+  head.className = "pl-toolcard__head";
+  head.setAttribute("aria-expanded", String(open));
+  head.addEventListener("click", () => {
+    head.setAttribute("aria-expanded", head.getAttribute("aria-expanded") === "true" ? "false" : "true");
+  });
+  row.appendChild(head);
+  card.appendChild(row);
+  return card;
+}
+
+// A reasoning card renders a DS ToolCard (same `.pl-toolcard__head`) inside a
+// `.reasoning-card` wrapper — it must NOT count as a tool block (#1526).
+function reasoningCard(open = false): HTMLElement {
+  const wrap = document.createElement("div");
+  wrap.className = "reasoning-card";
+  wrap.appendChild(toolCard(open));
+  return wrap;
+}
+
+function assistantMessage(cards: HTMLElement[]): HTMLElement {
+  const msg = document.createElement("div");
+  msg.className = "pl-message pl-message--assistant";
+  const list = document.createElement("div");
+  list.className = "tool-calls pl-toolcard-list";
+  cards.forEach((c) => list.appendChild(c));
+  msg.appendChild(list);
+  return msg;
+}
+
+function chatSurface(messages: HTMLElement[]): HTMLElement {
+  const slot = document.createElement("div");
+  slot.className = "chat-session-slot";
+  messages.forEach((m) => slot.appendChild(m));
+  document.body.appendChild(slot);
+  return slot;
+}
+
+function headStates(slot: HTMLElement): boolean[] {
+  return Array.from(slot.querySelectorAll(".pl-toolcard__head")).map(
+    (h) => h.getAttribute("aria-expanded") === "true",
+  );
+}
+
+describe("toggleLatestToolBlock (DOM)", () => {
+  beforeEach(() => __resetToolCollapseWalk());
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("no-ops when there is no chat surface or no tool blocks", () => {
+    expect(() => toggleLatestToolBlock()).not.toThrow();
+    chatSurface([assistantMessage([])]); // a message with zero tool cards
+    expect(() => toggleLatestToolBlock()).not.toThrow();
+  });
+
+  it("expands the latest block, collapses it, then walks upward", () => {
+    const slot = chatSurface([assistantMessage([toolCard(), toolCard(), toolCard()])]);
+
+    toggleLatestToolBlock();
+    expect(headStates(slot)).toEqual([false, false, true]); // expand latest
+
+    toggleLatestToolBlock();
+    expect(headStates(slot)).toEqual([false, false, false]); // collapse latest
+
+    toggleLatestToolBlock();
+    expect(headStates(slot)).toEqual([false, true, false]); // walk up → expand previous
+
+    toggleLatestToolBlock();
+    expect(headStates(slot)).toEqual([false, false, false]); // collapse previous
+
+    toggleLatestToolBlock();
+    expect(headStates(slot)).toEqual([true, false, false]); // walk up → expand oldest
+  });
+
+  it("targets the LAST message that has tool blocks", () => {
+    const older = assistantMessage([toolCard()]);
+    const newer = assistantMessage([toolCard(), toolCard()]);
+    const slot = chatSurface([older, newer]);
+
+    toggleLatestToolBlock();
+    // Only the newer message's latest card opened; the older one is untouched.
+    expect(headStates(older)).toEqual([false]);
+    expect(headStates(newer)).toEqual([false, true]);
+  });
+
+  it("ignores cards nested inside another block's body (subagent children / summary members)", () => {
+    const parent = toolCard();
+    const body = document.createElement("div");
+    body.className = "pl-toolcard__body";
+    body.appendChild(toolCard()); // a nested child card — not a top-level block
+    parent.appendChild(body);
+    const msg = assistantMessage([parent]);
+    expect(topLevelToggles(msg)).toHaveLength(1); // only the parent counts
+
+    const slot = chatSurface([msg]);
+    toggleLatestToolBlock();
+    // The parent (top-level) opened; the nested child stayed closed.
+    const [parentOpen, childOpen] = headStates(slot);
+    expect(parentOpen).toBe(true);
+    expect(childOpen).toBe(false);
+  });
+
+  it("skips body-less (disabled) cards", () => {
+    const disabled = toolCard();
+    disabled.querySelector("button")!.setAttribute("disabled", "");
+    disabled.querySelector("button")!.removeAttribute("aria-expanded");
+    const real = toolCard();
+    const msg = assistantMessage([disabled, real]);
+    expect(topLevelToggles(msg)).toHaveLength(1);
+
+    chatSurface([msg]);
+    toggleLatestToolBlock();
+    expect(real.querySelector("button")!.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("excludes reasoning cards — a reasoning-only turn is a no-op", () => {
+    const reasoning = reasoningCard();
+    const msg = assistantMessage([reasoning]);
+    expect(topLevelToggles(msg)).toHaveLength(0); // reasoning is not a tool block
+
+    chatSurface([msg]);
+    toggleLatestToolBlock();
+    // The reasoning card stays closed — Cmd+O had nothing to toggle.
+    expect(reasoning.querySelector("button")!.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("walks tool blocks only, skipping a leading reasoning card", () => {
+    const reasoning = reasoningCard();
+    const tool = toolCard();
+    const msg = assistantMessage([reasoning, tool]); // reasoning THEN a real tool call
+    expect(topLevelToggles(msg)).toHaveLength(1); // only the tool call counts
+
+    chatSurface([msg]);
+    toggleLatestToolBlock();
+    expect(tool.querySelector("button")!.getAttribute("aria-expanded")).toBe("true");
+    expect(reasoning.querySelector("button")!.getAttribute("aria-expanded")).toBe("false");
+  });
+});

--- a/apps/web/src/chat/toolCollapse.ts
+++ b/apps/web/src/chat/toolCollapse.ts
@@ -1,0 +1,131 @@
+// "Toggle latest tool block" keybinding action (ADR 0063, #1526). The tool-call disclosure
+// state lives INSIDE the DS `ToolCard` (an uncontrolled `useState`, flipped by clicking its
+// `.pl-toolcard__head` toggle) — there's no controlled `open` prop to drive from a store — so
+// this walks the rendered chat DOM and clicks the disclosure, exactly as the user would. That
+// keeps the streaming spotlight/summary render paths (ToolCalls.tsx / WorkBlock.tsx) untouched
+// and works uniformly across every one of them (WorkBlock fold, spotlight, settled cards, the
+// summary chip).
+//
+// Behavior: the first press expands the LATEST top-level tool block; pressing again collapses
+// it and moves the walk cursor UPWARD, so subsequent presses expand each older block newest →
+// oldest (see `resolveToggle`). A new turn (or a changed block set) resets the walk to the
+// latest block. No tool blocks ⇒ no-op.
+
+export type TogglePlan = {
+  /** Index (in DOM top→bottom order) of the block to toggle. */
+  index: number;
+  /** true = expand it, false = collapse it. */
+  expand: boolean;
+  /** Where the walk cursor lands for the next press. */
+  nextCursor: number;
+};
+
+/**
+ * Pure "toggle latest, then walk upward" decision. `expanded[i]` is each top-level tool
+ * block's disclosure state in DOM order (index 0 = topmost/oldest, last = latest/newest).
+ * `cursor` is the block the walk currently targets, or null / out-of-range = idle (start at
+ * the latest). Returns which block to toggle, whether to expand or collapse it, and the next
+ * cursor — or null when there are no blocks (no-op).
+ *
+ * Sequence for a fresh (idle) walk over a collapsed latest block:
+ *   press → expand latest (cursor stays)          [latest open]
+ *   press → collapse latest, cursor moves up       [all closed, cursor = prev]
+ *   press → expand prev (the "walk upward" step)    … and so on, newest → oldest
+ * Collapsing the topmost block sends the cursor out of range, so the next press wraps back to
+ * the latest rather than getting stuck.
+ */
+export function resolveToggle(expanded: boolean[], cursor: number | null): TogglePlan | null {
+  const n = expanded.length;
+  if (n === 0) return null;
+  let idx = cursor;
+  if (idx == null || idx < 0 || idx >= n) idx = n - 1; // idle → latest
+  if (!expanded[idx]) return { index: idx, expand: true, nextCursor: idx };
+  // Already open → collapse it, then walk upward to the previous block for the next press.
+  return { index: idx, expand: false, nextCursor: idx - 1 };
+}
+
+// The walk cursor + the block set it's keyed to. When the target message or its block count
+// changes (a new turn, or tools streaming in), the key changes and the cursor resets to the
+// latest — "when idle, target the most recent tool block in the last message".
+let walkCursor: number | null = null;
+let walkKey = "";
+
+// Stable per-message-node id so two different turns with the same tool-block COUNT still reset
+// the walk (React reuses the DOM node within a turn — same id — but mints a new one per turn).
+const messageKeys = new WeakMap<Element, number>();
+let messageKeySeq = 0;
+function keyFor(el: Element): number {
+  let k = messageKeys.get(el);
+  if (k == null) {
+    k = ++messageKeySeq;
+    messageKeys.set(el, k);
+  }
+  return k;
+}
+
+/** The visible chat surface — the active session slot, else any chat-scoped root. */
+function chatRoot(): Element | null {
+  return (
+    document.querySelector(".chat-session-slot:not([hidden])") ??
+    document.querySelector('[data-kb-scope~="chat"]')
+  );
+}
+
+/** Top-level TOOL-block disclosure toggles in a message, in DOM (top→bottom) order. Excludes
+ *  disabled (body-less) cards, reasoning cards (which render a DS ToolCard but aren't tool
+ *  calls — #1526 is "toggle the tool-call block"), and any card nested inside another block's
+ *  body/children/summary — a subagent child, a WorkBlock timeline card, or a folded summary
+ *  member — so the walk is over top-level tool blocks only. */
+export function topLevelToggles(message: Element): HTMLButtonElement[] {
+  const heads = message.querySelectorAll<HTMLButtonElement>(
+    ".pl-toolcard__head, .pl-toolcard-summary__head",
+  );
+  const out: HTMLButtonElement[] = [];
+  heads.forEach((head) => {
+    if (head.disabled) return; // a card with no body can't toggle
+    if (head.getAttribute("aria-expanded") == null) return;
+    if (head.closest(".reasoning-card")) return; // a reasoning card, not a tool call
+    if (head.closest(".pl-toolcard__body, .pl-toolcard__children, .pl-toolcard-summary__body")) {
+      return; // nested under another block — not a top-level block
+    }
+    out.push(head);
+  });
+  return out;
+}
+
+/** The last message that has any top-level tool block, with its toggles (newest last). */
+function latestToolBlocks(): { message: Element; toggles: HTMLButtonElement[] } | null {
+  const root = chatRoot();
+  if (!root) return null;
+  const messages = root.querySelectorAll(".pl-message");
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const toggles = topLevelToggles(messages[i]);
+    if (toggles.length) return { message: messages[i], toggles };
+  }
+  return null;
+}
+
+/** Keybinding action (ADR 0063): toggle the latest tool-call block in the current agent
+ *  output; repeated presses collapse then walk upward through the block stack. No-op when the
+ *  last message has no tool blocks. */
+export function toggleLatestToolBlock(): void {
+  const found = latestToolBlocks();
+  if (!found) return;
+  const { message, toggles } = found;
+  const key = `${keyFor(message)}:${toggles.length}`;
+  if (key !== walkKey) {
+    walkKey = key;
+    walkCursor = null; // new turn / changed block set → restart the walk at the latest
+  }
+  const expanded = toggles.map((t) => t.getAttribute("aria-expanded") === "true");
+  const plan = resolveToggle(expanded, walkCursor);
+  if (!plan) return;
+  walkCursor = plan.nextCursor;
+  toggles[plan.index].click(); // flip the DS ToolCard's internal disclosure
+}
+
+/** Test-only: clear the walk cursor between cases. */
+export function __resetToolCollapseWalk(): void {
+  walkCursor = null;
+  walkKey = "";
+}

--- a/apps/web/src/keybindings/coreKeybindings.ts
+++ b/apps/web/src/keybindings/coreKeybindings.ts
@@ -11,6 +11,7 @@
 // remap to non-reserved combos in Settings ▸ Keyboard.
 import { api } from "../lib/api";
 import { chatStore } from "../chat/chat-store";
+import { toggleLatestToolBlock } from "../chat/toolCollapse";
 import { useUI } from "../state/uiStore";
 import { registerKeybinding } from "../ext/keybindingRegistry";
 import { useKbIntents } from "./intents";
@@ -107,6 +108,20 @@ for (let n = 1; n <= 9; n++) {
     run: () => switchToIndex(n - 1),
   });
 }
+// Toggle the LATEST tool-call block in the current agent output (#1526): expand it, press
+// again to collapse it, press again to walk UPWARD to the previous block (newest → oldest).
+// `allowInInput` so it fires while typing in the composer (the common case — reviewing tool
+// output as the agent works). The host preventDefaults, so it also swallows the browser's
+// native ⌘O / Ctrl+O (open file) while focus is in the chat panel.
+registerKeybinding({
+  id: "chat.tool.toggle",
+  label: "Toggle latest tool block",
+  group: "Chat",
+  defaultKeys: "mod+o",
+  scope: "chat",
+  allowInInput: true,
+  run: () => toggleLatestToolBlock(),
+});
 
 // ── Panels (global toggles) ──────────────────────────────────────────────────────────
 // VS Code-style: ⌘B left rail, ⌘⌥B right panel, ⌘J bottom dock. Same desktop-vs-browser


### PR DESCRIPTION
Closes #1526.

**Draft for local UX testing** — the toggle/walk feel wants a human eye per the UI local-test gate.

## What
- Default **`Cmd+O` / `Ctrl+O`** toggles the **latest top-level tool-call block** in the current agent output. First press expands the newest; pressing again collapses it and **walks upward** (newest → oldest); idle targets the most recent block in the last message; no tool blocks → **no-op**.
- Registered through the **ADR-0063 keybinding system** (`chat.tool.toggle`, group "Chat", scope "chat", `allowInInput`) so it shows in **Settings ▸ Keyboard** and is rebindable; the host `preventDefault`s the browser's native Cmd/Ctrl+O while focus is in chat.

## Approach + DS gap
DS `ToolCard`/`ToolCardSummary` expose only uncontrolled `defaultOpen` (no controlled `open`/`onToggle`), so rather than lift state and remount cards (which would strobe the streaming spotlight), the action walks the rendered chat DOM and clicks the disclosure toggle — uniform across every render path, zero changes to `ToolCalls`/`WorkBlock`/`ChatSurface`. Contribute-back candidate: a controlled-open prop on DS ToolCard.

## Review fixes applied
- **[med, fixed]** `topLevelToggles` matched `.pl-toolcard__head`, which `ReasoningCard` also renders — so reasoning blocks counted as tool blocks (a reasoning-only turn toggled reasoning instead of no-op'ing; history turns walked into the reasoning card). Now excludes `.reasoning-card`; added 2 tests (reasoning-only turn = no-op; walk skips a leading reasoning card).

## Known tradeoff (your call on local test)
- "Latest block" identity shifts across streaming vs. settled states (the transient spotlight card during streaming vs. the WorkBlock fold after) — inherent to the DOM-click approach given the DS gap; mechanically correct, just fuzzier than a clean per-block model. Skipped the stretch ideas (expand-all, focus ring, arrow-nav).

## Gates
typecheck ✓; `vitest` toolCollapse 14/14 (incl. reasoning-card exclusion). e2e not run (draft; CI will run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)