### PR TITLE
fix(fleet): recover gracefully when the focused agent is down (no more boot-gate brick)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -87,7 +87,7 @@ import {
   type RightPanel,
   type Surface,
 } from "../state/uiStore";
-import { api, apiUrl, authToken, is401 } from "../lib/api";
+import { api, apiUrl, authToken, is401, isAgentNotRunning, currentSlug, agentHref, activateSlugAgent } from "../lib/api";
 import { PluginView, consoleTheme } from "./PluginView";
 import { UtilityWidget } from "./UtilityWidget";
 import { AppShell, Header, UtilityBar } from "@protolabsai/ui/app-shell";
@@ -368,6 +368,19 @@ export function App() {
   // copy/escape-hatch swap. STUCK_AFTER_MS=45s — past it, offer "Continue anyway"
   // so a graph that never compiles can't trap the operator on the loading screen.
   const bootFailed = !runtime && runtimeQ.isError;
+  // Focused fleet agent is DOWN (ADR 0042): a non-host slug whose boot probe keeps 409'ing
+  // ("agent not running") past a normal spawn window — `activate` didn't bring it up (or it
+  // failed to start). Without this the operator waited out the full ~30 retries for a generic
+  // "isn't responding" gate whose "Continue anyway" just opens a 409-broken app. Detect it
+  // early (≥6 retries ≈ ~6s at the 1s delay) and offer targeted recovery: return to the host
+  // console, or try starting the agent again. `failureReason`/`failureCount` are live during
+  // retries (TanStack Query v5), so recovery shows before the probe fully gives up.
+  const focusedSlug = currentSlug();
+  const agentDown =
+    focusedSlug !== "host" &&
+    !runtime &&
+    isAgentNotRunning(runtimeQ.failureReason) &&
+    runtimeQ.failureCount >= 6;
   // Token-gated first run (#873): the boot probe itself 401s. The BootGate's
   // "Starting… / isn't responding" copy is wrong for that — and its overlay
   // (z-1900) would cover the AuthGate dialog (z-1000) — so the gate yields to
@@ -742,19 +755,47 @@ export function App() {
           <BootGate
             logo={<ProtoLabsIcon variant="outline" size={56} decorative gradientStroke tone="accent" />}
             title={
-              bootFailed
-                ? `${bootName} isn’t responding`
-                : `Starting ${bootName}…`
+              agentDown
+                ? `Agent “${focusedSlug}” isn’t running`
+                : bootFailed
+                  ? `${bootName} isn’t responding`
+                  : `Starting ${bootName}…`
             }
             detail={
-              bootFailed
-                ? "The engine didn’t come up in time. It may still be warming up — give it another moment, then retry."
-                : bootStuck
-                  ? "This is taking longer than usual. The engine may still be compiling, or it may need attention in Settings."
-                  : "Warming up the engine — first launch (and finishing setup) can take up to a minute. Later launches are quick."
+              agentDown
+                ? "This fleet agent didn’t start. Return to the host console to keep working, or try starting it again."
+                : bootFailed
+                  ? "The engine didn’t come up in time. It may still be warming up — give it another moment, then retry."
+                  : bootStuck
+                    ? "This is taking longer than usual. The engine may still be compiling, or it may need attention in Settings."
+                    : "Warming up the engine — first launch (and finishing setup) can take up to a minute. Later launches are quick."
             }
             action={
-              bootFailed ? (
+              agentDown ? (
+                <div style={{ display: "flex", gap: 8 }}>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={() => {
+                      window.location.href = agentHref("host");
+                    }}
+                  >
+                    Return to host
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      void (async () => {
+                        await activateSlugAgent();
+                        void runtimeQ.refetch();
+                      })();
+                    }}
+                  >
+                    Try to start it
+                  </Button>
+                </div>
+              ) : bootFailed ? (
                 <Button variant="primary" size="sm" onClick={() => void runtimeQ.refetch()}>
                   Retry
                 </Button>

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { ApiError, apiUrl, drainSseBuffer, frameIsForeign, isColdStart, textFromParts, hitlFromParts } from "./api";
+import {
+  ApiError,
+  apiUrl,
+  drainSseBuffer,
+  frameIsForeign,
+  isColdStart,
+  isAgentNotRunning,
+  textFromParts,
+  hitlFromParts,
+} from "./api";
 
 describe("cold-start detection (ApiError / isColdStart)", () => {
   it("ApiError carries the HTTP status", () => {
@@ -24,6 +33,17 @@ describe("cold-start detection (ApiError / isColdStart)", () => {
     // than flashing "Load failed" in the tasks/notes panels.
     expect(isColdStart(new TypeError("Load failed"))).toBe(true);
     expect(isColdStart(new Error("Failed to fetch"))).toBe(true);
+  });
+});
+
+describe("focused-agent-down detection (isAgentNotRunning)", () => {
+  it("true ONLY for a 409 (the fleet proxy's 'agent not running')", () => {
+    expect(isAgentNotRunning(new ApiError(409, "agent 'x' is not running"))).toBe(true);
+    // 502 is a proxy/boot hiccup, not a definitively-down agent — stays a cold-start retry, not recovery.
+    expect(isAgentNotRunning(new ApiError(502, "not reachable"))).toBe(false);
+    expect(isAgentNotRunning(new ApiError(404, "nope"))).toBe(false);
+    expect(isAgentNotRunning(new TypeError("Load failed"))).toBe(false);
+    expect(isAgentNotRunning(undefined)).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -313,6 +313,14 @@ export function isColdStart(error: unknown): boolean {
   return true; // no HTTP response at all ⇒ not reachable yet (desktop sidecar booting)
 }
 
+/** The fleet proxy's "agent isn't running/registered" signal (ADR 0042): a 409 from a
+ *  slug-routed call. Distinct from `isColdStart` (which also rides 502/no-response) — this
+ *  is specifically "the focused fleet agent is down", used to offer a return-to-host recovery
+ *  once it persists past a normal spawn window instead of the generic "isn't responding" gate. */
+export function isAgentNotRunning(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 409;
+}
+
 /** True for a 401 from request() — retrying can't help until the operator supplies
  *  a token (#873); the AuthGate owns recovery. */
 export function is401(error: unknown): boolean {


### PR DESCRIPTION
## The brick

Add a fleet member that fails to start (or open a stopped one's slug) → the console **hangs at the boot gate**, then eventually a generic *"<name> isn't responding"* whose only escape *"Continue anyway"* opens a fully 409-broken app. (Repro that surfaced this: a "Test" member came up with `pid: null`; every `/agents/Test-…/api/*` call 409'd — goals, status, schema, sse-token, … — and the boot gate never got a `status`.)

**Why:** the focused agent lives in the URL (`/app/agent/<slug>/`), so *every* API call routes through the hub proxy, which returns **409 "agent not running"** for a down member. The boot probe retries ~30× into the generic gate — nothing tells the operator it's *one* agent, and there's no path back to a working console.

## The fix

When a **non-host slug** keeps 409'ing past a normal spawn window (`failureCount ≥ 6` ≈ ~6s at the 1s retry delay), the boot gate switches to **targeted recovery**:

- **Agent "<slug>" isn't running**
- **[Return to host]** → navigates to the host console (always works)
- **[Try to start it]** → re-runs `activateSlugAgent()` + refetches

Uses TanStack Query v5 `failureReason` / `failureCount` so it appears *during* retries, not only after the probe gives up. Host / cold-start / 502 paths unchanged — 502 (booting proxy) stays a cold-start retry, only 409 (definitively "not running") triggers recovery.

## Test

- New `isAgentNotRunning(err)` helper (409-only; distinct from `isColdStart`) + unit tests.
- `tsc` build green, **218 unit tests pass.**

## ⚠ Wants a manual check

Builds + typechecks, but the recovery UI itself I can't click-test — point a window at a stopped agent's slug (`/app/agent/<slug>/`) and confirm the card + both buttons behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)