### PR TITLE
feat(chat): /close + reopen-last-closed (Cmd/Ctrl+Shift+T) — reversible soft-close (#1525)

### DIFF
--- a/apps/web/e2e/commands.spec.ts
+++ b/apps/web/e2e/commands.spec.ts
@@ -6,7 +6,7 @@ import { SLASH_COMMANDS } from "./fixtures.mjs";
 // (GET /api/chat/commands) and autocompletes them as you type "/name".
 
 // Deterministic client-side commands (ADR 0057) surface FIRST, then the server skills.
-const CLIENT_SLASH = ["/new", "/clear", "/effort", "/bypass"];
+const CLIENT_SLASH = ["/new", "/clear", "/close", "/effort", "/bypass"];
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -26,6 +26,7 @@ import "./coreSlashCommands"; // registers /new, /clear, /effort via the slash-c
 import { findSlashCommand, registeredSlashCommands, slashTokenAt } from "../ext/slashRegistry";
 import { registeredComposerActions } from "../ext/composerRegistry";
 import { ChatMessageView } from "./ChatMessageView";
+import { RecentlyClosedMenu } from "./RecentlyClosedMenu";
 import { ComposerModelSelect } from "./ComposerModelSelect";
 import { filesFromTransfer, isLargePaste, pastedTextFile } from "./paste";
 import { inputHistory, pushInputHistory } from "./inputHistory";
@@ -209,6 +210,7 @@ export function ChatSurface({
           onTabContextMenu={onTabContextMenu}
           addLabel="New chat"
         />
+        <RecentlyClosedMenu />
       </div>
 
       <div className="chat-session-pool">

--- a/apps/web/src/chat/RecentlyClosedMenu.tsx
+++ b/apps/web/src/chat/RecentlyClosedMenu.tsx
@@ -1,0 +1,34 @@
+import { History } from "lucide-react";
+
+import { Menu, MenuItem } from "@protolabsai/ui/menu";
+
+import { chatStore, useClosedSessions } from "./chat-store";
+
+// "Recently closed" menu beside the chat tabs (#1525): lists soft-closed tabs newest-first and
+// reopens the picked one (reconnecting its server checkpoint with full agent context). Hidden
+// when nothing is stashed, so the tab row is unchanged until you've closed a tab. The keyboard
+// reopen is Cmd/Ctrl+Shift+T (chat.reopen); this is the discoverable, click-to-pick counterpart.
+export function RecentlyClosedMenu() {
+  const closed = useClosedSessions();
+  if (closed.length === 0) return null;
+  return (
+    <Menu
+      trigger={
+        <button
+          type="button"
+          className="chat-recently-closed"
+          aria-label="Recently closed chats"
+          title="Recently closed chats"
+        >
+          <History size={15} />
+        </button>
+      }
+    >
+      {closed.map((s) => (
+        <MenuItem key={s.id} onSelect={() => chatStore.reopenSession(s.id)}>
+          {s.title || "New chat"}
+        </MenuItem>
+      ))}
+    </Menu>
+  );
+}

--- a/apps/web/src/chat/chat-store.test.ts
+++ b/apps/web/src/chat/chat-store.test.ts
@@ -476,4 +476,39 @@ describe("closeSession / reopenLastClosed", () => {
     chatStore.reopenLastClosed(); // stack is empty → still a no-op
     expect(chatStore.getSnapshot().sessions.map((s) => s.id)).toEqual(before);
   });
+
+  it("returns undefined under the cap, and the evicted oldest when the stack overflows", async () => {
+    const { chatStore, MAX_CLOSED_SESSIONS } = await import("./chat-store");
+    const closedIds: string[] = [];
+    for (let i = 0; i < MAX_CLOSED_SESSIONS; i++) {
+      const s = chatStore.createSession();
+      closedIds.push(s.id);
+      expect(chatStore.closeSession(s.id)).toBeUndefined(); // under the cap → nothing evicted
+    }
+    // One more close overflows → the OLDEST (first-closed) falls off and is returned so the
+    // caller can purge-with-harvest its otherwise-orphaned server checkpoint.
+    const extra = chatStore.createSession();
+    const evicted = chatStore.closeSession(extra.id);
+    expect(evicted?.id).toBe(closedIds[0]);
+    // The evicted tab is no longer reopenable.
+    chatStore.reopenSession(closedIds[0]);
+    expect(chatStore.getSnapshot().sessions.map((s) => s.id)).not.toContain(closedIds[0]);
+  });
+
+  it("reopenSession restores a SPECIFIC stashed tab, leaving the rest stashed", async () => {
+    const { chatStore } = await import("./chat-store");
+    const b = chatStore.createSession();
+    const c = chatStore.createSession();
+    chatStore.closeSession(b.id); // older
+    chatStore.closeSession(c.id); // newer
+
+    chatStore.reopenSession(b.id); // reopen the OLDER one by id
+    const ids = () => chatStore.getSnapshot().sessions.map((s) => s.id);
+    expect(chatStore.getSnapshot().currentSessionId).toBe(b.id);
+    expect(ids()).toContain(b.id);
+    expect(ids()).not.toContain(c.id); // c is still stashed, not restored
+
+    chatStore.reopenLastClosed(); // c is still reopenable
+    expect(chatStore.getSnapshot().currentSessionId).toBe(c.id);
+  });
 });

--- a/apps/web/src/chat/chat-store.test.ts
+++ b/apps/web/src/chat/chat-store.test.ts
@@ -391,3 +391,89 @@ describe("cross-tab persistence", () => {
     expect(chatStore.getSnapshot().sessions.map((s) => s.id)).toEqual(before);
   });
 });
+
+// Soft-close + reopen (`/close` + Cmd/Ctrl+Shift+T, #1525). Unlike delete-forever, close
+// keeps the server checkpoint: it stashes a full ChatSession snapshot on an in-memory LIFO
+// stack and tombstones the id so the read-merge-write / cross-tab merge hides it. Reopen pops
+// the stack, re-inserts the SAME session (same a2a:<id> thread), switches to it, and CRITICALLY
+// lifts the tombstone so the restored tab isn't dropped again on the next persist.
+
+function onDiskIds(): string[] {
+  return JSON.parse(window.localStorage.getItem("protoagent.chat.sessions")!).sessions.map(
+    (s: { id: string }) => s.id,
+  );
+}
+
+describe("closeSession / reopenLastClosed", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.resetModules(); // fresh module-level closedSessions stack + tombstone set per test
+  });
+
+  it("stashes + hides the tab (state and persisted storage), then reopen restores it", async () => {
+    const { chatStore } = await import("./chat-store");
+    const a = chatStore.getSnapshot().currentSessionId!;
+    const b = chatStore.createSession();
+    chatStore.renameSession(b.id, "keep me");
+
+    chatStore.closeSession(b.id);
+    // Hidden from the live view (currentSessionId falls back to the surviving tab)…
+    expect(chatStore.getSnapshot().sessions.map((s) => s.id)).toEqual([a]);
+    expect(chatStore.getSnapshot().currentSessionId).toBe(a);
+    // …and tombstoned out of what we persist, so a reload / sibling tab won't show it.
+    expect(onDiskIds()).toEqual([a]);
+
+    // Reopen brings back the SAME session snapshot (same id → same a2a thread, full context).
+    chatStore.reopenLastClosed();
+    const snap = chatStore.getSnapshot();
+    const restored = snap.sessions.find((s) => s.id === b.id);
+    expect(restored?.title).toBe("keep me");
+    expect(snap.currentSessionId).toBe(b.id); // switched to it
+  });
+
+  it("reopen lifts the tombstone so the restored tab is persisted again (not re-dropped)", async () => {
+    const { chatStore } = await import("./chat-store");
+    const b = chatStore.createSession();
+    chatStore.closeSession(b.id);
+    expect(onDiskIds()).not.toContain(b.id); // tombstoned while stashed
+
+    chatStore.reopenLastClosed();
+    expect(onDiskIds()).toContain(b.id); // reopen's own flush keeps it (tombstone lifted)
+
+    // A later structural write must STILL keep it — proves the tombstone is truly gone, not
+    // that this one flush happened to include it.
+    chatStore.createSession();
+    expect(onDiskIds()).toContain(b.id);
+  });
+
+  it("is LIFO — reopen restores the most recently closed tab first", async () => {
+    const { chatStore } = await import("./chat-store");
+    const b = chatStore.createSession();
+    const c = chatStore.createSession();
+    chatStore.closeSession(b.id); // closed first
+    chatStore.closeSession(c.id); // closed last → reopened first
+
+    chatStore.reopenLastClosed();
+    expect(chatStore.getSnapshot().currentSessionId).toBe(c.id);
+    chatStore.reopenLastClosed();
+    expect(chatStore.getSnapshot().currentSessionId).toBe(b.id);
+  });
+
+  it("reopenLastClosed is a no-op on an empty stack", async () => {
+    const { chatStore } = await import("./chat-store");
+    const before = chatStore.getSnapshot();
+    chatStore.reopenLastClosed();
+    const after = chatStore.getSnapshot();
+    expect(after.sessions.map((s) => s.id)).toEqual(before.sessions.map((s) => s.id));
+    expect(after.currentSessionId).toBe(before.currentSessionId);
+  });
+
+  it("closeSession is a no-op for an unknown id (nothing stashed to reopen)", async () => {
+    const { chatStore } = await import("./chat-store");
+    const before = chatStore.getSnapshot().sessions.map((s) => s.id);
+    chatStore.closeSession("does-not-exist");
+    expect(chatStore.getSnapshot().sessions.map((s) => s.id)).toEqual(before);
+    chatStore.reopenLastClosed(); // stack is empty → still a no-op
+    expect(chatStore.getSnapshot().sessions.map((s) => s.id)).toEqual(before);
+  });
+});

--- a/apps/web/src/chat/chat-store.ts
+++ b/apps/web/src/chat/chat-store.ts
@@ -72,9 +72,17 @@ const STORAGE_KEY = (() => {
 const locallyDeletedIds = new Set<string>();
 
 // LIFO stack of soft-closed tabs (`/close`) — full ChatSession snapshots kept IN MEMORY so
-// reopenLastClosed re-inserts one and the SAME a2a:<id> thread reconnects with full agent
-// context. Distinct from delete-forever, which purges the server checkpoint via the API.
+// reopen re-inserts one and the SAME a2a:<id> thread reconnects with full agent context.
+// Distinct from delete-forever, which purges the server checkpoint via the API.
 const closedSessions: ChatSession[] = [];
+
+// A cached, newest-first {id,title} projection of `closedSessions` for the Recently-closed
+// menu. useSyncExternalStore needs a STABLE snapshot reference between changes — rebuild it
+// (a new array) only when the stack mutates, so getSnapshot can return the same ref otherwise.
+let closedSnapshot: ReadonlyArray<{ id: string; title: string }> = [];
+function refreshClosedSnapshot() {
+  closedSnapshot = closedSessions.map((s) => ({ id: s.id, title: s.title })).reverse();
+}
 
 function id(prefix: string) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -417,22 +425,34 @@ export const chatStore = {
    *  a2a:<id> thread with full agent context. Tombstoned like a delete so the read-merge-write
    *  / cross-tab merge won't resurrect the hidden tab; reopen lifts the tombstone. No-op for
    *  an unknown id. */
-  closeSession(sessionId: string) {
+  closeSession(sessionId: string): ChatSession | undefined {
     const snapshot = state.sessions.find((session) => session.id === sessionId);
-    if (!snapshot) return; // unknown id → nothing to close
+    if (!snapshot) return undefined; // unknown id → nothing to close
     closedSessions.push(snapshot); // LIFO — reopen pops the most recently closed
-    if (closedSessions.length > MAX_CLOSED_SESSIONS) closedSessions.shift(); // drop the oldest
+    // Overflow: the oldest falls off the reopen stack. It's no longer reopenable, so return
+    // it to the caller to purge-with-harvest (else its server checkpoint would be orphaned).
+    const evicted = closedSessions.length > MAX_CLOSED_SESSIONS ? closedSessions.shift() : undefined;
+    refreshClosedSnapshot();
     locallyDeletedIds.add(sessionId); // hide it from persist/merge until reopened
     setState((current) => removeSession(current, sessionId));
+    return evicted;
   },
 
-  /** Reopen the most recently soft-closed tab (Cmd/Ctrl+Shift+T). Pops the LIFO stack,
-   *  re-inserts the snapshot (respecting MAX_SESSIONS), and switches to it. CRITICAL: lift the
-   *  tombstone so the next persist / cross-tab merge keeps the restored tab (else it's dropped
-   *  again on the very next write). No-op when the stack is empty. */
+  /** Reopen the most recently soft-closed tab (Cmd/Ctrl+Shift+T) — the LIFO top. */
   reopenLastClosed() {
-    const restored = closedSessions.pop();
-    if (!restored) return; // empty stack → no-op
+    const last = closedSessions[closedSessions.length - 1];
+    if (last) chatStore.reopenSession(last.id);
+  },
+
+  /** Reopen a specific soft-closed tab by id (the Recently-closed menu). Removes it from the
+   *  reopen stack, re-inserts the snapshot (respecting MAX_SESSIONS), and switches to it.
+   *  CRITICAL: lift the tombstone so the next persist / cross-tab merge keeps the restored tab
+   *  (else it's dropped again on the very next write). No-op for an id not on the stack. */
+  reopenSession(sessionId: string) {
+    const idx = closedSessions.findIndex((s) => s.id === sessionId);
+    if (idx === -1) return; // not stashed → no-op
+    const [restored] = closedSessions.splice(idx, 1);
+    refreshClosedSnapshot();
     locallyDeletedIds.delete(restored.id); // un-tombstone so it persists again
     setState((current) => {
       // Guard against a duplicate (e.g. a cross-tab merge resurrected it while stashed):
@@ -570,4 +590,13 @@ export function useAnyChatStreaming(): boolean {
 const _closedCount = () => closedSessions.length;
 export function useClosedSessionsCount(): number {
   return useSyncExternalStore(chatStore.subscribe, _closedCount, () => 0);
+}
+
+// The soft-closed tabs available to reopen, newest-first ({id,title}) — powers the
+// Recently-closed menu. Returns the cached `closedSnapshot` (a stable ref between mutations,
+// rebuilt by refreshClosedSnapshot on close/reopen) so useSyncExternalStore doesn't loop.
+const _emptyClosed: ReadonlyArray<{ id: string; title: string }> = [];
+const _closedList = () => closedSnapshot;
+export function useClosedSessions(): ReadonlyArray<{ id: string; title: string }> {
+  return useSyncExternalStore(chatStore.subscribe, _closedList, () => _emptyClosed);
 }

--- a/apps/web/src/chat/chat-store.ts
+++ b/apps/web/src/chat/chat-store.ts
@@ -4,6 +4,9 @@ import type { ChatMessage } from "../lib/types";
 
 export const MAX_SESSIONS = 50;
 export const MAX_ACTIVE_SESSIONS = 5;
+// How many soft-closed tabs to keep on the reopen stack (Cmd/Ctrl+Shift+T). Bounded so the
+// stashed snapshots can't grow without limit; the oldest closed tab falls off when exceeded.
+export const MAX_CLOSED_SESSIONS = 10;
 
 export type ChatSession = {
   id: string;
@@ -63,8 +66,15 @@ const STORAGE_KEY = (() => {
 })();
 
 // Sessions this tab deleted — a lightweight per-tab tombstone so the cross-tab merge
-// never resurrects a chat we just removed from another tab's stale on-disk copy.
+// never resurrects a chat we just removed from another tab's stale on-disk copy. A
+// SOFT close (`/close`) tombstones too, so the read-merge-write / cross-tab merge hides
+// the stashed tab; reopenLastClosed lifts the tombstone so it persists again.
 const locallyDeletedIds = new Set<string>();
+
+// LIFO stack of soft-closed tabs (`/close`) — full ChatSession snapshots kept IN MEMORY so
+// reopenLastClosed re-inserts one and the SAME a2a:<id> thread reconnects with full agent
+// context. Distinct from delete-forever, which purges the server checkpoint via the API.
+const closedSessions: ChatSession[] = [];
 
 function id(prefix: string) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -285,6 +295,34 @@ export function ensureActiveSessions(state: ChatState, sessionId: string | null)
   return next;
 }
 
+/** Remove a session from `current` and fix up currentSessionId / activeSessions /
+ *  sessionStatusMap. Shared by deleteSession (hard, purges the server checkpoint) and
+ *  closeSession (soft, stashes for reopen) — the only difference is the API call + the
+ *  reopen stash, NOT the local list fix-up. */
+function removeSession(current: ChatState, sessionId: string): ChatState {
+  const sessions = current.sessions.filter((session) => session.id !== sessionId);
+  const currentSessionId =
+    current.currentSessionId === sessionId ? sessions[0]?.id || null : current.currentSessionId;
+  const sessionStatusMap = { ...current.sessionStatusMap };
+  delete sessionStatusMap[sessionId];
+  return {
+    ...current,
+    sessions,
+    currentSessionId,
+    activeSessions: ensureActiveSessions(
+      {
+        ...current,
+        sessions,
+        currentSessionId,
+        activeSessions: current.activeSessions.filter((id) => id !== sessionId),
+        sessionStatusMap,
+      },
+      currentSessionId,
+    ),
+    sessionStatusMap,
+  };
+}
+
 let initial = loadPersisted();
 let state: ChatState = {
   ...initial,
@@ -371,27 +409,45 @@ export const chatStore = {
 
   deleteSession(sessionId: string) {
     locallyDeletedIds.add(sessionId); // tombstone: the cross-tab merge won't resurrect it
+    setState((current) => removeSession(current, sessionId));
+  },
+
+  /** Soft-close a tab (`/close`): stash a full snapshot on the reopen stack and drop it from
+   *  view WITHOUT purging the server checkpoint — so reopenLastClosed reconnects the same
+   *  a2a:<id> thread with full agent context. Tombstoned like a delete so the read-merge-write
+   *  / cross-tab merge won't resurrect the hidden tab; reopen lifts the tombstone. No-op for
+   *  an unknown id. */
+  closeSession(sessionId: string) {
+    const snapshot = state.sessions.find((session) => session.id === sessionId);
+    if (!snapshot) return; // unknown id → nothing to close
+    closedSessions.push(snapshot); // LIFO — reopen pops the most recently closed
+    if (closedSessions.length > MAX_CLOSED_SESSIONS) closedSessions.shift(); // drop the oldest
+    locallyDeletedIds.add(sessionId); // hide it from persist/merge until reopened
+    setState((current) => removeSession(current, sessionId));
+  },
+
+  /** Reopen the most recently soft-closed tab (Cmd/Ctrl+Shift+T). Pops the LIFO stack,
+   *  re-inserts the snapshot (respecting MAX_SESSIONS), and switches to it. CRITICAL: lift the
+   *  tombstone so the next persist / cross-tab merge keeps the restored tab (else it's dropped
+   *  again on the very next write). No-op when the stack is empty. */
+  reopenLastClosed() {
+    const restored = closedSessions.pop();
+    if (!restored) return; // empty stack → no-op
+    locallyDeletedIds.delete(restored.id); // un-tombstone so it persists again
     setState((current) => {
-      const sessions = current.sessions.filter((session) => session.id !== sessionId);
-      const currentSessionId =
-        current.currentSessionId === sessionId ? sessions[0]?.id || null : current.currentSessionId;
-      const sessionStatusMap = { ...current.sessionStatusMap };
-      delete sessionStatusMap[sessionId];
+      // Guard against a duplicate (e.g. a cross-tab merge resurrected it while stashed):
+      // drop any existing copy, then append the snapshot on the RIGHT like a new tab.
+      const sessions = [...current.sessions.filter((s) => s.id !== restored.id), restored].slice(
+        -MAX_SESSIONS,
+      );
       return {
         ...current,
         sessions,
-        currentSessionId,
+        currentSessionId: restored.id,
         activeSessions: ensureActiveSessions(
-          {
-            ...current,
-            sessions,
-            currentSessionId,
-            activeSessions: current.activeSessions.filter((id) => id !== sessionId),
-            sessionStatusMap,
-          },
-          currentSessionId,
+          { ...current, sessions, currentSessionId: restored.id },
+          restored.id,
         ),
-        sessionStatusMap,
       };
     });
   },
@@ -506,4 +562,12 @@ const _anyStreaming = () =>
   Object.values(chatStore.getSnapshot().sessionStatusMap).some((s) => s === "streaming");
 export function useAnyChatStreaming(): boolean {
   return useSyncExternalStore(chatStore.subscribe, _anyStreaming, () => false);
+}
+
+// How many soft-closed tabs are stashed on the reopen stack. Returns a primitive so a
+// "reopen closed tab" affordance re-renders only when the count changes. close/reopen both
+// notify via setState, so this stays in sync without threading the stack through ChatState.
+const _closedCount = () => closedSessions.length;
+export function useClosedSessionsCount(): number {
+  return useSyncExternalStore(chatStore.subscribe, _closedCount, () => 0);
 }

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -30,8 +30,37 @@
 
 /* The tab-bar wrapper exists only to scope the right-click context menu (ADR 0036) to the
    tab strip — it generates no box, so the DS TabBar stays the flex child it was. */
+/* A flex row so the Recently-closed menu button (#1525) sits beside the DS TabBar. The
+   TabBar flex-grows (min-width:0 lets it shrink + scroll / go responsive); the trailing
+   button doesn't shrink. With no closed tabs the button renders nothing, so the row looks
+   exactly like the bare TabBar did. */
 .chat-tabbar-wrap {
-  display: contents;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.chat-tabbar-wrap > .pl-tabbar {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.chat-recently-closed {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius);
+  background: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+.chat-recently-closed:hover,
+.chat-recently-closed[data-state="open"] {
+  background: var(--bg-hover);
+  color: var(--fg);
 }
 
 /* Background-agent report card (ADR 0050/0062). The DS system message is a de-emphasized

--- a/apps/web/src/chat/coreSlashCommands.test.ts
+++ b/apps/web/src/chat/coreSlashCommands.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { findSlashCommand } from "../ext/slashRegistry";
-import "./coreSlashCommands"; // side-effect: registers /new, /clear, /effort
+import "./coreSlashCommands"; // side-effect: registers /new, /clear, /close, /effort
 
 import type { SlashContext } from "../ext/slashRegistry";
 
@@ -10,15 +10,21 @@ function ctx(over: Partial<SlashContext> = {}): SlashContext {
 }
 
 describe("core slash commands (dogfood the seam, ADR 0061)", () => {
-  it("registers /new, /clear, /effort through the same registry a fork uses", () => {
+  it("registers /new, /clear, /close, /effort through the same registry a fork uses", () => {
     expect(findSlashCommand("new")).toBeTruthy();
     expect(findSlashCommand("clear")).toBeTruthy();
+    expect(findSlashCommand("close")).toBeTruthy();
     expect(findSlashCommand("effort")).toBeTruthy();
   });
 
-  it("/clear and /effort are no-ops (return false → fall through) without a session", () => {
+  it("/clear, /close and /effort are no-ops (return false → fall through) without a session", () => {
     expect(findSlashCommand("clear")!.run(ctx())).toBe(false);
+    expect(findSlashCommand("close")!.run(ctx())).toBe(false);
     expect(findSlashCommand("effort")!.run(ctx())).toBe(false);
+  });
+
+  it("/close handles the command (returns true) when there is a session", () => {
+    expect(findSlashCommand("close")!.run(ctx({ sessionId: "s1" }))).toBe(true);
   });
 
   it("/effort with an unknown level notes the error and still handles it", () => {

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -38,7 +38,10 @@ registerSlashCommand({
     if (!ctx.sessionId) return false; // no session → not handled (falls through)
     // Soft close: keep the server checkpoint so reopen reconnects the same agent thread.
     // (Delete-forever is the ✕ / shift-click / context-menu path.)
-    chatStore.closeSession(ctx.sessionId);
+    const evicted = chatStore.closeSession(ctx.sessionId);
+    // If the reopen stack overflowed, the evicted tab is no longer reopenable — purge it for
+    // real (harvest=true summarizes it into memory first) so its checkpoint isn't orphaned.
+    if (evicted) void api.deleteChatSession(evicted.id, true).catch(() => {});
     ctx.focusComposer();
     return true;
   },

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -2,8 +2,8 @@
 // uses (`registerSlashCommand`), so the registry is the only path, never a special case
 // (the way the backend's `register_chat_command` has no core bypass). Imported for its
 // side effects by ChatSurface. `/new` opens a tab, `/clear` wipes this tab's history,
-// `/effort` sets this tab's reasoning effort. Behaviour ported verbatim from the old
-// hardcoded `runClientSlash` switch.
+// `/close` soft-closes this tab (reopen with Cmd/Ctrl+Shift+T), `/effort` sets this tab's
+// reasoning effort. Behaviour ported verbatim from the old hardcoded `runClientSlash` switch.
 
 import { registerSlashCommand } from "../ext/slashRegistry";
 import { api } from "../lib/api";
@@ -26,6 +26,19 @@ registerSlashCommand({
     if (!ctx.sessionId) return false; // no session → not handled (falls through)
     void api.deleteChatSession(ctx.sessionId, false).catch(() => {});
     chatStore.updateMessages(ctx.sessionId, []);
+    ctx.focusComposer();
+    return true;
+  },
+});
+
+registerSlashCommand({
+  name: "close",
+  description: "Close this tab (reopen with Cmd/Ctrl+Shift+T)",
+  run: (ctx) => {
+    if (!ctx.sessionId) return false; // no session → not handled (falls through)
+    // Soft close: keep the server checkpoint so reopen reconnects the same agent thread.
+    // (Delete-forever is the ✕ / shift-click / context-menu path.)
+    chatStore.closeSession(ctx.sessionId);
     ctx.focusComposer();
     return true;
   },

--- a/apps/web/src/keybindings/coreKeybindings.ts
+++ b/apps/web/src/keybindings/coreKeybindings.ts
@@ -79,6 +79,18 @@ registerKeybinding({
     chatStore.updateMessages(currentSessionId, []);
   },
 });
+// Reopen the most recently soft-closed tab (the `/close` companion) — the browser's own
+// "reopen closed tab". ⌘⇧T / Ctrl+⇧T is browser-reserved (like ⌘T above): it works in the
+// Tauri desktop app but a plain browser tab swallows it; rebindable in Settings ▸ Keyboard.
+registerKeybinding({
+  id: "chat.reopen",
+  label: "Reopen closed chat",
+  group: "Chat",
+  defaultKeys: "mod+shift+t",
+  scope: "chat",
+  allowInInput: true,
+  run: () => chatStore.reopenLastClosed(),
+});
 registerKeybinding({
   id: "chat.tab.next",
   label: "Next chat tab",


### PR DESCRIPTION
Closes #1525. Round 2, part 1 (client-only). Independent review verdict: **ship**.

## What
- **`/close`** stashes the current chat tab onto an in-memory **LIFO stack** rather than deleting it — the server `a2a:<session_id>` checkpoint **survives**.
- **`Cmd/Ctrl+Shift+T`** (`chat.reopen`) restores the last-closed tab with **full agent context** (reconnects the same thread).
- Distinct from the existing **delete-forever** verb (✕ / shift-click / context-menu / `/clear`), which purges the checkpoint.

## How
- `chat-store`: `closedSessions` LIFO (cap 10); `closeSession()` snapshots + tombstones (reusing `locallyDeletedIds`) + removes without the API call; `reopenLastClosed()` **lifts the tombstone before re-inserting** (the exact bug the design flagged — else the next persist/merge drops it again) and switches to it; `useClosedSessionsCount` selector. `deleteSession`'s list fix-up extracted to a shared `removeSession()` helper (behavior-preserving).
- `/close` mirrors `/clear`; `chat.reopen` registered like `chat.new`/`chat.clear` (scope `chat`, `allowInInput`, rebindable in Settings ▸ Keyboard; ⌘⇧T is browser-reserved but works in Tauri).

## Tests
`chat-store.test.ts` + `coreSlashCommands.test.ts`: 41 targeted pass; broader `src/chat` + `src/keybindings` 108 pass. Covers stash+hide, reopen-restores + tombstone-lift-persists-across-a-second-write, LIFO, empty/unknown no-ops.

## Known low-severity (noted, non-blocking)
- Soft-closing >10 tabs without a reload evicts the oldest from the undo stack; its tombstone/checkpoint aren't cleaned then (bounded, in-memory, by design).
- `useClosedSessionsCount` is exported but there's no visible reopen affordance yet (keybinding only, per the ask).
- The 2 pre-existing DS-0.53.0 tsc errors (App.tsx:883 / ChatSurface.tsx:209) are environment version-skew in untouched files — CI's `npm ci` resolves them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)