### PR TITLE
feat(chat): /compact — summarize + archive a thread, rewrite the checkpoint (#1527)

### DIFF
--- a/apps/web/e2e/commands.spec.ts
+++ b/apps/web/e2e/commands.spec.ts
@@ -6,7 +6,7 @@ import { SLASH_COMMANDS } from "./fixtures.mjs";
 // (GET /api/chat/commands) and autocompletes them as you type "/name".
 
 // Deterministic client-side commands (ADR 0057) surface FIRST, then the server skills.
-const CLIENT_SLASH = ["/new", "/clear", "/effort", "/bypass"];
+const CLIENT_SLASH = ["/new", "/clear", "/compact", "/effort", "/bypass"];
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });

--- a/apps/web/src/chat/coreSlashCommands.test.ts
+++ b/apps/web/src/chat/coreSlashCommands.test.ts
@@ -10,15 +10,17 @@ function ctx(over: Partial<SlashContext> = {}): SlashContext {
 }
 
 describe("core slash commands (dogfood the seam, ADR 0061)", () => {
-  it("registers /new, /clear, /effort through the same registry a fork uses", () => {
+  it("registers /new, /clear, /effort, /compact through the same registry a fork uses", () => {
     expect(findSlashCommand("new")).toBeTruthy();
     expect(findSlashCommand("clear")).toBeTruthy();
     expect(findSlashCommand("effort")).toBeTruthy();
+    expect(findSlashCommand("compact")).toBeTruthy();
   });
 
-  it("/clear and /effort are no-ops (return false → fall through) without a session", () => {
+  it("/clear, /effort, /compact are no-ops (return false → fall through) without a session", () => {
     expect(findSlashCommand("clear")!.run(ctx())).toBe(false);
     expect(findSlashCommand("effort")!.run(ctx())).toBe(false);
+    expect(findSlashCommand("compact")!.run(ctx())).toBe(false);
   });
 
   it("/effort with an unknown level notes the error and still handles it", () => {

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -7,7 +7,14 @@
 
 import { registerSlashCommand } from "../ext/slashRegistry";
 import { api } from "../lib/api";
+import type { ChatMessage } from "../lib/types";
 import { chatStore, DEFAULT_REASONING_EFFORT, REASONING_EFFORTS } from "./chat-store";
+
+// Local id for the system notes /compact posts (the command manages messages
+// directly, like /clear, so it needs to own the ids it can later replace).
+function noteId() {
+  return `sys-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
 
 registerSlashCommand({
   name: "new",
@@ -27,6 +34,74 @@ registerSlashCommand({
     void api.deleteChatSession(ctx.sessionId, false).catch(() => {});
     chatStore.updateMessages(ctx.sessionId, []);
     ctx.focusComposer();
+    return true;
+  },
+});
+
+registerSlashCommand({
+  name: "compact",
+  description: "Summarize & archive older history, keeping recent context",
+  run: (ctx) => {
+    if (!ctx.sessionId) return false; // no session → fall through
+    const sessionId = ctx.sessionId;
+    const messagesOf = () =>
+      chatStore.getSnapshot().sessions.find((s) => s.id === sessionId)?.messages ?? [];
+
+    // Optimistic note (own id so we can drop it once the server responds).
+    const pendingId = noteId();
+    chatStore.updateMessages(sessionId, [
+      ...messagesOf(),
+      {
+        id: pendingId,
+        role: "system",
+        content: "Compacting this conversation — archiving older history and summarizing…",
+        noteTone: "info",
+        createdAt: Date.now(),
+        status: "done",
+      },
+    ]);
+    ctx.focusComposer();
+
+    const note = (content: string, tone: ChatMessage["noteTone"]): ChatMessage => ({
+      id: noteId(),
+      role: "system",
+      content,
+      noteTone: tone,
+      createdAt: Date.now(),
+      status: "done",
+    });
+    // Drop only the optimistic note — preserve anything that streamed in meanwhile.
+    const withoutPending = () => messagesOf().filter((m) => m.id !== pendingId);
+
+    void api
+      .compactChatSession(sessionId)
+      .then((res) => {
+        // Never-lossy: only drop history when the server actually rewrote the
+        // checkpoint (archived + removed > 0). Otherwise just surface the status.
+        if (res.refused || !res.archived || res.removed <= 0) {
+          chatStore.updateMessages(sessionId, [
+            ...withoutPending(),
+            note(res.message, res.refused ? "warning" : "info"),
+          ]);
+          return;
+        }
+        // Mirror the server: replace the view with a summary bubble + the recent
+        // tail. Slice from the CURRENT messages (minus the pending note) so nothing
+        // that arrived during the compaction is lost.
+        const kept = res.kept > 0 ? withoutPending().slice(-res.kept) : [];
+        const summary = note(
+          `**Conversation compacted.** ${res.message}\n\n---\n\n${res.summary}`,
+          "success",
+        );
+        chatStore.updateMessages(sessionId, [summary, ...kept]);
+      })
+      .catch(() => {
+        chatStore.updateMessages(sessionId, [
+          ...withoutPending(),
+          note("Compaction failed — nothing was changed.", "danger"),
+        ]);
+      });
+
     return true;
   },
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1170,6 +1170,25 @@ export const api = {
     );
   },
 
+  // Compact a chat session server-side (#1527): archive the raw history into
+  // searchable memory, summarize it, and rewrite the LangGraph checkpoint to
+  // [summary, recent tail] so the agent keeps context at lower token cost. The
+  // checkpoint is the agent's REAL context, so this must be server-side — a
+  // client-only trim would leave the agent's context untouched. `refused` (never
+  // lossy: nothing could be archived) means the server left the thread intact.
+  compactChatSession(sessionId: string) {
+    return request<{
+      summary: string;
+      archived_chunks: number;
+      kept: number;
+      removed: number;
+      archived: boolean;
+      refused: boolean;
+      reason: string;
+      message: string;
+    }>(`/api/chat/sessions/${encodeURIComponent(sessionId)}/compact`, { method: "POST", body: {} });
+  },
+
   async streamChat(
     message: string,
     sessionId: string,

--- a/graph/compaction_op.py
+++ b/graph/compaction_op.py
@@ -1,0 +1,219 @@
+"""On-demand conversation compaction — the ``/compact`` operator gesture (#1527).
+
+This is the *manual*, whole-thread analogue of the automatic
+``SummarizationMiddleware`` (``graph/middleware/compaction.py``): instead of
+waiting for the context window to fill, an operator asks for a compaction now.
+The live LangGraph checkpoint is the agent's *real* context, so a client-only
+compaction would do nothing — this runs SERVER-SIDE against the checkpointer.
+
+The pass, for one thread:
+
+1. ``aget_state`` the current messages off the checkpoint.
+2. Render the **full** transcript and archive it into the searchable knowledge
+   store (``domain="conversation"``, ``namespace="chat-archive:<session_id>"``)
+   so nothing is lost — the raw history stays recallable via ``memory_recall``.
+3. Summarize the conversation with the cheap aux model.
+4. Rewrite the checkpoint to ``[RemoveMessage(REMOVE_ALL_MESSAGES), summary,
+   *recent_tail]`` via ``aupdate_state`` — so the next turn carries the whole
+   thread's context at a fraction of the token cost.
+
+**Never-lossy (hard invariant).** Compaction must never drop history it could
+not archive. If there is no knowledge store, or the archive write yields no
+chunks, or the summarizer produces nothing, we DO NOT touch the checkpoint and
+return ``refused=True`` — the operator keeps their full, intact context.
+
+**Message-boundary integrity (hard invariant).** The recent tail must never
+orphan a ``ToolMessage`` from the ``AIMessage(tool_calls=…)`` that spawned it —
+the next model call errors ("tool_call without response"). We reuse the same
+safe-cut the auto-summarizer uses: if the naive cutoff lands on a
+``ToolMessage``, walk back to include its parent ``AIMessage`` (so the pair is
+kept together), summarizing slightly more rather than splitting a pair.
+
+Host-free and unit-testable: it takes the graph, checkpointer, knowledge store,
+and config as arguments (no ``STATE`` import), mirroring
+``conversation_harvest.harvest_thread``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from graph.conversation_harvest import _default_summarizer, render_transcript
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_KEEP_MESSAGES = 20
+
+
+def _safe_cut_index(messages: list, keep_last: int) -> int:
+    """Index where the retained tail should start so it keeps at least
+    ``keep_last`` messages WITHOUT orphaning a ``ToolMessage`` from its parent
+    ``AIMessage``.
+
+    Mirrors ``SummarizationMiddleware._find_safe_cutoff`` /
+    ``_find_safe_cutoff_point``: land ``keep_last`` from the end, then, if that
+    lands on a ``ToolMessage``, walk *back* to the ``AIMessage`` whose
+    ``tool_calls`` produced it so the tool request/response pair stays together
+    (falling forward past the tool block only if no parent is found). Returns 0
+    when everything fits — keep it all.
+    """
+    n = len(messages)
+    if keep_last <= 0:
+        target = n  # keep nothing but the summary
+    elif n <= keep_last:
+        return 0
+    else:
+        target = n - keep_last
+
+    if target >= n or not isinstance(messages[target], ToolMessage):
+        return target
+
+    # target sits on a ToolMessage — gather the ids of the consecutive tool block
+    # and search backward for the AIMessage that requested them.
+    tool_call_ids: set[str] = set()
+    idx = target
+    while idx < n and isinstance(messages[idx], ToolMessage):
+        tcid = getattr(messages[idx], "tool_call_id", None)
+        if tcid:
+            tool_call_ids.add(tcid)
+        idx += 1
+    for i in range(target - 1, -1, -1):
+        m = messages[i]
+        if isinstance(m, AIMessage) and getattr(m, "tool_calls", None):
+            ai_ids = {tc.get("id") for tc in m.tool_calls if tc.get("id")}
+            if tool_call_ids & ai_ids:
+                return i
+    # No matching AIMessage (edge case) — fall forward past the orphan tool block.
+    return idx
+
+
+def _refused(reason: str, *, kept: int, archived: bool = False, archived_chunks: int = 0, summary: str = "") -> dict:
+    """A no-rewrite result. ``refused`` is the never-lossy signal (the caller must
+    NOT drop client history); ``too_short`` is a benign no-op, not a refusal."""
+    return {
+        "summary": summary,
+        "archived_chunks": archived_chunks,
+        "kept": kept,
+        "removed": 0,
+        "archived": archived,
+        "refused": reason not in ("", "too_short"),
+        "reason": reason,
+    }
+
+
+async def compact_thread(
+    graph,
+    checkpointer,
+    knowledge_store,
+    config,
+    thread_id: str,
+    session_id: str,
+    *,
+    summarizer=_default_summarizer,
+    keep_recent: int | None = None,
+) -> dict:
+    """Compact ``thread_id``'s live context: archive the raw transcript, summarize,
+    then rewrite the checkpoint to ``[summary, *recent_tail]``.
+
+    Returns ``{summary, archived_chunks, kept, removed, archived, refused,
+    reason}``. Honors the never-lossy invariant — a rewrite happens ONLY after the
+    raw history is safely archived and a non-empty summary exists.
+    """
+    if graph is None or checkpointer is None:
+        return _refused("no_checkpointer", kept=0)
+
+    lg_config = {"configurable": {"thread_id": thread_id}}
+    snapshot = await graph.aget_state(lg_config)
+    messages = list((getattr(snapshot, "values", None) or {}).get("messages") or [])
+
+    keep = keep_recent if keep_recent is not None else getattr(config, "compaction_keep_messages", _DEFAULT_KEEP_MESSAGES)
+    keep = max(0, int(keep))
+
+    # Already small enough — nothing to gain, nothing removed (not a refusal).
+    if len(messages) <= keep:
+        return _refused("too_short", kept=len(messages))
+
+    # Never-lossy: no archive target ⇒ never touch the checkpoint.
+    if knowledge_store is None:
+        return _refused("no_store", kept=len(messages))
+
+    # Archive the FULL transcript (uncapped) so the raw history is recallable —
+    # a capped render would silently drop the head we're about to remove.
+    full_transcript = render_transcript(messages, max_chars=None)
+    if not full_transcript.strip():
+        # Nothing renderable to archive (e.g. an all-tool-noise thread) — refuse
+        # rather than drop un-archived history.
+        return _refused("empty", kept=len(messages))
+
+    import asyncio
+
+    from knowledge import add_document
+
+    # add_document does blocking gateway work per chunk (embed + optional
+    # enrichment) — keep it off the event loop (mirrors conversation_harvest).
+    try:
+        chunk_ids = await asyncio.to_thread(
+            add_document,
+            knowledge_store,
+            full_transcript,
+            domain="conversation",
+            heading=f"Conversation archive ({session_id})",
+            namespace=f"chat-archive:{session_id}",
+        )
+    except Exception:
+        log.exception("[compact] archive failed for thread %s — refusing to rewrite", thread_id)
+        return _refused("archive_error", kept=len(messages))
+    if not chunk_ids:
+        return _refused("empty_archive", kept=len(messages))
+
+    # Summarize the capped tail (cost-bounded classification-grade work); the head
+    # beyond the cap is already archived + searchable, not lost.
+    try:
+        summary = (await summarizer(render_transcript(messages), config)).strip()
+    except Exception:
+        # The archive already succeeded; a summarizer failure must not 500 or leave
+        # the checkpoint half-rewritten. Refuse (never-lossy) — the raw history stands
+        # as a searchable archive and the live context is untouched.
+        log.exception("[compact] summarize failed for thread %s — refusing to rewrite", thread_id)
+        return _refused("summary_error", kept=len(messages), archived=True, archived_chunks=len(chunk_ids))
+    if not summary:
+        # We DID archive, but with no summary a rewrite would strip the context
+        # thread — keep the full live context (archive stands as a searchable bonus).
+        return _refused("no_summary", kept=len(messages), archived=True, archived_chunks=len(chunk_ids))
+
+    cut = _safe_cut_index(messages, keep)
+    recent_tail = messages[cut:]
+
+    from langchain_core.messages import RemoveMessage
+    from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
+    summary_msg = HumanMessage(
+        content=(
+            "Here is a summary of the earlier conversation "
+            "(the full transcript is archived and searchable via memory recall):\n\n"
+            f"{summary}"
+        ),
+        additional_kwargs={"lc_source": "compaction"},
+    )
+    await graph.aupdate_state(
+        lg_config,
+        {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), summary_msg, *recent_tail]},
+    )
+    log.info(
+        "[compact] thread %s: archived %d chunk(s), removed %d msg(s), kept %d",
+        thread_id,
+        len(chunk_ids),
+        cut,
+        len(recent_tail),
+    )
+    return {
+        "summary": summary,
+        "archived_chunks": len(chunk_ids),
+        "kept": len(recent_tail),
+        "removed": cut,
+        "archived": True,
+        "refused": False,
+        "reason": "",
+    }

--- a/graph/conversation_harvest.py
+++ b/graph/conversation_harvest.py
@@ -24,12 +24,14 @@ log = logging.getLogger(__name__)
 _MAX_TRANSCRIPT_CHARS = 16000
 
 
-def render_transcript(messages: list) -> str:
+def render_transcript(messages: list, *, max_chars: int | None = _MAX_TRANSCRIPT_CHARS) -> str:
     """Render a User/Assistant transcript from checkpoint messages.
 
     Assistant turns are run through ``extract_output`` (drop scratch_pad/think);
-    tool and system messages are skipped. Returns the most-recent
-    ``_MAX_TRANSCRIPT_CHARS`` when long.
+    tool and system messages are skipped. Truncated to the most-recent
+    ``max_chars`` when long; pass ``max_chars=None`` for the full transcript (the
+    compaction path archives the *whole* conversation losslessly before it
+    rewrites the live context — a capped render would silently drop the head).
     """
     lines: list[str] = []
     for m in messages:
@@ -43,8 +45,8 @@ def render_transcript(messages: list) -> str:
             if clean:
                 lines.append(f"Assistant: {clean}")
     transcript = "\n".join(lines)
-    if len(transcript) > _MAX_TRANSCRIPT_CHARS:
-        transcript = "…\n" + transcript[-_MAX_TRANSCRIPT_CHARS:]
+    if max_chars is not None and len(transcript) > max_chars:
+        transcript = "…\n" + transcript[-max_chars:]
     return transcript
 
 

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -27,7 +27,7 @@ from runtime.state import STATE
 log = logging.getLogger("protoagent.server")
 from server import agent_name
 from server.agent_init import _retire_thread
-from server.chat import chat
+from server.chat import chat, compact_session
 
 
 class ChatRequest(BaseModel):
@@ -74,6 +74,19 @@ def register_chat_routes(app, ui: str) -> None:
             except Exception as exc:  # noqa: BLE001 — cleanup is best-effort
                 log.warning("[chat] attachment cleanup failed for %s: %s", session_id, exc)
         return {"deleted": True, "harvested": chunk_id is not None}
+
+    @app.post("/api/chat/sessions/{session_id}/compact")
+    async def _api_compact_session(session_id: str):
+        """Compact a chat session's live context (#1527): archive the raw history
+        into searchable memory, summarize it, and rewrite the LangGraph checkpoint
+        to ``[summary, recent tail]`` so the agent keeps context at lower token
+        cost. Runs SERVER-SIDE — the checkpoint is the agent's real context, so a
+        client-only compaction would do nothing.
+
+        Never-lossy: if there's no store or the archive write yields nothing, the
+        checkpoint is left untouched and ``refused`` is true (the console then
+        keeps the full thread rather than dropping anything)."""
+        return await compact_session(session_id)
 
     @app.post("/api/chat/sessions/{session_id}/steer")
     async def _api_steer(session_id: str, body: dict | None = None):

--- a/server/chat.py
+++ b/server/chat.py
@@ -1162,6 +1162,62 @@ async def _chat_langgraph_stream(
             tracing.flush()
 
 
+def _compaction_message(result: dict) -> str:
+    """Human-readable status line for a compaction result — surfaced as the
+    system-note in the chat thread (and returned to non-UI callers)."""
+    reason = result.get("reason") or ""
+    if reason == "too_short":
+        return f"Nothing to compact — this conversation is already short ({result.get('kept', 0)} messages)."
+    if reason == "no_store":
+        return (
+            "Compaction skipped — no searchable knowledge store is configured, so the raw history "
+            "couldn't be archived. Nothing was changed (your full context is intact)."
+        )
+    if reason in ("empty", "empty_archive", "archive_error"):
+        return "Compaction skipped — the conversation couldn't be archived, so nothing was changed."
+    if reason in ("no_summary", "summary_error"):
+        return (
+            f"Archived {result.get('archived_chunks', 0)} chunk(s) to searchable memory, but the summary "
+            "couldn't be generated — kept your full context rather than compacting it."
+        )
+    if reason == "no_checkpointer":
+        return "Compaction unavailable — no conversation checkpoint to compact."
+    removed, kept = result.get("removed", 0), result.get("kept", 0)
+    return (
+        f"Compacted this conversation — archived {removed} older message(s) to searchable memory and kept the "
+        f"last {kept}. The agent now carries a summary of the earlier messages plus the recent ones, at a "
+        f"fraction of the token cost; the full raw history stays searchable via memory recall."
+    )
+
+
+async def compact_session(session_id: str, *, request_metadata: dict | None = None) -> dict:
+    """Compact a chat session's live context (the ``/compact`` gesture, #1527).
+
+    Resolves the session's checkpointer ``thread_id`` (the A2A ``a2a:<session_id>``
+    thread — the one the live streaming turns write to) and runs
+    ``compact_thread`` under the per-thread lock, so a compaction can never race a
+    live streaming turn on the same thread (mirrors the turn driver). Returns the
+    ``compact_thread`` result dict plus a human-readable ``message``.
+    """
+    base = {"summary": "", "archived_chunks": 0, "kept": 0, "removed": 0, "archived": False, "refused": True}
+    if STATE.graph is None:
+        return {**base, "reason": "setup", "message": "Setup required — finish the setup wizard first."}
+
+    from graph.compaction_op import compact_thread
+
+    tid = _resolve_thread_id(request_metadata, session_id)
+    async with _thread_lock(tid):
+        result = await compact_thread(
+            STATE.graph,
+            STATE.checkpointer,
+            STATE.knowledge_store,
+            STATE.graph_config,
+            tid,
+            session_id,
+        )
+    return {**result, "message": _compaction_message(result)}
+
+
 async def _chat_langgraph(message: str, session_id: str, *, model: str | None = None) -> list[dict[str, Any]]:
     """Non-streaming LangGraph entry — used by the console + OpenAI-compat."""
     from observability import tracing

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -79,6 +79,34 @@ def test_delete_session_harvest_is_opt_in(monkeypatch):
     ]
 
 
+def test_compact_session_route(monkeypatch):
+    # The route is a thin pass-through to server.chat.compact_session — forwards the
+    # path session_id and returns the compaction result dict verbatim.
+    import operator_api.chat_routes as cr
+
+    seen: list[str] = []
+
+    async def _fake_compact(session_id):
+        seen.append(session_id)
+        return {
+            "summary": "s",
+            "archived_chunks": 2,
+            "kept": 4,
+            "removed": 9,
+            "archived": True,
+            "refused": False,
+            "reason": "",
+            "message": "Compacted this conversation",
+        }
+
+    monkeypatch.setattr(cr, "compact_session", _fake_compact)
+    c = _client(monkeypatch)
+    body = c.post("/api/chat/sessions/s1/compact").json()
+    assert seen == ["s1"]
+    assert body["removed"] == 9 and body["kept"] == 4 and body["archived"] is True
+    assert body["message"] == "Compacted this conversation"
+
+
 def test_delete_session_cleans_ephemeral_attachments(monkeypatch):
     """Deleting a chat drops its session-scoped attachment chunks."""
     import operator_api.chat_routes as cr

--- a/tests/test_compaction_op.py
+++ b/tests/test_compaction_op.py
@@ -1,0 +1,189 @@
+"""Tests for on-demand conversation compaction (the /compact gesture, #1527)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage, ToolMessage
+from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
+from graph.checkpointer import build_sqlite_checkpointer
+from graph.compaction_op import compact_thread
+
+
+class _FakeGraph:
+    """Records aupdate_state calls; serves seeded messages from aget_state."""
+
+    def __init__(self, messages):
+        self._messages = messages
+        self.updates: list = []
+
+    async def aget_state(self, config):
+        return SimpleNamespace(values={"messages": list(self._messages)})
+
+    async def aupdate_state(self, config, update):
+        self.updates.append((config, update))
+
+
+class _FakeKnowledge:
+    def __init__(self, *, yields=True):
+        self.docs: list = []
+        self._yields = yields
+
+    def add_document(self, content, *, domain=None, heading=None, namespace=None, **kw):
+        self.docs.append({"content": content, "domain": domain, "heading": heading, "namespace": namespace})
+        return [1, 2] if self._yields else []
+
+
+async def _summ(transcript, config):
+    return "SUMMARY: user likes teal"
+
+
+async def _boom(transcript, config):
+    raise AssertionError("summarizer must not run on this path")
+
+
+async def _raise_summ(transcript, config):
+    raise RuntimeError("gateway down")
+
+
+def _cfg(keep):
+    return SimpleNamespace(compaction_keep_messages=keep)
+
+
+def test_compact_archives_and_rewrites_checkpoint():
+    msgs = [
+        HumanMessage(content="hi", id="h1"),
+        AIMessage(content="hello", id="a1"),
+        HumanMessage(content="favorite color?", id="h2"),
+        AIMessage(content="teal", id="a2"),
+    ]
+    g = _FakeGraph(msgs)
+    kb = _FakeKnowledge()
+    res = asyncio.run(compact_thread(g, object(), kb, _cfg(2), "a2a:s1", "s1", summarizer=_summ))
+
+    # Raw transcript archived into the conversation domain, session-scoped namespace.
+    assert kb.docs[0]["domain"] == "conversation"
+    assert kb.docs[0]["namespace"] == "chat-archive:s1"
+    assert "teal" in kb.docs[0]["content"] and "favorite color" in kb.docs[0]["content"]
+
+    assert res["summary"] == "SUMMARY: user likes teal"
+    assert res["archived"] is True and res["refused"] is False
+    assert res["removed"] == 2 and res["kept"] == 2 and res["archived_chunks"] == 2
+
+    # Checkpoint rewritten to [REMOVE_ALL, summary, *keep_recent].
+    assert len(g.updates) == 1
+    _config, update = g.updates[0]
+    out = update["messages"]
+    assert isinstance(out[0], RemoveMessage) and out[0].id == REMOVE_ALL_MESSAGES
+    assert isinstance(out[1], HumanMessage) and "SUMMARY: user likes teal" in out[1].content
+    assert out[1].additional_kwargs.get("lc_source") == "compaction"
+    assert [m.id for m in out[2:]] == ["h2", "a2"]  # the recent tail, untouched
+
+
+def test_compact_preserves_tool_call_pairing():
+    # Naive cutoff at keep=2 lands on the 2nd ToolMessage — the safe-cut must walk
+    # back to the AIMessage that spawned it so the pair isn't orphaned.
+    msgs = [
+        HumanMessage(content="q1", id="h1"),
+        AIMessage(content="", id="a1", tool_calls=[{"id": "t1", "name": "search", "args": {}}]),
+        ToolMessage(content="res1", id="tm1", tool_call_id="t1"),
+        AIMessage(content="answer1", id="a2"),
+        HumanMessage(content="q2", id="h2"),
+        AIMessage(content="", id="a3", tool_calls=[{"id": "t2", "name": "search", "args": {}}]),
+        ToolMessage(content="res2", id="tm2", tool_call_id="t2"),
+        AIMessage(content="answer2", id="a4"),
+    ]
+    g = _FakeGraph(msgs)
+    res = asyncio.run(compact_thread(g, object(), _FakeKnowledge(), _cfg(2), "a2a:s1", "s1", summarizer=_summ))
+
+    _config, update = g.updates[0]
+    tail = update["messages"][2:]
+    # The tail starts on the AIMessage(tool_calls) — NOT the orphaned ToolMessage.
+    assert [m.id for m in tail] == ["a3", "tm2", "a4"]
+    assert isinstance(tail[0], AIMessage) and tail[0].tool_calls
+    assert isinstance(tail[1], ToolMessage) and tail[1].tool_call_id == "t2"
+    assert res["removed"] == 5 and res["kept"] == 3
+
+
+def test_compact_refuses_without_store():
+    # Never-lossy: no archive target ⇒ the checkpoint is left untouched.
+    msgs = [HumanMessage(content=f"m{i}", id=f"m{i}") for i in range(6)]
+    g = _FakeGraph(msgs)
+    res = asyncio.run(compact_thread(g, object(), None, _cfg(2), "a2a:s1", "s1", summarizer=_boom))
+    assert res["refused"] is True and res["archived"] is False and res["reason"] == "no_store"
+    assert g.updates == []  # NO rewrite
+
+
+def test_compact_refuses_when_archive_yields_nothing():
+    # Never-lossy: archive wrote no chunks ⇒ don't rewrite (and don't even summarize).
+    msgs = [HumanMessage(content=f"m{i}", id=f"m{i}") for i in range(6)]
+    g = _FakeGraph(msgs)
+    kb = _FakeKnowledge(yields=False)
+    res = asyncio.run(compact_thread(g, object(), kb, _cfg(2), "a2a:s1", "s1", summarizer=_boom))
+    assert res["refused"] is True and res["archived"] is False and res["reason"] == "empty_archive"
+    assert g.updates == []
+
+
+def test_compact_refuses_when_summarizer_raises():
+    # Never-lossy: the archive already succeeded, but a summarizer exception must NOT
+    # 500 or half-rewrite the checkpoint — refuse and leave the live context intact.
+    msgs = [HumanMessage(content=f"m{i}", id=f"m{i}") for i in range(6)]
+    g = _FakeGraph(msgs)
+    kb = _FakeKnowledge()
+    res = asyncio.run(compact_thread(g, object(), kb, _cfg(2), "a2a:s1", "s1", summarizer=_raise_summ))
+    assert res["refused"] is True and res["reason"] == "summary_error"
+    assert res["archived"] is True and res["archived_chunks"] == 2  # the archive stands
+    assert g.updates == []  # NO checkpoint rewrite
+
+
+def test_compact_noop_when_already_short():
+    msgs = [HumanMessage(content="hi", id="h1"), AIMessage(content="yo", id="a1")]
+    g = _FakeGraph(msgs)
+    kb = _FakeKnowledge()
+    res = asyncio.run(compact_thread(g, object(), kb, _cfg(20), "a2a:s1", "s1", summarizer=_boom))
+    assert res["refused"] is False and res["reason"] == "too_short" and res["removed"] == 0
+    assert g.updates == [] and kb.docs == []  # nothing archived, nothing rewritten
+
+
+def test_compact_refuses_without_checkpointer():
+    res = asyncio.run(compact_thread(_FakeGraph([]), None, _FakeKnowledge(), _cfg(2), "a2a:s1", "s1", summarizer=_boom))
+    assert res["refused"] is True and res["reason"] == "no_checkpointer"
+
+
+def test_compact_rewrites_real_sqlite_checkpoint(tmp_path):
+    """End-to-end against a real compiled graph + SQLite checkpointer: the rewrite
+    actually lands (proves aupdate_state applies REMOVE_ALL + reducer, no as_node
+    ambiguity) and the resulting checkpoint is [summary, *recent_tail]."""
+    db = str(tmp_path / "c.db")
+    g = StateGraph(MessagesState)
+    g.add_node("n", lambda s: {"messages": []})  # no-op — we seed via the input
+    g.add_edge(START, "n")
+    g.add_edge("n", END)
+    saver = build_sqlite_checkpointer(db)
+    app = g.compile(checkpointer=saver)
+    cfg = {"configurable": {"thread_id": "a2a:s1"}}
+    seed = [
+        HumanMessage(content="q1"),
+        AIMessage(content="", tool_calls=[{"id": "t1", "name": "search", "args": {}}]),
+        ToolMessage(content="res1", tool_call_id="t1"),
+        AIMessage(content="answer1"),
+        HumanMessage(content="q2"),
+        AIMessage(content="answer2"),
+    ]
+    kb = _FakeKnowledge()
+
+    async def run():
+        await app.ainvoke({"messages": seed}, cfg)
+        res = await compact_thread(app, saver, kb, _cfg(2), "a2a:s1", "s1", summarizer=_summ)
+        snap = await app.aget_state(cfg)
+        return res, snap.values["messages"]
+
+    res, final = asyncio.run(run())
+    assert res["archived"] is True and res["removed"] == 4 and res["kept"] == 2
+    # [summary(Human), q2, answer2] — everything before the recent tail collapsed.
+    assert len(final) == 3
+    assert "SUMMARY" in final[0].content and final[0].additional_kwargs.get("lc_source") == "compaction"
+    assert final[1].content == "q2" and final[2].content == "answer2"


### PR DESCRIPTION
Closes #1527. Round 2, part 2. Independent review verdict: **ship** — but **not auto-merged**: it rewrites live LangGraph checkpoints (agent memory), so I'm holding it for your review + a live test first.

## What
Server-side `/compact`: summarize the current thread → archive the **full** raw transcript to the searchable knowledge store (`domain=conversation`, `namespace=chat-archive:<session_id>`) → rewrite the checkpoint to `[RemoveMessage(REMOVE_ALL_MESSAGES), summary, *recent_tail]`. The manual analogue of the automatic `SummarizationMiddleware`.

`graph/compaction_op.py` (host-free) → `server.chat.compact_session` (under `_thread_lock`) → `POST /api/chat/sessions/{id}/compact`; `/compact` client command + `api.compactChatSession`.

## Two hard invariants (verified by review)
- **Never-lossy** — the checkpoint is rewritten **only after** the raw history is archived *and* a non-empty summary exists. Refuses (no change) on `no_store` / `empty_archive` / `archive_error` / `no_summary` / `summary_error` / `no_checkpointer`.
- **Message-boundary integrity** — the retained tail never orphans a `ToolMessage` from its parent `AIMessage(tool_calls)` (reuses the middleware's safe-cut). Tested against a tool-call thread + a real-SQLite e2e.

The reviewer independently confirmed `aupdate_state` applies in a **multi-node** graph (the e2e used a single node), and that there are no new import-layering edges.

## Fixes I applied on top of the impl (from review)
- Wrapped the summarizer call in try/except → refuse `summary_error` (never-lossy, no 500) + a test.
- Corrected the success-note copy (it no longer overstates "keeps the full context"; says it carries a summary + recent tail, raw stays searchable).

## Accepted tradeoffs (noted, non-blocking)
- Long threads: the summarizer sees the 16k-char-capped tail (cost-bound); the head lives in the searchable archive, not auto in live context.
- The injected summary is a `HumanMessage` (mirrors `SummarizationMiddleware`) → on reload it renders as a user bubble.

## Verification done / still wanted
Done: `ruff` clean; `pytest -k compact` 37 + `test_compaction_op.py` 8 pass; changed TS typechecks clean. **Wanted before merge:** a live `/compact` on a real thread (needs a gateway for the aux summarizer) — I can wire a gateway into an isolated dev instance, or you run it on yours. Your call on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)