### PR TITLE
fix(issue-template): drop expected-vs-actual, make acceptance optional on bug form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -25,19 +25,12 @@ body:
     validations:
       required: true
   - type: textarea
-    id: expected-actual
-    attributes:
-      label: Expected vs. actual
-      description: What you expected to happen, and what actually happened.
-    validations:
-      required: true
-  - type: textarea
     id: acceptance
     attributes:
       label: Acceptance
       description: How we'll know it's fixed — verifiable criteria.
     validations:
-      required: true
+      required: false
   - type: input
     id: env
     attributes:


### PR DESCRIPTION
## What

Two changes to `.github/ISSUE_TEMPLATE/bug.yml`:

1. **Remove the "Expected vs. actual" field** from the bug report form.
2. **Make the "Acceptance" field optional** (`required: true` → `required: false`).

## Why

Per the maintainer's request — trim friction on the bug form. The required
fields still map cleanly to the issue gate (`.github/workflows/issue-gate.yml`):

- For `bug`-labeled issues the gate only requires a **Problem** section plus
  **Steps to reproduce / evidence** — it never required Acceptance for bugs
  (that check is enhancement-only).
- `hasRepro` is satisfied by "Steps to reproduce / evidence," so removing the
  expected-vs-actual field does **not** cause false `needs-info` labels.

No workflow change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)