### PR TITLE
chore: release v0.78.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.78.0] - 2026-07-01
+
 ### Added
 - **Developer panel — view & toggle developer flags** (#1506, ADR 0068). A new **Settings ▸ Developer**
   section (surfaced only off prod — a dev build, a non-prod `developer.channel`, or a `?dev` reveal —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.77.0"
+version = "0.78.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,35 @@
 [
   {
+    "version": "v0.78.0",
+    "date": "2026-07-01",
+    "changes": [
+      "Developer panel — view & toggle developer flags",
+      "Developer flags — backend foundation",
+      "Chat composer: terminal-style input history",
+      "Artifact panel: pan & zoom for diagrams",
+      "registerKeybinding on the fork extension seam",
+      "Watch primitive — supervise many external conditions at once",
+      "sdk.run_in_session(session_id, prompt)",
+      "Two-credential auth: auth.federation_token",
+      "Console set-goal form",
+      "Chat: slash commands trigger mid-input + render as command bubbles",
+      "Agent switcher: always available, with a Fleet-settings shortcut",
+      "Chat: Cmd/Ctrl+O toggles the latest tool-call block",
+      "Chat: /compact — summarize + archive a long thread",
+      "Knowledge panel: Upload / Add now open in a dialog",
+      "Goal mode is now drive-only; the monitor disposition is retired",
+      "Goal continuation protocol → tools",
+      "The A2A-streaming and non-streaming goal drive loops are unified (#1497), fixing a fresh-context thread-id drift.",
+      "Settings sub-panels share one container",
+      "wait tool output is conversational",
+      "Desktop app builds are on-demand",
+      "RCE-via-chat closed",
+      "Watch evaluation is serialized per watch id",
+      "New ADR 0066 (federation token + operator channel) and ADR 0067 (watch primitive); ADR 0030 marked superseded",
+      "PROTO.md § Run it"
+    ]
+  },
+  {
     "version": "v0.77.0",
     "date": "2026-07-01",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.78.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.78.0 -m 'Release v0.78.0' && git push origin v0.78.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).