### PR TITLE
fix(console-dev): default vite proxy to isolated :7871, not prod :7870

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Console dev server no longer defaults to the prod backend.** `apps/web/vite.config.ts` proxied
+  `npm run dev` / `npm run preview` backend calls to `:7870` (the default/prod instance the desktop
+  app runs) by default — so browser-based console development silently read and **wrote your real
+  `~/.protoagent` data**. It now defaults to the **isolated dev instance `:7871`** (`scripts/dev.sh`),
+  which is fail-safe (a clean "can't connect" when no dev backend is up, never a silent prod hit),
+  and prints a **loud red guard** if `PROTOAGENT_API_BASE` is ever pointed at `:7870`.
+
 ## [0.78.0] - 2026-07-01
 
 ### Added

--- a/PROTO.md
+++ b/PROTO.md
@@ -51,6 +51,14 @@ TypeScript is the console.
   the source of truth; `uv.lock` is tracked). `uv sync` to install.
 - **Console deps:** `npm ci` at the repo root (npm workspaces; the web app is
   `@protoagent/web`).
+- **Console dev loop (frontend):** `npm run dev` (HMR) / `npm run preview` (built dist) serve
+  the console on `:5173` and **proxy all backend calls (`/api`, `/a2a`, events, `/agents`,
+  `/plugins`, `/_ds`) to `PROTOAGENT_API_BASE`, default `http://127.0.0.1:7871`** — the
+  ISOLATED dev instance from `scripts/dev.sh`, **not** the default/prod `:7870` the desktop app
+  runs. So the correct loop is *`scripts/dev.sh` (backend, :7871) + `npm run dev` (frontend)* —
+  both isolated, so dev testing never touches your `~/.protoagent` data. Vite prints a loud red
+  guard if you ever point `PROTOAGENT_API_BASE` at `:7870`. (Historically it defaulted to
+  `:7870`, which silently crossed dev traffic into the prod/desktop instance.)
 
 ## Must pass before opening a PR
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,7 +3,27 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, new URL("../..", import.meta.url).pathname, "PROTOAGENT_");
-  const apiBase = env.PROTOAGENT_API_BASE || "http://127.0.0.1:7870";
+  // The dev/preview server proxies the console's backend calls to `apiBase`. It DEFAULTS to the
+  // ISOLATED dev instance (:7871, what `scripts/dev.sh` runs) — deliberately NOT the default/prod
+  // instance (:7870, what the desktop app runs). Rationale: `npm run dev`/`preview` must never
+  // silently read/write your real ~/.protoagent data. If no dev backend is up on :7871 you get a
+  // clean "can't connect" (fail-safe) instead of a silent prod hit. Override with PROTOAGENT_API_BASE.
+  const apiBase = env.PROTOAGENT_API_BASE || "http://127.0.0.1:7871";
+
+  // Loud guard: proxying the dev frontend at :7870 points it straight at the default/prod
+  // (desktop-app) instance — every console action would hit your real data. Scream about it.
+  if (apiBase.indexOf(":7870") !== -1) {
+    const bar = Array(77).join("═"); // ES5-safe (tsconfig.node lib predates String.repeat)
+    console.warn(
+      `\n\x1b[41m\x1b[97m\x1b[1m ${bar} \x1b[0m` +
+        `\n\x1b[41m\x1b[97m\x1b[1m  ⚠  DEV FRONTEND → ${apiBase} — the PROD / desktop-app backend (:7870).           \x1b[0m` +
+        `\n\x1b[41m\x1b[97m\x1b[1m     Console actions (chat, goals, /compact…) will read/WRITE your real          \x1b[0m` +
+        `\n\x1b[41m\x1b[97m\x1b[1m     ~/.protoagent data. Use an ISOLATED dev backend instead:                    \x1b[0m` +
+        `\n\x1b[41m\x1b[97m\x1b[1m       scripts/dev.sh          # isolated instance on :7871                       \x1b[0m` +
+        `\n\x1b[41m\x1b[97m\x1b[1m       unset PROTOAGENT_API_BASE (defaults to :7871), or set it to :7871.         \x1b[0m` +
+        `\n\x1b[41m\x1b[97m\x1b[1m ${bar} \x1b[0m\n`,
+    );
+  }
 
   // Module Federation was retired (ADR 0038): plugin UI is sandboxed iframes (untrusted /
   // generative) + the build-time fork seam (trusted) — no runtime remote loading.


### PR DESCRIPTION
## The bug (data crossing dev ↔ prod)
`apps/web/vite.config.ts` proxied the dev/preview server's backend calls — `/api`, `/a2a`, `/v1`, events, `/agents`, `/plugins`, `/_ds`, `/healthz` — to **`http://127.0.0.1:7870` by default**. That's the **default/prod instance the desktop app runs** (`~/.protoagent`). So doing console dev in the browser (`npm run dev`/`preview`) silently **read and wrote the desktop app's real data** — chats, goals, `/compact`, everything.

Yesterday's ADR-0065 instance isolation made the *backends* separable (`:7871` via `scripts/dev.sh` with its own data), but this frontend-proxy layer still pointed straight at prod, bypassing all of it.

## Fix
- Default `apiBase` → **`http://127.0.0.1:7871`** (the isolated `scripts/dev.sh` instance). Fail-safe: no dev backend up → a clean "can't connect", never a silent prod hit.
- **Loud red startup guard** if `PROTOAGENT_API_BASE` is ever pointed at `:7870`.
- Docs: PROTO.md § Run it documents the isolated dev loop (`scripts/dev.sh` + `npm run dev`); CHANGELOG `[Unreleased]`.

## Verified
`tsc -p tsconfig.node.json` clean (guard written ES5-safe for the node lib), `vite build` passes, and the guard renders correctly when forced at `:7870`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the web app’s default local proxy to use a separate development backend, helping avoid accidental use of real production data during local testing.
  * Added a clear warning when the app is configured to connect to the production backend, so users can spot risky setups before taking action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->