### PR TITLE
feat(fleet): data-driven archetype registry + apply persona on create (ADR 0042)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Agent archetypes are a data-driven registry** (ADR 0042). The new-agent picker + setup
+  wizard now read their built-in starter types from `config/archetype-catalog.json`
+  (served by `GET /api/archetypes`) instead of a hardcoded list — so archetypes can be added
+  or removed **without a code change**, and a fork/instance overrides the set by dropping its
+  own `archetype-catalog.json` in the live config dir (same override rule as
+  `plugin-catalog.json`/`mcp-catalog.json`). Ships **Basic** + **Custom**; installed bundles
+  that declare an `archetype:` block still self-register on top, now **deduped** by id + bundle
+  URL so a card can't appear twice.
+
+### Changed
+- **Fleet "New agent" now applies the archetype's persona**, not just its tools. Creating an
+  agent from an archetype writes its base `SOUL.md` into the new workspace (`POST /api/fleet`
+  gained a `soul` field), so a bundle agent arrives with its persona wired in.
+
 ### Fixed
 - **Console dev server no longer defaults to the prod backend.** `apps/web/vite.config.ts` proxied
   `npm run dev` / `npm run preview` backend calls to `:7870` (the default/prod instance the desktop
@@ -18,6 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `~/.protoagent` data**. It now defaults to the **isolated dev instance `:7871`** (`scripts/dev.sh`),
   which is fail-safe (a clean "can't connect" when no dev backend is up, never a silent prod hit),
   and prints a **loud red guard** if `PROTOAGENT_API_BASE` is ever pointed at `:7870`.
+- **Removed the broken built-in "Project Manager" archetype.** It pointed at
+  `protoLabsAI/pm-stack`, which was split/renamed (→ `product-stack`, `leadEngineer`,
+  `portfolio-manager-stack`); the stale URL no longer installed what the card promised. Those
+  stacks self-register as archetypes when installed, and the URL is now a data edit rather than
+  a code constant.
 
 ## [0.78.0] - 2026-07-01
 

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -111,7 +111,7 @@ export const FLEET = {
 
 export const ARCHETYPES = [
   { id: "basic", label: "Basic", icon: "Sparkles", blurb: "A plain agent — add tools later.", bundle: null, soul: "# Identity\n\nI am a general-purpose agent." },
-  { id: "pm-stack", label: "Project Manager", icon: "LayoutGrid", blurb: "PM tools + board.", bundle: "https://github.com/protoLabsAI/pm-stack", soul: "# Identity\n\nI am a project-management agent." },
+  { id: "product-stack", label: "Product Manager", icon: "Compass", blurb: "Research, strategy, and specs — rendered inline.", bundle: "https://github.com/protoLabsAI/product-stack", soul: "# Identity\n\nI am a product-management agent." },
   { id: "custom", label: "Custom", icon: "PenLine", blurb: "Write your own — fill in a template.", bundle: null, soul: "# Identity\n\n_Describe your agent in one paragraph._" },
 ];
 

--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -55,8 +55,8 @@ test("New agent → archetype picker → create returns to the list", async ({ p
   await openAgents(page);
   await page.getByRole("button", { name: "New agent" }).click();
   await expect(page.getByRole("heading", { name: "New agent" })).toBeVisible();
-  await expect(page.locator(".pl-radiocard")).toHaveCount(2); // DS RadioCard, from GET /api/archetypes
-  await page.locator(".pl-radiocard", { hasText: "Project Manager" }).click();
+  await expect(page.locator(".pl-radiocard")).toHaveCount(2); // DS RadioCard, from GET /api/archetypes (Custom filtered out)
+  await page.locator(".pl-radiocard", { hasText: "Product Manager" }).click();
   await page.getByLabel("Agent name").fill("newbot");
   await page.getByRole("button", { name: /Create/ }).click();
   await expect(page.locator(".fleet-row", { hasText: "newbot" })).toBeVisible();

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1088,7 +1088,14 @@ export const api = {
   archetypes() {
     return request<{ archetypes: Archetype[] }>("/api/archetypes");
   },
-  createAgent(body: { name: string; bundle?: string | null; port?: number; start?: boolean; shared_skills?: boolean }) {
+  createAgent(body: {
+    name: string;
+    bundle?: string | null;
+    soul?: string;
+    port?: number;
+    start?: boolean;
+    shared_skills?: boolean;
+  }) {
     return request<{ ok: boolean; agent: FleetAgent; installed: string[] }>("/api/fleet", {
       method: "POST",
       body,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -769,7 +769,7 @@ export type FleetStatus = { agents: FleetAgent[] };
 export type DiscoveredAgent = { name: string; url: string; host: string; port: number };
 
 export type Archetype = {
-  id: string; // "basic", or a bundle id e.g. "pm-stack"
+  id: string; // "basic"/"custom", or a bundle id e.g. "product-stack"
   label: string;
   icon: string; // lucide-react icon name
   blurb: string;

--- a/apps/web/src/settings/NewAgentPanel.tsx
+++ b/apps/web/src/settings/NewAgentPanel.tsx
@@ -31,7 +31,11 @@ export function NewAgentPanel({ onDone, onCancel }: { onDone?: (name: string) =>
   const nameOk = NAME_RE.test(name);
 
   const create = useMutation({
-    mutationFn: () => api.createAgent({ name: name.trim(), bundle: archetype?.bundle ?? null }),
+    // Carry the archetype's base SOUL so a bundle agent arrives WITH its persona, not just
+    // its tools (ADR 0042). Blank soul (bundle with no inline persona) → server leaves the
+    // agent on the default SOUL.
+    mutationFn: () =>
+      api.createAgent({ name: name.trim(), bundle: archetype?.bundle ?? null, soul: archetype?.soul || undefined }),
     onError: (e: Error) => toast({ tone: "error", title: "Couldn't create agent", message: e.message }),
     onSuccess: (res) => {
       qc.invalidateQueries({ queryKey: queryKeys.fleet });

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -153,9 +153,9 @@ export function SetupWizard({
 }) {
   const [step, setStep] = useState<Step>("welcome");
   const [state, setState] = useState<WizardState>(() => defaultState());
-  // Starter archetypes (Basic + Project Manager + installed bundles) — the same
-  // source the fleet new-agent picker uses. Each carries a base SOUL the persona
-  // step seeds when picked (ADR 0042).
+  // Starter archetypes (the archetype-catalog: Basic + Custom, plus any installed bundle
+  // that self-registers) — the same GET /api/archetypes source the fleet new-agent picker
+  // uses. Each carries a base SOUL the persona step seeds when picked (ADR 0042).
   const archetypes = useQuery(archetypesQuery());
   const acpAgentList = useQuery(acpAgentsQuery()).data?.agents ?? [];
   const [models, setModels] = useState<string[]>([]);
@@ -292,7 +292,7 @@ export function SetupWizard({
   }, [loaded, archetypeList, state.soul, state.archetype]);
 
   // The picked archetype drives the finish summary AND (Plan C) the bundle install:
-  // an archetype with a bundle (e.g. Project Manager → pm-stack) installs its plugins
+  // an archetype with a bundle (e.g. Product Manager → product-stack) installs its plugins
   // into this host on finish, so the persona arrives WITH its tools.
   const pickedArchetype = archetypeList.find((a) => a.id === state.archetype);
   const personaLabel = pickedArchetype?.label ?? state.archetype;
@@ -376,8 +376,8 @@ export function SetupWizard({
       if (state.initTasks) {
         await api.initTasks();
       }
-      // Plan C: if the chosen archetype carries a plugin bundle (e.g. Project
-      // Manager → pm-stack), install it into THIS host on finish — so the new user
+      // Plan C: if the chosen archetype carries a plugin bundle (e.g. Product
+      // Manager → product-stack), install it into THIS host on finish — so the new user
       // gets the persona AND its tools/board in one shot, not just the prose.
       // installPlugin auto-enables + hot-reloads the bundle's plugins (no restart).
       // A failure is non-fatal: setup is already written, so we finish anyway and

--- a/config/archetype-catalog.json
+++ b/config/archetype-catalog.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Curated archetype directory for the new-agent picker + setup wizard (ADR 0042), served by GET /api/archetypes. Data-driven so archetypes can be added or removed WITHOUT a code change — a fork or instance overrides this file by dropping its own archetype-catalog.json in the live config dir (same override rule as plugin-catalog.json / mcp-catalog.json). Fields: id (also the RadioCard value + React key — keep unique), label, icon (a lucide-react name), blurb, bundle (a git URL installed into the agent on create, or null for a code-free persona), and the base SOUL.md the persona step seeds — either soul_preset (a file STEM under config/soul-presets/, resolved server-side) or an inline soul string. Installed plugin bundles that declare an `archetype:` manifest block self-register on top of these and don't need an entry here (deduped by id + bundle URL). Keep `custom` LAST — it's the catch-all write-your-own persona.",
+  "archetypes": [
+    {
+      "id": "basic",
+      "label": "Basic",
+      "icon": "Sparkles",
+      "bundle": null,
+      "blurb": "A blank-slate agent — the core loop + built-in tools, no plugins.",
+      "soul_preset": "base"
+    },
+    {
+      "id": "custom",
+      "label": "Custom",
+      "icon": "PenLine",
+      "bundle": null,
+      "blurb": "Write your own — start from a SOUL template and fill it in.",
+      "soul_preset": "blank"
+    }
+  ]
+}

--- a/docs/guides/fleet.md
+++ b/docs/guides/fleet.md
@@ -9,7 +9,7 @@ primitives:
 |---|---|---|
 | **Workspace** | a named agent — its own config, secrets, plugins, scoped data, port | [0041](../adr/0041-workspaces-and-tiered-stores.md) |
 | **Bundle** | a curated, pinned set of plugins installed as one | [0040](../adr/0040-plugin-bundles.md) |
-| **Archetype** | a bundle presented as a starter *agent type* (or the built-in **Basic**) | [0042](../adr/0042-fleet-supervisor-unified-console.md) |
+| **Archetype** | a starter *agent type* in the new-agent picker — the built-in **Basic**/**Custom** (from a data-driven catalog) plus any installed bundle that declares one | [0042](../adr/0042-fleet-supervisor-unified-console.md) |
 | **Tiered stores** | per-agent private data + an opt-in shared **commons** | [0041](../adr/0041-workspaces-and-tiered-stores.md) |
 | **Supervisor** | run agents as persistent background processes (start/stop/status) | [0042](../adr/0042-fleet-supervisor-unified-console.md) |
 | **Unified console** | one slug-routed console that hot-swaps between running agents (per-agent layout/theme) | [0042](../adr/0042-fleet-supervisor-unified-console.md) |
@@ -17,8 +17,8 @@ primitives:
 ## Quick start
 
 ```bash
-# an agent from the "Project Manager" archetype (the pm-stack bundle)
-python -m server workspace new pm --bundle https://github.com/protoLabsAI/pm-stack
+# an agent from a bundle archetype (the product-stack bundle: PM toolkit + generative UI)
+python -m server workspace new pm --bundle https://github.com/protoLabsAI/product-stack
 
 # a blank-slate agent (the built-in Basic archetype — core loop + tools, no plugins)
 python -m server workspace new scratch
@@ -26,7 +26,7 @@ python -m server workspace new scratch
 # run the whole fleet in the background, then look at it
 python -m server fleet up
 python -m server fleet ls
-#   ● pm        :7871  pid 12345  [pm-stack]
+#   ● pm        :7871  pid 12345  [product-stack]
 #   ● scratch   :7872  pid 12346
 ```
 
@@ -57,7 +57,7 @@ suggested enable list + config. Install one into a workspace and you skip the
 plugin-by-plugin setup:
 
 ```bash
-python -m server plugin install https://github.com/protoLabsAI/pm-stack   # fans out + pins each member
+python -m server plugin install https://github.com/protoLabsAI/product-stack   # fans out + pins each member
 ```
 
 A bundle that carries an **`archetype:`** block becomes a **starter agent type** the
@@ -65,22 +65,30 @@ new-agent picker offers — additive metadata, no change to the bundle shape:
 
 ```yaml
 # protoagent.bundle.yaml
-id: pm-stack
+id: product-stack
 plugins: [ … ]
 enabled: [ … ]
 archetype:
-  label: Project Manager
-  icon: LayoutGrid
-  blurb: Board-driven shipping agent — decomposes an idea and ships it via coding agents.
+  label: Product Manager
+  icon: Compass
+  blurb: Researches, strategizes, and specs products from evidence — renders roadmaps and personas inline.
 ```
 
-Two starter types exist today:
+The picker draws from **two** sources:
 
-- **Basic** — built-in, ships with protoAgent: the bare agent loop + built-in tools, **no
-  plugins**. It's just `workspace new <name>` with no `--bundle` (the "start from scratch").
-- **Project Manager** — the [pm-stack](https://github.com/protoLabsAI/pm-stack) bundle.
+- **The archetype catalog** — `config/archetype-catalog.json`, served by `GET /api/archetypes`.
+  It ships the two code-free personas — **Basic** (the bare loop + tools, no plugins) and
+  **Custom** (write-your-own SOUL) — and is **data-driven**: add or remove archetypes by
+  editing the JSON, no code change. A fork or instance overrides it by dropping its own
+  `archetype-catalog.json` in the live config dir (same rule as `plugin-catalog.json`). Each
+  entry names a `soul_preset` (a file under `config/soul-presets/`) or an inline `soul` for the
+  base persona.
+- **Installed bundles** — any bundle whose manifest carries an `archetype:` block
+  **self-registers** on top of the catalog (deduped by id + bundle URL). Install the bundle
+  and its starter type appears in the picker for free — no catalog edit needed.
 
-Every future bundle that adds an `archetype:` block becomes a starter type for free. See
+Picking an archetype seeds the new agent's **persona** (its `SOUL.md`) from that base, and — if
+it carries a bundle — installs the bundle's plugins into the new agent. See
 [Install & publish plugins](./plugin-registry.md).
 
 ## Tiered stores — private by default, share what should be shared

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -218,6 +218,7 @@ def create(
     bundle: str | None = None,
     port: int | None = None,
     shared_skills: bool = False,
+    soul: str | None = None,
 ) -> dict:
     """Scaffold a workspace: its config dir, ``workspace.yaml``, and (with ``bundle``)
     an installed plugin bundle. Does not start it.
@@ -228,6 +229,10 @@ def create(
         secrets popped over (the gateway), so it boots ready-to-chat WITHOUT inheriting its
         plugins/skills. This is the fleet's default "new agent" (a blank agent, model carried).
       * neither — the plain blank template.
+
+    ``soul`` (the picked archetype's base SOUL.md, ADR 0042) is written into the workspace's
+    ``config/SOUL.md`` — the member's live persona — so an agent created from an archetype
+    arrives with its persona, not just its tools. Blank leaves the agent on the default SOUL.
     """
     name = _safe(name)
     if name.lower() in _RESERVED_NAMES:
@@ -264,6 +269,12 @@ def create(
             _overlay_model(cfg, ws, inherit_model)  # gateway only — not plugins/skills
         if shared_skills:
             _stamp_identity(cfg, name, True, instance_id=wid)
+
+    # The archetype persona (ADR 0042) — the member reads its SOUL at <ws>/config/SOUL.md
+    # (instance_root=<ws>), so scaffold it there. Only when non-empty: a blank archetype
+    # (or none) leaves the agent on the default SOUL rather than writing an empty persona.
+    if soul and soul.strip():
+        (cfg_dir / "SOUL.md").write_text(soul, encoding="utf-8")
 
     import yaml
 

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -134,14 +134,19 @@ def register_fleet_routes(app) -> None:
     async def _create_agent(body: dict = Body(...)):
         """Create an agent (optionally from a bundle archetype) and start it.
 
-        Body: ``{name, bundle?: <git-url>, port?: int, start?: bool=true,
-        shared_skills?: bool, inherit_config?: bool=true}``. A blank ``bundle`` is the built-in
+        Body: ``{name, bundle?: <git-url>, soul?: str, port?: int, start?: bool=true,
+        shared_skills?: bool, inherit_config?: bool=true}``. ``soul`` is the archetype's base
+        SOUL.md (persona), written into the workspace so a bundle agent gets its persona too.
+        A blank ``bundle`` is the built-in
         **Basic** archetype. By default a new agent is a **blank agent with the host's model
         config + secrets popped over** (the gateway only — NOT the host's plugins/skills), so it
         boots ready-to-chat. Set ``inherit_config: false`` for a fully blank agent you'll set up.
         """
         name = str(body.get("name", "")).strip()
         bundle = (str(body.get("bundle") or "").strip()) or None
+        # The archetype's base SOUL.md (the persona picked in the new-agent picker), written
+        # into the workspace so a bundle agent arrives WITH its persona, not just its tools.
+        soul = (str(body.get("soul") or "").strip()) or None
         port = body.get("port")
         start = bool(body.get("start", True))
         shared = bool(body.get("shared_skills", False))
@@ -157,7 +162,13 @@ def register_fleet_routes(app) -> None:
         try:
             # create() may overlay the host model + install a bundle (subprocess) — off the loop.
             ws = await asyncio.to_thread(
-                manager.create, name, bundle=bundle, port=port, shared_skills=shared, inherit_model=inherit_model
+                manager.create,
+                name,
+                bundle=bundle,
+                port=port,
+                shared_skills=shared,
+                inherit_model=inherit_model,
+                soul=soul,
             )
             agent = (
                 (await asyncio.to_thread(supervisor.start, name))
@@ -221,66 +232,130 @@ def register_fleet_routes(app) -> None:
         return {"archetypes": _archetypes()}
 
 
-def _archetypes() -> list[dict]:
-    """Built-in Basic + installed-bundle archetypes (cached in plugins.lock).
+def _norm_url(u: str | None) -> str:
+    """Canonicalize a git URL for dedupe (drop trailing ``.git`` / ``/``, lowercase) —
+    the same normalization the plugin catalog uses to match install state by URL."""
+    import re
 
-    Each archetype carries an optional ``soul`` — a base SOUL.md the setup
-    wizard seeds when the operator picks it (ADR 0042). Built-ins read it from
-    a ``config/soul-presets`` file; bundle archetypes declare it inline in
-    their ``archetype:`` manifest block.
+    return re.sub(r"\.git$", "", (u or "").strip().rstrip("/")).lower()
+
+
+# Last-resort archetypes if ``archetype-catalog.json`` is missing or unreadable — the two
+# code-free personas, so the picker + wizard always work even on a broken/forked config.
+_FALLBACK_ARCHETYPES = [
+    {
+        "id": "basic",
+        "label": "Basic",
+        "icon": "Sparkles",
+        "bundle": None,
+        "blurb": "A blank-slate agent — the core loop + built-in tools, no plugins.",
+        "soul_preset": "base",
+    },
+    {
+        "id": "custom",
+        "label": "Custom",
+        "icon": "PenLine",
+        "bundle": None,
+        "blurb": "Write your own — start from a SOUL template and fill it in.",
+        "soul_preset": "blank",
+    },
+]
+
+
+def _load_archetype_catalog() -> list[dict]:
+    """Built-in archetype entries from ``archetype-catalog.json`` — the live config dir
+    overrides the bundled seed (a fork adds/removes archetypes with NO code change), same
+    lookup order as the plugin/MCP catalogs. Falls back to Basic + Custom if the file is
+    absent or malformed, so the new-agent picker + wizard never come up empty-handed."""
+    import json
+
+    from infra.paths import instance_paths
+
+    ip = instance_paths()
+    for base in (ip.config_dir, ip.bundle_dir):
+        f = base / "archetype-catalog.json"
+        if f.exists():
+            try:
+                entries = (json.loads(f.read_text()) or {}).get("archetypes")
+                if isinstance(entries, list) and entries:
+                    return entries
+            except (json.JSONDecodeError, OSError):
+                log.warning("[fleet] archetype-catalog.json unreadable at %s", f)
+            break  # live dir wins even if broken — don't silently fall through to the seed
+    return _FALLBACK_ARCHETYPES
+
+
+def _archetypes() -> list[dict]:
+    """Starter agent types for the new-agent picker + setup wizard (ADR 0042).
+
+    Data-driven: the built-in set comes from ``archetype-catalog.json`` (see
+    ``_load_archetype_catalog``), merged with every installed bundle's ``archetype:``
+    manifest metadata (cached in ``plugins.lock``). Each archetype carries an optional
+    ``soul`` — a base SOUL.md the persona step seeds when the operator picks it: the catalog
+    names a ``soul_preset`` file under ``config/soul-presets/`` (resolved here) or an inline
+    ``soul``; a bundle declares it inline in its manifest. The whole list is deduped by id +
+    bundle URL (a catalog entry for a stack never doubles up with the same installed bundle),
+    and ``custom`` is kept LAST.
     """
     from graph.config_io import read_soul_preset
 
-    out = [
-        {
-            "id": "basic",
-            "label": "Basic",
-            "icon": "Sparkles",
-            "bundle": None,
-            "blurb": "A blank-slate agent — the core loop + built-in tools, no plugins.",
-            "soul": read_soul_preset("base"),
-        },
-        {
-            # Built-in PM archetype — installed FRESH from the git URL on each create (no pin),
-            # so a new PM agent always gets the latest pm-stack.
-            "id": "pm-stack",
-            "label": "Project Manager",
-            "icon": "LayoutGrid",
-            "bundle": "https://github.com/protoLabsAI/pm-stack",
-            "blurb": "Project-management tools + board — clones the latest pm-stack on create.",
-            "soul": read_soul_preset("project-manager"),
-        },
-    ]
+    out: list[dict] = []
+    custom: dict | None = None
+    seen_ids: set[str] = set()
+    seen_urls: set[str] = set()
+
+    for entry in _load_archetype_catalog():
+        aid = str(entry.get("id") or "").strip()
+        if not aid or aid in seen_ids:
+            continue
+        soul = entry.get("soul") or (read_soul_preset(str(entry["soul_preset"])) if entry.get("soul_preset") else "")
+        bundle = entry.get("bundle") or None
+        rec = {
+            "id": aid,
+            "label": entry.get("label", aid),
+            "icon": entry.get("icon", "Package"),
+            "bundle": bundle,
+            "blurb": entry.get("blurb", ""),
+            "soul": soul,
+        }
+        seen_ids.add(aid)
+        if bundle:
+            seen_urls.add(_norm_url(bundle))
+        if aid == "custom":
+            custom = rec  # hold it back so it stays last after bundle archetypes append
+        else:
+            out.append(rec)
+
+    # Installed bundles that declare `archetype:` metadata self-register as starter types —
+    # appended after the catalog, deduped by id + normalized bundle URL so a catalog entry
+    # for the same stack (or a bundle listed twice) never produces a duplicate RadioCard.
     try:
         from graph.plugins.installer import _read_lock
 
         for b in _read_lock().get("bundles") or []:
             arch = b.get("archetype") or {}
-            if arch.get("label"):
-                out.append(
-                    {
-                        "id": b.get("id"),
-                        "label": arch.get("label"),
-                        "icon": arch.get("icon", "Package"),
-                        "blurb": arch.get("blurb", ""),
-                        "bundle": b.get("source_url"),
-                        "soul": arch.get("soul", ""),
-                    }
-                )
+            bid = str(b.get("id") or "").strip()
+            url = b.get("source_url") or ""
+            if not arch.get("label") or not bid:
+                continue
+            if bid in seen_ids or (url and _norm_url(url) in seen_urls):
+                continue
+            seen_ids.add(bid)
+            if url:
+                seen_urls.add(_norm_url(url))
+            out.append(
+                {
+                    "id": bid,
+                    "label": arch.get("label"),
+                    "icon": arch.get("icon", "Package"),
+                    "blurb": arch.get("blurb", ""),
+                    "bundle": url or None,
+                    "soul": arch.get("soul", ""),
+                }
+            )
     except Exception:  # noqa: BLE001 — archetype discovery is best-effort
         log.warning("[fleet] archetype discovery failed", exc_info=True)
-    # "Custom" is the catch-all, kept LAST as more archetypes land above it — a
-    # blank-slate persona the operator writes themselves. Like Basic it carries no
-    # bundle, but it seeds the editor with the fill-in-the-blanks SOUL scaffold
-    # rather than a ready-to-use base prompt.
-    out.append(
-        {
-            "id": "custom",
-            "label": "Custom",
-            "icon": "PenLine",
-            "bundle": None,
-            "blurb": "Write your own — start from a SOUL template and fill it in.",
-            "soul": read_soul_preset("blank"),
-        }
-    )
+
+    if custom is not None:
+        out.append(custom)  # the catch-all write-your-own persona, always LAST
     return out

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -39,15 +39,60 @@ def test_archetypes_include_basic(client):
 
 
 def test_archetypes_carry_base_soul(client):
-    # Each archetype seeds the wizard's persona step with a base SOUL (ADR 0042) —
-    # the built-in Basic + PM read theirs from config/soul-presets/.
+    # Each archetype seeds the wizard's persona step with a base SOUL (ADR 0042) — the
+    # catalog names a soul_preset file under config/soul-presets/, resolved server-side.
     arr = client.get("/api/archetypes").json()["archetypes"]
     by_id = {a["id"]: a for a in arr}
     assert "soul" in by_id["basic"] and by_id["basic"]["soul"].strip()
-    assert by_id["pm-stack"]["soul"].strip()
     # "Custom" is the catch-all write-your-own archetype, kept last with the
     # fill-in template SOUL.
     assert arr[-1]["id"] == "custom" and by_id["custom"]["soul"].strip()
+
+
+def test_archetypes_fall_back_when_catalog_missing(client, monkeypatch):
+    # A missing/unreadable archetype-catalog.json must still yield the two code-free
+    # personas (Basic + Custom) so the picker never comes up empty (ADR 0042).
+    from operator_api import fleet_routes
+
+    monkeypatch.setattr(fleet_routes, "_load_archetype_catalog", lambda: fleet_routes._FALLBACK_ARCHETYPES)
+    arr = client.get("/api/archetypes").json()["archetypes"]
+    ids = [a["id"] for a in arr]
+    assert ids[0] == "basic" and ids[-1] == "custom"
+    assert all(a["soul"].strip() for a in arr)  # soul_preset resolved to real content
+
+
+def test_archetypes_dedupe_installed_bundle_against_catalog(client, monkeypatch):
+    # An installed bundle whose id/URL already appears in the catalog must NOT produce a
+    # duplicate RadioCard (duplicate React key + ambiguous radio value). Catalog wins.
+    from operator_api import fleet_routes
+
+    monkeypatch.setattr(
+        fleet_routes,
+        "_load_archetype_catalog",
+        lambda: [
+            {"id": "basic", "label": "Basic", "bundle": None, "soul_preset": "base"},
+            {"id": "acme", "label": "Acme", "bundle": "https://github.com/acme/stack.git", "soul": "x"},
+            {"id": "custom", "label": "Custom", "bundle": None, "soul_preset": "blank"},
+        ],
+    )
+
+    def fake_lock():
+        return {
+            "bundles": [
+                # same id as a catalog entry
+                {"id": "acme", "source_url": "https://other/url", "archetype": {"label": "Dup id"}},
+                # same URL (differing suffix) as the catalog's acme entry
+                {"id": "acme2", "source_url": "https://github.com/acme/stack", "archetype": {"label": "Dup url"}},
+                # genuinely new → appended
+                {"id": "fresh", "source_url": "https://github.com/x/y", "archetype": {"label": "Fresh"}},
+            ]
+        }
+
+    monkeypatch.setattr("graph.plugins.installer._read_lock", fake_lock)
+    ids = [a["id"] for a in client.get("/api/archetypes").json()["archetypes"]]
+    assert ids.count("acme") == 1 and "acme2" not in ids  # both duplicates dropped
+    assert "fresh" in ids
+    assert ids[-1] == "custom"  # custom stays last even after bundle archetypes append
 
 
 def test_create_list_start_stop_remove(client):
@@ -65,6 +110,30 @@ def test_create_list_start_stop_remove(client):
     assert client.delete("/api/fleet/alpha").json()["ok"]
     # The host (this instance) always self-registers, so only the peers are gone.
     assert not [a for a in client.get("/api/fleet").json()["agents"] if not a.get("host")]
+
+
+def test_create_writes_archetype_soul(client):
+    # The picked archetype's persona is written into the workspace SOUL.md (ADR 0042),
+    # so a created agent arrives WITH its persona, not just its tools.
+    from pathlib import Path
+
+    from graph.workspaces import manager
+
+    r = client.post("/api/fleet", json={"name": "persona", "start": False, "soul": "# Persona\nBe bold."})
+    assert r.status_code == 200
+    ws = next(w for w in manager.list_workspaces() if w["name"] == "persona")
+    assert (Path(ws["path"]) / "config" / "SOUL.md").read_text().startswith("# Persona")
+
+
+def test_create_without_soul_leaves_default(client):
+    # No/blank soul → no SOUL.md written, so the agent stays on the default persona.
+    from pathlib import Path
+
+    from graph.workspaces import manager
+
+    client.post("/api/fleet", json={"name": "plain", "start": False})
+    ws = next(w for w in manager.list_workspaces() if w["name"] == "plain")
+    assert not (Path(ws["path"]) / "config" / "SOUL.md").exists()
 
 
 def test_create_bad_name_is_400(client):


### PR DESCRIPTION
## Why

Prompted by an audit of the new-agent / setup-wizard **archetype** flow. Two problems surfaced:

1. **`pm-stack` is broken.** The built-in "Project Manager" archetype hardcoded `github.com/protoLabsAI/pm-stack`, but that repo was **split/renamed** into `product-stack` (PM toolkit + generative UI), `leadEngineer` (board-driven shipping), and `portfolio-manager-stack` (manager-of-teams). The card no longer installs what it promises.
2. **Archetypes required a code change** to add/remove — the list lived in `operator_api/fleet_routes.py::_archetypes()`.

## What

- **External registry.** Built-in archetypes now come from **`config/archetype-catalog.json`** (served by `GET /api/archetypes`), mirroring `plugin-catalog.json` / `mcp-catalog.json`: the live config dir overrides the bundled seed, so a **fork or instance adds/removes archetypes by editing data — no code change**. A hardcoded Basic+Custom fallback keeps the picker working if the file is missing/corrupt.
- **Seeds Basic + Custom only** (per product decision). Installed bundles that declare an `archetype:` manifest block still **self-register** on top — now **deduped by id + normalized bundle URL**, which also fixes a latent duplicate-`RadioCard` (duplicate React key) when a bundle's id/URL matched a catalog entry.
- **Fleet "New agent" applies the persona, not just the tools.** `POST /api/fleet` gained a `soul` field, threaded through `manager.create()` → written to the new workspace's `config/SOUL.md`. Previously a "Create from <stack>" agent got the bundle's plugins but a generic SOUL.
- Removed the dead built-in "Project Manager" (pointed at the moved repo). Those stacks self-register once installed; the URL is now a data edit, not a constant.

## Tests / docs

- `tests/test_fleet_routes.py`: catalog fallback, dedupe (id + URL, custom-stays-last), and the new persona-write on create. Existing `test_archetypes_carry_base_soul` updated off the removed `pm-stack`.
- e2e fixture + selector refreshed (`pm-stack` → `product-stack`); picker count stays 2 (Custom filtered).
- `docs/guides/fleet.md` reworked around the catalog + self-registration; CHANGELOG under `[Unreleased]`.

Local: `ruff` clean, `pytest tests/test_fleet_routes.py tests/test_workspaces.py` = 34 passed. FE typecheck/unit/e2e + live-smoke + lint-imports run in CI (not installed locally).

## Note

Touches first-run setup + new-agent flows — **leaving merge to you** rather than auto-merging on green, since it changes user-facing onboarding behavior. Follow-up candidates from the audit (not in this PR): the post-finish bundle-install message is swallowed by the wizard unmount; bundle archetypes with no inline `soul` seed an empty persona in the wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)