### PR TITLE
fix(paths): colocation warning keys on instance_root, not the shared box root (#1552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `portfolio-manager-stack`); the stale URL no longer installed what the card promised. Those
   stacks self-register as archetypes when installed, and the URL is now a data edit rather than
   a code constant.
+- **Instance collision warning no longer false-alarms on a shared box root** (#1552). The boot
+  "another instance can clobber your chat/knowledge/stores" warning keyed on the shared
+  `box_root`, so it fired for any second process on the machine — including a `dev` instance
+  (`~/.protoagent/dev`) that keeps entirely separate data. It now keys on **`instance_root`**:
+  it warns only when another live process shares *this* instance's data root (a genuine
+  clobber, e.g. the same instance run twice), and stays silent for box-only co-residents with
+  distinct `PROTOAGENT_INSTANCE` ids.
 
 ## [0.78.0] - 2026-07-01
 

--- a/infra/paths.py
+++ b/infra/paths.py
@@ -321,7 +321,18 @@ def register_instance(port: int | None = None, identity: str = "") -> None:
     try:
         d = _instances_dir()
         d.mkdir(parents=True, exist_ok=True)
-        (d / f"{os.getpid()}.json").write_text(json.dumps({"pid": os.getpid(), "port": port, "identity": identity}))
+        # Record the instance_root so colocation_warning can distinguish a genuine
+        # same-instance clobber from a harmless box-only co-resident (#1552).
+        (d / f"{os.getpid()}.json").write_text(
+            json.dumps(
+                {
+                    "pid": os.getpid(),
+                    "port": port,
+                    "identity": identity,
+                    "instance_root": str(instance_paths().instance_root),
+                }
+            )
+        )
     except Exception:  # noqa: BLE001
         pass
 
@@ -357,26 +368,41 @@ def colocated_instances() -> list[dict]:
                 rec = json.loads(f.read_text())
             except (OSError, ValueError):
                 rec = {}
-            out.append({"pid": pid, "port": rec.get("port"), "identity": rec.get("identity") or ""})
+            out.append(
+                {
+                    "pid": pid,
+                    "port": rec.get("port"),
+                    "identity": rec.get("identity") or "",
+                    "instance_root": rec.get("instance_root") or "",
+                }
+            )
     except Exception:  # noqa: BLE001
         return out
     return out
 
 
 def colocation_warning() -> str | None:
-    """A user-facing warning when another live instance shares this data root, else None."""
-    others = colocated_instances()
-    if not others:
+    """A user-facing warning when another live process shares THIS instance's data root
+    — i.e. the same ``instance_root`` (every store lives there, so they WOULD clobber each
+    other's chat / knowledge / checkpoints). Returns None otherwise.
+
+    Two instances that merely share the ``box_root`` (distinct ``PROTOAGENT_INSTANCE`` ids —
+    e.g. the desktop app on ``~/.protoagent`` plus a ``dev`` instance on ``~/.protoagent/dev``)
+    keep entirely separate stores and are NOT a clobber risk, so they are not flagged (#1552).
+    A co-resident whose heartbeat predates this field (no ``instance_root`` recorded) can't be
+    confirmed same-instance, so it's treated as distinct — favouring no false alarm."""
+    mine = str(instance_paths().instance_root)
+    same = [o for o in colocated_instances() if o.get("instance_root") == mine]
+    if not same:
         return None
     who = ", ".join(
         f"{o['identity'] or 'unknown'} (pid {o['pid']}" + (f", port {o['port']})" if o.get("port") else ")")
-        for o in others
+        for o in same
     )
-    root = instance_paths().box_root
     return (
-        f"Another running instance shares this machine's data root ({root}): {who}. "
-        "They can clobber each other's chat history, knowledge and stores — give each "
-        "instance its own PROTOAGENT_INSTANCE id (or stop the extra one)."
+        f"Another running process shares THIS instance's data root ({mine}): {who}. "
+        "They will clobber each other's chat history, knowledge and stores — stop one, or run "
+        "them as separate instances (a distinct PROTOAGENT_INSTANCE id, each on its own port)."
     )
 
 

--- a/tests/test_instance_scope.py
+++ b/tests/test_instance_scope.py
@@ -105,17 +105,46 @@ def test_heartbeats_live_at_box_root(monkeypatch, tmp_path):
     paths.unregister_instance()
 
 
-def test_colocated_sibling_detected_and_warned(monkeypatch, tmp_path):
+def test_colocated_sibling_same_instance_is_warned(monkeypatch, tmp_path):
+    """A sibling on the SAME instance_root (here: the unscoped default = box_root) shares
+    every store, so it IS a clobber warning."""
+    import json
+
     home = _home(monkeypatch, tmp_path)
+    mine = str(paths.instance_paths().instance_root)  # this process's instance_root
     d = home / ".instances"
     d.mkdir()
-    (d / "12345.json").write_text('{"pid": 12345, "port": 7871, "identity": "roxy"}')
+    (d / "12345.json").write_text(
+        json.dumps({"pid": 12345, "port": 7871, "identity": "roxy", "instance_root": mine})
+    )
     monkeypatch.setattr(paths, "_pid_alive", lambda pid: True)
     monkeypatch.setattr(paths, "_is_protoagent_pid", lambda pid: True)
     sibs = paths.colocated_instances()
-    assert sibs == [{"pid": 12345, "port": 7871, "identity": "roxy"}]
+    assert sibs == [{"pid": 12345, "port": 7871, "identity": "roxy", "instance_root": mine}]
     w = paths.colocation_warning()
-    assert "roxy" in w and "PROTOAGENT_INSTANCE" in w and str(home) in w
+    assert w and "roxy" in w and mine in w
+
+
+def test_box_only_coresident_is_not_warned(monkeypatch, tmp_path):
+    """#1552: a sibling that shares only the box_root — a DIFFERENT instance_root (e.g. a
+    ``dev`` instance under ``box_root/dev``) — keeps entirely separate stores, so it's
+    detected on the box but is NOT a clobber warning (the old false positive)."""
+    import json
+
+    home = _home(monkeypatch, tmp_path)
+    other = str(home / "a-different-instance")  # a distinct instance_root under the same box
+    assert other != str(paths.instance_paths().instance_root)
+    d = home / ".instances"
+    d.mkdir()
+    (d / "12345.json").write_text(
+        json.dumps({"pid": 12345, "port": 7871, "identity": "dev", "instance_root": other})
+    )
+    monkeypatch.setattr(paths, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(paths, "_is_protoagent_pid", lambda pid: True)
+    # Still discoverable on the box…
+    assert paths.colocated_instances()[0]["identity"] == "dev"
+    # …but a DISTINCT instance_root is not a data-loss warning.
+    assert paths.colocation_warning() is None
 
 
 def test_stale_heartbeats_pruned(monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #1552 — the false positive that (with the vite-proxy default, #1564) was the "crossing streams" scare.

## Bug
`infra/paths.colocation_warning()` warned *"Another running instance shares this machine's data root … they can clobber each other's chat history, knowledge and stores"* whenever **any** other protoAgent process was live — because heartbeats live at the **box tier** (`box_root/.instances`) and the check keyed on the shared **`box_root`**. So a `dev` instance (`~/.protoagent/dev`, entirely separate stores) tripped a **data-loss** warning against the desktop/default instance, and its suggested fix ("give each its own `PROTOAGENT_INSTANCE` id") was a no-op — they already had distinct ids.

## Fix
- Each heartbeat now records its **`instance_root`**.
- `colocation_warning()` warns **only when another live process shares this instance's `instance_root`** (a real clobber — e.g. the same instance launched twice on two ports). Box-only co-residents (distinct `PROTOAGENT_INSTANCE`) are detected but **not flagged**.
- A pre-field heartbeat (older build) is treated as distinct — favouring no false alarm.

## Tests
`tests/test_instance_scope.py`: same-`instance_root` → warns (accurate remediation); box-only distinct-`instance_root` → **silent**. Full instance-paths suites green (46 tests), ruff clean.

## Follow-up (noted in the issue, not here)
The secondary mDNS-advertise noise for isolated boots (`PROTOAGENT_FLEET_DISABLE` switch) is left as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)