### PR TITLE
fix(setup-wizard): surface bundle-install result via toast + fall back persona soul (ADR 0042)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it warns only when another live process shares *this* instance's data root (a genuine
   clobber, e.g. the same instance run twice), and stays silent for box-only co-residents with
   distinct `PROTOAGENT_INSTANCE` ids.
+- **Setup wizard: the archetype bundle-install result is no longer swallowed.** Finishing setup
+  unmounts the wizard, so the "tools are ready" / "couldn't auto-enable — turn them on in
+  Settings ▸ Plugins" outcome now shows as a **toast** (survives the unmount) instead of an
+  in-wizard message the user never saw.
+- **Setup wizard: picking a persona-less archetype no longer blanks the editor.** A bundle
+  archetype whose manifest declares no inline `soul:` now seeds the persona step with the base
+  SOUL as a fallback, rather than clearing the SOUL textarea.
 
 ## [0.78.0] - 2026-07-01
 

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { DropdownSelect, Field, FormField, Input, RadioCard, RadioCardGroup, SecretInput, Textarea } from "@protolabsai/ui/forms";
 import { Button, Callout } from "@protolabsai/ui/primitives";
 import { Alert, Spinner } from "@protolabsai/ui/data";
+import { useToast } from "@protolabsai/ui/overlays";
 import {
   Bot,
   Check,
@@ -23,6 +24,7 @@ import { errMsg } from "../lib/format";
 import { lucideIcon } from "../lib/lucideIcon";
 import { acpAgentsQuery, archetypesQuery } from "../lib/queries";
 import type { AgentConfig, Archetype, ConfigPayload } from "../lib/types";
+import { personaSoul } from "./persona";
 
 // Four steps: intro, then "who the agent is" (name + persona), then "how it thinks"
 // (the model/coding-agent runtime), then a summary. Identity + persona are one step.
@@ -168,6 +170,9 @@ export function SetupWizard({
   // Result of the last "Test connection" probe (a real completion). null = not
   // yet tested; invalidated whenever the key/base/model changes.
   const [tested, setTested] = useState<null | { ok: boolean; error: string }>(null);
+  // The bundle-install outcome is surfaced as a toast (not an in-wizard Callout): finishing
+  // setup unmounts the wizard, so a Callout would vanish before it's read.
+  const toast = useToast();
 
   const index = steps.indexOf(step);
 
@@ -271,9 +276,11 @@ export function SetupWizard({
 
   // Picking an archetype card seeds the editor with that archetype's base SOUL
   // — the same archetypes the fleet new-agent picker offers. The textarea stays
-  // freely editable below; this is an explicit "load this persona" action.
+  // freely editable below; this is an explicit "load this persona" action. A bundle
+  // archetype may ship no inline persona, so fall back to the base SOUL rather than
+  // blanking the editor (see personaSoul).
   function pickArchetype(a: Archetype) {
-    update({ archetype: a.id, soul: a.soul });
+    update({ archetype: a.id, soul: personaSoul(a, archetypeList) });
   }
 
   // Pre-fill the editor once with the default archetype's base SOUL so the persona
@@ -287,7 +294,7 @@ export function SetupWizard({
     if (!loaded || seededSoul.current || !archetypeList.length || state.soul.trim()) return;
     const a = archetypeList.find((x) => x.id === state.archetype) ?? archetypeList[0];
     seededSoul.current = true;
-    update({ archetype: a.id, soul: a.soul });
+    update({ archetype: a.id, soul: personaSoul(a, archetypeList) });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loaded, archetypeList, state.soul, state.archetype]);
 
@@ -382,22 +389,33 @@ export function SetupWizard({
       // installPlugin auto-enables + hot-reloads the bundle's plugins (no restart).
       // A failure is non-fatal: setup is already written, so we finish anyway and
       // point the user at Settings ▸ Plugins.
+      // Surface the outcome as a TOAST, not an in-wizard Callout: onFinished() below
+      // unmounts the wizard (setup_complete flips true), so a Callout would vanish before
+      // it's read — especially the enable/failure guidance the user needs to act on. The
+      // in-progress "Setting up…" message stays inline (the wizard is still open during the
+      // install await).
       if (pickedBundle) {
         setMessage(`Setting up the ${personaLabel} tools — this can take a few seconds…`);
         try {
           const r = await api.installPlugin(pickedBundle);
-          setMessage(
-            r.enable_error
-              ? `Setup complete. The ${personaLabel} tools installed but couldn't auto-enable (${r.enable_error}) — turn them on in Settings ▸ Plugins.`
-              : `Setup complete — ${personaLabel} tools are ready.`,
-          );
+          if (r.enable_error) {
+            toast({
+              tone: "info",
+              title: "Setup complete",
+              message: `${personaLabel} tools installed but couldn't auto-enable (${r.enable_error}) — turn them on in Settings ▸ Plugins.`,
+            });
+          } else {
+            toast({ tone: "success", title: "Setup complete", message: `${personaLabel} tools are ready.` });
+          }
         } catch (exc) {
-          setMessage(
-            `Setup complete, but installing the ${personaLabel} tools failed (${errMsg(exc)}). You can add them later in Settings ▸ Plugins.`,
-          );
+          toast({
+            tone: "error",
+            title: "Setup complete",
+            message: `Installing the ${personaLabel} tools failed (${errMsg(exc)}). Add them later in Settings ▸ Plugins.`,
+          });
         }
       } else {
-        setMessage(response.message);
+        toast({ tone: "success", title: "Setup complete", message: response.message || "Your agent is ready." });
       }
       onFinished();
     } catch (exc) {

--- a/apps/web/src/setup/persona.test.ts
+++ b/apps/web/src/setup/persona.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+
+import { personaSoul } from "./persona";
+import type { Archetype } from "../lib/types";
+
+const arch = (id: string, soul: string): Archetype => ({
+  id,
+  label: id,
+  icon: "Package",
+  blurb: "",
+  bundle: null,
+  soul,
+});
+
+const LIST: Archetype[] = [arch("basic", "# Base persona"), arch("custom", "# Fill me in")];
+
+describe("personaSoul", () => {
+  it("returns the archetype's own soul when it has one", () => {
+    expect(personaSoul(arch("basic", "# Base persona"), LIST)).toBe("# Base persona");
+  });
+
+  it("falls back to the basic archetype's soul for a bundle archetype with no inline persona", () => {
+    // A bundle archetype whose manifest omits `soul:` — must not blank the editor.
+    const bundle = { ...arch("product-stack", ""), bundle: "https://example/x" };
+    expect(personaSoul(bundle, LIST)).toBe("# Base persona");
+  });
+
+  it("treats a whitespace-only soul as empty and falls back", () => {
+    expect(personaSoul(arch("x", "   \n  "), LIST)).toBe("# Base persona");
+  });
+
+  it("returns empty string when there is no soul and no basic archetype to borrow from", () => {
+    expect(personaSoul(arch("x", ""), [arch("custom", "# c")])).toBe("");
+  });
+});

--- a/apps/web/src/setup/persona.ts
+++ b/apps/web/src/setup/persona.ts
@@ -1,0 +1,10 @@
+import type { Archetype } from "../lib/types";
+
+// The base SOUL an archetype seeds into the persona editor (ADR 0042). A bundle archetype
+// may declare no inline `soul:` in its manifest (soul === ""), so picking it must not blank
+// the editor — fall back to the base persona (the "basic" archetype's SOUL), leaving a
+// sensible, editable starting point rather than an empty textarea.
+export function personaSoul(a: Archetype, archetypes: Archetype[]): string {
+  if (a.soul?.trim()) return a.soul;
+  return archetypes.find((x) => x.id === "basic")?.soul ?? "";
+}


### PR DESCRIPTION
## Why

The two audit follow-ups from #1565 on the setup-wizard / archetype flow.

## What

**1. Post-finish bundle-install result was swallowed.** When an archetype carries a bundle (Plan C installs it into the host on finish), the outcome — "tools are ready", "couldn't auto-enable (…) — turn them on in Settings ▸ Plugins", or "install failed (…)" — was written as an in-wizard `Callout`. But `onFinished()` flips `setup_complete` and **unmounts the wizard** right after, so the message (and its actionable guidance) was never actually read. Now it's a **toast** (top-right stack, survives the unmount). The in-progress "Setting up…" hint stays inline since the wizard is still open during the install await.

**2. Persona-less bundle archetype blanked the editor.** `pickArchetype` set `soul: a.soul`, which is `""` for a bundle archetype whose manifest declares no inline `soul:` — clearing the SOUL textarea. New pure `personaSoul(a, archetypes)` helper falls back to the base SOUL (the `basic` archetype's persona); wired into both `pickArchetype` and the initial seed effect.

## Tests

- New `src/setup/persona.ts` + `persona.test.ts` (4 cases: own soul, empty→fallback, whitespace→fallback, no-basic→"").
- Web unit suite: **245 passed**.
- `tsc --noEmit`: touched files clean. (The 2 errors in `App.tsx`/`ChatSurface.tsx` are the known local **DS-skew** — local `node_modules` at `@protolabsai/ui@0.52.0` vs the 0.53.0 the code targets — unrelated to this change and clear under CI's `npm ci`.)

CHANGELOG under `[Unreleased]`. No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)