### PR TITLE
feat(plugins): rail context menu — version, update, uninstall (#1521, #1522)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -79,6 +79,7 @@ import { chatStore, useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { SettingsOverlay } from "../settings/SettingsOverlay";
 import { PluginSettingsDialog } from "../plugins/PluginSettingsDialog";
+import { PluginRailManage } from "../plugins/PluginRailManage";
 import { AppDrawer } from "./AppDrawer";
 import { HamburgerMenu } from "./HamburgerMenu";
 import { FleetSwitcher } from "./FleetSwitcher";
@@ -107,7 +108,7 @@ import { useToast } from "@protolabsai/ui/overlays";
 import { StatusPill } from "./StatusPill";
 import { WorkPanel } from "./WorkPanel";
 import { SetupWizard } from "../setup/SetupWizard";
-import { hostRuntimeStatusQuery, runtimeStatusQuery } from "../lib/queries";
+import { hostRuntimeStatusQuery, installedPluginsQuery, pluginUpdatesQuery, runtimeStatusQuery } from "../lib/queries";
 import { buildViews } from "../lib/viewRegistry";
 import { applyNavIntent, usePaletteRegistry } from "./usePaletteRegistry";
 import type { NavIntent } from "./usePaletteRegistry";
@@ -276,6 +277,14 @@ export function App() {
     refetchInterval: (q) => (q.state.data?.graph_loaded ? false : 2500),
   });
   const runtime = runtimeQ.data ?? null;
+
+  // Installed inventory + freshness — feed the rail context-menu plugin actions
+  // (#1521 / #1522) so a plugin icon's menu can show its version and offer Update /
+  // Uninstall. Lightweight + cached (the freshness poll is TTL-cached server-side);
+  // both degrade gracefully (retry:false), so a missing/erroring API just hides the
+  // extra menu items rather than blocking the menu.
+  const installedPluginsQ = useQuery(installedPluginsQuery());
+  const pluginUpdatesQ = useQuery(pluginUpdatesQuery());
 
   // Tenant uid is the HUB's, never the focused agent's (which changes on every fleet
   // swap and would wrongly wipe the chat view). Host-pinned, stable, low-churn.
@@ -884,10 +893,26 @@ export function App() {
           // A plugin view's rail id is `plugin:<pluginId>:<viewId>` — resolve the owning
           // plugin's id + display name so the menu can offer "Configure…" (ADR 0036/0059).
           const pluginId = id.startsWith("plugin:") ? id.split(":")[1] : undefined;
-          const pluginName = pluginId
-            ? (runtime?.plugins?.find((p) => p.id === pluginId)?.name ?? pluginId)
-            : undefined;
-          openContextMenu("rail-surface", e, { id, side, pluginId, pluginName });
+          const rec = pluginId ? runtime?.plugins?.find((p) => p.id === pluginId) : undefined;
+          const pluginName = pluginId ? (rec?.name ?? pluginId) : undefined;
+          // Version + lifecycle affordances (#1521 / #1522): removable = tracked in the
+          // writable plugins dir (git-installed / local copy; in-tree built-ins aren't in
+          // this list and are refused server-side); updatable = the freshness poll says
+          // this plugin is behind its ref. Both feed the Update / Uninstall menu gating.
+          const removable = pluginId ? (installedPluginsQ.data?.plugins ?? []).some((pl) => pl.id === pluginId) : false;
+          const updatable = pluginId
+            ? Boolean((pluginUpdatesQ.data?.plugins ?? []).find((u) => u.id === pluginId)?.behind)
+            : false;
+          openContextMenu("rail-surface", e, {
+            id,
+            side,
+            pluginId,
+            pluginName,
+            pluginVersion: rec?.version,
+            pluginBuiltin: rec?.builtin,
+            pluginRemovable: removable,
+            pluginUpdatable: updatable,
+          });
         }}
         onRailReorder={(next) => {
           // Chat can dock anywhere now — left, right, or the bottom dock. Its slot mounts
@@ -1147,6 +1172,9 @@ export function App() {
         onClose={closePluginConfig}
       />
     )}
+    {/* Rail context-menu plugin actions (#1521 / #1522) — fires an Update, or renders the
+        Uninstall confirm, for a plugin right-clicked on its rail icon. One root mount. */}
+    <PluginRailManage />
     </>
   );
 }

--- a/apps/web/src/contextMenu/registrations.test.ts
+++ b/apps/web/src/contextMenu/registrations.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import "./registrations"; // side-effect: registers the core menus (rail-surface, …)
+import { resolveMenu } from "./registry";
+import { useUI } from "../state/uiStore";
+
+type Item = { id: string; label?: unknown; danger?: boolean; disabled?: boolean };
+const ids = (entries: unknown[]) => (entries as Item[]).map((e) => e.id);
+
+// The rail-surface menu's plugin lifecycle affordances (#1521 / #1522): the App-side
+// trigger resolves a plugin's version / removable / updatable into `ctx`, and the menu
+// turns those into a version header, an "Update available" action, and a destructive
+// "Uninstall…" — each gated so an in-tree built-in never offers update/uninstall.
+describe("rail-surface plugin lifecycle menu (#1521 / #1522)", () => {
+  const baseCtx = { id: "plugin:board:board", side: "left" as const, pluginId: "board", pluginName: "Board" };
+
+  beforeEach(() => {
+    // The menu early-returns [] unless the surface id is a tracked member of its dock.
+    useUI.setState({ railOrder: { left: ["chat", "plugin:board:board"], right: [], bottom: [], hidden: [] } });
+  });
+
+  it("shows version, Update, and Uninstall for a removable, behind plugin", () => {
+    const entries = resolveMenu("rail-surface", { ...baseCtx, pluginVersion: "1.2.3", pluginRemovable: true, pluginUpdatable: true });
+    const items = entries as Item[];
+    expect(ids(items)).toEqual(expect.arrayContaining(["plugin-version", "update", "uninstall"]));
+    expect(items.find((i) => i.id === "plugin-version")?.label).toContain("1.2.3");
+    expect(items.find((i) => i.id === "uninstall")?.danger).toBe(true);
+  });
+
+  it("hides Update when up to date and Uninstall when not removable", () => {
+    const got = ids(resolveMenu("rail-surface", { ...baseCtx, pluginVersion: "1.2.3", pluginRemovable: false, pluginUpdatable: false }));
+    expect(got).toContain("plugin-version");
+    expect(got).not.toContain("update");
+    expect(got).not.toContain("uninstall");
+  });
+
+  it("never offers Update/Uninstall for an in-tree built-in", () => {
+    const got = ids(resolveMenu("rail-surface", { ...baseCtx, pluginBuiltin: true, pluginRemovable: true, pluginUpdatable: true }));
+    expect(got).not.toContain("update");
+    expect(got).not.toContain("uninstall");
+  });
+
+  it("omits the version header when the version is unknown", () => {
+    const got = ids(resolveMenu("rail-surface", { ...baseCtx, pluginRemovable: true, pluginUpdatable: false }));
+    expect(got).not.toContain("plugin-version");
+    expect(got).toContain("uninstall");
+  });
+});

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftRight, ChevronDown, ChevronUp, Eye, EyeOff, Pencil, Plus, Puzzle, SlidersHorizontal, X } from "lucide-react";
+import { ArrowLeftRight, ChevronDown, ChevronUp, Eye, EyeOff, Pencil, Plus, Puzzle, RefreshCw, SlidersHorizontal, Trash2, X } from "lucide-react";
 
 import { openView } from "../app/usePaletteRegistry";
 import { useUI } from "../state/uiStore";
@@ -10,6 +10,12 @@ import type { MenuEntry } from "./types";
 // rails (without disabling the plugin). Chat is movable across all three docks like any other
 // surface; plugin views carry their owning plugin's id/name in `ctx` (resolved by the App-side
 // trigger) so Configure can open that plugin's settings dialog.
+//
+// Plugin lifecycle (#1521 / #1522): the App-side trigger also resolves the plugin's installed
+// version, whether the freshness poll says it's behind (`pluginUpdatable`), and whether it lives
+// in the writable plugins dir (`pluginRemovable`). So the menu shows the version, an "Update
+// available" action when behind, and a destructive "Uninstall…" — both gated so an in-tree
+// built-in (which the server refuses to update/uninstall) never offers them.
 registerContextMenu({
   type: "rail-surface",
   items: (ctx: {
@@ -17,6 +23,10 @@ registerContextMenu({
     side: "left" | "right" | "bottom";
     pluginId?: string;
     pluginName?: string;
+    pluginVersion?: string;
+    pluginBuiltin?: boolean;
+    pluginRemovable?: boolean;
+    pluginUpdatable?: boolean;
   }): MenuEntry[] => {
     if (!ctx) return [];
     const ui = useUI.getState();
@@ -41,16 +51,33 @@ registerContextMenu({
     // is always present; Configure (plugin views only) opens the owning plugin's settings dialog;
     // Hide moves the surface to railOrder.hidden (restore from ⌘K or "Move to …"). Chat is never
     // hidden — it mounts unconditionally on its dock, so a hidden chat would render with no rail icon.
+    // Built-in / uninstall / update, all gated on the plugin's origin, cluster under Configure.
     const manage: MenuEntry[] = [];
     if (ctx.pluginId) {
       const pid = ctx.pluginId;
       const pname = ctx.pluginName ?? ctx.pluginId;
+      // Installed version — informational (a disabled, non-clickable header), so the menu
+      // answers "which version am I on?" without opening the manager.
+      if (ctx.pluginVersion) {
+        manage.push({ id: "plugin-version", label: `Version v${ctx.pluginVersion}`, disabled: true, run: () => {} });
+      }
       manage.push({
         id: "configure",
         label: "Configure…",
         icon: <SlidersHorizontal size={14} />,
         run: () => useUI.getState().openPluginConfig(pid, pname),
       });
+      // Update — only when the freshness poll says this plugin is behind its ref AND it's
+      // not an in-tree built-in (the server refuses to update those). Fires via the store;
+      // a root PluginRailManage runs the mutation + toast (up-to-date/pinned → no item).
+      if (ctx.pluginUpdatable && !ctx.pluginBuiltin) {
+        manage.push({
+          id: "update",
+          label: "Update available",
+          icon: <RefreshCw size={14} />,
+          run: () => useUI.getState().requestPluginUpdate(pid, pname),
+        });
+      }
     }
     // A rail-wide escape hatch on every icon: the all-plugins counterpart to the per-plugin
     // "Configure…" above — opens Settings ▸ Integrations.
@@ -66,6 +93,22 @@ registerContextMenu({
         label: "Hide",
         icon: <EyeOff size={14} />,
         run: () => useUI.getState().hideSurface(ctx.id),
+      });
+    }
+    // Uninstall — a destructive action set off by its own divider, offered only for a
+    // writable-dir plugin (git-installed / local copy) that isn't an in-tree built-in
+    // (the server refuses those, so they only get Disable in the manager). The store
+    // trigger opens a "This cannot be undone." confirm rendered by PluginRailManage.
+    if (ctx.pluginId && ctx.pluginRemovable && !ctx.pluginBuiltin) {
+      const pid = ctx.pluginId;
+      const pname = ctx.pluginName ?? ctx.pluginId;
+      manage.push({ id: "uninstall-div", divider: true });
+      manage.push({
+        id: "uninstall",
+        label: "Uninstall…",
+        icon: <Trash2 size={14} />,
+        danger: true,
+        run: () => useUI.getState().requestPluginUninstall(pid, pname),
       });
     }
     // Any surface — core, plugin, or chat — reorders within its dock and moves across, including

--- a/apps/web/src/plugins/PluginRailManage.tsx
+++ b/apps/web/src/plugins/PluginRailManage.tsx
@@ -1,0 +1,47 @@
+import { ConfirmDialog } from "@protolabsai/ui/overlays";
+import { useEffect } from "react";
+
+import { useUI } from "../state/uiStore";
+import { usePluginManage } from "./usePluginManage";
+
+// Root-mounted host for the rail context-menu plugin actions (#1521 / #1522, ADR 0036).
+// A right-click "Update available" / "Uninstall…" on a plugin's rail icon records the
+// pending action in the UI store; this component fires the update mutation (no confirm —
+// an update is non-destructive and reversible by a re-install) or renders the uninstall
+// confirm. Mounted once in App so the actions work regardless of whether the Plugins
+// settings panel is open. Success/failure surface via the shared toast, and the rail +
+// installed list refresh via the mutation's query invalidation.
+export function PluginRailManage() {
+  const pluginUpdate = useUI((s) => s.pluginUpdate);
+  const clearPluginUpdate = useUI((s) => s.clearPluginUpdate);
+  const pluginUninstall = useUI((s) => s.pluginUninstall);
+  const clearPluginUninstall = useUI((s) => s.clearPluginUninstall);
+  const { update, remove } = usePluginManage();
+
+  // Fire the requested update, consuming the trigger first so it runs exactly once
+  // (the next render sees `pluginUpdate` cleared and early-returns). The toast reports
+  // the outcome; no modal — an update doesn't need a confirm.
+  useEffect(() => {
+    if (!pluginUpdate) return;
+    const target = pluginUpdate;
+    clearPluginUpdate();
+    update.mutate(target);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pluginUpdate]);
+
+  return (
+    <ConfirmDialog
+      open={pluginUninstall !== undefined}
+      title="Uninstall plugin?"
+      confirmLabel="Uninstall"
+      destructive
+      onConfirm={() => {
+        if (pluginUninstall) remove.mutate(pluginUninstall);
+        clearPluginUninstall();
+      }}
+      onClose={clearPluginUninstall}
+    >
+      {pluginUninstall ? `Uninstall ${pluginUninstall.name}? This cannot be undone.` : undefined}
+    </ConfirmDialog>
+  );
+}

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -17,6 +17,7 @@ import { StatusPill } from "../app/StatusPill";
 import { InstallPluginDialog } from "./InstallPluginDialog";
 import { PluginSettingsDialog } from "./PluginSettingsDialog";
 import { PluginFreshness } from "./PluginFreshness";
+import { usePluginManage } from "./usePluginManage";
 import { catalogCategories, filterCatalog } from "./catalog";
 import { api } from "../lib/api";
 import type { CatalogPlugin, PluginUpdate, RuntimeStatus } from "../lib/types";
@@ -166,6 +167,9 @@ function LocalTab() {
   const [installOpen, setInstallOpen] = useState(false);
   const [uninstallPending, setUninstallPending] = useState<Plugin | null>(null);
   const [restartPending, setRestartPending] = useState(false);
+  // Update + uninstall mutations (toast + query-refresh) shared with the rail context
+  // menu (#1521 / #1522), so both entry points behave identically.
+  const { update, remove } = usePluginManage();
 
   const refreshAll = () => {
     qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
@@ -197,33 +201,13 @@ function LocalTab() {
   const onToggle = (p: Plugin) => toggle.mutate(p);
   const pendingId = toggle.isPending ? toggle.variables?.id : undefined;
 
-  const update = useMutation({
-    mutationFn: (p: Plugin) => api.updatePlugin(p.id),
-    onSuccess: (res, p) => {
-      qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
-      qc.invalidateQueries({ queryKey: queryKeys.pluginUpdates });
-      // A new version may declare new/changed config fields — refetch the schema (#1423).
-      qc.invalidateQueries({ queryKey: queryKeys.settings });
-      toast(
-        res.restart_recommended
-          ? { tone: "info", title: "Plugin updated", message: `${p.name}${res.version ? ` to v${res.version}` : ""} — restart to fully load its console view or background surface.` }
-          : { tone: "success", title: "Plugin updated", message: `${p.name}${res.version ? ` to v${res.version}` : ""}${res.reloaded ? " (hot-reloaded)" : ""}.` },
-      );
-    },
-    onError: (err: unknown, p) => toast({ tone: "error", title: "Couldn't update plugin", message: `${p.name}: ${errMsg(err)}` }),
-  });
-  const onUpdate = (p: Plugin) => update.mutate(p);
+  const onUpdate = (p: Plugin) => update.mutate({ id: p.id, name: p.name });
   const updatingId = update.isPending ? update.variables?.id : undefined;
   const updateById = new Map((updates.data?.plugins ?? []).map((u) => [u.id, u]));
 
   // Uninstall (DELETE /api/plugins/{id}) — removes the code + plugins.lock / enabled refs.
   // Refused server-side for in-tree built-ins, so it's only offered for plugins in the
-  // lock-backed inventory.
-  const remove = useMutation({
-    mutationFn: (p: Plugin) => api.uninstallPlugin(p.id),
-    onSuccess: (_res, p) => { refreshAll(); toast({ tone: "success", title: "Plugin uninstalled", message: `${p.name} removed.` }); },
-    onError: (err: unknown, p) => toast({ tone: "error", title: "Couldn't uninstall plugin", message: `${p.name}: ${errMsg(err)}` }),
-  });
+  // lock-backed inventory. The confirm gates the shared `remove` mutation.
   const onRemove = (p: Plugin) => setUninstallPending(p);
   const removingId = remove.isPending ? remove.variables?.id : undefined;
 
@@ -354,7 +338,7 @@ function LocalTab() {
         title="Uninstall plugin?"
         confirmLabel="Uninstall"
         destructive
-        onConfirm={() => { if (uninstallPending) remove.mutate(uninstallPending); setUninstallPending(null); }}
+        onConfirm={() => { if (uninstallPending) remove.mutate({ id: uninstallPending.id, name: uninstallPending.name }); setUninstallPending(null); }}
         onClose={() => setUninstallPending(null)}
       >
         {uninstallPending

--- a/apps/web/src/plugins/usePluginManage.ts
+++ b/apps/web/src/plugins/usePluginManage.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useToast } from "@protolabsai/ui/overlays";
+
+import { api } from "../lib/api";
+import { errMsg } from "../lib/format";
+import { queryKeys, runtimeStatusQuery } from "../lib/queries";
+
+// A plugin the actions target — just its id (for the API) + name (for the toast).
+export type PluginRef = { id: string; name: string };
+
+// Shared update + uninstall mutations for a single plugin (#1521 / #1522, ADR 0027).
+// Used by BOTH the Plugins manager rows (PluginsSurface) and the rail context-menu
+// actions (PluginRailManage), so the toast copy + query-refresh are identical wherever
+// a plugin is updated/removed. On success we refresh: runtime (the rail icons + the
+// loaded set), the installed inventory (removable list), the freshness poll, and the
+// settings schema (a new/removed plugin changes which config fields exist, #1423).
+export function usePluginManage() {
+  const qc = useQueryClient();
+  const toast = useToast();
+
+  const refreshAll = () => {
+    qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+    qc.invalidateQueries({ queryKey: queryKeys.installedPlugins });
+    qc.invalidateQueries({ queryKey: queryKeys.pluginUpdates });
+    qc.invalidateQueries({ queryKey: queryKeys.settings });
+  };
+
+  // Pull the latest code at the plugin's recorded ref + hot-reload (same path as enable).
+  const update = useMutation({
+    mutationFn: (p: PluginRef) => api.updatePlugin(p.id),
+    onSuccess: (res, p) => {
+      refreshAll();
+      toast(
+        res.restart_recommended
+          ? { tone: "info", title: "Plugin updated", message: `${p.name}${res.version ? ` to v${res.version}` : ""} — restart to fully load its console view or background surface.` }
+          : { tone: "success", title: "Plugin updated", message: `${p.name}${res.version ? ` to v${res.version}` : ""}${res.reloaded ? " (hot-reloaded)" : ""}.` },
+      );
+    },
+    onError: (err: unknown, p) => toast({ tone: "error", title: "Couldn't update plugin", message: `${p.name}: ${errMsg(err)}` }),
+  });
+
+  // Uninstall (DELETE) — removes the code + plugins.lock / enabled refs. Refused
+  // server-side for in-tree built-ins, so callers only offer it for writable-dir plugins.
+  const remove = useMutation({
+    mutationFn: (p: PluginRef) => api.uninstallPlugin(p.id),
+    onSuccess: (_res, p) => {
+      refreshAll();
+      toast({ tone: "success", title: "Plugin uninstalled", message: `${p.name} removed.` });
+    },
+    onError: (err: unknown, p) => toast({ tone: "error", title: "Couldn't uninstall plugin", message: `${p.name}: ${errMsg(err)}` }),
+  });
+
+  return { update, remove };
+}

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -306,6 +306,27 @@ describe("migrateUiState — v14 domain-first settings IA", () => {
   });
 });
 
+// Rail context-menu plugin actions (#1521 / #1522): request/clear the pending Update /
+// Uninstall a right-clicked plugin icon triggers; PluginRailManage reads + consumes them.
+describe("plugin rail actions", () => {
+  beforeEach(() => useUI.setState({ pluginUpdate: undefined, pluginUninstall: undefined }));
+
+  it("records and clears a pending update", () => {
+    useUI.getState().requestPluginUpdate("board", "Board");
+    expect(useUI.getState().pluginUpdate).toEqual({ id: "board", name: "Board" });
+    useUI.getState().clearPluginUpdate();
+    expect(useUI.getState().pluginUpdate).toBeUndefined();
+  });
+
+  it("records and clears a pending uninstall independently of update", () => {
+    useUI.getState().requestPluginUninstall("doom", "Doom");
+    expect(useUI.getState().pluginUninstall).toEqual({ id: "doom", name: "Doom" });
+    expect(useUI.getState().pluginUpdate).toBeUndefined();
+    useUI.getState().clearPluginUninstall();
+    expect(useUI.getState().pluginUninstall).toBeUndefined();
+  });
+});
+
 // The v13 migration adds the `hidden` bucket to a persisted railOrder that predates it, so the
 // shape is complete (actions also fall back to [] defensively).
 describe("migrateUiState — v13 hidden bucket", () => {

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -73,6 +73,16 @@ type UIState = {
   configurePlugin?: { id: string; name: string };
   openPluginConfig: (id: string, name: string) => void;
   closePluginConfig: () => void;
+  // Rail context-menu plugin actions (#1521 / #1522, ADR 0036). A right-click "Update
+  // available" / "Uninstall…" on a plugin's rail icon records the target here; a root
+  // PluginRailManage mount fires the update mutation or renders the uninstall confirm.
+  // EPHEMERAL — partialized out of persistence so a refresh never re-triggers one.
+  pluginUpdate?: { id: string; name: string };
+  requestPluginUpdate: (id: string, name: string) => void;
+  clearPluginUpdate: () => void;
+  pluginUninstall?: { id: string; name: string };
+  requestPluginUninstall: (id: string, name: string) => void;
+  clearPluginUninstall: () => void;
   rightCollapsed: boolean;
   leftCollapsed: boolean;
   rightWidth: number;
@@ -306,6 +316,12 @@ export const useUI = create<UIState>()(
       configurePlugin: undefined,
       openPluginConfig: (id, name) => set({ configurePlugin: { id, name } }),
       closePluginConfig: () => set({ configurePlugin: undefined }),
+      pluginUpdate: undefined,
+      requestPluginUpdate: (id, name) => set({ pluginUpdate: { id, name } }),
+      clearPluginUpdate: () => set({ pluginUpdate: undefined }),
+      pluginUninstall: undefined,
+      requestPluginUninstall: (id, name) => set({ pluginUninstall: { id, name } }),
+      clearPluginUninstall: () => set({ pluginUninstall: undefined }),
       rightCollapsed: false,
       leftCollapsed: false,
       rightWidth: 360,
@@ -454,8 +470,9 @@ export const useUI = create<UIState>()(
       version: 14, // …v12 Settings→utility pill · v13 railOrder.hidden bucket · v14 drop dead settingsScope (domain-first IA, ADR 0048)
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
       // Ephemeral overlay state — dropped from persistence so a refresh never reopens it
-      // (the Global settings overlay + the per-plugin Configure dialog).
-      partialize: ({ globalSettingsOpen: _o, globalSettingsSection: _s, configurePlugin: _c, ...rest }) => rest,
+      // (the Global settings overlay, the per-plugin Configure dialog, and the pending
+      // rail-menu Update/Uninstall action).
+      partialize: ({ globalSettingsOpen: _o, globalSettingsSection: _s, configurePlugin: _c, pluginUpdate: _pu, pluginUninstall: _pun, ...rest }) => rest,
     },
   ),
 );


### PR DESCRIPTION
Closes #1521, closes #1522. Independent review: **ship**.

Adds plugin **version**, **update-if-available**, and **uninstall** to the plugin **rail context menu** (the settings panel already had them; shared onto a `usePluginManage` hook). Backend already existed (`/api/plugins/updates`, `/{id}/update`, `DELETE /{id}`).

- Rail right-click → disabled `Version vX.Y.Z` header · `Update available` (only when freshness reports behind) · destructive `Uninstall…` (confirm dialog, exact copy).
- **Built-in / bundled-in-tree plugins are non-uninstallable/updatable** (gated client-side + server refuses).
- Update label is "Update available" not "Update to vX.Y.Z" — `GET /api/plugins/updates` only knows git-sha behind/pinned, not the target semver (fabricating one would be wrong).
- DS toasts; success refreshes installed list + rail.

Gates: tsc (both) clean, vitest 251/251. Low note: the installed/updates queries now mount at App root (TTL-cached, 5s per-remote timeout, degrade gracefully) so version/update state is ready at right-click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)