### PR TITLE
feat(marketing): data-driven /roadmap page from ROADMAP.md (#1532)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,27 @@
+# Roadmap
+
+Where protoAgent is headed, kept honest and light. This is the source of truth for the
+marketing site's `/roadmap` page — `scripts/roadmap.py build` parses it into
+`sites/marketing/data/roadmap.json`. Group items under `## Planned`, `## In progress`, or
+`## Shipped`; each bullet is a short **title** — one-line detail with an optional `(#issue)`
+or `(vX.Y.Z)` reference.
+
+## Planned
+
+- **One-command install** — a `curl | sh` bootstrap with an interactive CLI config wizard. (#1520)
+- **Migrate from Hermes** — a script that imports an existing Hermes agent into protoAgent. (#1515)
+- **Migrate from OpenClaw** — a script that imports an existing OpenClaw agent into protoAgent. (#1514)
+- **Federation token follow-ups** — management UI, peer rotation, and fleet integration for ADR 0066 tokens. (#1504)
+- **Rewind a chat thread** — jump a conversation back to an earlier message and branch from there. (#1535)
+
+## In progress
+
+- **Plugin management from the rail** — uninstall a plugin from the rail context menu and a plugin-management settings panel. (#1522)
+- **Plugin version + update** — show the installed version inline with an "update if available" action. (#1521)
+- **Live Work panel** — reflect goal, task, and schedule changes as they happen, without a manual refresh. (#1537)
+
+## Shipped
+
+- **/compact** — summarize and archive a long chat thread in a single command. (v0.78.0)
+- **Developer flags** — gate pre-release work behind local feature flags, with a Settings ▸ Developer panel. (v0.78.0)
+- **Watches** — supervise many external conditions at once as a first-class primitive. (v0.78.0)

--- a/scripts/roadmap.py
+++ b/scripts/roadmap.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Derive the marketing site's /roadmap data from ROADMAP.md.
+
+ROADMAP.md at the repo root is the human-owned source of truth: status sections
+(``## Planned`` / ``## In progress`` / ``## Shipped``) each holding a bullet list of
+items — a **bold title**, an em-dash one-line detail, and an optional ``(#issue)`` or
+``(vX.Y.Z)`` reference. This mirrors the CHANGELOG.md → changelog.json pipeline
+(see scripts/changelog.py): the markdown is the thing you edit; the JSON is derived so
+the Astro page stays a dumb renderer.
+
+    python scripts/roadmap.py build     # ROADMAP.md → sites/marketing/data/roadmap.json
+    python scripts/roadmap.py check     # fail if roadmap.json is stale (CI guard)
+
+Unlike changelog.json (a *curated* subset), roadmap.json is a faithful projection of
+ROADMAP.md — so ``build`` fully rewrites it and ``check`` fails when it drifts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+ROADMAP = Path(__file__).parent.parent / "ROADMAP.md"
+MARKETING_JSON = Path(__file__).parent.parent / "sites" / "marketing" / "data" / "roadmap.json"
+
+# Issue / release references carried in a trailing ``(...)`` — e.g. ``(#1520)`` or
+# ``(v0.78.0)``. The Astro page turns ``#N`` into an issue link and ``vX.Y.Z`` into a
+# release-tag link.
+_REF = r"#\d+|v\d+\.\d+\.\d+"
+
+
+def _strip_md(s: str) -> str:
+    """Markdown → plain text (the roadmap page renders plain text); drop ADR refs."""
+    s = re.sub(r"\*\*(.+?)\*\*", r"\1", s)  # **bold** → bold
+    s = re.sub(r"`([^`]+)`", r"\1", s)  # `code` → code
+    s = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", s)  # [text](url) → text
+    s = re.sub(r"\s*\(ADR[^)]*\)", "", s)  # drop "(ADR 0026)"
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _item(raw: str) -> dict[str, object]:
+    """Parse one folded bullet into ``{title, detail, refs}``.
+
+    ``- **Title** — detail sentence. (#1520)`` → title/detail split on the bold lead
+    (falling back to the first em-dash clause), with the trailing reference parenthetical
+    peeled off into ``refs``.
+    """
+    refs = re.findall(_REF, raw)
+    # Peel the trailing "(…#1520…)" / "(…v0.78.0…)" reference group off the detail.
+    body = re.sub(rf"\s*\(([^)]*(?:{_REF})[^)]*)\)\s*$", "", raw).strip()
+
+    bold = re.match(r"\*\*(.+?)\*\*\s*", body)
+    if bold:
+        title, detail = bold.group(1), body[bold.end() :]
+    else:  # no bold lead → split on the first em-dash / hyphen separator
+        parts = re.split(r"\s+[—–-]\s+", body, maxsplit=1)
+        title, detail = parts[0], (parts[1] if len(parts) > 1 else "")
+
+    detail = re.sub(r"^[—–-]\s*", "", detail).strip()
+    return {"title": _strip_md(title), "detail": _strip_md(detail), "refs": refs}
+
+
+def parse(text: str) -> list[dict[str, object]]:
+    """ROADMAP.md → ``[{status, items: [{title, detail, refs}]}]`` in document order.
+
+    Only ``## `` (level-2) headings open a status group; a ``# `` title and any intro
+    prose above the first group are ignored. Empty groups are dropped.
+    """
+    groups: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+    chunk: list[str] | None = None  # the current bullet's lines (lead + continuations)
+
+    def flush() -> None:
+        nonlocal chunk
+        if current is not None and chunk:
+            text = re.sub(r"\s+", " ", " ".join(chunk)).strip()
+            current["items"].append(_item(text))  # type: ignore[attr-defined]
+        chunk = None
+
+    for line in text.splitlines():
+        heading = re.match(r"^##\s+(.*\S)\s*$", line)
+        if heading:
+            flush()
+            current = {"status": heading.group(1).strip(), "items": []}
+            groups.append(current)
+            continue
+        bullet = re.match(r"^-\s+(.*)$", line)
+        if bullet:
+            flush()
+            chunk = [bullet.group(1)]
+        elif chunk is not None:
+            s = line.strip()
+            if not s or s.startswith("- ") or line.startswith("#"):
+                flush()  # blank / next bullet / heading ends the current bullet
+            else:
+                chunk.append(s)  # an indented continuation line
+    flush()
+    return [g for g in groups if g["items"]]
+
+
+def render(text: str) -> str:
+    """ROADMAP.md text → the exact JSON string written to roadmap.json."""
+    return json.dumps(parse(text), indent=2, ensure_ascii=False) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Derive roadmap.json from ROADMAP.md")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("build", help="parse ROADMAP.md → sites/marketing/data/roadmap.json")
+    sub.add_parser("check", help="fail if roadmap.json is out of date vs ROADMAP.md")
+    args = parser.parse_args()
+
+    out = render(ROADMAP.read_text(encoding="utf-8"))
+
+    if args.cmd == "build":
+        MARKETING_JSON.write_text(out, encoding="utf-8")
+        n = sum(len(g["items"]) for g in parse(ROADMAP.read_text(encoding="utf-8")))
+        print(f"roadmap: wrote {n} items to {MARKETING_JSON.name}")
+    elif args.cmd == "check":
+        current = MARKETING_JSON.read_text(encoding="utf-8") if MARKETING_JSON.exists() else ""
+        if current != out:
+            raise SystemExit(
+                f"{MARKETING_JSON.name} is out of date — run `python scripts/roadmap.py build`"
+            )
+        print("roadmap: roadmap.json is in sync with ROADMAP.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/sites/marketing/data/roadmap.json
+++ b/sites/marketing/data/roadmap.json
@@ -1,0 +1,94 @@
+[
+  {
+    "status": "Planned",
+    "items": [
+      {
+        "title": "One-command install",
+        "detail": "a curl | sh bootstrap with an interactive CLI config wizard.",
+        "refs": [
+          "#1520"
+        ]
+      },
+      {
+        "title": "Migrate from Hermes",
+        "detail": "a script that imports an existing Hermes agent into protoAgent.",
+        "refs": [
+          "#1515"
+        ]
+      },
+      {
+        "title": "Migrate from OpenClaw",
+        "detail": "a script that imports an existing OpenClaw agent into protoAgent.",
+        "refs": [
+          "#1514"
+        ]
+      },
+      {
+        "title": "Federation token follow-ups",
+        "detail": "management UI, peer rotation, and fleet integration for ADR 0066 tokens.",
+        "refs": [
+          "#1504"
+        ]
+      },
+      {
+        "title": "Rewind a chat thread",
+        "detail": "jump a conversation back to an earlier message and branch from there.",
+        "refs": [
+          "#1535"
+        ]
+      }
+    ]
+  },
+  {
+    "status": "In progress",
+    "items": [
+      {
+        "title": "Plugin management from the rail",
+        "detail": "uninstall a plugin from the rail context menu and a plugin-management settings panel.",
+        "refs": [
+          "#1522"
+        ]
+      },
+      {
+        "title": "Plugin version + update",
+        "detail": "show the installed version inline with an \"update if available\" action.",
+        "refs": [
+          "#1521"
+        ]
+      },
+      {
+        "title": "Live Work panel",
+        "detail": "reflect goal, task, and schedule changes as they happen, without a manual refresh.",
+        "refs": [
+          "#1537"
+        ]
+      }
+    ]
+  },
+  {
+    "status": "Shipped",
+    "items": [
+      {
+        "title": "/compact",
+        "detail": "summarize and archive a long chat thread in a single command.",
+        "refs": [
+          "v0.78.0"
+        ]
+      },
+      {
+        "title": "Developer flags",
+        "detail": "gate pre-release work behind local feature flags, with a Settings ▸ Developer panel.",
+        "refs": [
+          "v0.78.0"
+        ]
+      },
+      {
+        "title": "Watches",
+        "detail": "supervise many external conditions at once as a first-class primitive.",
+        "refs": [
+          "v0.78.0"
+        ]
+      }
+    ]
+  }
+]

--- a/sites/marketing/src/components/Footer.astro
+++ b/sites/marketing/src/components/Footer.astro
@@ -12,6 +12,7 @@ const year = 2026;
       <a href="/features" class="hover:text-white">Features</a>
       <a href="/docs/" target="_blank" rel="noopener noreferrer" class="hover:text-white">Docs</a>
       <a href="/plugins" class="hover:text-white">Plugins</a>
+      <a href="/roadmap" class="hover:text-white">Roadmap</a>
       <a href="/changelog" class="hover:text-white">Changelog</a>
       <a href="https://github.com/protoLabsAI/protoAgent" target="_blank" rel="noopener noreferrer" class="hover:text-white">GitHub</a>
     </div>

--- a/sites/marketing/src/components/Nav.astro
+++ b/sites/marketing/src/components/Nav.astro
@@ -14,6 +14,7 @@ const repo = 'https://github.com/protoLabsAI/protoAgent';
       <a href="/features" class="hover:text-white transition-colors hidden sm:inline">Features</a>
       <a href="/docs/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors">Docs</a>
       <a href="/plugins" class="hover:text-white transition-colors hidden sm:inline">Plugins</a>
+      <a href="/roadmap" class="hover:text-white transition-colors hidden sm:inline">Roadmap</a>
       <a href="/changelog" class="hover:text-white transition-colors hidden sm:inline">Changelog</a>
       <a href={repo} target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors">GitHub</a>
       <a href="/download" class="rounded-lg bg-[var(--color-accent)] px-3.5 py-1.5 font-medium text-[#0a0a0c] hover:brightness-110 transition-colors">Download</a>

--- a/sites/marketing/src/pages/roadmap.astro
+++ b/sites/marketing/src/pages/roadmap.astro
@@ -1,0 +1,104 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import roadmap from '../../data/roadmap.json';
+
+const repo = 'https://github.com/protoLabsAI/protoAgent';
+const issues = `${repo}/issues`;
+const releases = `${repo}/releases`;
+
+type Accent = { ring: string; fill: string; dot: string; text: string };
+
+// Per-status accent — brand lavender for active work, green for shipped, muted for the rest.
+const accents: Record<string, Accent> = {
+  'In progress': {
+    ring: 'color-mix(in srgb, var(--pl-color-brand-lavender) 50%, transparent)',
+    fill: 'color-mix(in srgb, var(--pl-color-brand-lavender) 15%, transparent)',
+    dot: 'var(--pl-color-brand-lavender)',
+    text: 'var(--pl-color-brand-lavender)',
+  },
+  Shipped: {
+    ring: 'color-mix(in srgb, #4ade80 45%, transparent)',
+    fill: 'color-mix(in srgb, #4ade80 12%, transparent)',
+    dot: '#4ade80',
+    text: '#4ade80',
+  },
+  Planned: {
+    ring: 'var(--pl-color-border)',
+    fill: 'var(--pl-color-bg-raised)',
+    dot: '#52525b',
+    text: 'var(--pl-color-fg-muted)',
+  },
+};
+const fallback = accents['Planned'];
+
+const refHref = (ref: string) =>
+  ref.startsWith('#') ? `${issues}/${ref.slice(1)}` : `${releases}/tag/${ref}`;
+---
+
+<BaseLayout
+  title="Roadmap — protoAgent"
+  description="What's planned, in progress, and recently shipped for protoAgent — the LangGraph + A2A agent template."
+>
+  <div class="max-w-2xl mx-auto px-6 py-24">
+    <h1 class="text-4xl font-bold mb-2">Roadmap</h1>
+    <p class="text-zinc-400 mb-16 text-lg">Where protoAgent is headed — kept honest and light.</p>
+
+    <div class="space-y-16">
+      {roadmap.map(({ status, items }) => {
+        const a = accents[status] ?? fallback;
+        return (
+          <section>
+            <div class="flex items-center gap-3 mb-6">
+              <span
+                class="w-2.5 h-2.5 rounded-full shrink-0"
+                style={`background: ${a.dot}`}
+              ></span>
+              <h2 class="text-xl font-semibold" style={`color: ${a.text}`}>{status}</h2>
+              <span
+                class="px-1.5 py-0.5 rounded text-xs font-mono border"
+                style={`background: ${a.fill}; border-color: ${a.ring}; color: ${a.text};`}
+              >
+                {items.length}
+              </span>
+            </div>
+
+            <ul class="space-y-4 border-l pl-6 ml-1" style="border-color: var(--pl-color-border)">
+              {items.map(({ title, detail, refs }) => (
+                <li class="relative">
+                  <span
+                    class="absolute -left-[1.6875rem] top-1.5 w-2 h-2 rounded-full border"
+                    style={`background: var(--pl-color-bg); border-color: ${a.ring};`}
+                  ></span>
+                  <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <span class="font-medium text-zinc-100">{title}</span>
+                    {refs.map((ref) => (
+                      <a
+                        href={refHref(ref)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="px-1.5 py-0.5 rounded font-mono text-xs border transition-colors hover:brightness-125"
+                        style={`background: ${a.fill}; border-color: ${a.ring}; color: ${a.text};`}
+                      >
+                        {ref}
+                      </a>
+                    ))}
+                  </div>
+                  {detail && <p class="text-sm text-zinc-400 mt-1">{detail}</p>}
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+
+    <div class="mt-16 pt-8 border-t border-white/5">
+      <p class="text-zinc-500 text-sm">
+        Plans shift — this tracks{' '}
+        <a href="https://github.com/protoLabsAI/protoAgent/issues" class="text-zinc-400 hover:text-zinc-200 transition-colors underline underline-offset-2">open issues</a>.
+        Shipped work lands in the{' '}
+        <a href="/changelog" class="text-zinc-400 hover:text-zinc-200 transition-colors underline underline-offset-2">changelog</a>.
+      </p>
+    </div>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
Closes #1532. Independent review: **ship**.

A `/roadmap` page for the marketing site, **mirroring the changelog pipeline** (source markdown → generator → data json → astro + nav link):
- **ROADMAP.md** (repo root) — `## Planned / ## In progress / ## Shipped`, bulleted `**title** — detail (#issue | vX.Y.Z)`. Seeded with real open-issue items + v0.78.0 shipped highlights.
- **scripts/roadmap.py** — `build` → `sites/marketing/data/roadmap.json`; `check` fails on drift (CI-guard analog of changelog's check). Standalone (doesn't entangle the release-critical changelog script).
- **roadmap.astro** — same `BaseLayout` + DS tokens as `changelog.astro`, grouped by status, ref chips linking to issues/release tags. Nav + Footer get a `/roadmap` link before Changelog.

Gates: `roadmap.py build`/`check` round-trip clean; `astro build` passes (`/roadmap/index.html` generated); `astro check` = 0 diagnostics on roadmap.astro (the 4 pre-existing errors are in untouched `plugins.astro`/`download.astro`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)