### PR TITLE
feat(chat): Rewind to here — truncate a thread + rewrite the checkpoint (#1535)

### DIFF
--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -2,7 +2,7 @@ import { Button } from "@protolabsai/ui/primitives";
 import { Message, MessageAction, MessageActions } from "@protolabsai/ui/ai";
 import { Tooltip } from "@protolabsai/ui/overlays";
 import { Spinner } from "@protolabsai/ui/data";
-import { ArrowDownToLine, Check, Clock, Coins, Copy, GitBranch, Gauge, Maximize2, RotateCcw } from "lucide-react";
+import { ArrowDownToLine, Check, Clock, Coins, Copy, GitBranch, Gauge, History, Maximize2, RotateCcw } from "lucide-react";
 
 import { openDocument } from "../docviewer";
 import { slashCommandName } from "../ext/slashRegistry";
@@ -22,6 +22,7 @@ export type ChatMessageActions = {
   copiedId?: string | null;
   onCopy?: (m: ChatMessage) => void;
   onFork?: (m: ChatMessage) => void;
+  onRewind?: (m: ChatMessage) => void;
   onRegenerate?: (id: string) => void;
   lastAssistantId?: string;
   regenDisabled?: boolean;
@@ -199,6 +200,9 @@ export function ChatMessageView({
           ) : null}
           {actions.onFork ? (
             <MessageAction label="Fork from here" icon={<GitBranch size={14} />} onClick={() => actions.onFork!(message)} />
+          ) : null}
+          {actions.onRewind ? (
+            <MessageAction label="Rewind to here" icon={<History size={14} />} onClick={() => actions.onRewind!(message)} />
           ) : null}
           {actions.onRegenerate && message.id === actions.lastAssistantId ? (
             <MessageAction

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -280,6 +280,9 @@ function ChatSessionSlot({
   const abortRef = useRef<AbortController | null>(null);
   // Transient "copied ✓" feedback on a message's copy action.
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  // The message a "Rewind to here" is pending confirmation on (null = dialog closed).
+  // Rewind is destructive (discards everything below), so it goes through a confirm.
+  const [pendingRewind, setPendingRewind] = useState<ChatMessage | null>(null);
   // Mid-turn steering: user messages queued WHILE a turn streams (optimistic),
   // reconciled at turn-end. The ref mirrors the state so the post-stream reconcile
   // (a stale render closure) reads the live queue.
@@ -887,6 +890,48 @@ function ChatSessionSlot({
     chatStore.renameSession(created.id, `${baseTitle} (fork)`);
   }
 
+  // Rewind the conversation to a message IN PLACE (vs fork's new tab): discard
+  // everything below it. Destructive + irreversible, so it's gated behind a confirm
+  // (pendingRewind opens the dialog); confirmRewind does the work. The server rewrite
+  // is the point — the LangGraph checkpoint is the agent's real context, so a
+  // client-only trim would leave the agent still "remembering" the discarded turns.
+  function rewindAtMessage(message: ChatMessage) {
+    if (!session || status === "streaming") return;
+    setPendingRewind(message);
+  }
+
+  async function confirmRewind(message: ChatMessage) {
+    if (!session) return;
+    const i = session.messages.findIndex((m) => m.id === message.id);
+    if (i < 0) return;
+    // WHICH occurrence of this exact text the clicked bubble is — client message ids never
+    // appear in the checkpoint, so the server resolves by content; identical replies can
+    // repeat, and this makes it pick the SAME one we clicked (not a later duplicate).
+    const want = (message.content || "").trim();
+    const occurrence = session.messages.slice(0, i).filter((m) => (m.content || "").trim() === want).length;
+    let found: boolean;
+    try {
+      // Roll the agent's live context back on the server FIRST (the checkpoint is
+      // the real memory); the client truncate below just mirrors the result.
+      found = (await api.rewindChatSession(session.id, message.id ?? "", message.content, occurrence)).found;
+    } catch (e) {
+      onError(`Couldn't rewind: ${errMsg(e)}`);
+      return;
+    }
+    // The server couldn't locate the message in the live checkpoint — leave the
+    // client thread intact rather than diverge (the agent would still "remember"
+    // turns the UI had dropped).
+    if (!found) {
+      onError("Couldn't rewind — that message is no longer in the agent's live context.");
+      return;
+    }
+    // Keep the prefix through the selected message; drop everything after it.
+    const snap = chatStore.getSnapshot().sessions.find((s) => s.id === session.id);
+    const base = snap?.messages ?? session.messages;
+    const at = base.findIndex((m) => m.id === message.id);
+    chatStore.updateMessages(session.id, base.slice(0, (at < 0 ? i : at) + 1));
+  }
+
   // Resume a paused (input-required) turn: submitting the HITL form/question
   // sends the response as a follow-up on the same session — the server feeds it
   // to the agent via Command(resume=…). A form response is serialized to JSON.
@@ -1254,6 +1299,7 @@ function ChatSessionSlot({
                 copiedId,
                 onCopy: copyMessage,
                 onFork: forkAtMessage,
+                onRewind: rewindAtMessage,
                 onRegenerate: regenerate,
                 lastAssistantId,
                 regenDisabled: status === "streaming",
@@ -1444,6 +1490,22 @@ function ChatSessionSlot({
           }}
         />
       </div>
+
+      <ConfirmDialog
+        open={pendingRewind !== null}
+        title="Rewind to here?"
+        confirmLabel="Rewind"
+        destructive
+        onConfirm={() => {
+          if (pendingRewind) void confirmRewind(pendingRewind);
+          setPendingRewind(null);
+        }}
+        onClose={() => setPendingRewind(null)}
+      >
+        <p style={{ margin: 0 }}>
+          This will discard everything below this message — cannot be undone.
+        </p>
+      </ConfirmDialog>
     </div>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1196,6 +1196,26 @@ export const api = {
     }>(`/api/chat/sessions/${encodeURIComponent(sessionId)}/compact`, { method: "POST", body: {} });
   },
 
+  // Rewind a chat session server-side (#1535): discard every message AFTER the
+  // target and rewrite the LangGraph checkpoint in place, rolling the agent's live
+  // context back to that point. The checkpoint is the agent's REAL context, so this
+  // must be server-side — a client-only truncate would leave the agent's memory
+  // intact. Intentionally DESTRUCTIVE (no archive) but never corrupting. `content`
+  // is the visible bubble's text: the console's client-side message ids never appear
+  // in the checkpoint, so the server locates the message by its rendered content.
+  rewindChatSession(sessionId: string, messageId: string, content?: string, occurrence?: number) {
+    return request<{
+      found: boolean;
+      kept: number;
+      removed: number;
+      reason: string;
+      message: string;
+    }>(`/api/chat/sessions/${encodeURIComponent(sessionId)}/rewind`, {
+      method: "POST",
+      body: { message_id: messageId, content, occurrence },
+    });
+  },
+
   async streamChat(
     message: string,
     sessionId: string,

--- a/graph/rewind_op.py
+++ b/graph/rewind_op.py
@@ -1,0 +1,179 @@
+"""On-demand conversation rewind — the "Rewind to here" operator gesture (#1535).
+
+The destructive sibling of ``compaction_op`` (the ``/compact`` gesture): instead
+of summarizing older history to save tokens, the operator points at a message and
+says "discard everything after this." The live LangGraph checkpoint is the agent's
+*real* context, so a client-only truncate would leave the agent's memory intact —
+this runs SERVER-SIDE against the checkpointer and rewrites the message log.
+
+The pass, for one thread:
+
+1. ``aget_state`` the current messages off the checkpoint.
+2. Locate the target message (by raw index, by message ``id``, or — the console
+   path — by matching its rendered ``content``, since the client's message ids are
+   client-generated and never appear in the checkpoint).
+3. Keep the prefix THROUGH the target, then rewrite the checkpoint to
+   ``[RemoveMessage(REMOVE_ALL_MESSAGES), *kept_prefix]`` via ``aupdate_state``.
+
+**Rewind is intentionally destructive** — unlike compaction it is NOT never-lossy:
+the messages after the cut are meant to be thrown away (there is no archive). What
+it must NOT do is *corrupt* the log.
+
+**Message-boundary integrity (hard invariant).** The kept prefix must never end on
+an ``AIMessage(tool_calls=…)`` whose ``ToolMessage`` responses fall past the cut —
+that leaves an orphaned tool_call and the next model call errors ("tool_call
+without response"). We reuse the same safe-cut idea as the auto-summarizer /
+``compaction_op._safe_cut_index``: if the naive cut lands inside a tool-call block,
+extend FORWARD to pull the answering ``ToolMessage``\\s back in, and only if that
+can't balance, fall BACK to before the requesting ``AIMessage``.
+
+Host-free and unit-testable: it takes the graph + checkpointer + thread id as
+arguments (no ``STATE`` import), mirroring ``compaction_op.compact_thread``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from langchain_core.messages import AIMessage, ToolMessage
+
+log = logging.getLogger(__name__)
+
+
+def _open_tool_calls(messages: list) -> set[str]:
+    """The tool_call ids REQUESTED by ``AIMessage.tool_calls`` in ``messages`` that
+    have no answering ``ToolMessage`` in the same slice — i.e. the tool calls a
+    kept prefix would orphan."""
+    opened: set[str] = set()
+    answered: set[str] = set()
+    for m in messages:
+        if isinstance(m, AIMessage) and getattr(m, "tool_calls", None):
+            for tc in m.tool_calls:
+                tid = tc.get("id")
+                if tid:
+                    opened.add(tid)
+        elif isinstance(m, ToolMessage):
+            tcid = getattr(m, "tool_call_id", None)
+            if tcid:
+                answered.add(tcid)
+    return opened - answered
+
+
+def _safe_cut_end(messages: list, end: int) -> int:
+    """Adjust ``end`` (an EXCLUSIVE cut — the kept prefix is ``messages[:end]``) so
+    it never orphans a ``ToolMessage`` from the ``AIMessage(tool_calls=…)`` that
+    spawned it.
+
+    The prefix-side analogue of ``compaction_op._safe_cut_index``: if the naive cut
+    would leave a tool-call block half-kept, first extend FORWARD over the answering
+    ``ToolMessage``\\s (keeping the request/response pair together, discarding
+    slightly less), and only if that still can't balance, fall BACK before the
+    requesting ``AIMessage`` (dropping the unanswered request). Returns ``end``
+    unchanged when the prefix is already balanced — including the keep-nothing /
+    keep-everything ends, which can't orphan anything.
+    """
+    n = len(messages)
+    end = max(0, min(end, n))
+    if end == 0 or end == n:
+        return end
+    # Forward: while the kept prefix has unanswered tool calls and the very next
+    # message is a ToolMessage answering the block, pull it in.
+    while end < n and isinstance(messages[end], ToolMessage) and _open_tool_calls(messages[:end]):
+        end += 1
+    # Back: if the prefix is still unbalanced (couldn't answer forward), retreat
+    # before the requesting AIMessage(s) until nothing is orphaned.
+    while end > 0 and _open_tool_calls(messages[:end]):
+        end -= 1
+    return end
+
+
+def _resolve_end(messages: list, *, target_index, target_id, target_content, occurrence=None) -> int | None:
+    """Index of the message JUST PAST the target (the naive, pre-safe-cut prefix
+    length), or ``None`` if the target can't be located.
+
+    Precedence: an explicit ``target_index`` wins; then a matching message ``id``;
+    then the LAST message whose ``content`` equals ``target_content`` (the console
+    path — the visible assistant bubble's text matches its final ``AIMessage``).
+    Last-occurrence is the conservative pick when identical replies repeat.
+    """
+    n = len(messages)
+    if target_index is not None:
+        idx = int(target_index)
+        if idx < 0:
+            idx += n  # allow -1 = last
+        if 0 <= idx < n:
+            return idx + 1
+        return None
+    if target_id is not None:
+        for i, m in enumerate(messages):
+            if getattr(m, "id", None) == target_id:
+                return i + 1
+        # fall through to content matching if an id was given but not found
+    if target_content is not None:
+        want = str(target_content).strip()
+        if want:
+            matches = [i for i in range(n) if str(getattr(messages[i], "content", "") or "").strip() == want]
+            if matches:
+                # The client sends WHICH occurrence of this content it clicked — identical
+                # replies can repeat, and picking the last match would silently keep a LATER
+                # duplicate the user meant to discard (defeating the whole point of rewind).
+                # Pick that same occurrence from the start; fall back to the last match
+                # (conservative — discards less, never corrupts) only when unaligned.
+                if occurrence is not None and 0 <= int(occurrence) < len(matches):
+                    return matches[int(occurrence)] + 1
+                return matches[-1] + 1
+    return None
+
+
+async def rewind_thread(
+    graph,
+    checkpointer,
+    thread_id: str,
+    *,
+    target_index: int | None = None,
+    target_id: str | None = None,
+    target_content: str | None = None,
+    occurrence: int | None = None,
+) -> dict:
+    """Rewind ``thread_id``'s live context to the target message: keep the prefix
+    through it and discard everything after, rewriting the checkpoint in place.
+
+    Returns ``{found, kept, removed, reason}``. ``found`` is false (with no rewrite)
+    when there's no checkpointer or the target can't be located; ``removed == 0`` is
+    a benign no-op (the target was already the last message). Boundary integrity is
+    enforced via ``_safe_cut_end`` — a rewind never leaves an orphaned tool_call.
+    """
+    if graph is None or checkpointer is None:
+        return {"found": False, "kept": 0, "removed": 0, "reason": "no_checkpointer"}
+
+    lg_config = {"configurable": {"thread_id": thread_id}}
+    snapshot = await graph.aget_state(lg_config)
+    messages = list((getattr(snapshot, "values", None) or {}).get("messages") or [])
+
+    raw_end = _resolve_end(
+        messages,
+        target_index=target_index,
+        target_id=target_id,
+        target_content=target_content,
+        occurrence=occurrence,
+    )
+    if raw_end is None:
+        return {"found": False, "kept": len(messages), "removed": 0, "reason": "not_found"}
+
+    end = _safe_cut_end(messages, raw_end)
+    kept = messages[:end]
+    removed = len(messages) - end
+
+    if removed <= 0:
+        # Target is already the tail — nothing to discard. Don't touch the checkpoint.
+        return {"found": True, "kept": len(kept), "removed": 0, "reason": "noop"}
+
+    from langchain_core.messages import RemoveMessage
+    from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
+    await graph.aupdate_state(
+        lg_config,
+        {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), *kept]},
+    )
+    log.info("[rewind] thread %s: kept %d msg(s), discarded %d", thread_id, len(kept), removed)
+    return {"found": True, "kept": len(kept), "removed": removed, "reason": ""}

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -27,7 +27,7 @@ from runtime.state import STATE
 log = logging.getLogger("protoagent.server")
 from server import agent_name
 from server.agent_init import _retire_thread
-from server.chat import chat, compact_session
+from server.chat import chat, compact_session, rewind_session
 
 
 class ChatRequest(BaseModel):
@@ -87,6 +87,29 @@ def register_chat_routes(app, ui: str) -> None:
         checkpoint is left untouched and ``refused`` is true (the console then
         keeps the full thread rather than dropping anything)."""
         return await compact_session(session_id)
+
+    @app.post("/api/chat/sessions/{session_id}/rewind")
+    async def _api_rewind_session(session_id: str, body: dict | None = None):
+        """Rewind a chat session to a target message (#1535): discard everything
+        AFTER it and rewrite the LangGraph checkpoint IN PLACE. Runs SERVER-SIDE —
+        the checkpoint is the agent's real context, so a client-only truncate would
+        leave the agent's memory intact.
+
+        The body carries the target: ``message_id`` and/or ``content`` (the console
+        sends the visible bubble's text, since its client-side message ids never
+        appear in the checkpoint), or an explicit ``index``. Intentionally
+        DESTRUCTIVE (no archive) but never corrupting — the kept prefix is trimmed
+        to a safe tool-call boundary so no orphaned tool_call is left behind."""
+        body = body or {}
+        idx = body.get("index")
+        occ = body.get("occurrence")
+        return await rewind_session(
+            session_id,
+            message_id=body.get("message_id"),
+            index=int(idx) if idx is not None else None,
+            content=body.get("content"),
+            occurrence=int(occ) if occ is not None else None,
+        )
 
     @app.post("/api/chat/sessions/{session_id}/steer")
     async def _api_steer(session_id: str, body: dict | None = None):

--- a/server/chat.py
+++ b/server/chat.py
@@ -1218,6 +1218,60 @@ async def compact_session(session_id: str, *, request_metadata: dict | None = No
     return {**result, "message": _compaction_message(result)}
 
 
+def _rewind_message(result: dict) -> str:
+    """Human-readable status line for a rewind result (surfaced to non-UI callers /
+    logs; the console just truncates its own thread on success)."""
+    reason = result.get("reason") or ""
+    if reason == "not_found":
+        return "Couldn't rewind — that message is no longer in the agent's live context."
+    if reason == "no_checkpointer":
+        return "Rewind unavailable — no conversation checkpoint to rewind."
+    if reason == "noop":
+        return "Nothing to rewind — that's already the last message."
+    return f"Rewound the conversation — discarded {result.get('removed', 0)} later message(s)."
+
+
+async def rewind_session(
+    session_id: str,
+    *,
+    message_id: str | None = None,
+    index: int | None = None,
+    content: str | None = None,
+    occurrence: int | None = None,
+    request_metadata: dict | None = None,
+) -> dict:
+    """Rewind a chat session's live context to a target message (the "Rewind to
+    here" gesture, #1535): discard everything after it and rewrite the LangGraph
+    checkpoint in place.
+
+    Resolves the session's checkpointer ``thread_id`` (the A2A ``a2a:<session_id>``
+    thread the live streaming turns write to) and runs ``rewind_thread`` under the
+    per-thread lock, so a rewind can never race a live streaming turn on the same
+    thread (mirrors ``compact_session``). The checkpoint is the agent's REAL
+    context, so a client-only truncate would leave it intact — the rewrite here is
+    what actually rolls the agent's memory back. Returns the ``rewind_thread``
+    result dict plus a human-readable ``message``.
+    """
+    base = {"found": False, "kept": 0, "removed": 0}
+    if STATE.graph is None:
+        return {**base, "reason": "setup", "message": "Setup required — finish the setup wizard first."}
+
+    from graph.rewind_op import rewind_thread
+
+    tid = _resolve_thread_id(request_metadata, session_id)
+    async with _thread_lock(tid):
+        result = await rewind_thread(
+            STATE.graph,
+            STATE.checkpointer,
+            tid,
+            target_index=index,
+            target_id=message_id,
+            target_content=content,
+            occurrence=occurrence,
+        )
+    return {**result, "message": _rewind_message(result)}
+
+
 async def _chat_langgraph(message: str, session_id: str, *, model: str | None = None) -> list[dict[str, Any]]:
     """Non-streaming LangGraph entry — used by the console + OpenAI-compat."""
     from observability import tracing

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -107,6 +107,38 @@ def test_compact_session_route(monkeypatch):
     assert body["message"] == "Compacted this conversation"
 
 
+def test_rewind_session_route(monkeypatch):
+    # The route is a thin pass-through to server.chat.rewind_session — forwards the
+    # path session_id + body target (message_id / content / index) and returns the
+    # rewind result dict verbatim.
+    import operator_api.chat_routes as cr
+
+    seen: list[dict] = []
+
+    async def _fake_rewind(session_id, *, message_id=None, index=None, content=None, occurrence=None):
+        seen.append(
+            {
+                "session_id": session_id,
+                "message_id": message_id,
+                "index": index,
+                "content": content,
+                "occurrence": occurrence,
+            }
+        )
+        return {"found": True, "kept": 4, "removed": 2, "reason": "", "message": "Rewound"}
+
+    monkeypatch.setattr(cr, "rewind_session", _fake_rewind)
+    c = _client(monkeypatch)
+    body = c.post(
+        "/api/chat/sessions/s1/rewind", json={"message_id": "m9", "content": "the answer"}
+    ).json()
+    assert seen == [
+        {"session_id": "s1", "message_id": "m9", "index": None, "content": "the answer", "occurrence": None}
+    ]
+    assert body["removed"] == 2 and body["kept"] == 4 and body["found"] is True
+    assert body["message"] == "Rewound"
+
+
 def test_delete_session_cleans_ephemeral_attachments(monkeypatch):
     """Deleting a chat drops its session-scoped attachment chunks."""
     import operator_api.chat_routes as cr

--- a/tests/test_rewind_op.py
+++ b/tests/test_rewind_op.py
@@ -1,0 +1,213 @@
+"""Tests for on-demand conversation rewind (the "Rewind to here" gesture, #1535)."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage, ToolMessage
+from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
+from graph.checkpointer import build_sqlite_checkpointer
+from graph.rewind_op import _open_tool_calls, _safe_cut_end, rewind_thread
+
+
+class _FakeGraph:
+    """Records aupdate_state calls; serves seeded messages from aget_state."""
+
+    def __init__(self, messages):
+        self._messages = messages
+        self.updates: list = []
+
+    async def aget_state(self, config):
+        return SimpleNamespace(values={"messages": list(self._messages)})
+
+    async def aupdate_state(self, config, update):
+        self.updates.append((config, update))
+
+
+def _tool_thread():
+    # A two-turn thread where each turn is [AI(tool_calls), Tool, AI(answer)].
+    return [
+        HumanMessage(content="q1", id="h1"),
+        AIMessage(content="", id="a1", tool_calls=[{"id": "t1", "name": "search", "args": {}}]),
+        ToolMessage(content="res1", id="tm1", tool_call_id="t1"),
+        AIMessage(content="answer1", id="a2"),
+        HumanMessage(content="q2", id="h2"),
+        AIMessage(content="", id="a3", tool_calls=[{"id": "t2", "name": "search", "args": {}}]),
+        ToolMessage(content="res2", id="tm2", tool_call_id="t2"),
+        AIMessage(content="answer2", id="a4"),
+    ]
+
+
+def test_rewind_truncates_by_index():
+    msgs = [
+        HumanMessage(content="hi", id="h1"),
+        AIMessage(content="hello", id="a1"),
+        HumanMessage(content="favorite color?", id="h2"),
+        AIMessage(content="teal", id="a2"),
+    ]
+    g = _FakeGraph(msgs)
+    res = asyncio.run(rewind_thread(g, object(), "a2a:s1", target_index=1))
+    assert res == {"found": True, "kept": 2, "removed": 2, "reason": ""}
+
+    # Checkpoint rewritten to [REMOVE_ALL, *kept_prefix].
+    assert len(g.updates) == 1
+    _config, update = g.updates[0]
+    out = update["messages"]
+    assert isinstance(out[0], RemoveMessage) and out[0].id == REMOVE_ALL_MESSAGES
+    assert [m.id for m in out[1:]] == ["h1", "a1"]  # everything after index 1 discarded
+
+
+def test_rewind_by_message_id():
+    msgs = _tool_thread()
+    g = _FakeGraph(msgs)
+    # Rewind to the first turn's final answer — keeps the whole first turn.
+    res = asyncio.run(rewind_thread(g, object(), "a2a:s1", target_id="a2"))
+    _config, update = g.updates[0]
+    assert [m.id for m in update["messages"][1:]] == ["h1", "a1", "tm1", "a2"]
+    assert res["removed"] == 4 and res["kept"] == 4
+
+
+def test_rewind_by_content_matches_last_occurrence():
+    # The console path: the client sends the visible bubble's text (its client-side
+    # message id is NOT in the checkpoint). Last-occurrence disambiguates repeats.
+    msgs = [
+        HumanMessage(content="q1", id="h1"),
+        AIMessage(content="done", id="a1"),
+        HumanMessage(content="q2", id="h2"),
+        AIMessage(content="done", id="a2"),
+        HumanMessage(content="q3", id="h3"),
+        AIMessage(content="final", id="a3"),
+    ]
+    g = _FakeGraph(msgs)
+    res = asyncio.run(rewind_thread(g, object(), "a2a:s1", target_id="client-xyz", target_content="done"))
+    # "client-xyz" isn't a checkpoint id → falls through to content, last "done" = a2.
+    _config, update = g.updates[0]
+    assert [m.id for m in update["messages"][1:]] == ["h1", "a1", "h2", "a2"]
+    assert res["removed"] == 2 and res["kept"] == 4
+
+
+def test_rewind_by_content_honors_occurrence():
+    # Duplicate replies: the client sends WHICH occurrence it clicked, so the server keeps
+    # through the RIGHT "done" — not the last one (which would silently retain turns the user
+    # meant to discard). Clicking the FIRST "done" (occurrence 0) keeps only [h1, a1].
+    msgs = [
+        HumanMessage(content="q1", id="h1"),
+        AIMessage(content="done", id="a1"),
+        HumanMessage(content="q2", id="h2"),
+        AIMessage(content="done", id="a2"),
+        HumanMessage(content="q3", id="h3"),
+        AIMessage(content="final", id="a3"),
+    ]
+    g = _FakeGraph(msgs)
+    res = asyncio.run(
+        rewind_thread(g, object(), "a2a:s1", target_content="done", occurrence=0)
+    )
+    _config, update = g.updates[0]
+    assert [m.id for m in update["messages"][1:]] == ["h1", "a1"]  # the FIRST "done", not a2
+    assert res["removed"] == 4 and res["kept"] == 2
+
+
+def test_rewind_preserves_tool_call_pairing():
+    # Rewind lands ON the AIMessage(tool_calls) — the safe-cut must extend FORWARD to
+    # pull in its ToolMessage so the request/response pair isn't orphaned.
+    msgs = _tool_thread()
+    g = _FakeGraph(msgs)
+    res = asyncio.run(rewind_thread(g, object(), "a2a:s1", target_id="a3"))
+    _config, update = g.updates[0]
+    kept = update["messages"][1:]
+    # Kept through a3's ToolMessage (tm2) — a4 (answer2) discarded, tm2 NOT orphaned.
+    assert [m.id for m in kept] == ["h1", "a1", "tm1", "a2", "h2", "a3", "tm2"]
+    assert isinstance(kept[-1], ToolMessage) and kept[-1].tool_call_id == "t2"
+    assert _open_tool_calls(kept) == set()  # no orphaned tool_call
+    assert res["removed"] == 1 and res["kept"] == 7
+
+
+def test_rewind_falls_back_before_toolcall_when_response_missing():
+    # Malformed/partial turn: the AIMessage(tool_calls) has NO answering ToolMessage.
+    # Forward can't balance, so safe-cut retreats to before the requesting AIMessage.
+    msgs = [
+        HumanMessage(content="q1", id="h1"),
+        AIMessage(content="", id="a1", tool_calls=[{"id": "t1", "name": "search", "args": {}}]),
+        ToolMessage(content="res1", id="tm1", tool_call_id="t1"),
+        AIMessage(content="answer1", id="a2"),
+        HumanMessage(content="q2", id="h2"),
+        AIMessage(content="", id="a3", tool_calls=[{"id": "t2", "name": "search", "args": {}}]),
+        AIMessage(content="answer2", id="a4"),  # no ToolMessage for t2
+    ]
+    g = _FakeGraph(msgs)
+    res = asyncio.run(rewind_thread(g, object(), "a2a:s1", target_id="a3"))
+    _config, update = g.updates[0]
+    kept = update["messages"][1:]
+    assert [m.id for m in kept] == ["h1", "a1", "tm1", "a2", "h2"]  # a3 dropped, no orphan
+    assert _open_tool_calls(kept) == set()
+    assert res["removed"] == 2 and res["kept"] == 5
+
+
+def test_rewind_noop_when_target_is_last():
+    msgs = [HumanMessage(content="hi", id="h1"), AIMessage(content="yo", id="a1")]
+    g = _FakeGraph(msgs)
+    res = asyncio.run(rewind_thread(g, object(), "a2a:s1", target_id="a1"))
+    assert res["found"] is True and res["removed"] == 0 and res["reason"] == "noop"
+    assert g.updates == []  # nothing after the target — no rewrite
+
+
+def test_rewind_not_found():
+    msgs = [HumanMessage(content="hi", id="h1"), AIMessage(content="yo", id="a1")]
+    g = _FakeGraph(msgs)
+    res = asyncio.run(rewind_thread(g, object(), "a2a:s1", target_id="nope", target_content="nomatch"))
+    assert res["found"] is False and res["reason"] == "not_found"
+    assert g.updates == []
+
+
+def test_rewind_refuses_without_checkpointer():
+    res = asyncio.run(rewind_thread(_FakeGraph([]), None, "a2a:s1", target_index=0))
+    assert res["found"] is False and res["reason"] == "no_checkpointer"
+
+
+def test_safe_cut_end_keeps_balanced_ends():
+    msgs = _tool_thread()
+    assert _safe_cut_end(msgs, 0) == 0  # keep-nothing can't orphan
+    assert _safe_cut_end(msgs, len(msgs)) == len(msgs)  # keep-all can't orphan
+    assert _safe_cut_end(msgs, 4) == 4  # already a clean turn boundary
+
+
+def test_rewind_rewrites_real_sqlite_checkpoint(tmp_path):
+    """End-to-end against a real compiled graph + SQLite checkpointer: the rewrite
+    actually lands (REMOVE_ALL + reducer, no as_node ambiguity) and the resulting
+    checkpoint is the kept prefix, with tool pairing intact."""
+    db = str(tmp_path / "c.db")
+    g = StateGraph(MessagesState)
+    g.add_node("n", lambda s: {"messages": []})  # no-op — we seed via the input
+    g.add_edge(START, "n")
+    g.add_edge("n", END)
+    saver = build_sqlite_checkpointer(db)
+    app = g.compile(checkpointer=saver)
+    cfg = {"configurable": {"thread_id": "a2a:s1"}}
+    seed = [
+        HumanMessage(content="q1"),
+        AIMessage(content="", tool_calls=[{"id": "t1", "name": "search", "args": {}}]),
+        ToolMessage(content="res1", tool_call_id="t1"),
+        AIMessage(content="answer1"),
+        HumanMessage(content="q2"),
+        AIMessage(content="answer2"),
+    ]
+
+    async def run():
+        await app.ainvoke({"messages": seed}, cfg)
+        snap0 = await app.aget_state(cfg)
+        # Rewind to the first turn's final answer (content "answer1").
+        res = await rewind_thread(app, saver, "a2a:s1", target_content="answer1")
+        snap = await app.aget_state(cfg)
+        return res, snap0.values["messages"], snap.values["messages"]
+
+    res, before, final = asyncio.run(run())
+    assert len(before) == 6  # sanity: the seed landed
+    assert res["found"] is True and res["removed"] == 2 and res["kept"] == 4
+    # Live context rolled back to [q1, AI(tool_calls), tool, answer1] — turn 2 gone.
+    assert len(final) == 4
+    assert final[-1].content == "answer1"
+    assert all("answer2" not in (m.content or "") for m in final)
+    assert _open_tool_calls(final) == set()  # tool pairing preserved


### PR DESCRIPTION
Closes #1535. Review: risky → **fixed**.

A destructive **"Rewind to here"** action on assistant messages (History icon, beside Fork): discards everything after the chosen message and **rewrites the `a2a:<session_id>` checkpoint** — a client-only trim would leave the agent still remembering the discarded turns. Mirrors `/compact`:
- `graph/rewind_op.py` (host-free) → `server.chat.rewind_session` (under `_thread_lock`) → `POST /api/chat/sessions/{id}/rewind`.
- Confirm dialog ("discard everything below this message — cannot be undone"); the client truncates only when the server reports `found`.
- **Boundary integrity:** `_safe_cut_end` never orphans a `tool_call` from its `ToolMessage` (tested against a tool-call thread + a real-SQLite e2e).

**Review fix applied — the one real risk:** client message ids don't exist in the checkpoint, so the server resolved by content, taking the **last** match; on duplicate assistant replies (e.g. "Done." twice) that silently kept a *later* duplicate the user meant to discard. The client now sends **which occurrence** of that text it clicked, and the server picks the same occurrence from the start (last-match only as an unaligned fallback). Added a test. The remaining low case (content-normalization drift → clean `found:false` refusal) is fail-safe.

Gates: ruff clean; 25 pytest (rewind_op + routes) pass; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)