### PR TITLE
fix(plugins): git clone --no-hardlinks so local-path installs don't flake

### DIFF
--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -189,17 +189,23 @@ def _summary(m: PluginManifest, *, source: str, ref: str, sha: str) -> dict:
 
 
 def _clone(url: str, ref: str | None, dest: Path) -> str:
-    """Clone ``url`` at ``ref`` into ``dest``; return the resolved commit SHA."""
+    """Clone ``url`` at ``ref`` into ``dest``; return the resolved commit SHA.
+
+    ``--no-hardlinks``: when ``url`` is a LOCAL path, ``git clone`` hardlinks the
+    source's object files by default, which intermittently fails with
+    ``fatal: hardlink different from source`` (a known local-clone race — it also
+    silently ignores ``--depth``). It's a no-op for the normal remote/network case,
+    so this only makes local-path installs (and the test fixtures) robust."""
     if ref and _SHA_RE.match(ref):
         # A specific commit: full clone (shallow can't reliably check out an
         # arbitrary SHA), then check it out.
-        _git("clone", "--no-recurse-submodules", url, str(dest), timeout=_CLONE_TIMEOUT_S)
+        _git("clone", "--no-hardlinks", "--no-recurse-submodules", url, str(dest), timeout=_CLONE_TIMEOUT_S)
         _git("checkout", ref, cwd=dest)
     elif ref:
         # A tag or branch: shallow clone of just that ref.
-        _git("clone", "--depth", "1", "--no-recurse-submodules", "--branch", ref, url, str(dest), timeout=_CLONE_TIMEOUT_S)
+        _git("clone", "--depth", "1", "--no-hardlinks", "--no-recurse-submodules", "--branch", ref, url, str(dest), timeout=_CLONE_TIMEOUT_S)
     else:
-        _git("clone", "--depth", "1", "--no-recurse-submodules", url, str(dest), timeout=_CLONE_TIMEOUT_S)
+        _git("clone", "--depth", "1", "--no-hardlinks", "--no-recurse-submodules", url, str(dest), timeout=_CLONE_TIMEOUT_S)
     return _git("rev-parse", "HEAD", cwd=dest)
 
 


### PR DESCRIPTION
Fixes a recurring CI flake: `tests/test_plugin_installer.py::test_install_deps_rejects_non_pep508_requires_pip[…]` failed **3 times today** across unrelated PRs (#1566, #1571, …).

## Root cause
```
warning: --depth is ignored in local clones; use file:// instead.
fatal: hardlink different from source at '…/objects/pack/tmp_idx_…'
```
`git clone` of a **local path** hardlinks the source's object files by default. That "hardlink different from source" check intermittently fails (a known local-clone race), and `--depth` is silently ignored for local clones. The installer's test fixtures install from a **local** git repo, so they trip it.

## Fix
Add `--no-hardlinks` to all three `_clone` paths in `graph/plugins/installer.py`. It's a **no-op for the normal remote/network clone** (real plugin installs from git URLs, where hardlinks never applied), so it only makes local-path installs — and the test fixtures — robust.

## Verified
Full `test_plugin_installer.py` suite (26) passes; looped the previously-flaky test **25× → 25/25**. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of local-path installs, reducing clone-related issues during setup.
  * Ensured installs behave more consistently across different reference types, including branches, tags, and specific commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->