### PR TITLE
fix(plugins): a stale untracked live copy can't shadow a newer bundled plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gained a `soul` field), so a bundle agent arrives with its persona wired in.
 
 ### Fixed
+- **A stale untracked plugin copy no longer shadows a newer bundled one.** The loader let the
+  live/installed plugins dir override the bundled tree *unconditionally*, so a plugin that was
+  once git-installed and later bundled in-tree (e.g. the artifact plugin @ 0.11.3 vs the bundled
+  0.14.0) stayed stuck on the old installed copy forever — it never updated with the app. Now an
+  **untracked** live copy only wins when it's **not older** than the bundle; an intentional
+  install/override (tracked in `plugins.lock`) still wins at any version.
+- **Plugin install `git clone --no-hardlinks`** — cloning a plugin from a local path hardlinked
+  source objects and intermittently failed with `fatal: hardlink different from source` (a known
+  local-clone race that also silently ignores `--depth`); a no-op for the normal remote/network
+  clone. Fixes recurring CI flakiness in the installer tests.
 - **Console dev server no longer defaults to the prod backend.** `apps/web/vite.config.ts` proxied
   `npm run dev` / `npm run preview` backend calls to `:7870` (the default/prod instance the desktop
   app runs) by default — so browser-based console development silently read and **wrote your real

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -50,9 +50,43 @@ class PluginLoadResult:
     meta: list[dict] = field(default_factory=list)
 
 
-def discover_plugins(roots: list[Path]) -> list[PluginManifest]:
-    """Find plugins (dirs with a manifest) under *roots*. Live overrides bundle
-    by id (later root wins)."""
+def _version_key(v: str) -> tuple[int, int, int]:
+    """Best-effort semver sort key: ``"0.14.0" → (0, 14, 0)``. A non-numeric part
+    sorts as ``-1`` so a malformed version can't spuriously beat a real one."""
+    parts: list[int] = []
+    for p in str(v or "0").split(".")[:3]:
+        m = re.match(r"\d+", p.strip())
+        parts.append(int(m.group()) if m else -1)
+    while len(parts) < 3:
+        parts.append(0)
+    return (parts[0], parts[1], parts[2])
+
+
+def _tracked_ids() -> set[str]:
+    """Plugin ids recorded in ``plugins.lock`` — an INTENTIONAL install/override, vs
+    an untracked hand-placed/leftover copy. Best-effort (empty on any error)."""
+    try:
+        from graph.plugins import installer
+
+        return {e.get("id") for e in installer._read_lock().get("plugins", []) if e.get("id")}
+    except Exception:  # noqa: BLE001
+        return set()
+
+
+def discover_plugins(roots: list[Path], *, tracked_ids: set[str] | None = None) -> list[PluginManifest]:
+    """Find plugins (dirs with a manifest) under *roots*, later roots (the live/installed
+    dir) taking precedence over earlier ones (the bundled dir) by id — but ONLY when the live
+    copy that is UNTRACKED (not in ``plugins.lock``) only wins when it's NOT OLDER than the
+    bundled one.
+
+    This stops a stale, untracked leftover from shadowing the bundled plugin: a plugin that was
+    once git-installed (e.g. artifact @ 0.11.3) and later bundled in-tree at a newer version
+    (0.14.0) would otherwise stay stuck on the old installed copy forever, never updating with
+    the app. An intentional install/override (tracked in the lock) still wins at ANY version;
+    a same-or-newer untracked copy (a dev override) still wins too. ``tracked_ids`` defaults to
+    the ``plugins.lock`` ids."""
+    if tracked_ids is None:
+        tracked_ids = _tracked_ids()
     by_id: dict[str, PluginManifest] = {}
     for root in roots:
         if not (root and root.exists() and root.is_dir()):
@@ -61,7 +95,14 @@ def discover_plugins(roots: list[Path]) -> list[PluginManifest]:
             if not child.is_dir():
                 continue
             manifest = load_manifest(child)
-            if manifest is not None:
+            if manifest is None:
+                continue
+            incumbent = by_id.get(manifest.id)
+            if (
+                incumbent is None
+                or manifest.id in tracked_ids
+                or _version_key(manifest.version) >= _version_key(incumbent.version)
+            ):
                 by_id[manifest.id] = manifest
     return list(by_id.values())
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -112,6 +112,37 @@ def test_discover_live_overrides_bundle(tmp_path, monkeypatch) -> None:
     assert found["dup"] == "from-live"
 
 
+def _mk_versioned(root: Path, pid: str, version: str, desc: str) -> None:
+    d = root / pid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "protoagent.plugin.yaml").write_text(
+        f"id: {pid}\nname: {pid}\nversion: {version}\ndescription: {desc}\n", encoding="utf-8"
+    )
+
+
+def test_discover_stale_untracked_older_does_not_shadow_newer_bundle(tmp_path) -> None:
+    # The artifact-shadow bug: an UNTRACKED leftover from when the plugin was git-installed
+    # (@0.11.3) must NOT shadow the newer bundled copy (@0.14.0) — else it never updates with
+    # the app. Older + untracked → the bundle wins.
+    bundle = tmp_path / "bundle"
+    live = tmp_path / "live"
+    _mk_versioned(bundle, "dup", "0.14.0", "from-bundle")
+    _mk_versioned(live, "dup", "0.11.3", "from-live")
+    found = {m.id: (m.version, m.description) for m in discover_plugins([bundle, live], tracked_ids=set())}
+    assert found["dup"] == ("0.14.0", "from-bundle")
+
+
+def test_discover_tracked_override_wins_at_any_version(tmp_path) -> None:
+    # An INTENTIONAL install (tracked in plugins.lock) still overrides the bundle — even when
+    # it's OLDER — because it's a deliberate pin, not a stale leftover.
+    bundle = tmp_path / "bundle"
+    live = tmp_path / "live"
+    _mk_versioned(bundle, "dup", "0.14.0", "from-bundle")
+    _mk_versioned(live, "dup", "0.11.3", "from-live")
+    found = {m.id: m.description for m in discover_plugins([bundle, live], tracked_ids={"dup"})}
+    assert found["dup"] == "from-live"
+
+
 def test_disabled_plugin_not_loaded(tmp_path, monkeypatch) -> None:
     root = tmp_path / "plugins"
     _make_plugin(root, "offplug", enabled=False, tool="off_tool")


### PR DESCRIPTION
The systemic fix behind the artifact "stuck on 0.11.3" bug (found while diagnosing why the bundled artifact plugin wasn't updating with the app).

## Bug
`graph/plugins/loader.discover_plugins` let the **live/installed** plugins dir override the **bundled** tree *unconditionally* ("live overrides bundle by id"). So a plugin that was once git-installed and later **bundled in-tree** — e.g. `artifact @ 0.11.3` left in `~/Library/…/plugins/artifact` vs the bundled `0.14.0` — stayed **stuck on the old installed copy forever**. It never updated with the app, and #1521's "update" couldn't reach a bundled plugin.

## Fix — track/version-aware precedence
An **untracked** live copy (not in `plugins.lock`) only wins when it's **not older** than the bundle. An **intentional** install/override (tracked in the lock) still wins at **any** version; a same-or-newer untracked dev override still wins. `discover_plugins` gains an optional `tracked_ids` (defaults to the lock ids); `_version_key` does a best-effort semver compare.

## Tests
Older untracked leftover → **bundle wins**; tracked override → **live wins at any version**; the existing same-version live-override still wins. `test_plugins.py` 38 pass, ruff clean.

Also changelogs the sibling `git clone --no-hardlinks` flake fix (#1573). Together these make bundled plugins actually track the app version. *(The stale copy on the reporter's machine was also removed manually; restarting the app falls through to bundled 0.14.0.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)