### PR TITLE
fix(artifact): pointer-lock, crisp fit-to-window, persist selection (v0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gained a `soul` field), so a bundle agent arrives with its persona wired in.
 
 ### Fixed
+- **Artifact plugin (0.15.0) — pointer lock now works in games/canvas/3D artifacts.**
+  `requestPointerLock()` from generated code threw *"Pointer lock requires the window to have
+  focus"*: pointer-lock is a Permissions-Policy feature that must be delegated via `allow=` at
+  **every** iframe nesting level, and the policy was missing even though the `allow-pointer-lock`
+  sandbox token was present. The console plugin-view iframe now sends `allow="… ; pointer-lock"`
+  and the nested artifact iframe carries `allow="pointer-lock"` too.
+- **Artifact plugin (0.15.0) — SVG / Mermaid now render crisply instead of pixelating on zoom.**
+  The graphic viewport CSS-transform-scaled a `will-change` raster layer, so WKWebView (the desktop
+  app's Safari engine) rasterized the SVG at 1× then GPU-scaled the bitmap → blurry on zoom-in. It's
+  replaced by a **crisp fit-to-window**: the `<svg>` scales as a vector to fit the frame (no transform,
+  no raster layer). Pan/zoom + the zoom buttons are intentionally dropped in favor of a sharp fit.
+- **Artifact plugin (0.15.0) — the selected artifact + version now survive a tab switch.** Switching
+  console tabs unmounts/remounts the plugin-view iframe, reloading the shell fresh; it used to snap
+  back to the latest artifact. The selection (`{selId, selVer, followNewest}`) is now persisted to
+  `localStorage`, with a fallback to auto-follow-newest if the pinned artifact was deleted.
 - **A stale untracked plugin copy no longer shadows a newer bundled one.** The loader let the
   live/installed plugins dir override the bundled tree *unconditionally*, so a plugin that was
   once git-installed and later bundled in-tree (e.g. the artifact plugin @ 0.11.3 vs the bundled

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -257,18 +257,20 @@ export function PluginView({ view }: { view: PluginViewType }) {
             {reachable ? (
               // sandbox: allow-popups (+ -to-escape-sandbox) so links / window.open inside
               // a plugin open as normal un-sandboxed pages instead of being blocked.
-              // allow-pointer-lock so a plugin (or a nested artifact iframe inside it) can
-              // capture the mouse — needed for games / canvas / 3D; pointer lock must be
-              // granted at EVERY nesting level, and Esc always releases it.
-              // allow: clipboard via Permissions-Policy (no sandbox token exists for it) so
-              // copy/paste works in plugin UIs.
+              // Pointer lock needs BOTH the allow-pointer-lock sandbox token AND the
+              // pointer-lock Permissions-Policy in `allow=` — and the policy has to be
+              // delegated at EVERY nesting level, so the nested artifact iframe (which sets
+              // its own allow="pointer-lock") can capture the mouse for games / canvas / 3D.
+              // Esc always releases it.
+              // allow: clipboard + pointer-lock via Permissions-Policy (no sandbox token
+              // exists for clipboard) so copy/paste + pointer capture work in plugin UIs.
               <iframe
                 ref={frameRef}
                 className="plugin-view-frame"
                 src={apiUrl(src)}
                 title={view.label}
                 sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-pointer-lock"
-                allow="clipboard-read; clipboard-write"
+                allow="clipboard-read; clipboard-write; pointer-lock"
                 onLoad={handleLoad}
                 onError={() => setError(`The plugin page at ${src} didn’t respond.`)}
                 style={{ visibility: loaded ? "visible" : "hidden" }}

--- a/plugins/artifact/__init__.py
+++ b/plugins/artifact/__init__.py
@@ -776,7 +776,7 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
   </div>
   <div id="stage">
     <div id="empty">No artifact yet. Ask the agent to render one — a chart, diagram, or widget.</div>
-    <iframe id="frame" sandbox="allow-scripts allow-pointer-lock" referrerpolicy="no-referrer"></iframe>
+    <iframe id="frame" sandbox="allow-scripts allow-pointer-lock" allow="pointer-lock" referrerpolicy="no-referrer"></iframe>
     <div id="editor">
       <textarea id="code" class="pl-input" spellcheck="false" placeholder="Edit the artifact source…"></textarea>
       <div id="ebar">
@@ -905,53 +905,18 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
     + '#md blockquote{margin:1em 0;padding-left:1em;border-left:3px solid var(--pl-color-border,rgba(255,255,255,.2));color:var(--pl-color-fg-muted,#9aa0aa)}'
     + '#md img{max-width:100%}#md .mermaid{background:none;border:0;padding:0}';
 
-  // Pan/zoom viewport for the GRAPHIC kinds (svg + mermaid — #1495). Both render an <svg>
-  // into the sandboxed frame; wrap it in a transform-driven viewport so large diagrams can be
-  // explored: scroll-wheel / pinch to zoom (cursor-anchored), click-drag to pan, Reset to re-fit.
+  // Crisp fit-to-window viewport for the GRAPHIC kinds (svg + mermaid — #1517). Both render an
+  // <svg> into the sandboxed frame; scale it as a VECTOR to fit the frame (max-width/height:100%,
+  // !important to beat mermaid's inline max-width:Npx on its own svg). No CSS transform / raster
+  // layer: transform-scaling rasterized the SVG at 1x then GPU-scaled the bitmap, so zooming in
+  // pixelated/blurred on WKWebView. This keeps it sharp at any size (pan/zoom traded for crispness).
   // Self-contained (needs no DS stylesheet) — styled off the base() token carry.
   var VP_CSS = '<style>html,body{margin:0;height:100%;overflow:hidden}'
-    + '#__vp{position:absolute;inset:0;overflow:hidden;cursor:grab;touch-action:none}'
-    + '#__vp.__drag{cursor:grabbing}'
-    + '#__cv{position:absolute;top:0;left:0;transform-origin:0 0;will-change:transform}'
-    + '#__zb{position:fixed;top:8px;right:8px;display:flex;gap:4px;z-index:2147483646;opacity:.4;transition:opacity .12s}'
-    + '#__zb:hover{opacity:1}'
-    + '#__zb button{height:26px;min-width:26px;padding:0 7px;font:13px/1 ui-sans-serif,system-ui,sans-serif;cursor:pointer;'
-    + 'color:var(--pl-color-fg,#ededed);background:var(--pl-color-bg,#18181b);'
-    + 'border:1px solid var(--pl-color-border,rgba(255,255,255,.16));border-radius:6px}'
-    + '#__zb button:hover{border-color:var(--pl-color-accent,#9b87f2)}</style>';
-  var ZBAR = '<div id="__zb"><button id="__zi" title="Zoom in" aria-label="Zoom in">+</button>'
-    + '<button id="__zo" title="Zoom out" aria-label="Zoom out">−</button>'
-    + '<button id="__zr" title="Reset view" aria-label="Reset view">Reset</button></div>';
-  // Transforms #__cv; exposes window.__artFit so an ASYNC renderer (mermaid) can re-fit once its
-  // <svg> exists. Cursor-anchored zoom keeps the point under the pointer fixed; fit() re-centers.
-  var PANZOOM = '<script>(function(){'
-    + 'var vp=document.getElementById("__vp"),cv=document.getElementById("__cv");if(!vp||!cv)return;'
-    + 'var k=1,x=0,y=0,MIN=0.05,MAX=40;'
-    + 'function apply(){cv.style.transform="translate("+x+"px,"+y+"px) scale("+k+")";}'
-    + 'function clamp(v){return v<MIN?MIN:(v>MAX?MAX:v);}'
-    + 'function fit(){cv.style.transform="none";'
-    + 'var r=cv.getBoundingClientRect(),cw=r.width,ch=r.height,vw=vp.clientWidth,vh=vp.clientHeight;'
-    + 'if(!cw||!ch){k=1;x=0;y=0;return apply();}'
-    + 'var s=Math.min((vw-24)/cw,(vh-24)/ch);if(!(s>0)||s>1)s=1;'
-    + 'k=s;x=(vw-cw*s)/2;y=(vh-ch*s)/2;apply();}'
-    + 'function zoomAt(px,py,f){var nk=clamp(k*f);f=nk/k;x=px-f*(px-x);y=py-f*(py-y);k=nk;apply();}'
-    + 'vp.addEventListener("wheel",function(e){e.preventDefault();var rc=vp.getBoundingClientRect();'
-    + 'zoomAt(e.clientX-rc.left,e.clientY-rc.top,Math.exp(-e.deltaY*0.0015));},{passive:false});'
-    + 'var dn=false,lx=0,ly=0;'
-    + 'vp.addEventListener("pointerdown",function(e){if(e.button!==0)return;dn=true;lx=e.clientX;ly=e.clientY;'
-    + 'vp.classList.add("__drag");try{vp.setPointerCapture(e.pointerId);}catch(_){}});'
-    + 'vp.addEventListener("pointermove",function(e){if(!dn)return;x+=e.clientX-lx;y+=e.clientY-ly;lx=e.clientX;ly=e.clientY;apply();});'
-    + 'function up(){dn=false;vp.classList.remove("__drag");}'
-    + 'vp.addEventListener("pointerup",up);vp.addEventListener("pointercancel",up);'
-    + 'function cz(f){var rc=vp.getBoundingClientRect();zoomAt(rc.width/2,rc.height/2,f);}'
-    + 'var zi=document.getElementById("__zi"),zo=document.getElementById("__zo"),zr=document.getElementById("__zr");'
-    + 'if(zi)zi.addEventListener("click",function(){cz(1.25);});'
-    + 'if(zo)zo.addEventListener("click",function(){cz(0.8);});'
-    + 'if(zr)zr.addEventListener("click",fit);'
-    + 'window.__artFit=fit;window.addEventListener("resize",fit);requestAnimationFrame(fit);'
-    + '})();<\/script>';
-  // Wrap graphic content in the viewport + controls (svg + mermaid share this).
-  function viewport(inner){ return VP_CSS + '<body><div id="__vp"><div id="__cv">' + inner + '</div></div>' + ZBAR + PANZOOM; }
+    + '#__vp{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;padding:12px;box-sizing:border-box}'
+    + '#__vp pre.mermaid{display:contents}'
+    + '#__vp svg{max-width:100% !important;max-height:100% !important;width:auto !important;height:auto !important;display:block}</style>';
+  // Wrap graphic content in the fit-to-window viewport (svg + mermaid share this).
+  function viewport(inner){ return VP_CSS + '<body><div id="__vp">' + inner + '</div>'; }
 
   function srcdoc(kind, code) {
     if (kind === "html") return dsLink() + base(kind) + code;
@@ -959,9 +924,7 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
     if (kind === "mermaid") return '<!doctype html>' + base(kind) + viewport('<pre class="mermaid">' + esc(code) + '</pre>') +
       cdn("mermaid") +
       '<script>mermaid.initialize({startOnLoad:false,theme:"dark"});'
-      + 'try{var __p=mermaid.run();if(__p&&__p.then)__p.then(function(){if(window.__artFit)window.__artFit();});}catch(_){}'
-      + 'setTimeout(function(){if(window.__artFit)window.__artFit();},80);'
-      + 'setTimeout(function(){if(window.__artFit)window.__artFit();},400);<\/script></body>';
+      + 'try{mermaid.run();}catch(_){}<\/script></body>';
     if (kind === "markdown") return mdDoc(code);
     // `react`: import map + UMD react/react-dom/babel, compiled as a MODULE so `import` works
     // (no-import artifacts still run — they use the UMD React/ReactDOM globals as before).
@@ -1019,6 +982,15 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
       $estat=document.getElementById("estat");
   var editing=false;
 
+  // Persist the user's selection (artifact + version + whether to auto-follow the newest) so it
+  // STICKS across a tab-away/back — the plugin-view iframe unmounts on tab switch, so the shell
+  // reloads fresh; without this it snapped back to the latest artifact. Same-origin page → plain
+  // localStorage; best-effort (a blocked/full store just no-ops).
+  var SEL_KEY = "protoartifact.sel";
+  function saveSel(){ try{ localStorage.setItem(SEL_KEY, JSON.stringify({selId:selId, selVer:selVer, followNewest:followNewest})); }catch(_){} }
+  function loadSel(){ try{ var s=JSON.parse(localStorage.getItem(SEL_KEY)||"null");
+    if(s&&typeof s==="object"){ selId=s.selId||null; selVer=(s.selVer==null?null:s.selVer); followNewest=(s.followNewest!==false); } }catch(_){} }
+
   function selArt(){ for(var i=0;i<arts.length;i++) if(arts[i].id===selId) return arts[i]; return arts[0]||null; }
   function verIdx(a){ // selVer clamped to a's range; null/out-of-range → latest (auto-follow)
     if(!a) return 0; var n=a.versions.length;
@@ -1047,12 +1019,12 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
 
   $art.addEventListener("change", function(e){
     selId=e.target.value; selVer=null; followNewest=(selId===(curId||(arts[0]&&arts[0].id)));
-    render();
+    saveSel(); render();
   });
   $vprev.addEventListener("click", function(){ var a=selArt(); if(!a)return; var vi=verIdx(a);
-    if(vi>0){ selVer=vi-1; followNewest=false; render(); } });
+    if(vi>0){ selVer=vi-1; followNewest=false; saveSel(); render(); } });
   $vnext.addEventListener("click", function(){ var a=selArt(); if(!a)return; var vi=verIdx(a);
-    if(vi<a.versions.length-1){ selVer=vi+1; if(selVer===a.versions.length-1) selVer=null; render(); } });
+    if(vi<a.versions.length-1){ selVer=vi+1; if(selVer===a.versions.length-1) selVer=null; saveSel(); render(); } });
 
   $dl.addEventListener("click", function(){
     var a=selArt(); if(!a)return; var vi=verIdx(a), v=a.versions[vi];
@@ -1069,7 +1041,7 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
       clearTimeout(delT); delT=setTimeout(function(){ if(delArm===a.id){delArm=null;$del.textContent="Delete";} },3000); return; }
     clearTimeout(delT); delArm=null; $del.textContent="Delete";
     try{ await kit.apiFetch("/api/plugins/artifact/artifact/"+encodeURIComponent(a.id),{method:"DELETE"}); }catch(e){}
-    selId=null; selVer=null; followNewest=true; poll();
+    selId=null; selVer=null; followNewest=true; saveSel(); poll();
   });
 
   // In-panel code editor — edit the SELECTED version's source and save it as a NEW
@@ -1097,7 +1069,7 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
       var r=await kit.apiFetch("/api/plugins/artifact/artifact/"+encodeURIComponent(a.id),
         {method:"PUT",headers:{"Content-Type":"application/json"},body:JSON.stringify({code:$code.value})});
       if(!r.ok) throw 0;
-      followNewest=true; await poll(); exitEdit();   // show the just-saved new version
+      followNewest=true; saveSel(); await poll(); exitEdit();   // show the just-saved new version
     }catch(e){ $estat.textContent="Save failed"; }
     $run.disabled=false;
   });
@@ -1131,6 +1103,11 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
       var r = await kit.apiFetch("/api/plugins/artifact/history");
       var d = await r.json(); arts = (d && d.artifacts) || []; curId = (d && d.current) || null;
       if (followNewest) { selId = curId || (arts[0] && arts[0].id) || null; selVer = null; }
+      // A pinned selection whose artifact was deleted (not in arts) would strand the panel on a
+      // dead id — fall back to auto-follow + newest and re-persist so it doesn't linger.
+      else if (selId && !arts.some(function(a){ return a.id===selId; })) {
+        followNewest = true; selId = curId || (arts[0] && arts[0].id) || null; selVer = null; saveSel();
+      }
       rebuildArtSelect(); render();
     } catch (e) { /* transient */ }
   }
@@ -1138,7 +1115,7 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
   // protoagent:init, so the gated history poll authenticates) or a short timer
   // for the no-handshake case (standalone page / older host).
   var booted = false;
-  function boot(){ if (booted) return; booted = true; poll(); setInterval(poll, 1500); }
+  function boot(){ if (booted) return; booted = true; loadSel(); poll(); setInterval(poll, 1500); }
   kit.initPluginView(boot);
   setTimeout(boot, 800);
   document.addEventListener("visibilitychange", function(){ if(!document.hidden && booted) poll(); }); // refresh on return

--- a/plugins/artifact/protoagent.plugin.yaml
+++ b/plugins/artifact/protoagent.plugin.yaml
@@ -1,6 +1,6 @@
 id: artifact
 name: Artifact
-version: 0.14.0
+version: 0.15.0
 # Needs the host to serve the DS plugin-kit at /_ds/ (protoAgent #893, v0.34.0) —
 # the shell page links it for theming + the authed handshake, and artifacts inject it
 # so `.pl-*` design-system classes work inside the sandbox.

--- a/tests/test_artifact_plugin.py
+++ b/tests/test_artifact_plugin.py
@@ -473,23 +473,25 @@ def test_ask_bridge_is_wired(monkeypatch, tmp_path):
     assert "e.source!==$frame.contentWindow" in html
 
 
-def test_graphic_kinds_get_a_panzoom_viewport(monkeypatch, tmp_path):
-    """svg + mermaid render into a transform-driven pan/zoom viewport (#1495): scroll-wheel
-    zoom (cursor-anchored), click-drag pan, and a Reset-to-fit control. Both kinds share the
-    one `viewport(...)` wrapper; mermaid re-fits after its async render via window.__artFit."""
+def test_graphic_kinds_get_a_crisp_fit_to_window_viewport(monkeypatch, tmp_path):
+    """svg + mermaid render into a CRISP fit-to-window viewport (#1517): the <svg> scales as a
+    VECTOR to fit the frame (max-width/height:100% !important — the !important beats mermaid's
+    inline max-width:Npx). No CSS transform / raster layer, which pixelated on zoom-in in
+    WKWebView; pan/zoom is intentionally traded away for crispness. Both kinds share the one
+    `viewport(...)` wrapper."""
     html = _load(monkeypatch, tmp_path)._SHELL_HTML
-    # the viewport scaffold + controls exist.
-    assert 'id="__vp"' in html and 'id="__cv"' in html
-    assert 'id="__zi"' in html and 'id="__zo"' in html and 'id="__zr"' in html  # zoom in/out/reset
-    # wheel-to-zoom (cursor-anchored) + drag-to-pan wiring.
-    assert 'addEventListener("wheel"' in html and "{passive:false}" in html
-    assert 'addEventListener("pointerdown"' in html and 'addEventListener("pointermove"' in html
-    assert "transform-origin:0 0" in html  # transform applied to #__cv
-    # both graphic kinds route through the shared wrapper; the old bare-centering is gone.
+    # the viewport container exists and fits the svg crisply as a vector.
+    assert 'id="__vp"' in html
+    assert "max-width:100% !important" in html and "max-height:100% !important" in html
+    assert "width:auto !important" in html and "height:auto !important" in html
+    # both graphic kinds route through the shared wrapper.
     assert "function viewport(inner)" in html
-    assert "place-items:center" not in html  # svg no longer just centers a static graphic
-    # mermaid's async render re-fits the freshly-drawn <svg>.
-    assert "window.__artFit" in html
+    # the old transform-driven raster pan/zoom scaffold + controls are GONE (they pixelated).
+    assert 'id="__cv"' not in html
+    assert 'id="__zi"' not in html and 'id="__zo"' not in html and 'id="__zr"' not in html
+    assert "will-change" not in html and "transform-origin" not in html
+    assert 'addEventListener("wheel"' not in html  # no scroll-zoom
+    assert "__artFit" not in html  # no async re-fit — the fit is pure CSS now
 
 
 def test_libs_are_vendored_same_origin_not_cdn(monkeypatch, tmp_path):


### PR DESCRIPTION
Three artifact-panel fixes (bundled plugin → **0.15.0**).

### 1. Pointer lock in nested iframes
`requestPointerLock()` from generated code threw *"requires the window to have focus"*. Pointer-lock is a **Permissions-Policy** feature that must be delegated via `allow=` at **every** nesting level — only the `allow-pointer-lock` sandbox tokens were present. Added `allow="pointer-lock"` to the console plugin-view iframe (`PluginView.tsx`, which had clipboard-only) **and** the nested artifact `#frame` iframe.

### 2. SVG/Mermaid zoom pixelated → crisp fit-to-window
The pan/zoom viewport CSS-transform-scaled a `will-change: transform` layer; the desktop app's **WKWebView rasterizes it at 1× then GPU-scales the bitmap** → the blur. Replaced with a **crisp vector fit-to-window**: the `<svg>` scales to fit (`max-width/height:100% !important`, beating mermaid's inline sizing; `pre.mermaid{display:contents}`), no transform/raster/pan/zoom. Per the reporter's preference (fit over the broken zoom).

### 3. Selection no longer snaps to latest on tab switch
`selId/selVer/followNewest` were in-memory; switching console tabs remounts the plugin iframe → fresh shell → snapped to the newest. Now persisted to `localStorage` and restored in `boot()` before the first poll; the poll keeps the pin unless `followNewest`, and falls back to newest only if the pinned artifact was deleted.

### Gates
`pytest tests/test_artifact_plugin.py` 53 pass (the panzoom test was rewritten to assert the fit-to-window markup); ruff clean; `import plugins.artifact` OK. *(Bundled → reaches the desktop app on its next build; a dev/rebuild picks it up now.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)