### PR TITLE
feat(install): one-command curl|sh installer with a parity CLI wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **One-command install** — `curl -fsSL .../scripts/install.sh | sh` takes a fresh
+  machine from zero to a running, configured protoAgent. It checks prerequisites
+  (Docker + curl), pulls `ghcr.io/protolabsai/protoagent:latest`, runs it
+  (loopback-published, named volume, `restart:unless-stopped`, `PROTOAGENT_UI=console`),
+  then drives a **CLI config wizard over the same `/api/config/*` endpoints as the
+  browser setup wizard** (gateway URL, silent API-key entry, live model probe +
+  validation, agent name). Idempotent (re-run updates the image, keeps data, offers
+  to re-run the wizard), works over a plain SSH session (no-TTY → start + finish in
+  the browser), and POSIX-sh (`| sh`). On non-amd64 hosts (Apple Silicon) it targets
+  the amd64 image under emulation with a clear notice. Versioned at
+  [`scripts/install.sh`](scripts/install.sh); see
+  [Deploy with Docker → one-command install](docs/guides/deploy-docker.md#one-command-install).
 - **Agent archetypes are a data-driven registry** (ADR 0042). The new-agent picker + setup
   wizard now read their built-in starter types from `config/archetype-catalog.json`
   (served by `GET /api/archetypes`) instead of a hardcoded list — so archetypes can be added

--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ through every wizard step with screenshots.
 Once you're happy and want to ship it as your own image in your
 own GHCR: [Customize & deploy](./docs/guides/customize-and-deploy.md).
 
+## One-command install (Docker)
+
+No clone, no Python — for a fresh box you just SSH'd into. Pulls the published
+image, runs it, and walks a CLI wizard (the same `/api/config/*` endpoints the
+browser wizard uses) to configure a provider, model, and agent name:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/protoLabsAI/protoAgent/main/scripts/install.sh | sh
+```
+
+Re-running updates the image (the data volume is preserved) and offers to
+re-run the wizard. Works over a plain SSH session — with no TTY it starts the
+container and points you at the console to finish. See
+[Deploy with Docker → one-command install](./docs/guides/deploy-docker.md#one-command-install).
+
 ## Run headless
 
 The web console is optional — protoAgent is an **API-first agent server**. Run it

--- a/docs/guides/deploy-docker.md
+++ b/docs/guides/deploy-docker.md
@@ -11,6 +11,57 @@ export OPENAI_API_KEY=sk-... A2A_AUTH_TOKEN=$(openssl rand -hex 24)
 docker compose up -d --build
 ```
 
+## One-command install
+
+For a fresh machine you just SSH'd into — no clone, no Python, no hand-written
+`docker run`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/protoLabsAI/protoAgent/main/scripts/install.sh | sh
+```
+
+[`scripts/install.sh`](https://github.com/protoLabsAI/protoAgent/blob/main/scripts/install.sh)
+is versioned in the repo (so it tracks the agent) and:
+
+1. **Checks prerequisites** — Docker (+ a running daemon) and curl.
+2. **Pulls** `ghcr.io/protolabsai/protoagent:latest`.
+3. **Runs** it — published to **loopback** (`127.0.0.1:7870`), a named data
+   volume (`protoagent-sandbox`), `--restart unless-stopped`, and `PROTOAGENT_UI=console`
+   so the console serves at `/app`.
+4. **Runs a CLI wizard** that drives the **same `/api/config/*` endpoints as the
+   browser setup wizard** — provider gateway URL, API key (silent), model
+   (fetched + validated live), and agent name — so it stays in parity for free.
+5. **Prints** where the agent is running.
+
+It's **idempotent**: re-running pulls the latest image, keeps the data volume,
+and offers to re-run the wizard. Over a **plain SSH session with no TTY** it
+starts the container and points you at `/app` to finish setup in a browser.
+
+**Serving the vanity URL.** The one-liner above uses the GitHub-raw URL, which
+works today. To serve it from `https://agent.protolabs.studio/install.sh`
+instead, point that path at the raw file (a CDN/redirect or a one-line reverse
+proxy) — the script content is identical.
+
+**Overrides** (all optional env vars):
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `PROTOAGENT_PORT` | `7870` | Host port |
+| `PROTOAGENT_BIND` | `127.0.0.1` | Host bind address (widen only with `A2A_AUTH_TOKEN`) |
+| `PROTOAGENT_VOLUME` | `protoagent-sandbox` | Data volume name |
+| `PROTOAGENT_IMAGE` | `ghcr.io/protolabsai/protoagent:latest` | Image ref |
+| `PROTOAGENT_INSTALL_URL` | — | Configure an **already-running** instance (skips Docker) |
+| `PROTOAGENT_INSTALL_NONINTERACTIVE` | — | `1` = start only, never prompt |
+| `A2A_AUTH_TOKEN` | — | Bearer required to widen the bind past loopback |
+
+> **Architecture note.** The published image is currently **linux/amd64**. On
+> Apple Silicon / arm64 the installer targets amd64 explicitly so Docker Desktop
+> runs it under emulation (a slower first boot); native-ARM performance needs a
+> multi-arch image or a local build. On amd64 hosts it runs natively.
+
+For a **pre-configured, config-as-code** deploy (bake settings into your own
+image, no wizard) use the seed pattern below instead.
+
 ## The one trap to avoid
 
 The image declares `VOLUME /opt/protoagent/config`. That's deliberate — it persists wizard/console edits — but it means a config **volume** holds the live `langgraph-config.yaml`. So if you bake your config **as the live file** (`COPY my-config.yaml /opt/protoagent/config/langgraph-config.yaml`), the volume freezes your first-boot copy and **silently shadows every later image update**: enabling a plugin in a new image just… does nothing. Don't bake the live file.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,296 @@
+#!/bin/sh
+# protoAgent — one-command installer.
+#
+#   curl -fsSL https://raw.githubusercontent.com/protoLabsAI/protoAgent/main/scripts/install.sh | sh
+#
+# Takes a fresh machine from zero to a running, configured protoAgent:
+#   1. checks prerequisites (Docker + curl)
+#   2. pulls ghcr.io/protolabsai/protoagent:latest
+#   3. runs it (loopback-published, named volume, restart:unless-stopped)
+#   4. drives a config wizard that hits the SAME /api/config/* endpoints the
+#      browser setup wizard uses — so it stays in parity for free
+#   5. writes the config and prints where the agent is running
+#
+# Re-running is safe: it pulls the latest image, preserves the data volume, and
+# offers to re-run the wizard. Works over a plain SSH session (no browser); when
+# there's no TTY it starts the container and points you at the console to finish.
+#
+# POSIX sh on purpose (the `| sh` entrypoint) — no bashisms.
+#
+# Overridable via env:
+#   PROTOAGENT_IMAGE       image ref            (default ghcr.io/protolabsai/protoagent:latest)
+#   PROTOAGENT_CONTAINER   container name       (default protoagent)
+#   PROTOAGENT_VOLUME      data volume name     (default protoagent-sandbox)
+#   PROTOAGENT_PORT        host port            (default 7870)
+#   PROTOAGENT_BIND        host bind address    (default 127.0.0.1 — loopback)
+#   PROTOAGENT_DEFAULT_API_BASE / _DEFAULT_MODEL   wizard defaults
+#   PROTOAGENT_INSTALL_URL         configure an already-running instance; skip Docker
+#   PROTOAGENT_INSTALL_NONINTERACTIVE=1   never prompt (start only; finish in browser)
+#   A2A_AUTH_TOKEN         bearer for a non-loopback bind (see docs)
+
+set -eu
+
+# ── Config ────────────────────────────────────────────────────────────────
+IMAGE=${PROTOAGENT_IMAGE:-ghcr.io/protolabsai/protoagent:latest}
+CONTAINER=${PROTOAGENT_CONTAINER:-protoagent}
+VOLUME=${PROTOAGENT_VOLUME:-protoagent-sandbox}
+PORT=${PROTOAGENT_PORT:-7870}
+BIND=${PROTOAGENT_BIND:-127.0.0.1}
+DEFAULT_API_BASE=${PROTOAGENT_DEFAULT_API_BASE:-https://api.proto-labs.ai/v1}
+DEFAULT_MODEL=${PROTOAGENT_DEFAULT_MODEL:-protolabs/reasoning}
+TARGET_URL=${PROTOAGENT_INSTALL_URL:-}
+BASE_URL="http://127.0.0.1:${PORT}"
+
+# The published image is currently linux/amd64. On a non-amd64 host (Apple
+# Silicon, arm64 servers) a bare `docker pull` errors on the missing native
+# manifest, so target amd64 explicitly — Docker Desktop then runs it under
+# emulation. Override with PROTOAGENT_PLATFORM (e.g. once a native image exists).
+PLATFORM=${PROTOAGENT_PLATFORM:-}
+if [ -z "$PLATFORM" ]; then
+  case "$(uname -m)" in
+    x86_64|amd64) PLATFORM='' ;;
+    *)            PLATFORM='linux/amd64' ;;
+  esac
+fi
+
+# ── Output helpers ────────────────────────────────────────────────────────
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  C_R=$(printf '\033[31m'); C_G=$(printf '\033[32m'); C_Y=$(printf '\033[33m')
+  C_B=$(printf '\033[36m'); C_0=$(printf '\033[0m')
+else
+  C_R=''; C_G=''; C_Y=''; C_B=''; C_0=''
+fi
+say()  { printf '%s\n' "$*"; }
+info() { printf '%s==>%s %s\n' "$C_B" "$C_0" "$*"; }
+good() { printf '%s ✓%s %s\n' "$C_G" "$C_0" "$*"; }
+warn() { printf '%s ! %s %s\n' "$C_Y" "$C_0" "$*" >&2; }
+die()  { printf '%s ✗ %s %s\n' "$C_R" "$C_0" "$*" >&2; exit 1; }
+
+# ── TTY / interactivity ───────────────────────────────────────────────────
+# `curl | sh` feeds the script on stdin, so prompts must read /dev/tty.
+if [ -r /dev/tty ]; then TTY=/dev/tty; else TTY=; fi
+if [ -n "$TTY" ] && [ "${PROTOAGENT_INSTALL_NONINTERACTIVE:-0}" != 1 ]; then
+  INTERACTIVE=1
+else
+  INTERACTIVE=0
+fi
+
+# ── Small helpers ─────────────────────────────────────────────────────────
+need() { command -v "$1" >/dev/null 2>&1 || die "'$1' is required but not found. $2"; }
+
+# ask VAR "Question" "default"  — reads from /dev/tty, falls back to default.
+ask() {
+  if [ -n "$3" ]; then _ask_p="$2 [$3]: "; else _ask_p="$2: "; fi
+  printf '%s' "$_ask_p" > "$TTY"
+  IFS= read -r _ask_ans < "$TTY" || _ask_ans=
+  [ -z "$_ask_ans" ] && _ask_ans=$3
+  eval "$1=\$_ask_ans"
+}
+
+# ask_secret VAR "Prompt"  — no echo.
+ask_secret() {
+  printf '%s: ' "$2" > "$TTY"
+  stty -echo < "$TTY" 2>/dev/null || true
+  IFS= read -r _sec < "$TTY" || _sec=
+  stty echo < "$TTY" 2>/dev/null || true
+  printf '\n' > "$TTY"
+  eval "$1=\$_sec"
+}
+
+# JSON: minimal, dependency-free (no jq). Values we read are simple scalars.
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+json_str()    { printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n1; }
+json_true()   { printf '%s' "$1" | grep -q "\"$2\"[[:space:]]*:[[:space:]]*true"; }
+json_models() {
+  printf '%s' "$1" \
+    | sed -n 's/.*"models"[[:space:]]*:[[:space:]]*\[\([^]]*\)\].*/\1/p' \
+    | tr ',' '\n' | sed 's/^[[:space:]]*"//; s/"[[:space:]]*$//' | sed '/^$/d'
+}
+
+# HTTP: never return nonzero (would trip `set -e`); status lands in HTTP_CODE.
+HTTP_CODE=000
+HTTP_BODY=""
+http_get() {
+  if _r=$(curl -sS -m "${2:-20}" -w '\n%{http_code}' "$1" 2>/dev/null); then
+    HTTP_CODE=$(printf '%s' "$_r" | tail -n1)
+    HTTP_BODY=$(printf '%s' "$_r" | sed '$d')
+  else
+    HTTP_CODE=000; HTTP_BODY=""
+  fi
+  return 0
+}
+http_post_json() {
+  if _r=$(printf '%s' "$2" | curl -sS -m "${3:-60}" -H 'Content-Type: application/json' \
+            --data-binary @- -w '\n%{http_code}' "$1" 2>/dev/null); then
+    HTTP_CODE=$(printf '%s' "$_r" | tail -n1)
+    HTTP_BODY=$(printf '%s' "$_r" | sed '$d')
+  else
+    HTTP_CODE=000; HTTP_BODY=""
+  fi
+  return 0
+}
+
+# ── Docker ────────────────────────────────────────────────────────────────
+run_container() {
+  PLAT_ARG=''
+  if [ -n "$PLATFORM" ]; then
+    PLAT_ARG="--platform $PLATFORM"
+    warn "Host is $(uname -m); running the ${PLATFORM} image under emulation (slower first boot)."
+  fi
+  info "Pulling ${IMAGE} (this can take a minute) …"
+  # shellcheck disable=SC2086  # PLAT_ARG must word-split into two args (or none)
+  docker pull $PLAT_ARG "$IMAGE" >/dev/null || die "docker pull failed for ${IMAGE}"
+  if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+    info "Replacing existing '${CONTAINER}' container — the '${VOLUME}' data volume is kept."
+    docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  fi
+  info "Starting '${CONTAINER}' on ${BIND}:${PORT} …"
+  # PROTOAGENT_UI=console flips the baked headless image to serve the console
+  # (assets always ship). ALLOW_OPEN=1: the in-container 0.0.0.0 bind is fenced
+  # by the loopback port publish — same posture as the bundled docker-compose.
+  # shellcheck disable=SC2086  # PLAT_ARG must word-split into two args (or none)
+  docker run -d $PLAT_ARG \
+    --name "$CONTAINER" \
+    --restart unless-stopped \
+    -p "${BIND}:${PORT}:7870" \
+    -v "${VOLUME}:/sandbox" \
+    -e PROTOAGENT_UI=console \
+    -e PROTOAGENT_ALLOW_OPEN=1 \
+    -e "A2A_AUTH_TOKEN=${A2A_AUTH_TOKEN:-}" \
+    --security-opt no-new-privileges:true \
+    "$IMAGE" >/dev/null || die "docker run failed — see: docker logs ${CONTAINER}"
+}
+
+wait_ready() {
+  info "Waiting for protoAgent to accept connections …"
+  _i=0
+  while [ "$_i" -lt 90 ]; do
+    # setup-status answers 200 pre-configuration; /healthz only goes 200 AFTER
+    # setup (the graph compiles then), so it's the wrong readiness signal here.
+    http_get "${BASE_URL}/api/config/setup-status" 5
+    [ "$HTTP_CODE" = 200 ] && { good "Server is up."; return 0; }
+    _i=$((_i + 1)); sleep 2
+  done
+  die "protoAgent did not come up in time. Inspect: docker logs ${CONTAINER}"
+}
+
+# ── Wizard (mirrors apps/web SetupWizard over the same endpoints) ──────────
+wizard() {
+  http_get "${BASE_URL}/api/config/setup-status" 10
+  [ "$HTTP_CODE" = 200 ] || die "Cannot reach ${BASE_URL} (HTTP ${HTTP_CODE})."
+
+  if json_true "$HTTP_BODY" setup_complete; then
+    if [ "$INTERACTIVE" = 1 ]; then
+      ask _RE "protoAgent is already configured — re-run the setup wizard? [y/N]" ""
+      case "$_RE" in
+        y|Y|yes|YES) : ;;
+        *) info "Keeping the existing configuration."; return 0 ;;
+      esac
+    else
+      info "protoAgent is already configured; leaving its settings untouched."
+      return 0
+    fi
+  fi
+
+  if [ "$INTERACTIVE" != 1 ]; then
+    warn "No interactive terminal — skipping the config wizard."
+    say  "Finish setup in a browser at ${BASE_URL}/app, or re-run this script from a terminal."
+    return 0
+  fi
+
+  say ""
+  info "Let's configure your agent."
+  ask AGENT_NAME "Agent name" "protoagent"
+  ask API_BASE   "Model gateway URL (OpenAI-compatible)" "$DEFAULT_API_BASE"
+  ask_secret API_KEY "API key (blank if your gateway needs none)"
+
+  info "Fetching available models …"
+  http_post_json "${BASE_URL}/api/config/models" \
+    "{\"api_base\":\"$(json_escape "$API_BASE")\",\"api_key\":\"$(json_escape "$API_KEY")\"}" 30
+  MODELS=$(json_models "$HTTP_BODY")
+  MODEL=""
+  if [ -n "$MODELS" ]; then
+    say "Available models:"
+    printf '%s\n' "$MODELS" | awk '{ printf "  %2d) %s\n", NR, $0 }' > "$TTY"
+    _count=$(printf '%s\n' "$MODELS" | wc -l | tr -d ' ')
+    ask _PICK "Choose a number, or type a model name" "1"
+    if printf '%s' "$_PICK" | grep -q '^[0-9][0-9]*$' && \
+       [ "$_PICK" -ge 1 ] && [ "$_PICK" -le "$_count" ]; then
+      MODEL=$(printf '%s\n' "$MODELS" | sed -n "${_PICK}p")
+    else
+      MODEL=$_PICK
+    fi
+  else
+    _perr=$(json_str "$HTTP_BODY" error)
+    [ -n "$_perr" ] && warn "Could not list models: ${_perr}"
+    ask MODEL "Model name" "$DEFAULT_MODEL"
+  fi
+  [ -z "$MODEL" ] && MODEL=$DEFAULT_MODEL
+
+  info "Testing '${MODEL}' …"
+  http_post_json "${BASE_URL}/api/config/test-model" \
+    "{\"api_base\":\"$(json_escape "$API_BASE")\",\"api_key\":\"$(json_escape "$API_KEY")\",\"model\":\"$(json_escape "$MODEL")\"}" 60
+  if json_true "$HTTP_BODY" ok; then
+    good "Connection OK."
+  else
+    _terr=$(json_str "$HTTP_BODY" error)
+    warn "Connection test failed: ${_terr:-unknown error}"
+    ask _CONT "Save this configuration anyway? [y/N]" ""
+    case "$_CONT" in
+      y|Y|yes|YES) : ;;
+      *) die "Aborted — re-run the script to try again." ;;
+    esac
+  fi
+
+  info "Writing configuration …"
+  _key=""
+  [ -n "$API_KEY" ] && _key=",\"api_key\":\"$(json_escape "$API_KEY")\""
+  _cfg="{\"config\":{\"agent_runtime\":\"native\",\"model\":{\"provider\":\"openai\",\"name\":\"$(json_escape "$MODEL")\",\"api_base\":\"$(json_escape "$API_BASE")\"${_key}},\"identity\":{\"name\":\"$(json_escape "$AGENT_NAME")\"}}}"
+  http_post_json "${BASE_URL}/api/config/setup" "$_cfg" 120
+  if json_true "$HTTP_BODY" ok; then
+    good "Setup complete."
+  else
+    _merr=$(json_str "$HTTP_BODY" message)
+    warn "Setup did not complete cleanly: ${_merr:-unknown}. Finish it in the console at ${BASE_URL}/app."
+  fi
+}
+
+success() {
+  say ""
+  say "${C_G}  protoAgent is running.${C_0}"
+  say "  Console:  ${BASE_URL}/app"
+  say "  API:      ${BASE_URL}/v1      (OpenAI-compatible)"
+  say "  A2A:      ${BASE_URL}/a2a"
+  if [ -z "$TARGET_URL" ]; then
+    say ""
+    say "  Manage it:"
+    say "    docker logs -f ${CONTAINER}     # follow logs"
+    say "    docker stop ${CONTAINER}        # stop"
+    say "    docker start ${CONTAINER}       # start"
+    say "    re-run this installer            # update to the latest image"
+    say ""
+    say "  Data persists in the '${VOLUME}' Docker volume."
+  fi
+  say ""
+}
+
+main() {
+  case "${1:-}" in
+    -h|--help) sed -n '2,40p' "$0" 2>/dev/null || say "See the header of scripts/install.sh."; exit 0 ;;
+  esac
+  need curl "Install curl and re-run."
+  if [ -n "$TARGET_URL" ]; then
+    BASE_URL=$TARGET_URL
+    info "Configuring the protoAgent already running at ${BASE_URL} (skipping Docker)."
+  else
+    need docker "Install Docker — https://docs.docker.com/get-docker/ — and re-run."
+    docker info >/dev/null 2>&1 || die "Docker is installed but its daemon isn't running. Start Docker and re-run."
+    run_container
+    BASE_URL="http://127.0.0.1:${PORT}"
+    wait_ready
+  fi
+  wizard
+  success
+}
+
+main "$@"


### PR DESCRIPTION
## What

`curl -fsSL https://raw.githubusercontent.com/protoLabsAI/protoAgent/main/scripts/install.sh | sh` takes a fresh machine from zero to a running, configured protoAgent — the equivalent of protoCLI's one-liner.

[`scripts/install.sh`](../blob/feat/one-command-install/scripts/install.sh) (POSIX-sh, so `| sh` works):

1. **Checks prerequisites** — Docker (+ daemon) and curl.
2. **Pulls** `ghcr.io/protolabsai/protoagent:latest`.
3. **Runs** it — loopback publish (`127.0.0.1:7870`), named volume (`protoagent-sandbox`), `--restart unless-stopped`, `PROTOAGENT_UI=console` (flips the headless image to serve `/app`), `PROTOAGENT_ALLOW_OPEN=1` (the in-container `0.0.0.0` bind is fenced by the loopback publish — same posture as the bundled compose).
4. **Runs a CLI wizard** that drives the **same `/api/config/*` endpoints as the browser `SetupWizard`** — gateway URL, silent API-key entry, live model probe + validation, agent name — so it stays in parity for free (no reimplemented provider logic).
5. **Prints** where the agent is running + how to manage it.

**Idempotent** (re-run pulls latest, keeps the data volume, offers to re-run the wizard) · **SSH/no-TTY safe** (prompts read `/dev/tty`; no TTY → start the container and finish in the browser) · **arch-aware** (amd64 image runs under emulation on Apple Silicon with a notice; native on amd64).

## Acceptance criteria (#1520)

- [x] `curl … | sh` → running, configured agent
- [x] CLI wizard covers the same config surface as the frontend wizard (drives the same endpoints)
- [x] Works in a plain SSH session (no browser)
- [x] Idempotent — updates the image + offers to re-run the wizard
- [x] Script checked into the repo (`scripts/install.sh`)

## Verification

- `shellcheck -s sh` clean
- Mock-server scenarios: model-menu pick, empty-list fallback + blank-key **omission**, non-interactive skip, already-configured re-run
- **Real-image Docker smoke** (isolated throwaway container/volume/port): boots without the token gate refusing, `PROTOAGENT_UI=console` serves `/app` (200), loopback-only publish, `unless-stopped` restart policy
- **Full integration**: pty-driven real wizard → real `/api/config/models` + `test-model` + `setup` → fake gateway → `setup_complete=true` → `/healthz` 200 (graph compiled, agent live)

## Notes / follow-ups

- The one-liner uses the **GitHub-raw URL** (works today). Serving it from `https://agent.protolabs.studio/install.sh` is a DNS/redirect step — the content is identical (documented).
- The published image is **linux/amd64**; native ARM would need a **multi-arch image** (a `docker-publish.yml` buildx change) — left out here to avoid doubling the rolling-build CI cost. Installer handles ARM via emulation today.

Docs: README "One-command install (Docker)" + `docs/guides/deploy-docker.md#one-command-install`. CHANGELOG under `[Unreleased] → Added`.

Closes #1520

🤖 Generated with [Claude Code](https://claude.com/claude-code)