### PR TITLE
feat(memory): provenance stamping (fact→source session) + cited memory_recall (ADR 0069 R1c)

### DIFF
--- a/graph/conversation_harvest.py
+++ b/graph/conversation_harvest.py
@@ -111,12 +111,16 @@ async def harvest_thread(
 
         from knowledge import add_document
 
+        # source=<thread_id> is the machine-readable provenance link (ADR 0069
+        # D5) — the heading carries it for humans, but recall/audit key on the
+        # row's source column.
         chunk_ids = await asyncio.to_thread(
             add_document,
             knowledge_store,
             summary,
             domain="conversation",
             heading=f"Conversation summary ({thread_id})",
+            source=thread_id,
             namespace=namespace,
         )
         chunk_id = chunk_ids[0] if chunk_ids else None
@@ -131,7 +135,12 @@ async def harvest_thread(
         if getattr(config, "knowledge_facts", False):
             from graph.memory_facts import extract_and_store_facts
 
-            kwargs = {"knowledge_store": knowledge_store, "config": config, "namespace": namespace}
+            kwargs = {
+                "knowledge_store": knowledge_store,
+                "config": config,
+                "namespace": namespace,
+                "source": thread_id,
+            }
             if fact_extractor is not None:
                 kwargs["extractor"] = fact_extractor
             await extract_and_store_facts(transcript, **kwargs)

--- a/graph/memory_facts.py
+++ b/graph/memory_facts.py
@@ -94,9 +94,19 @@ def _jaccard(a: set[str], b: set[str]) -> float:
     return len(a & b) / len(a | b)
 
 
-def consolidate_and_store(knowledge_store, facts: list[str], *, namespace: str | None = None) -> dict:
+def consolidate_and_store(
+    knowledge_store,
+    facts: list[str],
+    *,
+    namespace: str | None = None,
+    source: str | None = None,
+) -> dict:
     """Store ``facts`` as ``finding_type="fact"``, skipping near-duplicates of
     facts already present in the same ``namespace``. Returns counts.
+
+    ``source`` is the originating session/thread id (provenance, ADR 0069 D5);
+    when the caller has none it falls back to the legacy ``"harvest"`` literal
+    rather than an empty source.
 
     Best-effort: a store that lacks ``list_chunks`` (e.g. a minimal test stub)
     degrades to add-only. Never raises.
@@ -120,7 +130,7 @@ def consolidate_and_store(knowledge_store, facts: list[str], *, namespace: str |
         rid = knowledge_store.add_chunk(
             fact,
             domain="fact",
-            source="harvest",
+            source=source or "harvest",
             source_type="extracted",
             finding_type="fact",
             namespace=namespace,
@@ -137,6 +147,7 @@ async def extract_and_store_facts(
     knowledge_store,
     config,
     namespace: str | None = None,
+    source: str | None = None,
     extractor=_default_extractor,
 ) -> dict:
     """Extract durable facts from ``transcript`` and consolidate them into the
@@ -149,7 +160,7 @@ async def extract_and_store_facts(
     except Exception:  # noqa: BLE001
         log.exception("[memory] fact extraction failed")
         return {"added": 0, "skipped": 0}
-    counts = consolidate_and_store(knowledge_store, facts, namespace=namespace)
+    counts = consolidate_and_store(knowledge_store, facts, namespace=namespace, source=source)
     if counts["added"] or counts["skipped"]:
         log.info(
             "[memory] facts: +%d new, %d dup-skipped (ns=%s)", counts["added"], counts["skipped"], namespace or "-"

--- a/tests/test_conversation_harvest.py
+++ b/tests/test_conversation_harvest.py
@@ -28,8 +28,10 @@ class _FakeKnowledge:
     def __init__(self):
         self.chunks = []
 
-    def add_chunk(self, content, domain=None, heading=None, *, namespace=None, **kw):
-        self.chunks.append({"content": content, "domain": domain, "heading": heading, "namespace": namespace})
+    def add_chunk(self, content, domain=None, heading=None, *, source=None, namespace=None, **kw):
+        self.chunks.append(
+            {"content": content, "domain": domain, "heading": heading, "source": source, "namespace": namespace}
+        )
         return f"chunk-{len(self.chunks)}"
 
 
@@ -70,6 +72,8 @@ def test_harvest_thread_summarizes_into_knowledge(tmp_path):
     assert cid == "chunk-1"
     assert kb.chunks[0]["domain"] == "conversation"
     assert "teal" in kb.chunks[0]["content"]
+    # Provenance (ADR 0069 D5): the row links back to the retired thread.
+    assert kb.chunks[0]["source"] == "a2a:chat-1"
 
 
 def test_harvest_extracts_facts_when_enabled(tmp_path):
@@ -104,9 +108,13 @@ def test_harvest_extracts_facts_when_enabled(tmp_path):
     )
     assert cid is not None
     # Episodic summary (conversation) + semantic fact (fact), both namespaced.
-    assert len(store.list_chunks(domain="conversation", namespace="proj-x")) == 1
+    summaries = store.list_chunks(domain="conversation", namespace="proj-x")
+    assert len(summaries) == 1
     facts = store.list_chunks(domain="fact", namespace="proj-x")
     assert len(facts) == 1 and "teal" in facts[0].content
+    # Provenance (ADR 0069 D5): both rows carry the originating thread id.
+    assert summaries[0].source == "a2a:chat-1"
+    assert facts[0].source == "a2a:chat-1"
 
 
 def test_harvest_skips_facts_when_disabled(tmp_path):

--- a/tests/test_memory_facts.py
+++ b/tests/test_memory_facts.py
@@ -83,6 +83,17 @@ def test_namespace_scopes_dedup(tmp_path):
     assert len(store.list_chunks(domain="fact", namespace="proj-b")) == 1
 
 
+def test_facts_carry_source_session(tmp_path):
+    """ADR 0069 D5: a fact row links back to the session it was extracted from;
+    without a session id the legacy "harvest" literal is kept (never empty)."""
+    store = KnowledgeStore(tmp_path / "kb.db")
+    consolidate_and_store(store, ["deploys on Fridays"], namespace="p", source="a2a:chat-42")
+    consolidate_and_store(store, ["releases are manual"], namespace="p")
+    by_content = {c.content: c for c in store.list_chunks(domain="fact", limit=10)}
+    assert by_content["deploys on Fridays"].source == "a2a:chat-42"
+    assert by_content["releases are manual"].source == "harvest"
+
+
 def test_extract_and_store_facts_end_to_end(tmp_path):
     store = KnowledgeStore(tmp_path / "kb.db")
 
@@ -96,6 +107,7 @@ def test_extract_and_store_facts_end_to_end(tmp_path):
             knowledge_store=store,
             config=object(),
             namespace="ns1",
+            source="a2a:chat-7",
             extractor=fake_extractor,
         )
     )
@@ -103,6 +115,8 @@ def test_extract_and_store_facts_end_to_end(tmp_path):
     facts = store.list_chunks(domain="fact", namespace="ns1", limit=10)
     # The store guardrail (ADR 0021 Phase 1) strips scratch_pad even here.
     assert all("scratch_pad" not in f.content.lower() for f in facts)
+    # Provenance threads through the extraction path (ADR 0069 D5).
+    assert all(f.source == "a2a:chat-7" for f in facts)
 
 
 def test_extract_noop_without_store():

--- a/tests/test_memory_provenance.py
+++ b/tests/test_memory_provenance.py
@@ -1,0 +1,68 @@
+"""ADR 0069 D5: memory_recall / memory_list cite each row's provenance —
+source session, stored date (date precision), and namespace, when set."""
+
+from __future__ import annotations
+
+import asyncio
+
+from knowledge.store import KnowledgeStore
+from tools.lg_tools import _build_memory_tools, _memory_citation
+
+
+def _by_name(tools):
+    return {t.name: t for t in tools}
+
+
+# ── the citation helper itself ──────────────────────────────────────────────
+
+
+def test_memory_citation_full_and_partial():
+    assert (
+        _memory_citation(source="a2a:chat-42", created_at="2026-07-01T09:30:00+00:00", namespace="proj-x")
+        == " (src: a2a:chat-42, 2026-07-01, ns: proj-x)"
+    )
+    # Unset fields are simply omitted — no dangling separators.
+    assert _memory_citation(created_at="2026-07-01T09:30:00+00:00") == " (2026-07-01)"
+    assert _memory_citation(source="a2a:chat-42") == " (src: a2a:chat-42)"
+    # Nothing to cite → no suffix at all (no empty parens).
+    assert _memory_citation() == ""
+
+
+# ── memory_recall renders the citation ──────────────────────────────────────
+
+
+def test_memory_recall_cites_source_date_and_namespace(tmp_path):
+    ks = KnowledgeStore(db_path=str(tmp_path / "kb.db"))
+    ks.add_chunk("The operator prefers teal", domain="fact", source="a2a:chat-42", namespace="proj-x")
+    stored = ks.list_chunks(limit=1)[0]
+
+    recall = _by_name(_build_memory_tools(ks))["memory_recall"]
+    out = asyncio.run(recall.ainvoke({"query": "teal"}))
+    assert "The operator prefers teal" in out
+    assert "src: a2a:chat-42" in out
+    assert stored.created_at[:10] in out  # date precision, from the row itself
+    assert "ns: proj-x" in out
+
+
+def test_memory_recall_citation_omits_unset_source(tmp_path):
+    ks = KnowledgeStore(db_path=str(tmp_path / "kb.db"))
+    ks.add_chunk("gateway alias is protolabs/reasoning", domain="general")
+    stored = ks.list_chunks(limit=1)[0]
+
+    recall = _by_name(_build_memory_tools(ks))["memory_recall"]
+    out = asyncio.run(recall.ainvoke({"query": "gateway alias"}))
+    assert "src:" not in out and "ns:" not in out
+    assert stored.created_at[:10] in out  # date still cited
+
+
+# ── memory_list gets the same treatment (src/ns; created_at already leads) ──
+
+
+def test_memory_list_cites_source_and_namespace(tmp_path):
+    ks = KnowledgeStore(db_path=str(tmp_path / "kb.db"))
+    ks.add_chunk("summary of the auth thread", domain="conversation", source="a2a:chat-9", namespace="proj-y")
+
+    memory_list = _by_name(_build_memory_tools(ks))["memory_list"]
+    out = asyncio.run(memory_list.ainvoke({}))
+    assert "src: a2a:chat-9" in out
+    assert "ns: proj-y" in out

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -536,6 +536,25 @@ def _ingest_should_inline(src: str, is_url: bool) -> bool:
         return True
 
 
+def _memory_citation(
+    *,
+    source: str | None = None,
+    created_at: str | None = None,
+    namespace: str | None = None,
+) -> str:
+    """Compact provenance suffix for a memory row (ADR 0069 D5), e.g.
+    ``" (src: a2a:chat-42, 2026-07-01, ns: proj-x)"``. Empty when there's
+    nothing to cite; ``created_at`` is trimmed to date precision."""
+    parts: list[str] = []
+    if source:
+        parts.append(f"src: {source}")
+    if created_at:
+        parts.append(str(created_at)[:10])
+    if namespace:
+        parts.append(f"ns: {namespace}")
+    return f" ({', '.join(parts)})" if parts else ""
+
+
 def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None) -> list:
     """Bind memory tools to a ``KnowledgeStore``. Returns a list.
 
@@ -718,8 +737,9 @@ def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None)
     async def memory_recall(query: str, k: int = 5) -> str:
         """Search long-term memory for chunks relevant to ``query``.
 
-        Returns the top-k matches, one per line. Pull this when the
-        operator asks something where stored context is more reliable
+        Returns the top-k matches, one per line, each citing its provenance
+        when known — source session, stored date, namespace. Pull this when
+        the operator asks something where stored context is more reliable
         than the model's own training data ("what's my coffee order?",
         "remind me what we decided about the auth migration").
 
@@ -733,7 +753,11 @@ def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None)
         results = await asyncio.to_thread(knowledge_store.search, query, k=clamped_k)
         if not results:
             return "No matches."
-        lines = [f"[{r.get('domain', '?')}] {r['preview']}" for r in results]
+        lines = [
+            f"[{r.get('domain', '?')}] {r['preview']}"
+            + _memory_citation(source=r.get("source"), created_at=r.get("created_at"), namespace=r.get("namespace"))
+            for r in results
+        ]
         return "\n".join(lines)
 
     @tool
@@ -755,7 +779,9 @@ def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None)
             preview = (c.content or "")[:200]
             # Lead with the chunk id so a caller (e.g. the `dream` consolidation
             # pass) can target a stale/superseded fact with `forget_memory`.
-            lines.append(f"#{c.id} {c.created_at} {head} {preview}")
+            # created_at already leads the line, so the citation adds src/ns only.
+            cite = _memory_citation(source=c.source, namespace=c.namespace)
+            lines.append(f"#{c.id} {c.created_at} {head} {preview}{cite}")
         return "\n".join(lines)
 
     @tool


### PR DESCRIPTION
Lane R1c of the ADR 0069 memory-delivery rework (#1577) — **D5, provenance stamping**.

## Problem

Nothing machine-readable linked a memory row to the session it came from:

- Extracted facts landed with the literal `source="harvest"` (`graph/memory_facts.py`).
- Harvested conversation summaries only carried their thread id inside the human-readable heading (`graph/conversation_harvest.py`).

So `memory_recall` couldn't cite where a memory came from, and the upcoming trust/audit tooling (D6 injection record, D7 inspector, D8 trust tiers) had nothing to key on.

## Changes

- **`graph/conversation_harvest.py`** — the summary row now stores the retiring thread's id in its `source` column (heading unchanged; `source_type` untouched), and the thread id is threaded into the fact-extraction pass.
- **`graph/memory_facts.py`** — `extract_and_store_facts` / `consolidate_and_store` accept a `source` session/thread id and stamp it on each fact row (`source_type="extracted"` kept). With no session id available it falls back to the legacy `"harvest"` literal so the column is never empty. `conversation_harvest` is the only production caller (verified by grep).
- **`tools/lg_tools.py`** — `memory_recall` hit lines now carry a compact citation: `(src: <session>, <date>, ns: <namespace>)` with unset parts omitted and `created_at` trimmed to date precision. `memory_list` gets the same `src`/`ns` treatment (its lines already lead with the full `created_at`). Edits are confined to the recall/list rendering plus one module-level helper, to stay out of the sibling lane's way in `_build_memory_tools`.

## Tests

- Harvested summary row carries the thread id in `source` (fake store + real `KnowledgeStore`).
- Extracted fact rows carry the originating session id; source-less consolidation falls back to `"harvest"`.
- New `tests/test_memory_provenance.py`: citation helper formatting (full/partial/empty), `memory_recall` cites src/date/ns and omits unset fields, `memory_list` cites src/ns.

## Gates

- `ruff check .` ✅
- `lint-imports` ✅ (3 contracts kept; run via `uvx --from import-linter==2.11` matching CI's pin)
- `python -m pytest tests/ -q` ✅ 2612 passed, 5 skipped
- `python scripts/live_smoke.py` ✅ LIVE SMOKE PASSED

Refs ADR 0069 (D5) / PR #1577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)