### PR TITLE
fix(chat): no shared api-default session, no unknown.json pooling, unified thread-id prefix (ADR 0069 R1b)

### DIFF
--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -84,6 +84,12 @@ def _persist_session(state: dict, trace_id: str) -> None:
         from observability import tracing
 
         session_id = tracing.current_session_id() or ""
+    if not session_id:
+        # ADR 0069 D4: no identity anywhere → skip. The old ``unknown.json``
+        # fallback pooled unrelated sessions into one file that then got
+        # injected everywhere via <prior_sessions>.
+        log.warning("[memory] no session_id resolved — skipping session persistence")
+        return
     messages_raw: list = state.get("messages", []) or []
 
     # --- Extract user-visible messages ---
@@ -160,7 +166,7 @@ def _persist_session(state: dict, trace_id: str) -> None:
         return
 
     # --- Atomic write ---
-    filename = f"{session_id or 'unknown'}.json"
+    filename = f"{session_id}.json"
     dest = os.path.join(base, filename)
     tmp_fd = None
     tmp_path = None

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import secrets
 import time
 
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -31,9 +32,22 @@ from server.chat import chat, compact_session, rewind_session
 
 
 class ChatRequest(BaseModel):
+    # Omitted/blank session_id → a unique per-call id is minted (ADR 0069 D4).
+    # The old literal "api-default" pooled every anonymous caller into ONE
+    # checkpointer thread and ONE session-memory file.
     message: str
-    session_id: str = "api-default"
+    session_id: str = ""
     model: str | None = None  # per-tab model override; None → configured default
+
+
+_B36 = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+
+def _mint_session_id() -> str:
+    """Unique per-call session id — ``api-<epoch-ms>-<6 base36>``, mirroring the
+    console's ``chat-<ts>-<rand>`` shape (apps/web chat-store ``id()``)."""
+    rand = "".join(secrets.choice(_B36) for _ in range(6))
+    return f"api-{int(time.time() * 1000)}-{rand}"
 
 
 def register_chat_routes(app, ui: str) -> None:
@@ -46,9 +60,12 @@ def register_chat_routes(app, ui: str) -> None:
     # --- Chat API -----------------------------------------------------------
     @app.post("/api/chat")
     async def _api_chat(req: ChatRequest):
-        result = await chat(req.message, req.session_id, model=req.model)
+        # Echo the (possibly minted) session_id so callers can continue the
+        # session — additive key, existing consumers unaffected.
+        session_id = req.session_id.strip() or _mint_session_id()
+        result = await chat(req.message, session_id, model=req.model)
         parts = [m["content"] for m in result if m.get("role") == "assistant" and m.get("content")]
-        return {"response": "\n\n".join(parts), "messages": result}
+        return {"response": "\n\n".join(parts), "messages": result, "session_id": session_id}
 
     @app.delete("/api/chat/sessions/{session_id}")
     async def _api_delete_session(session_id: str, harvest: bool = False):
@@ -61,8 +78,10 @@ def register_chat_routes(app, ui: str) -> None:
         operator may be deleting it precisely to get rid of it. The TTL prune
         sweep keeps its own config-driven default (``checkpoint_harvest_enabled``).
 
-        Both ``a2a:{session_id}`` and ``chat:{session_id}`` threads are retired
-        with cascade so goal-mode ``:goal-iter-N`` sub-threads are not orphaned."""
+        Both ``a2a:{session_id}`` and the legacy ``chat:{session_id}`` threads are
+        retired (non-streaming turns keyed ``chat:`` before ADR 0069 unified the
+        prefix) with cascade so goal-mode ``:goal-iter-N`` sub-threads are not
+        orphaned."""
         chunk_id = await _retire_thread(f"a2a:{session_id}", harvest=harvest, cascade=True)
         await _retire_thread(f"chat:{session_id}", harvest=False, cascade=True)  # only harvest once
         # Ephemeral chat attachments are session-scoped (ADR 0021) — drop them so a

--- a/server/chat.py
+++ b/server/chat.py
@@ -99,11 +99,11 @@ def _goal_continuation_config(config: dict, goal_state) -> dict:
     Same-session goals reuse ``config`` (the checkpointer keeps the transcript so the model
     sees prior iterations). Fresh-context goals (Ralph loop) get a scoped, per-iteration
     ``thread_id`` so the checkpointer starts clean each turn — derived from the CURRENT
-    ``config`` thread_id so the streaming (``a2a:…``) and non-streaming (``chat:…``) drive
-    loops build it identically instead of each hand-rolling it. (They had drifted: the two
-    paths re-derived the base thread_id differently and only the streaming one set
-    ``recursion_limit`` — this unifies both.) Durable state lives in the goal's plan
-    artifact on disk, not the thread.
+    ``config`` thread_id so the streaming and non-streaming drive loops (both ``a2a:…``
+    since ADR 0069 unified the prefix) build it identically instead of each hand-rolling
+    it. (They had drifted: the two paths re-derived the base thread_id differently and
+    only the streaming one set ``recursion_limit`` — this unifies both.) Durable state
+    lives in the goal's plan artifact on disk, not the thread.
     """
     if not (goal_state and getattr(goal_state, "fresh_context", False)):
         return config
@@ -1315,11 +1315,12 @@ async def _chat_langgraph(message: str, session_id: str, *, model: str | None = 
             if parsed_skill is not None:
                 message = _skill_directive(*parsed_skill)
 
-            # `chat:` namespaces non-streaming sessions in the shared checkpointer,
-            # apart from the A2A `a2a:` ones (was `gradio:` — renamed when the Gradio
-            # UI was removed; non-streaming chat is short-lived so the one-time
-            # re-key on upgrade is harmless).
-            config = {"configurable": {"thread_id": f"chat:{session_id}"}}
+            # Same thread-id resolution as the streaming path (ADR 0069 D4): the
+            # non-streaming turns used to key `chat:{session_id}` apart from the
+            # streaming `a2a:{session_id}` ones, so the SAME session reached via
+            # both APIs split into two histories. Old `chat:*` checkpoints orphan
+            # once on upgrade — non-streaming chat is short-lived, so harmless.
+            config = {"configurable": {"thread_id": _resolve_thread_id(None, session_id)}}
 
             def _last_ai(result) -> str:
                 for msg in reversed(result.get("messages", [])):

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -1,6 +1,7 @@
 """Chat / goal / health / OpenAI-compat routes (ADR 0023 phase 3 extraction)."""
 
 import json
+import re
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -27,6 +28,36 @@ def _client(monkeypatch, *, graph=object(), goal=None, chat_reply=None):
 def test_api_chat_joins_assistant_parts(monkeypatch):
     c = _client(monkeypatch)
     body = c.post("/api/chat", json={"message": "hi"}).json()
+    assert body["response"] == "echo:hi"
+
+
+def test_api_chat_mints_unique_session_id_when_omitted(monkeypatch):
+    # ADR 0069 D4: an omitted/blank session_id must NOT pool callers into a
+    # shared "api-default" thread + memory file — each call mints a unique id
+    # and the response echoes it so the caller can continue the session.
+    import operator_api.chat_routes as cr
+
+    seen: list[str] = []
+
+    async def _fake_chat(message, session_id, *, model=None):
+        seen.append(session_id)
+        return [{"role": "assistant", "content": "ok"}]
+
+    c = _client(monkeypatch)
+    monkeypatch.setattr(cr, "chat", _fake_chat)
+
+    b1 = c.post("/api/chat", json={"message": "hi"}).json()
+    b2 = c.post("/api/chat", json={"message": "hi", "session_id": "  "}).json()
+    for body in (b1, b2):
+        assert re.fullmatch(r"api-\d{13,}-[a-z0-9]{6}", body["session_id"])
+    assert b1["session_id"] != b2["session_id"]
+    assert seen == [b1["session_id"], b2["session_id"]]  # minted id reached chat()
+
+
+def test_api_chat_echoes_explicit_session_id(monkeypatch):
+    c = _client(monkeypatch)
+    body = c.post("/api/chat", json={"message": "hi", "session_id": "tab-1"}).json()
+    assert body["session_id"] == "tab-1"
     assert body["response"] == "echo:hi"
 
 

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -433,16 +433,18 @@ def test_persist_session_falls_back_to_contextvar_session_id(tmp_path):
     assert data["session_id"] == "ctx-sid-42"
 
 
-def test_persist_session_unknown_only_when_no_session_id_anywhere(tmp_path):
-    """With neither a state session_id nor a contextvar value, fall back to
-    the historical unknown.json so persistence still happens."""
+def test_persist_session_skips_when_no_session_id_anywhere(tmp_path):
+    """With neither a state session_id nor a contextvar value, persistence is
+    SKIPPED (ADR 0069 D4) — the old unknown.json fallback pooled unrelated
+    sessions into one file that <prior_sessions> then injected everywhere."""
     mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
 
     state = {"session_id": "", "messages": [], "context": "", "captured_messages": []}
     with patch("observability.tracing.current_session_id", return_value=""):
         mod._persist_session(state, "t-none")
 
-    assert (tmp_path / "unknown.json").exists()
+    assert not (tmp_path / "unknown.json").exists()
+    assert not list(tmp_path.glob("*.json")), "no session file should be written without an id"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_thread_id_resolver.py
+++ b/tests/test_thread_id_resolver.py
@@ -81,8 +81,8 @@ def test_same_session_goal_reuses_config():
 
 
 def test_fresh_context_scopes_thread_from_current_config():
-    # Streaming (a2a:) and non-streaming (chat:) bases both derive the SAME shape — the
-    # per-iteration sub-thread comes from the CURRENT thread_id (no drift), recursion_limit
+    # Any base (a2a: or a legacy chat:) derives the SAME shape — the per-iteration
+    # sub-thread comes from the CURRENT thread_id (no drift), recursion_limit
     # normalized on both.
     a2a = _goal_continuation_config({"configurable": {"thread_id": "a2a:s1"}, "recursion_limit": 200}, _goal(True, 4))
     assert a2a == {"configurable": {"thread_id": "a2a:s1:goal-iter-4"}, "recursion_limit": 200}
@@ -93,3 +93,30 @@ def test_fresh_context_scopes_thread_from_current_config():
 def test_fresh_context_missing_thread_id_falls_back():
     out = _goal_continuation_config({}, _goal(True, 2))
     assert out["configurable"]["thread_id"] == "goal:goal-iter-2"
+
+
+# --- unified thread-id prefix (ADR 0069 D4) --------------------------------------------
+
+
+async def test_nonstreaming_chat_keys_the_streaming_thread(monkeypatch):
+    """The non-streaming path (console /api/chat + OpenAI-compat) must key the SAME
+    checkpointer thread as the streaming A2A path for the same session — it used to
+    use ``chat:<sid>`` vs ``a2a:<sid>``, splitting one session into two histories."""
+    from langchain_core.messages import AIMessage
+
+    from server.chat import chat
+
+    class _Graph:
+        seen_config = None
+
+        async def ainvoke(self, payload, config=None):
+            self.seen_config = config
+            return {"messages": [AIMessage(content="ok")]}
+
+    g = _Graph()
+    monkeypatch.setattr(STATE, "graph", g, raising=False)
+    monkeypatch.setattr(STATE, "goal_controller", None, raising=False)
+    monkeypatch.setattr(STATE, "thread_id_resolver", None, raising=False)
+
+    await chat("hello", "s1")
+    assert g.seen_config["configurable"]["thread_id"] == _resolve_thread_id(None, "s1") == "a2a:s1"


### PR DESCRIPTION
## What

Round 1 lane R1b of the memory delivery layer (ADR 0069, D4 — identity hygiene; tasklist in #1577). Three session-identity defects that pooled or split session state:

### 1. `POST /api/chat` shared `"api-default"` session
Any two callers omitting `session_id` shared **one checkpointer thread and one session-memory file**. Now an omitted/blank `session_id` mints a unique per-call id — `api-<epoch-ms>-<6 base36>`, mirroring the console's `chat-<ts>-<rand>` convention — and the response echoes it as an additive `session_id` key so callers can continue the session. Explicit ids pass through unchanged; existing consumers of `response`/`messages` are unaffected.

### 2. `unknown.json` pooling in `_persist_session`
When no session id resolved from state or the tracing contextvar, the session summary was written to a shared `unknown.json` — pooling unrelated sessions into one file that then got injected via `<prior_sessions>`. Now persistence is **skipped** with a `log.warning`. (Touches only `_persist_session` — the loader half of `graph/middleware/memory.py` belongs to a sibling lane.)

### 3. Split `a2a:`/`chat:` thread-id prefixes
The streaming A2A path keyed the checkpointer `a2a:{session_id}` while the non-streaming `/api/chat` + OpenAI-compat path keyed `chat:{session_id}` — the **same session reached via both APIs split into two histories**. Both paths now resolve through `_resolve_thread_id` (default `a2a:{session_id}`), which also extends the fork thread-id-resolver seam (#571) to the non-streaming path.

**Blast radius (deliberate, one-time):** existing `chat:*`-keyed checkpoints orphan — old non-streaming `/api/chat` threads lose continuity once on upgrade. Acceptable: non-streaming chat sessions are short-lived. Session delete keeps retiring the legacy `chat:{session_id}` thread (cascade included), so orphaned rows still clean up; the TTL prune sweep also covers them. Goal-iter child threads derive from the *current* config thread id (`_goal_continuation_config`), so they follow the unified prefix automatically.

## Tests

- Two omitted-`session_id` calls mint distinct `api-…` ids that reach `chat()` and are echoed back; explicit ids pass through.
- Empty session id everywhere → no file written, no `unknown.json` (flipped the old test that asserted the pooling fallback).
- Non-streaming `chat()` keys the same `a2a:{sid}` thread as the streaming resolver default.

## Gates

- `ruff check .` ✓
- `lint-imports` ✓ (3 contracts kept)
- `python -m pytest tests/ -q` ✓ (2610 passed, 5 skipped)
- `python scripts/live_smoke.py` ✓ (LIVE SMOKE PASSED)

Refs ADR 0069 / PR #1577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)