### PR TITLE
fix(chat): non-streaming turn must hold the per-thread lock on the shared a2a thread (ADR 0069 R1b follow-up)

### DIFF
--- a/server/chat.py
+++ b/server/chat.py
@@ -1333,11 +1333,17 @@ async def _chat_langgraph(message: str, session_id: str, *, model: str | None = 
             goal_active = (
                 STATE.goal_controller is not None and STATE.goal_controller.active_goal(session_id) is not None
             )
-            with goal_turn(goal_active):
-                result = await STATE.graph.ainvoke(
-                    {"messages": [HumanMessage(content=message)], "session_id": session_id, **_model_extra},
-                    config=config,
-                )
+            # Sharing the streaming thread means sharing its serialization contract:
+            # every other writer to `a2a:{sid}` (the streaming turn driver,
+            # compact_session, rewind_session) holds the per-thread lock — an
+            # unlocked graph turn here could lost-update a concurrent one (e.g. the
+            # desktop /api/chat fallback racing a console /compact on the same tab).
+            async with _thread_lock(config["configurable"]["thread_id"]):
+                with goal_turn(goal_active):
+                    result = await STATE.graph.ainvoke(
+                        {"messages": [HumanMessage(content=message)], "session_id": session_id, **_model_extra},
+                        config=config,
+                    )
             raw = _last_ai(result)
             response = extract_output(raw)
 
@@ -1378,15 +1384,20 @@ async def _chat_langgraph(message: str, session_id: str, *, model: str | None = 
                     # reuse `config`. Same shared helper as the streaming path (no drift).
                     cont_config = _goal_continuation_config(config, decision.state)
 
-                    with goal_turn():
-                        result = await STATE.graph.ainvoke(
-                            {
-                                "messages": [HumanMessage(content=decision.message)],
-                                "session_id": session_id,
-                                **_model_extra,
-                            },
-                            config=cont_config,
-                        )
+                    # Lock the BASE thread (mirrors the streaming driver, which holds it
+                    # across the whole goal loop): same-session iterations write `config`'s
+                    # thread directly; fresh-context ones still exclude compact/rewind/
+                    # streaming turns keyed on the base id.
+                    async with _thread_lock(config["configurable"]["thread_id"]):
+                        with goal_turn():
+                            result = await STATE.graph.ainvoke(
+                                {
+                                    "messages": [HumanMessage(content=decision.message)],
+                                    "session_id": session_id,
+                                    **_model_extra,
+                                },
+                                config=cont_config,
+                            )
                     nxt = extract_output(_last_ai(result))
                     if nxt:
                         response = nxt

--- a/tests/test_thread_id_resolver.py
+++ b/tests/test_thread_id_resolver.py
@@ -120,3 +120,27 @@ async def test_nonstreaming_chat_keys_the_streaming_thread(monkeypatch):
 
     await chat("hello", "s1")
     assert g.seen_config["configurable"]["thread_id"] == _resolve_thread_id(None, "s1") == "a2a:s1"
+
+
+async def test_nonstreaming_chat_holds_the_thread_lock(monkeypatch):
+    """Sharing the streaming thread means sharing its serialization contract: the
+    non-streaming graph turn must run under ``_thread_lock(a2a:<sid>)`` — every other
+    writer (streaming driver, compact_session, rewind_session) holds it, so an
+    unlocked turn here could lost-update a concurrent one."""
+    from langchain_core.messages import AIMessage
+
+    from server.chat import _thread_lock, chat
+
+    locked_during_invoke: list[bool] = []
+
+    class _Graph:
+        async def ainvoke(self, payload, config=None):
+            locked_during_invoke.append(_thread_lock(config["configurable"]["thread_id"]).locked())
+            return {"messages": [AIMessage(content="ok")]}
+
+    monkeypatch.setattr(STATE, "graph", _Graph(), raising=False)
+    monkeypatch.setattr(STATE, "goal_controller", None, raising=False)
+    monkeypatch.setattr(STATE, "thread_id_resolver", None, raising=False)
+
+    await chat("hello", "s-lock")
+    assert locked_during_invoke == [True]


### PR DESCRIPTION
Adversarial-review follow-up to #1580 (ADR 0069 R1b, lane R1b-hygiene) — the PR had already auto-merged when review completed, so the fix lands as its own PR.

**Defect.** #1580 unified the non-streaming `/api/chat` path onto the streaming `a2a:{session_id}` checkpointer thread, but skipped that thread's serialization contract: every other writer — the streaming turn driver, `compact_session`, `rewind_session` — serializes on `_thread_lock(tid)` precisely to prevent lost-update checkpoint corruption (`server/chat.py` documents this at the lock). The unified non-streaming graph turn was the one unlocked writer.

**Reachable race.** The desktop console falls back to POST `/api/chat` with the SAME session id its streaming turns and `/compact` gesture use (`apps/web/src/lib/api.ts`). Pre-#1580 the paths wrote disjoint threads (`chat:` vs `a2a:`) so they could not collide; post-unification an in-flight non-streaming turn can race a concurrent compact/rewind/streaming turn on the same thread → corrupted checkpoint history.

**Fix.** Wrap both graph invocations in `_chat_langgraph` (initial turn + goal-continuation loop) in `async with _thread_lock(...)`, locked on the base thread id like the streaming driver. Regression test asserts the lock is held during the graph invoke (verified to fail without the fix).

Gates: ruff clean, lint-imports 3 kept / 0 broken, pytest 2625 passed / 5 skipped.

Refs ADR 0069 / #1577 / #1580.

🤖 Generated with [Claude Code](https://claude.com/claude-code)