### PR TITLE
docs(memory): de-link ADR 0069 in starter-tools until the ADR doc merges (R1a review follow-up)

### DIFF
--- a/docs/reference/starter-tools.md
+++ b/docs/reference/starter-tools.md
@@ -155,7 +155,7 @@ Returns `"No matches."` when nothing scores above the keyword threshold.
 async def recall_session(session_id: str) -> str
 ```
 
-Expands one entry from the auto-injected `<prior_sessions>` digest into the full persisted session summary — messages and final output, reasoning-stripped, capped at ~6 000 chars ([ADR 0069](/adr/0069-memory-delivery-layer)). The digest itself carries only one attributed line per prior session (id · timestamp · surface · topic · message count), so this tool is the on-demand path to a prior session's content. Errors cleanly on an unknown or malformed id.
+Expands one entry from the auto-injected `<prior_sessions>` digest into the full persisted session summary — messages and final output, reasoning-stripped, capped at ~6 000 chars (ADR 0069<!-- TODO(#1577): restore the /adr/0069-memory-delivery-layer link once the ADR doc merges -->). The digest itself carries only one attributed line per prior session (id · timestamp · surface · topic · message count), so this tool is the on-demand path to a prior session's content. Errors cleanly on an unknown or malformed id.
 
 ## `memory_list`
 


### PR DESCRIPTION
Review follow-up for #1581 (ADR 0069 R1a).

#1581 linked `/adr/0069-memory-delivery-layer` from `docs/reference/starter-tools.md`, but the ADR page only exists on #1577 (still open — its Python-tests check is failing, so auto-merge is stuck). VitePress's dead-link check therefore fails the **Deploy docs to GitHub Pages** build on every push to main (first failure: run 28547732661 on the #1581 merge commit), freezing the docs site.

Fix: keep the ADR 0069 reference as plain text with a `TODO(#1577)` HTML comment so the link is restored once the ADR doc lands. `npm run docs:build` passes locally with this change; ruff / lint-imports / pytest (2624 passed, 5 skipped) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)