### PR TITLE
ci(docs): run the docs build on every PR so it can gate merges

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,8 +7,11 @@ on:
   # PR-level gate (#976): vitepress fails the build on parse errors AND dead links,
   # so running docs:build here catches doc breakage at review time instead of letting
   # it merge green and only go red on the main-only deploy. Build-only — no deploy.
+  # Unfiltered on purpose: `build` is a REQUIRED check in the main ruleset, and a
+  # path-filtered required check never reports on non-matching PRs, blocking them
+  # forever. Running everywhere (~30s) is the price of making red docs unmergeable
+  # (a dead link once automerged and froze the Pages deploy on every main push).
   pull_request:
-    paths: ['docs/**', 'package.json', 'package-lock.json', '.github/workflows/docs.yml']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Follow-up to the #1581 incident: a dead docs link automerged and froze the GitHub Pages deploy on every main push, because the docs `build` job is (a) path-filtered on PRs and (b) **not a required status check** — so automerge fired on first-green of the required set while the docs build was red.

Fix is two-part:
1. **This PR** — drop the `pull_request` path filter so `build` reports on every PR (~30s; a path-filtered required check would never report on non-docs PRs and block them forever).
2. **Ruleset** — after this merges, `build` gets added to the main ruleset's required status checks (admin API change, done separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)