### PR TITLE
feat(knowledge): collapsible source grouping + Shift+click quick-delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stripped, capped), with a path-traversal-safe id guard. The on-demand
   counterpart to the new digest below.
   ([ADR 0069](docs/adr/0069-memory-delivery-layer.md))
+- **Knowledge Base view — collapsible source grouping + Shift+click quick-delete.** Chunks
+  from the same ingested source (a YouTube transcript, a multi-page doc) now collapse under
+  one section header showing the source title, type, and chunk count — with a Collapse/Expand-all
+  toolbar toggle. Only sources with ≥2 loaded chunks group; single/sourceless chunks stay flat
+  (no regression). Open state persists per source; an active search force-expands so matches stay
+  visible. And **Shift+click** a chunk's delete button now removes it immediately (no confirm),
+  matching the chat-tab quick-delete — the plain click still confirms. (#1575, #1582)
 - **One-command install** — `curl -fsSL .../scripts/install.sh | sh` takes a fresh
   machine from zero to a running, configured protoAgent. It checks prerequisites
   (Docker + curl), pulls `ghcr.io/protolabsai/protoagent:latest`, runs it

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -687,6 +687,18 @@ export const KNOWLEDGE_CHUNKS = [
     created_at: "2026-06-02T09:00:00+00:00",
     tier: "private",   // private to this agent → eligible for Share (promote)
   },
+  // A multi-chunk ingested source (#1575) → renders as one collapsible section
+  // ("… · 3 chunks"). ids 11/12 above stay flat (single/no source), so the
+  // list + promote/unshare specs are unaffected.
+  { id: 13, heading: "", content: "Switchbacks keep the grade walkable.", preview: "Switchbacks keep the grade walkable.",
+    domain: "media", source: "Hiking with Kevin — Christina Mariani", source_type: "youtube", finding_type: null,
+    created_at: "2026-06-04T10:00:00+00:00", tier: null },
+  { id: 14, heading: "", content: "Bring more water than you think.", preview: "Bring more water than you think.",
+    domain: "media", source: "Hiking with Kevin — Christina Mariani", source_type: "youtube", finding_type: null,
+    created_at: "2026-06-04T10:01:00+00:00", tier: null },
+  { id: 15, heading: "", content: "The summit view pays off the climb.", preview: "The summit view pays off the climb.",
+    domain: "media", source: "Hiking with Kevin — Christina Mariani", source_type: "youtube", finding_type: null,
+    created_at: "2026-06-04T10:02:00+00:00", tier: null },
 ];
 
 // Delegate registry (ADR 0025) — types schema + a sample roster for the panel.

--- a/apps/web/e2e/knowledge.spec.ts
+++ b/apps/web/e2e/knowledge.spec.ts
@@ -51,3 +51,51 @@ test("layered knowledge shows tier badges and shares / unshares the commons", as
   await dialog.getByRole("button", { name: "Unshare", exact: true }).click();
   await expect(surface.getByLabel("unshare entry 11", { exact: true })).toHaveCount(0);
 });
+
+test("Shift+click deletes a chunk immediately, plain click still confirms (#1582)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Knowledge" }).click();
+  const surface = page.getByTestId("knowledge-store");
+  await expect(surface).toBeVisible();
+
+  const del12 = surface.getByLabel("delete entry 12", { exact: true });
+  await expect(del12).toBeVisible();
+
+  // Plain click → the confirmation dialog (safe path preserved). Back out; chunk stays.
+  await del12.click();
+  const confirm = page.getByRole("dialog", { name: "Delete this knowledge entry?" });
+  await expect(confirm).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(confirm).toHaveCount(0);
+  await expect(del12).toBeVisible();
+
+  // Shift+click → no dialog, chunk removed immediately (chat-tab quick-delete parity).
+  await del12.click({ modifiers: ["Shift"] });
+  await expect(page.getByRole("dialog", { name: "Delete this knowledge entry?" })).toHaveCount(0);
+  await expect(surface.getByLabel("delete entry 12", { exact: true })).toHaveCount(0);
+});
+
+test("groups a multi-chunk source into a collapsible section (#1575)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Knowledge" }).click();
+  const surface = page.getByTestId("knowledge-store");
+  await expect(surface).toBeVisible();
+
+  // The 3-chunk YouTube source collapses under one header (title + count), closed by default.
+  const header = surface.getByRole("button", { name: /Hiking with Kevin/ });
+  await expect(header).toBeVisible();
+  await expect(header).toContainText("3 chunks");
+  await expect(header).toHaveAttribute("aria-expanded", "false");
+  await expect(surface.getByText("Switchbacks keep the grade walkable.")).toHaveCount(0); // hidden while collapsed
+
+  // Loose chunks (single/no source) still render flat — no regression.
+  await expect(surface.getByText("Releases are cut manually via workflow_dispatch.")).toBeVisible();
+
+  // Clicking the header expands it → the chunks render; clicking again collapses.
+  await header.click();
+  await expect(header).toHaveAttribute("aria-expanded", "true");
+  await expect(surface.getByText("Switchbacks keep the grade walkable.")).toBeVisible();
+  await expect(surface.getByText("The summit view pays off the climb.")).toBeVisible();
+  await header.click();
+  await expect(surface.getByText("Switchbacks keep the grade walkable.")).toHaveCount(0);
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -486,6 +486,14 @@ const server = createServer(async (req, res) => {
       knowledgeChunks.splice(i, 1); // removed from the commons
       return sendJson(res, { enabled: true, forgotten: true });
     }
+    if (req.method === "DELETE" && /^\/api\/knowledge\/chunks\/\d+$/.test(pathname)) {
+      // Actually drop the chunk so the list re-render reflects the delete (the
+      // quick-delete spec asserts it disappears). Reset via /api/__test__/knowledge/reset.
+      const id = Number(pathname.split("/").at(-1));
+      const i = knowledgeChunks.findIndex((x) => x.id === id);
+      if (i >= 0) knowledgeChunks.splice(i, 1);
+      return sendJson(res, { enabled: true, deleted: i >= 0 });
+    }
     if (pathname === "/api/settings") {
       // ADR 0047: a layer-aware save — "agent" (per-agent leaf, default) or "host"
       // (box-shared host-config.yaml). The mock just echoes which layer it wrote.

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1811,6 +1811,24 @@ textarea {
 .knowledge-chunk-form-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
 .knowledge-chunk-form-row > :first-child { flex: 1; min-width: 180px; }
 .knowledge-chunk-actions { display: flex; gap: 2px; }
+/* Shift held → the delete button arms red (chat-tab quick-delete parity, #1582). */
+.knowledge-del-armed, .knowledge-del-armed svg { color: var(--pl-color-danger, #e5484d); }
+
+/* Collapsible source groups in the Knowledge Base (#1575). A group is a plain
+   list item holding a full-width header button + (when open) a nested card list. */
+.kb-group { list-style: none; display: flex; flex-direction: column; gap: 8px; }
+.kb-group-header {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 8px 12px; border: 1px solid var(--border); border-radius: var(--radius);
+  background: var(--bg-raised); color: var(--fg); cursor: pointer; text-align: left;
+}
+.kb-group-header:hover { border-color: var(--border-strong); }
+.kb-group-caret { flex: none; color: var(--fg-muted); transition: transform 0.12s ease; }
+.kb-group-title {
+  flex: 1; min-width: 0; font-size: 13px; font-weight: 600;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.kb-group-body { margin-left: 14px; }
 
 /* New/Edit skill dialog (PlaybooksSurface) — a little more space between fields than
    the knowledge inline form it grew out of. (Body padding is the app-wide

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -3,7 +3,7 @@ import { Alert } from "@protolabsai/ui/data";
 import { ConfirmDialog, Dialog, useToast } from "@protolabsai/ui/overlays";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowDownFromLine, ArrowUpToLine, Database, FileUp, Library, Pencil, Plus, Trash2 } from "lucide-react";
+import { ArrowDownFromLine, ArrowUpToLine, ChevronRight, ChevronsDownUp, ChevronsUpDown, Database, FileUp, Library, Pencil, Plus, Trash2 } from "lucide-react";
 
 import { useEffect, useState } from "react";
 
@@ -281,6 +281,23 @@ export function KnowledgeStore() {
     onError: (e) => onError(errMsg(e)),
   });
 
+  // Shift+click a delete button → hard-delete with NO confirm dialog — the same
+  // quick-delete the chat tabs use (#1582). While Shift is held the delete buttons
+  // arm (turn red) to signal the fast path. Mirrors ChatSurface's shiftDel.
+  const [shiftDel, setShiftDel] = useState(false);
+  useEffect(() => {
+    const sync = (e: KeyboardEvent) => setShiftDel(e.shiftKey);
+    const clear = () => setShiftDel(false);
+    window.addEventListener("keydown", sync);
+    window.addEventListener("keyup", sync);
+    window.addEventListener("blur", clear);
+    return () => {
+      window.removeEventListener("keydown", sync);
+      window.removeEventListener("keyup", sync);
+      window.removeEventListener("blur", clear);
+    };
+  }, []);
+
   function startEdit(c: KnowledgeChunk) {
     setAdding(false);
     setEditingId(c.id);
@@ -288,6 +305,133 @@ export function KnowledgeStore() {
   }
 
   const total = stats.chunks ?? stats.total ?? 0;
+
+  // Collapsible source grouping (#1575): chunks from the same ingested source
+  // collapse under one section header. Only a source with ≥2 loaded chunks becomes
+  // a section — sourceless + single-chunk sources stay flat (no regression). Open
+  // state persists per source; an active search force-expands so matches stay visible.
+  const GROUPS_LS_KEY = "protoagent.kb.openGroups";
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>(() => {
+    try { return JSON.parse(localStorage.getItem(GROUPS_LS_KEY) || "{}") as Record<string, boolean>; }
+    catch { return {}; }
+  });
+  const persistGroups = (next: Record<string, boolean>) => {
+    setOpenGroups(next);
+    try { localStorage.setItem(GROUPS_LS_KEY, JSON.stringify(next)); } catch { /* private mode — ignore */ }
+  };
+  const searching = debouncedQuery.trim().length > 0;
+  const isGroupOpen = (src: string) => searching || (openGroups[src] ?? false);
+  const toggleGroup = (src: string) => persistGroups({ ...openGroups, [src]: !(openGroups[src] ?? false) });
+
+  const sourceCounts = new Map<string, number>();
+  for (const c of results) if (c.source) sourceCounts.set(c.source, (sourceCounts.get(c.source) ?? 0) + 1);
+  const groupSources = [...sourceCounts.entries()].filter(([, n]) => n >= 2).map(([s]) => s);
+  const isGrouped = (c: KnowledgeChunk) => !!c.source && (sourceCounts.get(c.source) ?? 0) >= 2;
+  const allGroupsOpen = groupSources.length > 0 && groupSources.every((s) => openGroups[s]);
+  const toggleAllGroups = () => {
+    const next = { ...openGroups };
+    for (const s of groupSources) next[s] = !allGroupsOpen;
+    persistGroups(next);
+  };
+
+  const renderCard = (c: KnowledgeChunk) => (
+    <li key={c.id} className="playbook-card">
+      {editingId === c.id ? (
+        <ChunkForm
+          draft={draft}
+          setDraft={setDraft}
+          onSave={() => save.mutate()}
+          onCancel={() => { setEditingId(null); setDraft(EMPTY_DRAFT); }}
+          saving={save.isPending}
+          saveLabel="Save changes"
+        />
+      ) : (
+        <>
+          <div className="playbook-main">
+            <div className="playbook-title">
+              <span title={`domain: ${c.domain}`}>
+                <Badge status="success">
+                  <Database size={12} /> {c.domain}
+                </Badge>
+              </span>
+              {c.finding_type ? (
+                <span title="finding type">
+                  <Badge status="neutral">{c.finding_type}</Badge>
+                </span>
+              ) : null}
+              {c.tier === "commons" ? (
+                <span title="Shared commons — readable by every agent on this box">
+                  <Badge status="neutral">
+                    <Library size={12} /> commons
+                  </Badge>
+                </span>
+              ) : c.tier === "private" ? (
+                <span title="Private to this agent — share to make it readable by the fleet">
+                  <Badge status="neutral">private</Badge>
+                </span>
+              ) : null}
+              {c.heading ? <strong>{c.heading}</strong> : null}
+            </div>
+            <p className="playbook-desc">{c.content || c.preview}</p>
+            {c.source ? (
+              <div className="playbook-tools">
+                <code>{c.source}</code>
+              </div>
+            ) : null}
+          </div>
+          <div className="playbook-meta">
+            <span title="added">{ago(c.created_at)}</span>
+            <span className="knowledge-chunk-actions">
+              {c.tier === "private" ? (
+                <Button
+                  icon
+                  variant="ghost"
+                  type="button"
+                  title="Share to the commons (every agent on this box can then recall it)"
+                  onClick={() => promote.mutate(c)}
+                  loading={promotingId === c.id}
+                  aria-label={`share entry ${c.id}`}
+                >
+                  <ArrowUpToLine size={14} />
+                </Button>
+              ) : null}
+              {c.tier === "commons" ? (
+                // Commons chunks are read-only here (edit/delete target the PRIVATE
+                // tier) — manage them with Unshare, the inverse of Share.
+                <Button
+                  icon
+                  variant="ghost"
+                  type="button"
+                  title="Unshare — remove from the commons (no other agent will recall it)"
+                  onClick={() => setForgetPending(c)}
+                  aria-label={`unshare entry ${c.id}`}
+                >
+                  <ArrowDownFromLine size={14} />
+                </Button>
+              ) : (
+                <>
+                  <Button icon variant="ghost" type="button" title="Edit entry" onClick={() => startEdit(c)} aria-label={`edit entry ${c.id}`}>
+                    <Pencil size={14} />
+                  </Button>
+                  <Button
+                    icon
+                    variant="ghost"
+                    type="button"
+                    className={shiftDel ? "knowledge-del-armed" : undefined}
+                    title={shiftDel ? "Delete now — Shift skips the confirmation" : "Delete entry (Shift+click to skip confirm)"}
+                    onClick={(e) => { if (e.shiftKey) del.mutate(c.id); else setPendingDelete(c); }}
+                    aria-label={`delete entry ${c.id}`}
+                  >
+                    <Trash2 size={14} />
+                  </Button>
+                </>
+              )}
+            </span>
+          </div>
+        </>
+      )}
+    </li>
+  );
 
   return (
     <section className="panel stage-panel" data-testid="knowledge-store">
@@ -300,6 +444,18 @@ export function KnowledgeStore() {
             <QuickSetting keys={["knowledge.top_k", "knowledge.embeddings"]} title="Recall" label="Knowledge recall settings" />
             {enabled ? (
               <>
+                {groupSources.length > 0 ? (
+                  <Button
+                    icon
+                    variant="ghost"
+                    type="button"
+                    onClick={toggleAllGroups}
+                    title={allGroupsOpen ? "Collapse all sources" : "Expand all sources"}
+                    aria-label={allGroupsOpen ? "collapse all sources" : "expand all sources"}
+                  >
+                    {allGroupsOpen ? <ChevronsDownUp size={16} /> : <ChevronsUpDown size={16} />}
+                  </Button>
+                ) : null}
                 <Button
                   icon
                   variant="ghost"
@@ -389,96 +545,42 @@ export function KnowledgeStore() {
           )
         ) : (
           <ul className="playbook-list">
-            {results.map((c) => (
-              <li key={c.id} className="playbook-card">
-                {editingId === c.id ? (
-                  <ChunkForm
-                    draft={draft}
-                    setDraft={setDraft}
-                    onSave={() => save.mutate()}
-                    onCancel={() => { setEditingId(null); setDraft(EMPTY_DRAFT); }}
-                    saving={save.isPending}
-                    saveLabel="Save changes"
-                  />
-                ) : (
-                  <>
-                    <div className="playbook-main">
-                      <div className="playbook-title">
-                        <span title={`domain: ${c.domain}`}>
-                          <Badge status="success">
-                            <Database size={12} /> {c.domain}
-                          </Badge>
-                        </span>
-                        {c.finding_type ? (
-                          <span title="finding type">
-                            <Badge status="neutral">{c.finding_type}</Badge>
-                          </span>
-                        ) : null}
-                        {c.tier === "commons" ? (
-                          <span title="Shared commons — readable by every agent on this box">
-                            <Badge status="neutral">
-                              <Library size={12} /> commons
-                            </Badge>
-                          </span>
-                        ) : c.tier === "private" ? (
-                          <span title="Private to this agent — share to make it readable by the fleet">
-                            <Badge status="neutral">private</Badge>
-                          </span>
-                        ) : null}
-                        {c.heading ? <strong>{c.heading}</strong> : null}
-                      </div>
-                      <p className="playbook-desc">{c.content || c.preview}</p>
-                      {c.source ? (
-                        <div className="playbook-tools">
-                          <code>{c.source}</code>
-                        </div>
-                      ) : null}
-                    </div>
-                    <div className="playbook-meta">
-                      <span title="added">{ago(c.created_at)}</span>
-                      <span className="knowledge-chunk-actions">
-                        {c.tier === "private" ? (
-                          <Button
-                            icon
-                            variant="ghost"
-                            type="button"
-                            title="Share to the commons (every agent on this box can then recall it)"
-                            onClick={() => promote.mutate(c)}
-                            loading={promotingId === c.id}
-                            aria-label={`share entry ${c.id}`}
-                          >
-                            <ArrowUpToLine size={14} />
-                          </Button>
-                        ) : null}
-                        {c.tier === "commons" ? (
-                          // Commons chunks are read-only here (edit/delete target the PRIVATE
-                          // tier) — manage them with Unshare, the inverse of Share.
-                          <Button
-                            icon
-                            variant="ghost"
-                            type="button"
-                            title="Unshare — remove from the commons (no other agent will recall it)"
-                            onClick={() => setForgetPending(c)}
-                            aria-label={`unshare entry ${c.id}`}
-                          >
-                            <ArrowDownFromLine size={14} />
-                          </Button>
-                        ) : (
-                          <>
-                            <Button icon variant="ghost" type="button" title="Edit entry" onClick={() => startEdit(c)} aria-label={`edit entry ${c.id}`}>
-                              <Pencil size={14} />
-                            </Button>
-                            <Button icon variant="ghost" type="button" title="Delete entry" onClick={() => setPendingDelete(c)} aria-label={`delete entry ${c.id}`}>
-                              <Trash2 size={14} />
-                            </Button>
-                          </>
-                        )}
-                      </span>
-                    </div>
-                  </>
-                )}
-              </li>
-            ))}
+            {(() => {
+              // Emit a source's section once (at its first chunk) so grouped sources
+              // appear in first-seen order, interleaved with loose (flat) chunks.
+              const emitted = new Set<string>();
+              return results.map((c) => {
+                if (!isGrouped(c)) return renderCard(c);
+                const src = c.source as string;
+                if (emitted.has(src)) return null;
+                emitted.add(src);
+                const members = results.filter((x) => x.source === src);
+                const open = isGroupOpen(src);
+                const st = members.find((m) => m.source_type)?.source_type;
+                return (
+                  <li key={`grp:${src}`} className="kb-group">
+                    <button
+                      type="button"
+                      className="kb-group-header"
+                      aria-expanded={open}
+                      onClick={() => toggleGroup(src)}
+                    >
+                      <ChevronRight
+                        size={14}
+                        className="kb-group-caret"
+                        style={{ transform: open ? "rotate(90deg)" : undefined }}
+                      />
+                      <span className="kb-group-title" title={src}>{src}</span>
+                      {st ? <Badge status="neutral">{st}</Badge> : null}
+                      <Badge status="neutral">{members.length} chunks</Badge>
+                    </button>
+                    {open ? (
+                      <ul className="playbook-list kb-group-body">{members.map(renderCard)}</ul>
+                    ) : null}
+                  </li>
+                );
+              });
+            })()}
           </ul>
         )}
       </div>


### PR DESCRIPTION
Two Knowledge Base view improvements from the queue. **Draft** — console UX, so it's under the local-test gate (please eyeball it running); mark ready when you're happy.

## #1575 — collapsible source grouping
Chunks from the same ingested source collapse under one section header (title + `source_type` badge + "N chunks"), interleaved with flat chunks in **first-seen order**.

- Only sources with **≥2 loaded chunks** become a section — sourceless / single-chunk sources render flat (**no regression**).
- Open state **persists per source** (localStorage); an **active search force-expands** so matches stay visible.
- **Collapse/Expand-all** toolbar toggle, shown only when groups exist.

## #1582 — Shift+click quick-delete
Shift+click a chunk's delete button hard-deletes with **no confirm dialog** — matching the chat-tab quick-delete exactly (shared `shiftDel` key-state; the button **arms red** while Shift is held). Plain click still opens the confirmation.

## Implementation
- Extracted the per-chunk card into a `renderCard()` (shared by flat + grouped rendering) — that's why both issues land in one commit.
- CSS: `.kb-group*` section styles + `.knowledge-del-armed`.

## Tests / verification
- Mock now honors `DELETE /api/knowledge/chunks/{id}` (actually drops the chunk) + 3 same-source fixture chunks.
- 2 new e2e: grouping expand/collapse (header shows "3 chunks", `aria-expanded` toggles, collapsed hides content, flat chunks unaffected); shift-delete removes immediately vs plain-click confirms.
- **Green locally:** `tsc --noEmit` clean · `vite build` · **4/4** knowledge e2e (2 existing + 2 new) · **251** unit · nav + layout e2e (18).

## Acceptance
**#1582:** Shift+click deletes immediately ✅ · plain click still confirms ✅ · consistent with chat-tab ✅
**#1575:** same-source chunks grouped ✅ · header shows title + count ✅ · click toggles ✅ · default collapsed + remembers state ✅ · sourceless fallback (flat, no regression) ✅ · stretch: Collapse/Expand-all ✅

Closes #1575
Closes #1582

🤖 Generated with [Claude Code](https://claude.com/claude-code)