### PR TITLE
feat(operator-api): memory inspector REST — session summaries + hot memory (ADR 0069 R2c API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Memory-inspector REST surface** (`/api/memory/*`) — the audit surface for the
+  memory delivery layer ([ADR 0069](docs/adr/0069-memory-delivery-layer.md) D7,
+  API half; console UI follows). List/get/delete the persisted **session
+  summaries** behind the `<prior_sessions>` digest (list rows reuse the digest
+  derivation, get returns the same render `recall_session` expands, ids share its
+  path-traversal-safe guard) and list/edit/delete **hot memory** — the
+  `domain="hot"` chunks injected every turn (edits are pinned to `hot`, deletes
+  only resolve hot ids). Bearer-gated like every operator route; documented in
+  [Operator REST API](docs/reference/operator-api.md).
 - **`recall_session(session_id)` starter tool** — expands one entry from the
   prior-sessions digest into that session's full persisted summary (reasoning-
   stripped, capped), with a path-traversal-safe id guard. The on-demand

--- a/docs/reference/operator-api.md
+++ b/docs/reference/operator-api.md
@@ -69,6 +69,20 @@ is a map — `operator_api/*.py` is the source of truth for exact request/respon
 | POST · PUT · DELETE | `/api/playbooks[/{id}]` | Create / edit / delete a skill |
 | POST | `/api/playbooks/{id}/promote` | Promote a private skill into the commons |
 
+## Memory inspector
+
+The audit surface for the memory delivery layer
+([ADR 0069](../adr/0069-memory-delivery-layer.md) D7): the persisted session
+summaries behind the `<prior_sessions>` digest, and the hot-memory chunks
+injected every turn.
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/memory/sessions` | List session summaries (digest fields: id, timestamp, surface, topic, message count, size) |
+| GET · DELETE | `/api/memory/sessions/{session_id}` | Full rendered summary (what `recall_session` returns) / delete one |
+| GET | `/api/memory/hot` | List hot-memory chunks (`domain="hot"`) |
+| PUT · DELETE | `/api/memory/hot/{chunk_id}` | Edit (revision stays `hot`) / delete a hot chunk |
+
 ## Activity, inbox & events
 
 | Method | Path | Purpose |

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -200,6 +200,18 @@ def _persist_session(state: dict, trace_id: str) -> None:
 
 _DIGEST_TOPIC_MAX_CHARS = 80
 
+# Session ids become filenames under memory_path() — restrict to the characters
+# real ids use (``:`` included — e.g. ``background:job``) so a crafted id can't
+# path-traverse out of the memory dir. Shared by the ``recall_session`` tool and
+# the memory-inspector API (ADR 0069 D7).
+_SESSION_ID_SAFE_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._:-")
+
+
+def is_safe_session_id(session_id: str) -> bool:
+    """True when *session_id* maps safely onto ``{memory_path()}/{id}.json`` —
+    non-empty and confined to ``[A-Za-z0-9._:-]`` (no path separators, no NUL)."""
+    return bool(session_id) and set(session_id) <= _SESSION_ID_SAFE_CHARS
+
 # The always-present framing header (ADR 0069 D1): the digest lists OTHER
 # sessions, never the current conversation — the old unlabeled verbatim block
 # made fresh threads narrate other threads' history as their own.
@@ -225,8 +237,10 @@ def _surface_for(session_id: str) -> str:
     return "a2a/other"
 
 
-def _digest_line(summary: dict) -> str:
-    """One attributed line: ``session_id · timestamp · surface · topic · N msgs``.
+def digest_entry(summary: dict) -> dict:
+    """Structured digest fields for ONE persisted summary — the derivation
+    behind :func:`_digest_line`, shared with the memory-inspector API
+    (ADR 0069 D7) so list rows can't drift from the injected digest.
 
     ``topic`` is derived from the FIRST USER message only — no assistant text,
     no message bodies (ADR 0069 D1: identity confusion + poisoning surface).
@@ -234,7 +248,6 @@ def _digest_line(summary: dict) -> str:
     from graph.output_format import strip_reasoning
 
     sid = str(summary.get("session_id") or "unknown")
-    ts = str(summary.get("timestamp") or "unknown")
     msgs = summary.get("messages", []) or []
     topic = ""
     for m in msgs:
@@ -243,7 +256,22 @@ def _digest_line(summary: dict) -> str:
             break
     if len(topic) > _DIGEST_TOPIC_MAX_CHARS:
         topic = topic[: _DIGEST_TOPIC_MAX_CHARS - 1] + "…"
-    return f"  {sid} · {ts} · {_surface_for(sid)} · {topic or '(no user message)'} · {len(msgs)} msgs"
+    return {
+        "session_id": sid,
+        "timestamp": str(summary.get("timestamp") or "unknown"),
+        "surface": _surface_for(sid),
+        "topic": topic,
+        "message_count": len(msgs),
+    }
+
+
+def _digest_line(summary: dict) -> str:
+    """One attributed line: ``session_id · timestamp · surface · topic · N msgs``."""
+    e = digest_entry(summary)
+    return (
+        f"  {e['session_id']} · {e['timestamp']} · {e['surface']} · "
+        f"{e['topic'] or '(no user message)'} · {e['message_count']} msgs"
+    )
 
 
 def format_session_summary(summary: dict) -> str:

--- a/operator_api/memory_routes.py
+++ b/operator_api/memory_routes.py
@@ -48,9 +48,21 @@ def _session_path(session_id: str) -> str | None:
 
 def _hot_chunks(store) -> list[dict]:
     """Hot-memory rows in the console's chunk shape. list_chunks yields Chunk
-    objects (plain store) or tier-tagged dicts (LayeredKnowledgeStore)."""
+    objects (plain store) or tier-tagged dicts (LayeredKnowledgeStore).
+
+    Commons-tier rows are EXCLUDED: on a layered store ``get_hot_memory`` (the
+    actual per-turn injection) and ``add_chunk``/``delete_by_id`` all delegate
+    to the PRIVATE store, and ids are per-backend — a commons hot chunk never
+    injects, and letting its id pass the mutation gates would make
+    ``delete_by_id`` hit whatever PRIVATE row shares that numeric id (an
+    arbitrary KB chunk). Commons curation stays with promote/forget on the
+    knowledge surface."""
     rows = store.list_chunks(domain="hot", limit=_HOT_LIST_LIMIT)
-    return [_knowledge_row(c if isinstance(c, dict) else c.as_dict()) for c in rows]
+    return [
+        _knowledge_row(c)
+        for c in (c if isinstance(c, dict) else c.as_dict() for c in rows)
+        if c.get("tier") != "commons"
+    ]
 
 
 def register_memory_routes(app) -> None:

--- a/operator_api/memory_routes.py
+++ b/operator_api/memory_routes.py
@@ -1,0 +1,176 @@
+"""Memory-inspector routes for the operator console (ADR 0069 D7).
+
+The audit surface for the memory *delivery* layer: which session summaries
+exist on disk (the ``{memory_path()}/{session_id}.json`` files behind the
+``<prior_sessions>`` digest) and which hot-memory chunks ride every turn —
+view/delete for summaries, view/edit/delete for hot chunks. A security control
+first (SpAIware-class memory poisoning gets *detected* here), UX second.
+
+Generic chunk CRUD already lives in ``knowledge_routes``; these routes add the
+domain-scoped view the inspector needs: a hot edit is pinned to
+``domain="hot"`` (can't silently demote the chunk out of always-on injection)
+and a hot delete only resolves ids that ARE hot chunks (can't reach arbitrary
+KB rows). Session-summary ids share the ``recall_session`` filename guard, so
+a crafted id can't path-traverse out of the memory dir.
+
+Auth: gated by the server-level ``/api/*`` bearer middleware
+(``a2a_impl.auth``) like every other operator route — nothing here is public.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+
+from fastapi.responses import JSONResponse
+
+from operator_api.knowledge_routes import _knowledge_row
+from runtime.state import STATE
+
+log = logging.getLogger("protoagent.server")
+
+# get_hot_memory injects the 100 newest hot chunks; the inspector lists a wider
+# window so the operator can also curate the backlog that no longer injects.
+_HOT_LIST_LIMIT = 500
+
+
+def _session_path(session_id: str) -> str | None:
+    """Map *session_id* to its summary file, or None when the id fails the
+    ``[A-Za-z0-9._:-]`` guard (path-traversal safe: no separators survive)."""
+    from graph.middleware.memory import is_safe_session_id, memory_path
+
+    if not is_safe_session_id(session_id):
+        return None
+    return os.path.join(memory_path(), f"{session_id}.json")
+
+
+def _hot_chunks(store) -> list[dict]:
+    """Hot-memory rows in the console's chunk shape. list_chunks yields Chunk
+    objects (plain store) or tier-tagged dicts (LayeredKnowledgeStore)."""
+    rows = store.list_chunks(domain="hot", limit=_HOT_LIST_LIMIT)
+    return [_knowledge_row(c if isinstance(c, dict) else c.as_dict()) for c in rows]
+
+
+def register_memory_routes(app) -> None:
+    """Register the ``/api/memory/*`` memory-inspector routes."""
+
+    # --- Session summaries ---------------------------------------------------
+    # The files SessionSummaryMiddleware persists — the source the digest is
+    # built from. List rows reuse the digest derivation (graph.middleware.memory
+    # digest_entry) so the inspector shows exactly what the agent is told.
+
+    @app.get("/api/memory/sessions")
+    async def _api_memory_sessions():
+        from graph.middleware.memory import digest_entry, memory_path
+
+        base = memory_path()
+        sessions: list[tuple[float, dict]] = []
+        if os.path.isdir(base):
+            for fname in os.listdir(base):
+                if not fname.endswith(".json"):
+                    continue
+                fpath = os.path.join(base, fname)
+                try:
+                    size = os.path.getsize(fpath)
+                    mtime = os.path.getmtime(fpath)
+                    with open(fpath, encoding="utf-8") as fh:
+                        summary = json.load(fh)
+                except (OSError, json.JSONDecodeError, ValueError) as exc:
+                    log.warning("[memory] skipping unreadable summary %s: %s", fpath, exc)
+                    continue
+                entry = digest_entry(summary)
+                entry["size_bytes"] = size
+                sessions.append((mtime, entry))
+        sessions.sort(key=lambda t: t[0], reverse=True)  # newest first, like the digest
+        return {"sessions": [e for _, e in sessions]}
+
+    @app.get("/api/memory/sessions/{session_id}")
+    async def _api_memory_session_get(session_id: str):
+        from graph.middleware.memory import digest_entry, format_session_summary
+
+        fpath = _session_path(session_id)
+        if fpath is None:
+            return JSONResponse({"detail": "invalid session_id"}, status_code=400)
+        try:
+            with open(fpath, encoding="utf-8") as fh:
+                summary = json.load(fh)
+        except FileNotFoundError:
+            return JSONResponse({"detail": "no session summary with that id"}, status_code=404)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            return JSONResponse({"detail": f"session summary unreadable: {exc}"}, status_code=422)
+        entry = digest_entry(summary)
+        entry["trace_id"] = summary.get("trace_id")  # links the summary to its trace
+        entry["rendered"] = format_session_summary(summary)  # same render recall_session returns
+        return {"session": entry}
+
+    @app.delete("/api/memory/sessions/{session_id}")
+    async def _api_memory_session_delete(session_id: str):
+        fpath = _session_path(session_id)
+        if fpath is None:
+            return JSONResponse({"detail": "invalid session_id"}, status_code=400)
+        try:
+            os.remove(fpath)
+        except FileNotFoundError:
+            return JSONResponse({"detail": "no session summary with that id"}, status_code=404)
+        except OSError as exc:
+            log.warning("[memory] delete of summary %s failed: %s", fpath, exc)
+            return JSONResponse({"detail": f"delete failed: {exc}"}, status_code=500)
+        return {"deleted": True, "session_id": session_id}
+
+    # --- Hot memory ----------------------------------------------------------
+    # The domain="hot" chunks get_hot_memory injects every turn.
+
+    @app.get("/api/memory/hot")
+    async def _api_memory_hot():
+        if STATE.knowledge_store is None:
+            return {"enabled": False, "chunks": []}
+        try:
+            chunks = _hot_chunks(STATE.knowledge_store)
+        except Exception:  # noqa: BLE001 — never 500 the console
+            log.exception("[memory] hot-memory list failed")
+            chunks = []
+        return {"enabled": True, "chunks": chunks}
+
+    @app.put("/api/memory/hot/{chunk_id}")
+    async def _api_memory_hot_update(chunk_id: int, body: dict | None = None):
+        store = STATE.knowledge_store
+        if store is None:
+            return {"enabled": False, "id": None}
+        body = body or {}
+        content = str(body.get("content", "")).strip()
+        if not content:
+            return JSONResponse({"detail": "content is required"}, status_code=400)
+        cur = next((c for c in _hot_chunks(store) if c.get("id") == chunk_id), None)
+        if cur is None:
+            return JSONResponse({"detail": "no hot-memory chunk with that id"}, status_code=404)
+        # Same composition as the generic chunk edit (knowledge_routes): add the
+        # new revision FIRST, then delete the old — a failed add must never lose
+        # the original. domain is pinned to "hot" so an inspector edit can't
+        # move the chunk out of always-on injection.
+        new_id = await asyncio.to_thread(
+            lambda: store.add_chunk(
+                content,
+                "hot",
+                heading=(str(body.get("heading", "")).strip() or cur.get("heading") or None),
+                source=cur.get("source") or "console",
+                source_type="operator",
+            )
+        )
+        if new_id is None:
+            return JSONResponse({"detail": "the store rejected the new revision"}, status_code=400)
+        deleted = await asyncio.to_thread(store.delete_by_id, chunk_id)
+        if not deleted:
+            log.warning("[memory] edit of hot chunk %s left the old row (delete failed)", chunk_id)
+        return {"enabled": True, "id": new_id, "replaced": bool(deleted)}
+
+    @app.delete("/api/memory/hot/{chunk_id}")
+    async def _api_memory_hot_delete(chunk_id: int):
+        store = STATE.knowledge_store
+        if store is None:
+            return {"enabled": False, "deleted": False}
+        if not any(c.get("id") == chunk_id for c in _hot_chunks(store)):
+            return JSONResponse({"detail": "no hot-memory chunk with that id"}, status_code=404)
+        deleted = await asyncio.to_thread(store.delete_by_id, chunk_id)
+        return {"enabled": True, "deleted": bool(deleted)}

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -660,6 +660,12 @@ def _main():
     # Knowledge store + Playbooks (ADR 0020). Extracted to
     # operator_api/knowledge_routes.py (ADR 0023 phase 3).
     register_knowledge_routes(fastapi_app)
+
+    # Memory inspector (ADR 0069 D7) — /api/memory/*: the session summaries
+    # behind the <prior_sessions> digest + always-injected hot memory.
+    from operator_api.memory_routes import register_memory_routes
+
+    register_memory_routes(fastapi_app)
     register_plugin_routes(fastapi_app)
 
     # Operator server controls — POST /api/restart (graceful self-restart). Gated by

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -1,0 +1,197 @@
+"""Memory-inspector routes (ADR 0069 D7) — /api/memory/* exposes the session
+summaries behind the <prior_sessions> digest (list/get/delete, traversal-safe
+ids) and the always-injected hot-memory chunks (list/edit/delete, pinned to
+domain="hot")."""
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from operator_api.memory_routes import register_memory_routes
+
+
+def _client(monkeypatch, tmp_path, *, knowledge=None):
+    import runtime.state as rs
+
+    monkeypatch.setenv("MEMORY_PATH", str(tmp_path))  # memory_path() resolves per call
+    monkeypatch.setattr(rs.STATE, "knowledge_store", knowledge, raising=False)
+    app = FastAPI()
+    register_memory_routes(app)
+    return TestClient(app)
+
+
+def _write(d, sid, messages, **extra):
+    (d / f"{sid}.json").write_text(
+        json.dumps({"session_id": sid, "timestamp": "2026-07-01T00:00:00Z", "messages": messages, **extra})
+    )
+
+
+# ── session summaries ─────────────────────────────────────────────────────────
+
+
+def test_sessions_list_returns_digest_fields(tmp_path, monkeypatch):
+    _write(tmp_path, "chat-abc", [{"role": "user", "content": "plan the launch"}, {"role": "assistant", "content": "ok"}])
+    c = _client(monkeypatch, tmp_path)
+    rows = c.get("/api/memory/sessions").json()["sessions"]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["session_id"] == "chat-abc"
+    assert row["surface"] == "chat"
+    assert row["topic"] == "plan the launch"  # first USER message only
+    assert row["message_count"] == 2
+    assert row["timestamp"] == "2026-07-01T00:00:00Z"
+    assert row["size_bytes"] > 0
+    assert "rendered" not in row  # list stays digest-sized
+
+
+def test_sessions_list_newest_first_and_skips_non_json(tmp_path, monkeypatch):
+    import os
+
+    _write(tmp_path, "s-old", [{"role": "user", "content": "old"}])
+    _write(tmp_path, "s-new", [{"role": "user", "content": "new"}])
+    (tmp_path / "junk.txt").write_text("not a summary")
+    old = tmp_path / "s-old.json"
+    os.utime(old, (old.stat().st_atime, old.stat().st_mtime - 100))
+    c = _client(monkeypatch, tmp_path)
+    rows = c.get("/api/memory/sessions").json()["sessions"]
+    assert [r["session_id"] for r in rows] == ["s-new", "s-old"]
+
+
+def test_sessions_list_empty_dir(tmp_path, monkeypatch):
+    c = _client(monkeypatch, tmp_path)
+    assert c.get("/api/memory/sessions").json() == {"sessions": []}
+
+
+def test_session_get_renders_full_summary(tmp_path, monkeypatch):
+    _write(tmp_path, "background:job1", [{"role": "user", "content": "check the feeds"}], final_output="all quiet")
+    c = _client(monkeypatch, tmp_path)
+    body = c.get("/api/memory/sessions/background:job1").json()["session"]
+    assert body["session_id"] == "background:job1"
+    assert body["surface"] == "background"
+    # rendered = format_session_summary — the same expansion recall_session returns
+    assert "check the feeds" in body["rendered"]
+    assert "all quiet" in body["rendered"]
+
+
+def test_session_get_unknown_404(tmp_path, monkeypatch):
+    c = _client(monkeypatch, tmp_path)
+    assert c.get("/api/memory/sessions/nope").status_code == 404
+
+
+def test_session_id_guard_rejects_unsafe_ids(tmp_path, monkeypatch):
+    # The recall_session filename guard: [A-Za-z0-9._:-] only, so a crafted id
+    # (encoded separators, spaces) can't escape the memory dir. An encoded "/"
+    # never even routes to the handler (404); everything else that does route
+    # is rejected by the guard (400). Both never touch the filesystem.
+    outside = tmp_path / "secret.json"  # sibling of the memory dir below
+    outside.write_text("{}")
+    memdir = tmp_path / "memory"
+    memdir.mkdir()
+    c = _client(monkeypatch, memdir)
+    assert c.get("/api/memory/sessions/..%2Fsecret").status_code in (400, 404)
+    assert c.delete("/api/memory/sessions/..%2Fsecret").status_code in (400, 404)
+    for bad in ("..%5C..%5Cconfig", "a%20b", "~root"):
+        assert c.get(f"/api/memory/sessions/{bad}").status_code == 400
+        assert c.delete(f"/api/memory/sessions/{bad}").status_code == 400
+    assert outside.exists()  # no traversal attempt reached outside the dir
+
+
+def test_session_id_guard_charset():
+    from graph.middleware.memory import is_safe_session_id
+
+    assert is_safe_session_id("chat-1_a.b:c")
+    for bad in ("", "../x", "a/b", "a\\b", "a b", "a\x00b"):
+        assert not is_safe_session_id(bad)
+
+
+def test_session_delete(tmp_path, monkeypatch):
+    _write(tmp_path, "s1", [{"role": "user", "content": "bye"}])
+    c = _client(monkeypatch, tmp_path)
+    assert c.delete("/api/memory/sessions/s1").json() == {"deleted": True, "session_id": "s1"}
+    assert not (tmp_path / "s1.json").exists()
+    assert c.delete("/api/memory/sessions/s1").status_code == 404  # already gone
+
+
+# ── hot memory ────────────────────────────────────────────────────────────────
+
+
+class _HotKS:
+    """Store double: dict rows (the LayeredKnowledgeStore list_chunks shape),
+    tracking add/delete like the knowledge-routes CRUD double."""
+
+    def __init__(self):
+        self.rows = [
+            {"id": 3, "content": "operator prefers dark mode", "domain": "hot", "created_at": "2026-07-01", "source": "console"}
+        ]
+        self.added: list[tuple] = []
+        self.deleted: list[int] = []
+        self.next_id = 9
+
+    def list_chunks(self, domain=None, limit=50, **kwargs):
+        assert domain == "hot"  # the inspector never lists other domains
+        return self.rows
+
+    def add_chunk(self, content, domain="general", **kwargs):
+        self.added.append((content, domain, kwargs))
+        return self.next_id
+
+    def delete_by_id(self, chunk_id):
+        self.deleted.append(chunk_id)
+        return True
+
+
+def test_hot_list(tmp_path, monkeypatch):
+    c = _client(monkeypatch, tmp_path, knowledge=_HotKS())
+    body = c.get("/api/memory/hot").json()
+    assert body["enabled"] is True
+    row = body["chunks"][0]
+    assert (row["id"], row["content"], row["created_at"], row["source"]) == (
+        3,
+        "operator prefers dark mode",
+        "2026-07-01",
+        "console",
+    )
+
+
+def test_hot_edit_pins_domain_and_adds_before_deleting(tmp_path, monkeypatch):
+    ks = _HotKS()
+    c = _client(monkeypatch, tmp_path, knowledge=ks)
+    body = c.put("/api/memory/hot/3", json={"content": "prefers light mode"}).json()
+    assert body == {"enabled": True, "id": 9, "replaced": True}
+    content, domain, kwargs = ks.added[0]
+    assert (content, domain) == ("prefers light mode", "hot")  # never demoted out of hot
+    assert kwargs["source_type"] == "operator"
+    assert ks.deleted == [3]
+
+
+def test_hot_edit_keeps_old_row_when_add_fails(tmp_path, monkeypatch):
+    ks = _HotKS()
+    ks.add_chunk = lambda *a, **k: None  # store rejects the revision
+    c = _client(monkeypatch, tmp_path, knowledge=ks)
+    assert c.put("/api/memory/hot/3", json={"content": "x"}).status_code == 400
+    assert ks.deleted == []  # the original survives
+
+
+def test_hot_edit_unknown_id_404(tmp_path, monkeypatch):
+    ks = _HotKS()
+    c = _client(monkeypatch, tmp_path, knowledge=ks)
+    assert c.put("/api/memory/hot/99", json={"content": "x"}).status_code == 404
+    assert ks.added == [] and ks.deleted == []
+
+
+def test_hot_delete_only_resolves_hot_ids(tmp_path, monkeypatch):
+    ks = _HotKS()
+    c = _client(monkeypatch, tmp_path, knowledge=ks)
+    assert c.delete("/api/memory/hot/3").json() == {"enabled": True, "deleted": True}
+    assert ks.deleted == [3]
+    # An id that is NOT a hot chunk 404s — this surface can't delete arbitrary KB rows.
+    assert c.delete("/api/memory/hot/42").status_code == 404
+    assert ks.deleted == [3]
+
+
+def test_hot_disabled_without_store(tmp_path, monkeypatch):
+    c = _client(monkeypatch, tmp_path)
+    assert c.get("/api/memory/hot").json() == {"enabled": False, "chunks": []}
+    assert c.delete("/api/memory/hot/1").json() == {"enabled": False, "deleted": False}
+    assert c.put("/api/memory/hot/1", json={"content": "x"}).json() == {"enabled": False, "id": None}

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -190,6 +190,24 @@ def test_hot_delete_only_resolves_hot_ids(tmp_path, monkeypatch):
     assert ks.deleted == [3]
 
 
+def test_hot_excludes_commons_tier(tmp_path, monkeypatch):
+    # On a LayeredKnowledgeStore, list_chunks unions private+commons with
+    # PER-BACKEND ids while get_hot_memory/add_chunk/delete_by_id delegate to
+    # private only. A commons hot row must not appear in the list (it never
+    # injects) and — critically — its id must not pass the mutation gates:
+    # delete_by_id would hit whatever PRIVATE row shares the numeric id.
+    ks = _HotKS()
+    ks.rows = [
+        {**ks.rows[0], "tier": "private"},
+        {"id": 7, "content": "shared fact", "domain": "hot", "created_at": "2026-07-01", "source": "commons", "tier": "commons"},
+    ]
+    c = _client(monkeypatch, tmp_path, knowledge=ks)
+    assert [r["id"] for r in c.get("/api/memory/hot").json()["chunks"]] == [3]
+    assert c.delete("/api/memory/hot/7").status_code == 404
+    assert c.put("/api/memory/hot/7", json={"content": "x"}).status_code == 404
+    assert ks.deleted == [] and ks.added == []  # private row 7 untouched
+
+
 def test_hot_disabled_without_store(tmp_path, monkeypatch):
     c = _client(monkeypatch, tmp_path)
     assert c.get("/api/memory/hot").json() == {"enabled": False, "chunks": []}

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -438,10 +438,6 @@ def _extract_text_from_html(content: bytes) -> str:
 _MEMORY_RECALL_MAX_K = 20
 _MEMORY_LIST_MAX_LIMIT = 200
 _RECALL_SESSION_MAX_CHARS = 6000
-# Session ids become filenames under memory_path() — restrict to the characters
-# real ids use (``:`` included — e.g. ``background:job``) so a crafted id can't
-# path-traverse out of the memory dir.
-_SESSION_ID_SAFE_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._:-")
 
 # Fork tool denylist — names dropped from ``get_all_tools``. Set once from config
 # (``tools.disabled``) by ``set_disabled_tools`` at config load/reload, so a fork
@@ -781,12 +777,13 @@ def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None)
         import json
         import os
 
+        from graph.middleware.memory import format_session_summary, is_safe_session_id, memory_path
+
         sid = (session_id or "").strip()
         # Filename guard: ids map to {memory_path()}/{sid}.json, so anything
         # outside the safe charset (path separators, "..", NUL) is rejected.
-        if not sid or not set(sid) <= _SESSION_ID_SAFE_CHARS:
+        if not is_safe_session_id(sid):
             return f"Error: invalid session_id {session_id!r} — pass an id from <prior_sessions>."
-        from graph.middleware.memory import format_session_summary, memory_path
 
         fpath = os.path.join(memory_path(), f"{sid}.json")
         try:


### PR DESCRIPTION
## Summary

The API half of the **ADR 0069 D7 memory inspector** ([ADR 0069](docs/adr/0069-memory-delivery-layer.md), tasklist lane R2c — console UI lands in a later lane): an operator audit surface for the memory delivery layer. Security control first — this is how SpAIware-class memory poisoning gets *detected* — UX second.

### Route table

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/memory/sessions` | List persisted session summaries — one digest-derived row each: `session_id`, `timestamp`, `surface`, `topic`, `message_count`, `size_bytes` (newest first) |
| GET | `/api/memory/sessions/{session_id}` | Digest fields + `trace_id` + `rendered` (the same `format_session_summary` render `recall_session` expands); 400 invalid id, 404 unknown, 422 unreadable file |
| DELETE | `/api/memory/sessions/{session_id}` | Remove the summary file; 400 invalid id, 404 unknown |
| GET | `/api/memory/hot` | List `domain="hot"` chunks (`id`, `content`, `heading`, `source`, `source_type`, `created_at`, …) — the chunks injected every turn |
| PUT | `/api/memory/hot/{chunk_id}` | Edit a hot chunk — revision **pinned to `domain="hot"`**, add-the-revision-first-then-delete (a failed add never loses the original); 404 when the id is not a hot chunk |
| DELETE | `/api/memory/hot/{chunk_id}` | Delete a hot chunk; only resolves ids that ARE hot chunks (can't reach arbitrary KB rows) |

All routes are gated by the server-level `/api/*` bearer middleware (`a2a_impl.auth`) like every other operator route — no unauthenticated surface.

### Design notes

- **Reuse, not duplication (#1581 helpers):** list rows come from a new public `graph.middleware.memory.digest_entry()` — the exact derivation `_digest_line` renders, so the inspector can never drift from the injected `<prior_sessions>` digest. The session-id → filename mapping shares a new `is_safe_session_id()` (`[A-Za-z0-9._:-]` only, path-traversal safe) with the `recall_session` tool, replacing the tool's private frozenset.
- **Hot routes are the gap the generic chunk CRUD leaves:** `knowledge_routes` already has `PUT/DELETE /api/knowledge/chunks/{id}`, but its edit defaults `domain` to `general` (would silently demote a hot chunk out of always-on injection) and its delete reaches any KB row. The `/api/memory/hot/*` routes add the domain-scoped semantics the inspector needs; row normalization reuses `_knowledge_row`.
- Stays clear of the sibling R2b lane (`operator_api/injection_routes.py`); no existing route files touched; no new config keys (no golden changes); import layering verified (`operator_api → graph` is allowed; 3 contracts kept).

## Gates

- `ruff check .` ✓
- `lint-imports` (uvx import-linter 2.11) ✓ — 3 contracts kept
- `python -m pytest tests/ -q` ✓ — 2639 passed, 5 skipped
- `python scripts/live_smoke.py` ✓
- `npm run docs:build` ✓ (docs page touched; existing page — no nav regen needed)

## Tests

`tests/test_memory_routes.py` (operator_api fixture style: bare FastAPI + registrar + TestClient, `MEMORY_PATH` → tmp dir, store double): list/get/delete happy paths, digest-field shape, newest-first ordering, unknown-id 404s, traversal/unsafe-id rejection (guard unit tests + HTTP-level probes, nothing outside the memory dir reachable), hot list/edit/delete incl. pinned-domain + add-before-delete ordering, and disabled-store degradation.

> Draft per lane protocol — the review lane marks ready + arms automerge after fixes land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)