### PR TITLE
chore(ci): make workflows fork-friendly — guard org-specific/expensive jobs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           node-version: "20"
       - name: Verify workspace config (.beads / .automaker / owned runners)
+        # Fork-friendly (#1534): the .beads/.automaker/owned-runner baseline is the
+        # protoLabs *fleet* standard, so it runs across the fleet (protoLabsAI/*) —
+        # keeping gina/protoTrader/roxy conformant — but is skipped on external forks,
+        # which are free to diverge. The job stays green either way (the server.py
+        # guard below still runs everywhere).
+        if: startsWith(github.repository, 'protoLabsAI/')
         # The npm package is still 1.0.0 (predates verify-workspace-config),
         # so run the script directly. It's zero-dependency (node builtins
         # only), so no `npm install` is needed. Switch to

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -58,8 +58,9 @@ jobs:
     name: ${{ matrix.target }}
     # Manual dispatch only (see the `on:` block) — the tag-push trigger was retired
     # because the macOS/Windows matrix on every release was the repo's dominant CI cost.
-    # The repo guard keeps forks from running the matrix.
-    if: github.repository == 'protoLabsAI/protoAgent'
+    # Fork-friendly (#1534): a fork can dispatch its own (unsigned) build; the repo
+    # clause keeps forks from auto-building should a tag trigger ever return.
+    if: github.repository == 'protoLabsAI/protoAgent' || github.event_name == 'workflow_dispatch'
     # Per-leg runner, overridable by repo variable so the expensive macOS/Windows
     # legs can move off GitHub-hosted runners (10×/2× billing multipliers) onto
     # Namespace profiles WITHOUT editing this file — the moment the org provisions

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,11 +24,16 @@ permissions:
 env:
   REGISTRY: ghcr.io
   # Normalise the image name — GHCR paths are case-sensitive and Docker refuses
-  # uppercase; github.repository would otherwise yield a mixed-case value.
-  IMAGE_NAME: protolabsai/protoagent
+  # uppercase; github.repository would otherwise yield a mixed-case value. A fork
+  # that opts in (see the job guard) sets its own `IMAGE_NAME` repo variable.
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'protolabsai/protoagent' }}
 
 jobs:
   build-and-push:
+    # Fork-friendly (#1534): the hardcoded default pushes to protoLabs' GHCR, which
+    # forks can't write to. Only the canonical repo runs by default; a fork opts in
+    # by setting the `DOCKER_PUBLISH_ENABLED` repo variable (+ its own `IMAGE_NAME`).
+    if: github.repository == 'protoLabsAI/protoAgent' || vars.DOCKER_PUBLISH_ENABLED == 'true'
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 30
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,8 +44,11 @@ jobs:
 
   deploy:
     needs: build
-    # Never deploy from a PR — PRs only validate the build above.
-    if: github.event_name != 'pull_request'
+    # Never deploy from a PR — PRs only validate the build above. Fork-friendly
+    # (#1534): deploys to protoLabs' GitHub Pages, so only the canonical repo runs
+    # it — a fork without Pages configured would otherwise get a deploy error. The
+    # `build` job above is unguarded on purpose: forks want it (catches VitePress breakage).
+    if: github.event_name != 'pull_request' && github.repository == 'protoLabsAI/protoAgent'
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     environment:
       name: github-pages

--- a/.github/workflows/marketing-deploy.yml
+++ b/.github/workflows/marketing-deploy.yml
@@ -26,6 +26,9 @@ concurrency:
 jobs:
   deploy:
     name: Build & deploy to Cloudflare Pages
+    # Fork-friendly (#1534): deploys to protoLabs' Cloudflare Pages project and needs
+    # CLOUDFLARE_* secrets no fork has — so only the canonical repo runs it.
+    if: github.repository == 'protoLabsAI/protoAgent'
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: protolabsai/protoagent
+  # Overridable (#1534): a fork that opts into RELEASE_ENABLED sets its own
+  # `IMAGE_NAME` repo variable to push to its GHCR instead of protoLabs'.
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'protolabsai/protoagent' }}
 
 jobs:
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   URL so a card can't appear twice.
 
 ### Changed
+- **CI workflows are fork-friendly** (#1534). Org-specific / expensive workflows no longer
+  auto-run or fail on forks: `docker-publish` (opt in with `DOCKER_PUBLISH_ENABLED` + your own
+  `IMAGE_NAME`), `marketing-deploy` and the GitHub Pages **docs deploy** (canonical-repo only —
+  the docs *build* still runs on fork PRs), and the `desktop-build` (a fork can `workflow_dispatch`
+  its own unsigned build). The `checks.yml` `workspace-config` step now runs fleet-wide
+  (`protoLabsAI/*`) and is skipped on external forks, so a fresh fork gets green CI out of the box;
+  the `server.py` guard still runs everywhere. `release.yml`/`docker-publish.yml` `IMAGE_NAME` is
+  now an overridable repo variable. Lint, tests, fleet-integration, live-smoke, web-e2e, issue-gate,
+  and secret-scan are unchanged (they're already fork-safe). See
+  [Customize & deploy → un-freeze the release pipeline](docs/guides/customize-and-deploy.md#3-un-freeze-the-release-pipeline).
 - **Fleet "New agent" now applies the archetype's persona**, not just its tools. Creating an
   agent from an archetype writes its base `SOUL.md` into the new workspace (`POST /api/fleet`
   gained a `soul` field), so a bundle agent arrives with its persona wired in.

--- a/docs/guides/customize-and-deploy.md
+++ b/docs/guides/customize-and-deploy.md
@@ -60,12 +60,30 @@ gh variable set RELEASE_ENABLED --body true   # in your fork's repo
 
 `prepare-release.yml` and `release.yml` gate on `if: vars.RELEASE_ENABLED == 'true'`.
 
+The image-publishing workflows are guarded the same way (#1534) — they only run on
+the canonical repo by default (a fork can't push to protoLabs' GHCR), so on a fork
+they're skipped, never failed. To publish your fork's own image, set two variables:
+
+```bash
+gh variable set DOCKER_PUBLISH_ENABLED --body true          # enable docker-publish.yml
+gh variable set IMAGE_NAME --body 'yourorg/youragent'       # your GHCR path (also used by release.yml)
+```
+
+`IMAGE_NAME` defaults to `protolabsai/protoagent` when unset. The **marketing** and
+**GitHub Pages docs deploy** workflows are canonical-only (protoLabs Cloudflare/Pages
+targets); the **desktop build** is manual — a fork can `workflow_dispatch` it to get
+unsigned test artifacts.
+
 ## 3b. Stay conformant with the fleet workspace-config standard
 
 Every fleet-watched repo carries a shared baseline enforced by
 [`protoLabsAI/release-tools`](https://github.com/protoLabsAI/release-tools)
-`verify-workspace-config`, and **`checks.yml` runs it on every PR** — so a
-non-conformant fork goes red in CI. The rules that bite most often:
+`verify-workspace-config`. **`checks.yml` runs it on every PR within the protoLabs
+fleet** (any `protoLabsAI/*` repo) — so a non-conformant fleet repo goes red in CI.
+**External forks are exempt** (the step is skipped, the job still passes), so you're
+free to adopt or diverge from this standard. To enforce it in your own fork anyway,
+run the check locally (below) or drop the `startsWith(github.repository, 'protoLabsAI/')`
+guard on that step. The rules that bite most often:
 
 - **Owned runners.** Every workflow `runs-on:` must be
   `namespace-profile-protolabs-linux`, never a GitHub-hosted label


### PR DESCRIPTION
Closes #1534. **Draft** while I run a self-review pass (per our automerge-safety practice) — will mark ready once verified.

Forks inherit all 9 workflows; several auto-run and fail (missing secrets, wrong GHCR org) or burn minutes on protoLabs-only checks. This guards them so a **fresh fork gets green CI out of the box**, while the **canonical repo is unchanged** — every guard is `canonical || opt-in`, so `github.repository == 'protoLabsAI/protoAgent'` is always true here and nothing that runs today stops running.

| Workflow | Change |
|---|---|
| `docker-publish` | `if: canonical \|\| vars.DOCKER_PUBLISH_ENABLED == 'true'`; `IMAGE_NAME` → overridable repo var |
| `marketing-deploy` | canonical-only (needs protoLabs Cloudflare secrets) |
| `docs` | guard the **deploy** job (canonical-only); the PR **build** gate still runs on forks |
| `desktop-build` | `canonical \|\| workflow_dispatch` — a fork can dispatch its own unsigned build; no auto-build |
| `checks` (`workspace-config`) | verify step runs **fleet-wide** (`startsWith(…, 'protoLabsAI/')`) — keeps gina/protoTrader/roxy conformant — skipped on external forks; the `server.py` guard still runs everywhere |
| `release` | `IMAGE_NAME` overridable repo var |

**Unchanged (already fork-safe):** lint, tests, fleet-integration, live-smoke, web-e2e, issue-gate, secret-scan.

### Why `startsWith` for workspace-config (not exact match)
The issue suggested `== 'protoLabsAI/protoAgent'`, but docs §3b documents the `.beads`/`.automaker`/owned-runner baseline as the **fleet** standard that `protoLabsAI/*` repos enforce. An exact match would silently stop the fleet forks from enforcing it. `startsWith(…, 'protoLabsAI/')` keeps the fleet conformant while exempting external forks. Docs §3b updated to match.

### Verification
- All 6 workflows yaml-parse clean.
- Ran the real `release-tools verify-workspace-config` against the branch → **0 errors, 9 passed** (2 pre-existing biome warnings, unrelated).
- Canonical-safety: every guard evaluates true on `protoLabsAI/protoAgent`.

### Docs
`customize-and-deploy` §3 now documents `DOCKER_PUBLISH_ENABLED` + `IMAGE_NAME`; §3b clarifies workspace-config is fleet-scoped. CHANGELOG under `[Unreleased] → Changed`.

### Acceptance (#1534)
- [x] docker-publish doesn't run/fail on forks
- [x] marketing-deploy doesn't run/fail on forks
- [x] docs deploy guarded; PR build gate still works
- [x] desktop-build: forks dispatch-only, no auto-run clutter (already dispatch-only)
- [x] checks workspace-config doesn't fail on forks
- [x] forks get green CI (lint/tests/fleet/live-smoke/web-e2e/secret-scan)
- [x] issue-gate + secret-scan still work on forks

🤖 Generated with [Claude Code](https://claude.com/claude-code)