### PR TITLE
feat(memory): namespace-scoped injection, incognito threads, per-turn injection record (ADR 0069 R2a/R2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Namespace-scoped auto-injection** (`knowledge.inject_namespaces`,
+  [ADR 0069](docs/adr/0069-memory-delivery-layer.md) D3a). When set, the per-turn
+  auto-injected RAG recall only considers chunks in the listed namespaces (`""`
+  matches un-namespaced chunks); default unset = unfiltered, so box-commons
+  sharing keeps working. Filters both the keyword and vector rankings on hybrid
+  stores; tool-driven `memory_recall` is deliberately unscoped. See
+  [the knowledge guide](docs/guides/knowledge.md#memory-delivery-controls-adr-0069).
+- **Incognito threads** (ADR 0069 D3b) — a per-message `incognito` flag
+  (`POST /api/chat` body field, or A2A message metadata on the streaming path)
+  that skips BOTH session-summary persistence and memory injection (prior-session
+  digest, hot memory, RAG) for that turn; the skill index still injects. Carried
+  through graph state (`ProtoAgentState.incognito`), stamped explicitly each turn.
+  Backend only — the console thread toggle rides a later lane.
+- **Per-turn memory-injection record** (ADR 0069 D6) — every model call that had
+  memory auto-injected appends an id-attributed row (digest session ids, hot-memory
+  chunk ids, RAG chunk ids, approx tokens) to an instance-scoped SQLite log
+  (`observability/injection_log.py`, `<instance_root>/memory-injections.db`),
+  readable via `GET /api/memory/injections?session_id=&limit=` (newest-first).
+  Makes "why did it say that?" answerable and gives memory-poisoning forensics a
+  paper trail: store row → source session → the turns it entered.
 - **`recall_session(session_id)` starter tool** — expands one entry from the
   prior-sessions digest into that session's full persisted summary (reasoning-
   stripped, capped), with a path-traversal-safe id guard. The on-demand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [the knowledge guide](docs/guides/knowledge.md#memory-delivery-controls-adr-0069).
 - **Incognito threads** (ADR 0069 D3b) — a per-message `incognito` flag
   (`POST /api/chat` body field, or A2A message metadata on the streaming path)
-  that skips BOTH session-summary persistence and memory injection (prior-session
-  digest, hot memory, RAG) for that turn; the skill index still injects. Carried
-  through graph state (`ProtoAgentState.incognito`), stamped explicitly each turn.
-  Backend only — the console thread toggle rides a later lane.
+  that skips session-summary persistence, memory injection (prior-session
+  digest, hot memory, RAG) for that turn, and the retire-time conversation
+  harvest (the transcript never enters the knowledge store); the skill index
+  still injects. Carried through graph state (`ProtoAgentState.incognito`),
+  stamped explicitly each turn. Backend only — the console thread toggle rides
+  a later lane.
 - **Per-turn memory-injection record** (ADR 0069 D6) — every model call that had
   memory auto-injected appends an id-attributed row (digest session ids, hot-memory
   chunk ids, RAG chunk ids, approx tokens) to an instance-scoped SQLite log

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -95,6 +95,13 @@ knowledge:
   # consolidate them into the store. Rides the harvest pass (ADR 0021).
   facts: true
   top_k: 5
+  # Namespace scope for the per-turn AUTO-INJECTED recall (ADR 0069 D3a). Unset =
+  # no filter (every chunk is eligible — box-commons sharing keeps working). When
+  # set, only chunks whose `namespace` matches a listed value auto-inject; include
+  # "" to also match un-namespaced chunks. memory_recall stays unscoped.
+  # inject_namespaces:
+  #   - "projects/alpha"
+  #   - ""
   # Document chunking on ingest (ADR 0021) — large bodies (conversation
   # summaries, pasted docs) are split into overlapping passages BEFORE
   # embedding, so each passage gets its own vector instead of one diluted

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -94,8 +94,10 @@ outside the scope.
 
 A turn flagged **incognito** leaves no memory trail and reads none in: the
 session-summary write is skipped (nothing to show up in later threads'
-`<prior_sessions>` digest), and the digest / hot-memory / RAG injection is skipped
-for that turn (the skill index still injects — it's capability, not memory).
+`<prior_sessions>` digest), the digest / hot-memory / RAG injection is skipped
+for that turn (the skill index still injects — it's capability, not memory), and
+the retire-time conversation harvest skips the thread (its transcript is never
+summarized into the knowledge store).
 
 - **`POST /api/chat`** — pass `"incognito": true` in the request body (additive;
   default `false`).

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -64,6 +64,64 @@ When a knowledge store is wired, the agent gets these (operator-curatable under
 `GET /api/runtime/status` reports the store status; `GET /api/knowledge/search`
 backs the console browser.
 
+## Memory delivery controls (ADR 0069)
+
+What the store *holds* and what gets *pushed into the prompt each turn* are separate
+surfaces ([ADR 0069](/adr/0069-memory-delivery-layer)). Three controls gate and audit
+the delivery side:
+
+### Scope the auto-inject to namespaces
+
+Every chunk carries an optional `namespace` (session attachments use
+`attach:<session_id>`; forks/plugins set their own). By default the per-turn
+auto-inject searches **everything**. To restrict what can enter the prompt unasked:
+
+```yaml
+knowledge:
+  inject_namespaces: []       # default: empty = no filter (everything eligible)
+  # inject_namespaces:        # when set: only these namespaces auto-inject
+  #   - "projects/alpha"
+  #   - ""                    # the empty string matches UN-namespaced chunks
+```
+
+This gates **only the automatic injection** (`KnowledgeMiddleware`) — tool-driven
+recall (`memory_recall`) is deliberately unscoped, so out-of-scope knowledge stays
+reachable on demand with the model's intent visible as a tool call. Hybrid stores
+filter both the keyword and vector rankings, so a fused hit can never come from
+outside the scope.
+
+### Incognito threads
+
+A turn flagged **incognito** leaves no memory trail and reads none in: the
+session-summary write is skipped (nothing to show up in later threads'
+`<prior_sessions>` digest), and the digest / hot-memory / RAG injection is skipped
+for that turn (the skill index still injects — it's capability, not memory).
+
+- **`POST /api/chat`** — pass `"incognito": true` in the request body (additive;
+  default `false`).
+- **A2A / console streaming path** — set `incognito: true` in the message
+  **metadata** (alongside `model` / `reasoning_effort`).
+
+The flag is per-message and stamped explicitly on every turn, so a thread is only
+as incognito as its latest message — send the flag on each turn of a thread you
+want kept out of memory. (A console thread toggle rides a later UI lane.)
+
+### The per-turn injection record
+
+Every model call that had memory injected appends one row to an instance-scoped
+log (`<instance_root>/memory-injections.db`) recording **which** digest sessions,
+hot-memory chunk ids, and RAG chunk ids entered the prompt, and roughly how many
+tokens they cost. This is the forensics half of the poisoning story: store row →
+source session → the turns it was injected into.
+
+```
+GET /api/memory/injections?session_id=<id>&limit=50
+```
+
+returns `{"injections": [...]}` newest-first — omit `session_id` for all sessions.
+Each row: `ts`, `session_id`, `digest_session_ids`, `hot_chunk_ids`,
+`rag_chunk_ids`, `approx_tokens`.
+
 ## Sharing knowledge across a fleet (the commons)
 
 By default each agent's knowledge store is **private** (`scope: scoped`) — what one

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -98,6 +98,7 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
                 top_k=config.knowledge_top_k,
                 skills_index=_skills_index,
                 skills_top_k=config.skills_top_k,
+                inject_namespaces=config.knowledge_inject_namespaces,
             )
         )
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -424,6 +424,12 @@ class LangGraphConfig:
     # How many recalled chunks are injected per turn. Bumped 5 → 10 (RAG bake-off:
     # more candidates in-context lifted answer quality at sub-million-chunk scale).
     knowledge_top_k: int = 10
+    # Namespace scope for the AUTO-INJECT RAG search (ADR 0069 D3a). Empty (the
+    # default) = unfiltered — today's behavior, so box-commons sharing keeps
+    # working. When set, only chunks whose `namespace` matches a listed value
+    # are auto-injected; include "" to also match un-namespaced chunks. Gates
+    # only what enters the prompt unasked — memory_recall stays unscoped.
+    knowledge_inject_namespaces: list[str] = field(default_factory=list)
     # Hybrid-retrieval tuning (HybridKnowledgeStore knobs, ADR 0021) — surfaced so
     # they're tunable without editing the store / via the retrieval eval:
     #   vector_k  — FTS5 + vector candidates fused per query (the RRF pool).
@@ -912,6 +918,7 @@ class LangGraphConfig:
             image_describe_model=knowledge.get("image_describe_model", cls.image_describe_model),
             knowledge_embeddings=knowledge.get("embeddings", cls.knowledge_embeddings),
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),
+            knowledge_inject_namespaces=list(knowledge.get("inject_namespaces", []) or []),
             knowledge_vector_k=knowledge.get("vector_k", cls.knowledge_vector_k),
             knowledge_rrf_k=knowledge.get("rrf_k", cls.knowledge_rrf_k),
             knowledge_min_score=knowledge.get("min_score", cls.knowledge_min_score),

--- a/graph/conversation_harvest.py
+++ b/graph/conversation_harvest.py
@@ -87,8 +87,9 @@ async def harvest_thread(
     Both carry ``namespace`` for later per-project scoping.
 
     Returns the summary chunk id, or None when there's nothing to harvest (no
-    store, no checkpoint, empty transcript, or a summarizer failure). Never
-    raises — harvesting is best-effort and must not block retirement.
+    store, no checkpoint, incognito thread — ADR 0069 D3b, empty transcript,
+    or a summarizer failure). Never raises — harvesting is best-effort and
+    must not block retirement.
     """
     if knowledge_store is None:
         return None
@@ -96,7 +97,17 @@ async def harvest_thread(
         tup = await checkpointer.aget_tuple({"configurable": {"thread_id": thread_id}})
         if tup is None:
             return None
-        messages = (tup.checkpoint or {}).get("channel_values", {}).get("messages", [])
+        channel_values = (tup.checkpoint or {}).get("channel_values", {})
+        # Incognito thread (ADR 0069 D3b): "no memory trail" must hold at
+        # retirement too — without this gate the retire sweep (harvest_enabled
+        # defaults ON) would summarize the transcript into the knowledge store,
+        # where RAG re-injects it into later prompts. Same per-message
+        # semantics as _persist_session: the channel holds the last stamped
+        # value, so a thread is as incognito as its latest turn.
+        if channel_values.get("incognito"):
+            log.info("[harvest] thread %s is incognito — skipping harvest", thread_id)
+            return None
+        messages = channel_values.get("messages", [])
         transcript = render_transcript(messages)
         if not transcript.strip():
             return None

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -78,6 +78,7 @@ class KnowledgeMiddleware(AgentMiddleware):
         top_k: int = 5,
         skills_index: "SkillsIndex | None" = None,
         skills_top_k: int = 5,
+        inject_namespaces: list[str] | None = None,
     ):
         super().__init__()
         self._store = knowledge_store
@@ -88,10 +89,17 @@ class KnowledgeMiddleware(AgentMiddleware):
         # demand via load_skill — so this caps the per-turn "table of contents",
         # not what's usable.
         self._skills_top_k = skills_top_k
+        # Namespace scope for the auto-inject RAG search (ADR 0069 D3a,
+        # `knowledge.inject_namespaces`). Empty/None = unfiltered (today's
+        # behavior — box-commons sharing keeps working); "" in the list matches
+        # un-namespaced chunks. Tool-driven recall (memory_recall) is NOT
+        # scoped by this — it only gates what enters the prompt unasked.
+        self._inject_namespaces = list(inject_namespaces or [])
         # Lazily loaded on first before_model call; None = not yet loaded.
         # Refreshed after _PRIOR_SESSIONS_TTL_S so sessions persisted after boot
         # become visible (the cache is otherwise frozen for the process life).
         self._prior_sessions_cache: str | None = None
+        self._prior_sessions_ids: list[str] = []
         self._prior_sessions_loaded_at: float = 0.0
 
     # ---------------------------------------------------------------------------
@@ -107,16 +115,21 @@ class KnowledgeMiddleware(AgentMiddleware):
         """Format the most-recent persisted sessions as a ``<prior_sessions>``
         block for injection.
 
-        Delegates to the shared :func:`graph.middleware.memory.load_prior_sessions`
+        Delegates to the shared :func:`graph.middleware.memory.load_prior_sessions_digest`
         (ADR 0021) — one source of truth, with read-time reasoning stripping —
         so this and ``SessionSummaryMiddleware`` can't drift. ``memory_path`` defaults
         to the writer's resolved ``memory_path()`` (no duplicate path literal,
-        same can't-drift reasoning). Never raises.
+        same can't-drift reasoning). Also stashes the digest's session ids on
+        ``self._prior_sessions_ids`` so the per-turn injection record (ADR 0069
+        D6) can attribute what was injected. Never raises.
         """
-        from graph.middleware.memory import load_prior_sessions
+        from graph.middleware.memory import load_prior_sessions_digest
         from graph.middleware.memory import memory_path as _memory_path
 
-        return load_prior_sessions(memory_path or _memory_path(), max_sessions, max_tokens)
+        block, self._prior_sessions_ids = load_prior_sessions_digest(
+            memory_path or _memory_path(), max_sessions, max_tokens
+        )
+        return block
 
     # ---------------------------------------------------------------------------
     # Skill index (progressive disclosure — ADR 0060)
@@ -176,8 +189,18 @@ class KnowledgeMiddleware(AgentMiddleware):
         hits — in that order) is wrapped in one <injected_memory> envelope
         with untrusted-reference framing (ADR 0069 D2). The skill index is
         not memory and stays outside the envelope.
+
+        Incognito threads (ADR 0069 D3b, ``state["incognito"]``) get NO memory
+        injection at all — no digest, no hot memory, no RAG — while the skill
+        index (capability, not memory) still injects. Whatever memory IS
+        injected is recorded, id-attributed, in the per-instance injection log
+        (ADR 0069 D6) so "what entered this turn?" stays answerable.
         """
         memory_parts: list[str] = []
+        digest_ids: list[str] = []
+        hot_ids: list[int] = []
+        rag_ids: list[int] = []
+        incognito = bool(state.get("incognito"))
 
         # Load prior sessions with a TTL cache (lazy + periodic refresh).
         # Suppressed on goal-driven turns: unrelated cross-session history
@@ -188,14 +211,20 @@ class KnowledgeMiddleware(AgentMiddleware):
         if self._prior_sessions_cache is None or (now - self._prior_sessions_loaded_at) > _PRIOR_SESSIONS_TTL_S:
             self._prior_sessions_cache = self.load_memory()
             self._prior_sessions_loaded_at = now
-        if self._prior_sessions_cache and not _in_goal_turn():
+        if self._prior_sessions_cache and not incognito and not _in_goal_turn():
             memory_parts.append(self._prior_sessions_cache)
+            digest_ids = list(self._prior_sessions_ids)
 
         # Hot memory — always-on operator facts (domain="hot"). Loaded per turn
         # (not cached) so a freshly-added hot fact is seen immediately.
-        if self._store is not None and hasattr(self._store, "get_hot_memory"):
+        if not incognito and self._store is not None and hasattr(self._store, "get_hot_memory"):
             try:
-                hot = self._store.get_hot_memory()
+                if hasattr(self._store, "get_hot_memory_entries"):
+                    entries = self._store.get_hot_memory_entries()
+                    hot_ids = [cid for cid, _ in entries]
+                    hot = "\n".join(piece for _, piece in entries)
+                else:  # custom backend without the id-attributed reader
+                    hot = self._store.get_hot_memory()
                 if hot:
                     memory_parts.append(f"[Always-on facts (hot memory):]\n{hot}")
             except Exception as exc:  # noqa: BLE001 - never break the loop on memory
@@ -208,7 +237,7 @@ class KnowledgeMiddleware(AgentMiddleware):
         # conversation. The model pulls a full procedure on demand via load_skill.
         skill_block = self._skill_index_block()
 
-        if messages:
+        if messages and not incognito:
             # Find the last human message
             last_human: str | None = None
             for msg in reversed(messages):
@@ -217,16 +246,19 @@ class KnowledgeMiddleware(AgentMiddleware):
                     break
 
             if last_human and self._store is not None:
-                results = self._store.search(last_human, k=self._top_k)
+                results = self._search_scoped(last_human)
                 if results:
                     context_parts = ["[Relevant knowledge from previous sessions:]"]
                     for r in results:
                         context_parts.append(f"- [{r['table']}] {r['preview']}")
+                        if r.get("id") is not None:
+                            rag_ids.append(r["id"])
                     memory_parts.append("\n".join(context_parts))
 
         parts: list[str] = []
         if memory_parts:
             parts.append(_wrap_injected_memory(memory_parts))
+            self._record_injection(state, memory_parts, digest_ids, hot_ids, rag_ids)
         if skill_block:
             parts.append(skill_block)
 
@@ -234,6 +266,43 @@ class KnowledgeMiddleware(AgentMiddleware):
             return None
 
         return {"context": "\n\n".join(parts)}
+
+    def _search_scoped(self, query: str) -> list[dict]:
+        """The auto-inject RAG search, namespace-scoped when configured (ADR
+        0069 D3a). A backend whose ``search`` predates the ``namespace`` kwarg
+        gets the unfiltered call and a post-filter on each hit's ``namespace``
+        field, so the configured scope holds either way."""
+        if not self._inject_namespaces:
+            return self._store.search(query, k=self._top_k)
+        try:
+            return self._store.search(query, k=self._top_k, namespace=self._inject_namespaces)
+        except TypeError:
+            allowed = set(self._inject_namespaces)
+            results = self._store.search(query, k=self._top_k)
+            return [r for r in results if (r.get("namespace") or "") in allowed]
+
+    def _record_injection(
+        self,
+        state,
+        memory_parts: list[str],
+        digest_ids: list[str],
+        hot_ids: list[int],
+        rag_ids: list[int],
+    ) -> None:
+        """Append this model call's injected-memory row to the per-instance
+        injection log (ADR 0069 D6). Best-effort — never breaks a turn."""
+        try:
+            from observability.injection_log import injection_log
+
+            injection_log().record(
+                session_id=state.get("session_id", "") or "",
+                digest_session_ids=digest_ids,
+                hot_chunk_ids=hot_ids,
+                rag_chunk_ids=rag_ids,
+                approx_tokens=max(1, len("\n\n".join(memory_parts)) // 4),
+            )
+        except Exception as exc:  # noqa: BLE001 — forensics must never break the loop
+            log.debug("[knowledge] injection record failed: %s", exc)
 
     async def abefore_model(self, state, runtime) -> dict | None:
         """Async version — same logic, off the event loop.

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -74,6 +74,12 @@ def _persist_session(state: dict, trace_id: str) -> None:
     if _PERSISTENCE_DISABLED:
         return
 
+    # Incognito thread (ADR 0069 D3b): the operator asked for NO session-memory
+    # trail — nothing written, so nothing can be injected into later sessions.
+    if state.get("incognito"):
+        log.info("[memory] incognito session — skipping session persistence")
+        return
+
     # ``session_id`` is not a declared graph-state field, so LangGraph drops the
     # key the chat path passes into ``ainvoke`` — ``state.get`` returns "" and
     # every session would collapse into a single ``unknown.json`` (pooling and
@@ -292,10 +298,21 @@ def load_prior_sessions(
     approximation). ``memory_dir`` defaults to the writer's resolved
     ``memory_path()``. Never raises.
     """
+    return load_prior_sessions_digest(memory_dir, max_sessions, max_tokens)[0]
+
+
+def load_prior_sessions_digest(
+    memory_dir: str | None = None,
+    max_sessions: int = 10,
+    max_tokens: int = 2000,
+) -> tuple[str, list[str]]:
+    """:func:`load_prior_sessions` plus the session ids the digest ended up
+    carrying (post token-trim), in digest order — the attribution the per-turn
+    injection record needs (ADR 0069 D6) without re-parsing the block."""
     if memory_dir is None:
         memory_dir = memory_path()
     if not os.path.isdir(memory_dir):
-        return ""
+        return "", []
     try:
         entries: list[tuple[float, str]] = []
         for fname in os.listdir(memory_dir):
@@ -308,9 +325,9 @@ def load_prior_sessions(
                 continue
         entries.sort(reverse=True)  # newest first
     except OSError:
-        return ""
+        return "", []
     if not entries:
-        return "<prior_sessions/>"
+        return "<prior_sessions/>", []
 
     summaries: list[dict] = []
     for _, fpath in entries[:max_sessions]:
@@ -320,16 +337,18 @@ def load_prior_sessions(
         except (OSError, json.JSONDecodeError, ValueError):
             continue
     if not summaries:
-        return "<prior_sessions/>"
+        return "<prior_sessions/>", []
 
-    formatted = [_digest_line(s) for s in summaries]
-    while formatted:
-        if max(1, len("\n".join([_DIGEST_HEADER, *formatted])) // 4) <= max_tokens:
+    # (session_id, line) pairs so the ids stay parallel through the token trim.
+    lines = [(str(s.get("session_id") or "unknown"), _digest_line(s)) for s in summaries]
+    while lines:
+        if max(1, len("\n".join([_DIGEST_HEADER, *(line for _, line in lines)])) // 4) <= max_tokens:
             break
-        formatted.pop()  # drop oldest (newest-first ordering)
-    if not formatted:
-        return "<prior_sessions/>"
-    return "<prior_sessions>\n" + "\n".join([_DIGEST_HEADER, *formatted]) + "\n</prior_sessions>"
+        lines.pop()  # drop oldest (newest-first ordering)
+    if not lines:
+        return "<prior_sessions/>", []
+    block = "<prior_sessions>\n" + "\n".join([_DIGEST_HEADER, *(line for _, line in lines)]) + "\n</prior_sessions>"
+    return block, [sid for sid, _ in lines]
 
 
 # ---------------------------------------------------------------------------

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -242,6 +242,17 @@ FIELDS: list[Field] = [
     ),
     # ── Knowledge / memory ───────────────────────────────────────────────────
     Field("knowledge.top_k", "knowledge_top_k", "Knowledge recall top-k", "number", "Knowledge", minimum=1),
+    # Scope filter for the auto-inject RAG search (ADR 0069 D3a).
+    Field(
+        "knowledge.inject_namespaces",
+        "knowledge_inject_namespaces",
+        "Auto-inject namespaces",
+        "string_list",
+        "Knowledge",
+        "Restrict per-turn auto-injected knowledge (RAG) to chunks in these namespaces — one "
+        "per line; an empty line matches un-namespaced chunks. Empty = no filter (everything "
+        "is eligible, today's behavior). Tool-driven recall (memory_recall) is not affected.",
+    ),
     # Tier (ADR 0041 / bd-2wu) — mirrors `skills.scope`; the commons lives at `commons.path`.
     Field(
         "knowledge.scope",
@@ -705,6 +716,7 @@ FIELDS: list[Field] = [
 _KNOWLEDGE_SUBSECTION = {
     # Recall — what the agent retrieves into context, and how.
     "knowledge.top_k": "Recall",
+    "knowledge.inject_namespaces": "Recall",
     "knowledge.scope": "Recall",
     "knowledge.embeddings": "Recall",
     "knowledge.embed_model": "Recall",

--- a/graph/state.py
+++ b/graph/state.py
@@ -26,6 +26,13 @@ class ProtoAgentState(AgentState):
     # Session tracking (A2A / chat session ID)
     session_id: NotRequired[str]
 
+    # Incognito thread (ADR 0069 D3b): no session-memory persistence, no memory
+    # injection for this thread. Set per turn by the chat entry paths (A2A
+    # message metadata / POST /api/chat); read by SessionSummaryMiddleware and
+    # KnowledgeMiddleware from state (current_session_id() is empty in tool
+    # bodies — state is the reliable carrier).
+    incognito: NotRequired[bool]
+
     # Per-turn model override (per chat tab) — read by ModelOverrideMiddleware to
     # swap the lead model for this turn; unset → the configured default.
     model: NotRequired[str]

--- a/knowledge/hybrid_store.py
+++ b/knowledge/hybrid_store.py
@@ -30,7 +30,7 @@ import sqlite3
 import time
 from collections.abc import Callable
 
-from knowledge.store import KnowledgeStore
+from knowledge.store import KnowledgeStore, _namespace_clause
 
 log = logging.getLogger(__name__)
 
@@ -257,20 +257,34 @@ class HybridKnowledgeStore(KnowledgeStore):
                 db.close()
         return super().delete_by_namespace(namespace)
 
-    def _vector_search(self, query_vec: list[float], k: int, domain: str | None) -> list[int]:
+    def _vector_search(
+        self,
+        query_vec: list[float],
+        k: int,
+        domain: str | None,
+        namespace: str | list[str] | None = None,
+    ) -> list[int]:
         """Return chunk ids ranked by cosine similarity (brute force)."""
         db = self._get_db()
         if db is None:
             return []
+        where: list[str] = []
+        params: list = []
+        if domain:
+            where.append("c.domain = ?")
+            params.append(domain)
+        ns_sql, ns_params = _namespace_clause(namespace, col="c.namespace")
+        if ns_sql:
+            where.append(ns_sql)
+            params.extend(ns_params)
+        sql = (
+            "SELECT v.chunk_id, v.vec FROM chunk_vectors v "
+            "JOIN chunks c ON c.id = v.chunk_id WHERE " + " AND ".join(where)
+            if where
+            else "SELECT chunk_id, vec FROM chunk_vectors"
+        )
         try:
-            if domain:
-                rows = db.execute(
-                    "SELECT v.chunk_id, v.vec FROM chunk_vectors v "
-                    "JOIN chunks c ON c.id = v.chunk_id WHERE c.domain = ?",
-                    (domain,),
-                ).fetchall()
-            else:
-                rows = db.execute("SELECT chunk_id, vec FROM chunk_vectors").fetchall()
+            rows = db.execute(sql, params).fetchall()
         except sqlite3.DatabaseError:
             return []
         finally:
@@ -293,21 +307,30 @@ class HybridKnowledgeStore(KnowledgeStore):
 
     # ── hybrid search ────────────────────────────────────────────────────────────
 
-    def search(self, query, k: int = 5, *, domain: str | None = None) -> list[dict]:
+    def search(
+        self,
+        query,
+        k: int = 5,
+        *,
+        domain: str | None = None,
+        namespace: str | list[str] | None = None,
+    ) -> list[dict]:
         """RRF-fuse the FTS5 ranking with a vector ranking.
 
         Falls back to pure FTS5 when embeddings are unavailable (no embed_fn,
         circuit open, or the query fails to embed) — same shape, never raises.
+        ``namespace`` (ADR 0069 D3a) filters BOTH rankings, so a fused hit can
+        never come from outside the requested scope.
         """
         if not query or not query.strip():
             return []
 
-        base = super().search(query, k=self._vector_k, domain=domain)
+        base = super().search(query, k=self._vector_k, domain=domain, namespace=namespace)
         query_vec = self._embed(query)
         if query_vec is None:
             return base[:k]
 
-        vec_ids = self._vector_search(query_vec, self._vector_k, domain)
+        vec_ids = self._vector_search(query_vec, self._vector_k, domain, namespace)
         if not vec_ids:
             return base[:k]
 

--- a/knowledge/layered.py
+++ b/knowledge/layered.py
@@ -46,12 +46,20 @@ class LayeredKnowledgeStore:
         return getattr(self._private, name)
 
     # ── read: commons ∪ private, fused with RRF over rank ─────────────────────
-    def search(self, query: str, k: int = 5, *, domain: str | None = None) -> list[dict]:
+    def search(
+        self,
+        query: str,
+        k: int = 5,
+        *,
+        domain: str | None = None,
+        namespace: str | list[str] | None = None,
+    ) -> list[dict]:
         """Top-k across BOTH tiers, fused by RRF over each tier's rank, tier-tagged.
         A chunk promoted into the commons (same content as its private original) is
-        de-duped — the private record wins (it's editable) but keeps the summed score."""
-        priv = self._private.search(query, k, domain=domain)
-        comm = self._commons.search(query, k, domain=domain)
+        de-duped — the private record wins (it's editable) but keeps the summed score.
+        ``namespace`` (ADR 0069 D3a) is passed through to both tiers."""
+        priv = self._private.search(query, k, domain=domain, namespace=namespace)
+        comm = self._commons.search(query, k, domain=domain, namespace=namespace)
 
         fused: dict[str, dict] = {}
         scores: dict[str, float] = {}

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -155,6 +155,30 @@ def _escape_like(text: str) -> str:
     )
 
 
+def _namespace_clause(namespace: str | list[str] | None, col: str = "namespace") -> tuple[str, list[str]]:
+    """SQL predicate + params for a namespace filter (ADR 0069 D3a).
+
+    Accepts one value or a list. The empty string ``""`` in the filter matches
+    rows with NO namespace (NULL or ''), so scoped auto-inject can still include
+    un-namespaced chunks — most rows written before namespaces were filtered.
+    ``None`` / empty list → no predicate (unfiltered, today's behavior).
+    """
+    if namespace is None:
+        return "", []
+    values = [namespace] if isinstance(namespace, str) else [str(v) for v in namespace]
+    if not values:
+        return "", []
+    named = [v for v in values if v != ""]
+    arms: list[str] = []
+    params: list[str] = []
+    if named:
+        arms.append(f"{col} IN ({','.join('?' for _ in named)})")
+        params.extend(named)
+    if len(named) != len(values):  # "" requested → match un-namespaced rows
+        arms.append(f"({col} IS NULL OR {col} = '')")
+    return "(" + " OR ".join(arms) + ")", params
+
+
 def _fts_quote(token: str) -> str:
     """Quote a token for FTS5 MATCH so it's treated as a literal phrase.
 
@@ -548,6 +572,7 @@ class KnowledgeStore:
         k: int = 5,
         *,
         domain: str | None = None,
+        namespace: str | list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """Top-k chunks matching ``query``. Shape matches what the
         ``KnowledgeMiddleware`` consumes: each result has ``table``,
@@ -555,6 +580,9 @@ class KnowledgeStore:
 
         Uses FTS5 when available, else a tokenized LIKE fallback. Returns
         an empty list on no matches or DB failure (never raises).
+        ``namespace`` (ADR 0069 D3a) optionally restricts hits to the given
+        namespace value(s) — see :func:`_namespace_clause` for the ``""``
+        (un-namespaced rows) convention. ``None`` = unfiltered.
         """
         if not query or not query.strip():
             return []
@@ -563,9 +591,9 @@ class KnowledgeStore:
             return []
         try:
             rows = (
-                self._search_fts(db, query, k, domain)
+                self._search_fts(db, query, k, domain, namespace)
                 if self._fts_available
-                else self._search_like(db, query, k, domain)
+                else self._search_like(db, query, k, domain, namespace)
             )
         except sqlite3.DatabaseError as exc:
             log.warning("[knowledge] search failed: %s", exc)
@@ -591,6 +619,7 @@ class KnowledgeStore:
         query: str,
         k: int,
         domain: str | None,
+        namespace: str | list[str] | None = None,
     ) -> list[sqlite3.Row]:
         # Sanitize to FTS5-safe tokens; OR them so a multi-word query
         # matches any of the keywords (closer to LIKE behaviour).
@@ -602,20 +631,22 @@ class KnowledgeStore:
         if not tokens:
             return []
         match = " OR ".join(_fts_quote(t) for t in tokens)
+        where = ["chunks_fts MATCH ?"]
+        params: list[Any] = [match]
         if domain:
-            return db.execute(
-                "SELECT c.* FROM chunks_fts f "
-                "JOIN chunks c ON c.id = f.rowid "
-                "WHERE chunks_fts MATCH ? AND c.domain = ? "
-                "ORDER BY rank LIMIT ?",
-                (match, domain, k),
-            ).fetchall()
+            where.append("c.domain = ?")
+            params.append(domain)
+        ns_sql, ns_params = _namespace_clause(namespace, col="c.namespace")
+        if ns_sql:
+            where.append(ns_sql)
+            params.extend(ns_params)
+        params.append(k)
         return db.execute(
             "SELECT c.* FROM chunks_fts f "
             "JOIN chunks c ON c.id = f.rowid "
-            "WHERE chunks_fts MATCH ? "
+            f"WHERE {' AND '.join(where)} "
             "ORDER BY rank LIMIT ?",
-            (match, k),
+            params,
         ).fetchall()
 
     def _search_like(
@@ -624,6 +655,7 @@ class KnowledgeStore:
         query: str,
         k: int,
         domain: str | None,
+        namespace: str | list[str] | None = None,
     ) -> list[sqlite3.Row]:
         tokens = [t for t in re.findall(r"[\w']+", query) if t]
         if not tokens:
@@ -643,6 +675,10 @@ class KnowledgeStore:
         if domain:
             sql += " AND domain = ?"
             params.append(domain)
+        ns_sql, ns_params = _namespace_clause(namespace)
+        if ns_sql:
+            sql += f" AND {ns_sql}"
+            params.extend(ns_params)
         sql += " ORDER BY score DESC, id DESC LIMIT ?"
         params.append(k)
         return db.execute(sql, params).fetchall()
@@ -695,6 +731,24 @@ class KnowledgeStore:
         finally:
             db.close()
 
+    def get_hot_memory_entries(self, max_chars: int = 6000) -> list[tuple[int, str]]:
+        """The ``(chunk_id, formatted piece)`` pairs behind :meth:`get_hot_memory`.
+
+        Id-attributed so the per-turn injection record (ADR 0069 D6) can name
+        exactly which hot chunks entered a model call. Same selection/budget
+        semantics as ``get_hot_memory`` (one source of truth — it joins this).
+        """
+        chunks = self.list_chunks(domain="hot", limit=100)  # newest-first
+        entries: list[tuple[int, str]] = []
+        total = 0
+        for c in chunks:  # newest-first → oldest trimmed when over budget
+            piece = (f"[{c.heading}] " if c.heading else "") + c.content
+            if total + len(piece) > max_chars:
+                break
+            entries.append((c.id, piece))
+            total += len(piece)
+        return entries
+
     def get_hot_memory(self, max_chars: int = 6000) -> str:
         """Concatenate every ``domain="hot"`` chunk for always-on injection.
 
@@ -703,16 +757,7 @@ class KnowledgeStore:
         this each turn so a newly-added hot fact is seen immediately. Returns
         "" when there are none; trims oldest-first if over ``max_chars``.
         """
-        chunks = self.list_chunks(domain="hot", limit=100)  # newest-first
-        formatted: list[str] = []
-        total = 0
-        for c in chunks:  # newest-first → oldest trimmed when over budget
-            piece = (f"[{c.heading}] " if c.heading else "") + c.content
-            if total + len(piece) > max_chars:
-                break
-            formatted.append(piece)
-            total += len(piece)
-        return "\n".join(formatted)
+        return "\n".join(piece for _, piece in self.get_hot_memory_entries(max_chars))
 
     def stats(self) -> dict[str, int]:
         """Return per-domain chunk counts plus a ``total`` key."""

--- a/observability/injection_log.py
+++ b/observability/injection_log.py
@@ -1,0 +1,165 @@
+"""Per-turn memory-injection record (ADR 0069 D6).
+
+One append-only row per model call that had memory auto-injected: which
+prior-session digest entries, hot-memory chunks, and RAG hits entered the
+prompt, when, for which session, at what approximate token cost. This is the
+forensics substrate for "why did it say that?" and for detecting
+SpAIware-class memory poisoning — the store row → source session → turns it
+was injected into chain ends here.
+
+Written best-effort from ``KnowledgeMiddleware.before_model`` (a write failure
+never breaks a turn); read by the operator console via
+``GET /api/memory/injections`` (``operator_api/injection_routes.py``).
+Instance-scoped SQLite at ``instance_root/memory-injections.db`` (ADR 0004),
+following the ``TelemetryStore`` conventions (WAL, busy_timeout, connection
+per call).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# The id-list columns, stored as JSON arrays (TEXT) and decoded on read.
+_JSON_COLUMNS = ("digest_session_ids", "hot_chunk_ids", "rag_chunk_ids")
+
+
+class InjectionLog:
+    def __init__(self, db_path: str) -> None:
+        self.path = str(db_path)
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        db = sqlite3.connect(self.path)
+        db.execute("PRAGMA journal_mode=WAL")  # concurrent reads during writes
+        db.execute("PRAGMA busy_timeout=5000")  # wait (don't error) on lock contention
+        db.row_factory = sqlite3.Row
+        return db
+
+    def _init_db(self) -> None:
+        db = self._connect()
+        try:
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS injections (
+                    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts                 TEXT NOT NULL,
+                    session_id         TEXT NOT NULL DEFAULT '',
+                    digest_session_ids TEXT NOT NULL DEFAULT '[]',
+                    hot_chunk_ids      TEXT NOT NULL DEFAULT '[]',
+                    rag_chunk_ids      TEXT NOT NULL DEFAULT '[]',
+                    approx_tokens      INTEGER NOT NULL DEFAULT 0
+                )
+                """
+            )
+            db.execute("CREATE INDEX IF NOT EXISTS ix_injections_session ON injections(session_id)")
+            db.commit()
+        finally:
+            db.close()
+
+    def record(
+        self,
+        *,
+        session_id: str = "",
+        digest_session_ids: list[str] | None = None,
+        hot_chunk_ids: list[int] | None = None,
+        rag_chunk_ids: list[int] | None = None,
+        approx_tokens: int = 0,
+    ) -> None:
+        """Append one injection row. Best-effort — never raises (a telemetry
+        write must not break the model call that triggered it)."""
+        try:
+            db = self._connect()
+        except sqlite3.DatabaseError:
+            log.warning("[injection-log] connect failed at %s", self.path)
+            return
+        try:
+            db.execute(
+                "INSERT INTO injections "
+                "(ts, session_id, digest_session_ids, hot_chunk_ids, rag_chunk_ids, approx_tokens) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (
+                    datetime.now(UTC).isoformat(),
+                    session_id or "",
+                    json.dumps(list(digest_session_ids or [])),
+                    json.dumps(list(hot_chunk_ids or [])),
+                    json.dumps(list(rag_chunk_ids or [])),
+                    int(approx_tokens),
+                ),
+            )
+            db.commit()
+        except sqlite3.DatabaseError as exc:
+            log.warning("[injection-log] record failed: %s", exc)
+        finally:
+            db.close()
+
+    def recent(self, session_id: str | None = None, limit: int = 50) -> list[dict]:
+        """Injection rows, newest first, id-list columns decoded to Python lists.
+
+        ``session_id`` empty/None → all sessions (the empty string is a filter
+        VALUE only for rows that recorded no session identity, so it is treated
+        as "no filter" — matching the route's querystring semantics)."""
+        where, params = "", []
+        if session_id:
+            where, params = "WHERE session_id = ?", [session_id]
+        db = self._connect()
+        try:
+            rows = db.execute(
+                f"SELECT * FROM injections {where} ORDER BY id DESC LIMIT ?",
+                [*params, max(1, int(limit))],
+            ).fetchall()
+        except sqlite3.DatabaseError as exc:
+            log.warning("[injection-log] recent failed: %s", exc)
+            return []
+        finally:
+            db.close()
+        out: list[dict] = []
+        for r in rows:
+            d = dict(r)
+            for col in _JSON_COLUMNS:
+                try:
+                    d[col] = json.loads(d.get(col) or "[]")
+                except (json.JSONDecodeError, TypeError):
+                    d[col] = []
+            out.append(d)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Default per-instance log (lazy singleton)
+# ---------------------------------------------------------------------------
+
+_default_log: InjectionLog | None = None
+
+
+def injection_log() -> InjectionLog:
+    """The per-instance injection log, created lazily on first use — NOT at
+    import time (env identity is finalized after this module imports; mirrors
+    ``memory_path()``). Shared by the middleware writer and the operator read
+    route so both see one DB. ``PROTOAGENT_INJECTION_LOG`` env overrides the
+    path verbatim (same convention as ``MEMORY_PATH``; the test suite points
+    it at a temp DB so runs never append to a real instance store)."""
+    global _default_log
+    if _default_log is None:
+        raw = os.environ.get("PROTOAGENT_INJECTION_LOG", "").strip()
+        if raw:
+            _default_log = InjectionLog(str(Path(raw).expanduser()))
+        else:
+            from infra.paths import instance_paths
+
+            _default_log = InjectionLog(str(instance_paths().store("memory-injections.db")))
+    return _default_log
+
+
+def reset_injection_log() -> None:
+    """Drop the lazy singleton so the next ``injection_log()`` re-resolves its
+    path from the environment (mirrors ``infra.paths.reset_instance_paths``)."""
+    global _default_log
+    _default_log = None

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -38,6 +38,10 @@ class ChatRequest(BaseModel):
     message: str
     session_id: str = ""
     model: str | None = None  # per-tab model override; None → configured default
+    # Incognito thread (ADR 0069 D3b): no session-memory persistence and no
+    # memory injection for this turn. Additive, default False — existing
+    # callers are unaffected.
+    incognito: bool = False
 
 
 _B36 = "0123456789abcdefghijklmnopqrstuvwxyz"
@@ -63,7 +67,7 @@ def register_chat_routes(app, ui: str) -> None:
         # Echo the (possibly minted) session_id so callers can continue the
         # session — additive key, existing consumers unaffected.
         session_id = req.session_id.strip() or _mint_session_id()
-        result = await chat(req.message, session_id, model=req.model)
+        result = await chat(req.message, session_id, model=req.model, incognito=req.incognito)
         parts = [m["content"] for m in result if m.get("role") == "assistant" and m.get("content")]
         return {"response": "\n\n".join(parts), "messages": result, "session_id": session_id}
 

--- a/operator_api/injection_routes.py
+++ b/operator_api/injection_routes.py
@@ -1,0 +1,37 @@
+"""Memory-injection record routes (ADR 0069 D6).
+
+The read surface over ``observability/injection_log.py`` — one route the
+operator console (memory inspector, D7) and ad-hoc forensics use to answer
+"which memory entered which turn?". Registrar-style
+(``register_injection_routes(app)``), matching ``register_telemetry_routes``.
+
+Deliberately its OWN file: a sibling lane owns ``operator_api/memory_routes.py``
+(session-summary CRUD), so the two memory surfaces land without touching each
+other's files.
+"""
+
+from __future__ import annotations
+
+
+def register_injection_routes(app) -> None:
+    """Register the ``/api/memory/injections`` read-only route on ``app``."""
+
+    @app.get("/api/memory/injections")
+    async def _api_memory_injections(session_id: str = "", limit: int = 50):
+        """Per-model-call injection rows, newest first.
+
+        ``session_id`` filters to one session; empty/omitted = all sessions.
+        Each row: ``ts``, ``session_id``, ``digest_session_ids`` (prior-session
+        digest entries injected), ``hot_chunk_ids`` / ``rag_chunk_ids``
+        (knowledge-store chunk ids), ``approx_tokens``.
+        """
+        import asyncio
+
+        from observability.injection_log import injection_log
+
+        rows = await asyncio.to_thread(
+            injection_log().recent,
+            session_id=session_id.strip() or None,
+            limit=min(max(1, limit), 500),
+        )
+        return {"injections": rows}

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -692,6 +692,12 @@ def _main():
     # operator_api/telemetry_routes.py (ADR 0023 phase 3).
     register_telemetry_routes(fastapi_app)
 
+    # Memory-injection record (ADR 0069 D6) — which memory items entered which
+    # turn. Read-only forensics surface over observability/injection_log.py.
+    from operator_api.injection_routes import register_injection_routes
+
+    register_injection_routes(fastapi_app)
+
     # Live config / SOUL editing, model probe/test, setup wizard, and
     # schema-driven settings. Extracted to operator_api/config_routes.py
     # (ADR 0023 phase 3).

--- a/server/chat.py
+++ b/server/chat.py
@@ -281,7 +281,9 @@ def _setup_required_message() -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-async def chat(message: str, session_id: str, *, model: str | None = None) -> list[dict[str, Any]]:
+async def chat(
+    message: str, session_id: str, *, model: str | None = None, incognito: bool = False
+) -> list[dict[str, Any]]:
     """Route a user message through LangGraph and return the final assistant
     response as a list of ``{"role": "assistant", "content": ...}`` dicts.
 
@@ -289,11 +291,13 @@ async def chat(message: str, session_id: str, *, model: str | None = None) -> li
     endpoint. The A2A handler uses ``_chat_langgraph_stream`` instead to
     capture tool events and emit the cost-v1 DataPart on the terminal
     artifact. ``model`` overrides the lead model for this turn (per-tab / per
-    OpenAI request); unset → the configured default.
+    OpenAI request); unset → the configured default. ``incognito`` (ADR 0069
+    D3b) marks the turn as leaving no memory trail: no session-summary
+    persistence, no memory injection.
     """
     if STATE.graph is None:
         return _setup_required_message()
-    return await _chat_langgraph(message, session_id, model=model)
+    return await _chat_langgraph(message, session_id, model=model, incognito=incognito)
 
 
 # Cap tool input/output previews so a single frame stays small on the wire.
@@ -400,7 +404,15 @@ def _last_tool_text(result) -> str:
 
 
 async def _run_turn_stream(
-    message: str, session_id: str, config: dict, *, resume_value=None, images=None, model=None, reasoning_effort=None
+    message: str,
+    session_id: str,
+    config: dict,
+    *,
+    resume_value=None,
+    images=None,
+    model=None,
+    reasoning_effort=None,
+    incognito=False,
 ):
     """Run one graph turn over ``astream_events``.
 
@@ -437,6 +449,10 @@ async def _run_turn_stream(
         else {
             "messages": _drain_background_messages(session_id) + [human],
             "session_id": session_id,
+            # Incognito (ADR 0069 D3b): always stamped explicitly — the channel
+            # persists in the checkpointer, so an omitted key would silently
+            # inherit a previous turn's value instead of the caller's intent.
+            "incognito": bool(incognito),
             # Per-tab model + reasoning-effort override (ModelOverrideMiddleware reads
             # both); omit each key when unset so the configured default applies.
             **({"model": model} if model else {}),
@@ -837,6 +853,9 @@ async def _run_native_turn(message, session_id, config, *, request_metadata=None
     # runs — initial, kicker, goal continuation. Unset → the configured default.
     _model = ((request_metadata or {}).get("model") or "").strip() or None
     _effort = ((request_metadata or {}).get("reasoning_effort") or "").strip() or None
+    # Incognito thread (ADR 0069 D3b): the console/A2A caller sets metadata
+    # `incognito: true` per message — no session persistence, no memory injection.
+    _incognito = bool((request_metadata or {}).get("incognito"))
     # When a goal is already active, the whole turn is goal-driven (suppress cross-session
     # prior_sessions on the initial turn + kicker, matching the continuation turns).
     goal_active = STATE.goal_controller is not None and STATE.goal_controller.active_goal(session_id) is not None
@@ -864,6 +883,7 @@ async def _run_native_turn(message, session_id, config, *, request_metadata=None
                 images=images,
                 model=_model,
                 reasoning_effort=_effort,
+                incognito=_incognito,
             ):
                 if kind == "__raw__":
                     accumulated_raw = payload
@@ -931,7 +951,7 @@ async def _run_native_turn(message, session_id, config, *, request_metadata=None
             cont_raw = ""
             with goal_turn():
                 async for kind, payload in _run_turn_stream(
-                    decision.message, session_id, cont_config, model=_model, reasoning_effort=_effort
+                    decision.message, session_id, cont_config, model=_model, reasoning_effort=_effort, incognito=_incognito
                 ):
                     if kind == "__raw__":
                         cont_raw = payload
@@ -1272,7 +1292,9 @@ async def rewind_session(
     return {**result, "message": _rewind_message(result)}
 
 
-async def _chat_langgraph(message: str, session_id: str, *, model: str | None = None) -> list[dict[str, Any]]:
+async def _chat_langgraph(
+    message: str, session_id: str, *, model: str | None = None, incognito: bool = False
+) -> list[dict[str, Any]]:
     """Non-streaming LangGraph entry — used by the console + OpenAI-compat."""
     from observability import tracing
     from langchain_core.messages import HumanMessage, AIMessage
@@ -1280,7 +1302,10 @@ async def _chat_langgraph(message: str, session_id: str, *, model: str | None = 
     from graph.goals.goal_turn import goal_turn
 
     # Per-turn model override (ModelOverrideMiddleware reads state["model"]).
-    _model_extra = {"model": model} if (model or "").strip() else {}
+    # Incognito is stamped explicitly every turn (the channel persists in the
+    # checkpointer — an omitted key would inherit the previous turn's value).
+    _state_extra = {"model": model} if (model or "").strip() else {}
+    _state_extra["incognito"] = bool(incognito)
 
     async with tracing.trace_session(
         session_id=session_id,
@@ -1341,7 +1366,7 @@ async def _chat_langgraph(message: str, session_id: str, *, model: str | None = 
             async with _thread_lock(config["configurable"]["thread_id"]):
                 with goal_turn(goal_active):
                     result = await STATE.graph.ainvoke(
-                        {"messages": [HumanMessage(content=message)], "session_id": session_id, **_model_extra},
+                        {"messages": [HumanMessage(content=message)], "session_id": session_id, **_state_extra},
                         config=config,
                     )
             raw = _last_ai(result)
@@ -1394,7 +1419,7 @@ async def _chat_langgraph(message: str, session_id: str, *, model: str | None = 
                                 {
                                     "messages": [HumanMessage(content=decision.message)],
                                     "session_id": session_id,
-                                    **_model_extra,
+                                    **_state_extra,
                                 },
                                 config=cont_config,
                             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,22 @@ def _reset_instance_paths():
     reset_instance_paths()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_injection_log(tmp_path, monkeypatch):
+    """Point the per-turn injection log (ADR 0069 D6) at a per-test temp DB.
+
+    ``KnowledgeMiddleware.before_model`` appends an injection row whenever it
+    injects memory — which many unrelated tests drive — so without this every
+    local/CI test run would write rows into the developer's REAL instance
+    store. Lazy: only tests that actually trigger a record create the DB."""
+    from observability.injection_log import reset_injection_log
+
+    monkeypatch.setenv("PROTOAGENT_INJECTION_LOG", str(tmp_path / "injection-log.db"))
+    reset_injection_log()
+    yield
+    reset_injection_log()
+
+
 def pytest_configure(config):  # noqa: ARG001
     """Prepend site-packages to sys.path before any test imports occur."""
     site_dirs = site.getsitepackages()

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -11,7 +11,7 @@ def _client(monkeypatch, *, graph=object(), goal=None, chat_reply=None):
     import operator_api.chat_routes as cr
     import runtime.state as rs
 
-    async def _fake_chat(message, session_id, *, model=None):
+    async def _fake_chat(message, session_id, *, model=None, incognito=False):
         suffix = f"@{model}" if model else ""
         return chat_reply or [{"role": "assistant", "content": f"echo:{message}{suffix}"}]
 
@@ -39,7 +39,7 @@ def test_api_chat_mints_unique_session_id_when_omitted(monkeypatch):
 
     seen: list[str] = []
 
-    async def _fake_chat(message, session_id, *, model=None):
+    async def _fake_chat(message, session_id, *, model=None, incognito=False):
         seen.append(session_id)
         return [{"role": "assistant", "content": "ok"}]
 
@@ -65,6 +65,25 @@ def test_api_chat_threads_per_tab_model(monkeypatch):
     c = _client(monkeypatch)
     body = c.post("/api/chat", json={"message": "hi", "model": "protolabs/fast"}).json()
     assert body["response"] == "echo:hi@protolabs/fast"  # model reached chat()
+
+
+def test_api_chat_passes_incognito_flag(monkeypatch):
+    # ADR 0069 D3b: `incognito` rides the request body into chat() (default
+    # False — existing callers unaffected).
+    import operator_api.chat_routes as cr
+
+    seen: list[bool] = []
+
+    async def _fake_chat(message, session_id, *, model=None, incognito=False):
+        seen.append(incognito)
+        return [{"role": "assistant", "content": "ok"}]
+
+    c = _client(monkeypatch)
+    monkeypatch.setattr(cr, "chat", _fake_chat)
+
+    c.post("/api/chat", json={"message": "hi"})
+    c.post("/api/chat", json={"message": "hi", "incognito": True})
+    assert seen == [False, True]
 
 
 def test_openai_completion_honors_model_override(monkeypatch):

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -116,6 +116,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "knowledge_embedder": "",
     "knowledge_embeddings": True,
     "knowledge_facts": True,
+    "knowledge_inject_namespaces": [],
     "knowledge_middleware": True,
     "knowledge_top_k": 5,
     "knowledge_vector_k": 20,

--- a/tests/test_conversation_harvest.py
+++ b/tests/test_conversation_harvest.py
@@ -168,6 +168,38 @@ def test_harvest_noop_on_unknown_thread(tmp_path):
     assert out is None and kb.chunks == []
 
 
+def test_harvest_skips_incognito_thread(tmp_path):
+    """ADR 0069 D3b: incognito means NO memory trail — the retire sweep
+    (harvest_enabled defaults ON) must not summarize the thread into the
+    knowledge store, where RAG would re-inject it into later prompts."""
+    from graph.state import ProtoAgentState
+
+    db = str(tmp_path / "c.db")
+    g = StateGraph(ProtoAgentState)
+    g.add_node("n", lambda s: {"messages": [AIMessage(content="noted")]})
+    g.add_edge(START, "n")
+    g.add_edge("n", END)
+
+    async def main():
+        app = g.compile(checkpointer=build_sqlite_checkpointer(db))
+        await app.ainvoke(
+            {"messages": [HumanMessage(content="my secret color is teal")], "incognito": True},
+            {"configurable": {"thread_id": "a2a:incog"}},
+        )
+
+    asyncio.run(main())
+    saver = build_sqlite_checkpointer(db)
+    kb = _FakeKnowledge()
+
+    async def _boom(transcript, config):
+        raise AssertionError("incognito thread must not be summarized")
+
+    out = asyncio.run(
+        harvest_thread("a2a:incog", checkpointer=saver, knowledge_store=kb, config=object(), summarizer=_boom)
+    )
+    assert out is None and kb.chunks == []
+
+
 def test_find_aged_threads_and_delete(tmp_path):
     import sqlite3
 

--- a/tests/test_memory_injection_controls.py
+++ b/tests/test_memory_injection_controls.py
@@ -1,0 +1,329 @@
+"""ADR 0069 R2a/R2b — namespace-scoped auto-inject, incognito threads, and the
+per-turn injection record.
+
+Covers the three delivery-layer controls this round adds:
+
+  1. D3a — ``knowledge.inject_namespaces``: the store's ``search`` filters by
+     namespace (FTS5 + LIKE + hybrid vector paths), the middleware passes the
+     filter through only when configured, and a legacy backend without the
+     kwarg still gets the scope honored via post-filter.
+  2. D3b — incognito: ``_persist_session`` skips, ``KnowledgeMiddleware``
+     injects no memory (skills still inject), end-to-end through the REAL
+     agent graph (state plumbing, not just the hooks).
+  3. D6 — the injection log records id-attributed rows per model call, and
+     ``GET /api/memory/injections`` returns them newest-first (incl. the
+     empty-session-id edge = no filter).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from langchain_core.messages import HumanMessage
+
+from graph.middleware.knowledge import KnowledgeMiddleware
+from knowledge.store import KnowledgeStore
+
+
+def _seed_namespaced(store: KnowledgeStore) -> None:
+    store.add_chunk("gravity pulls apples in alpha", namespace="projects/alpha")
+    store.add_chunk("gravity pulls apples in beta", namespace="projects/beta")
+    store.add_chunk("gravity pulls apples unscoped")  # namespace=None
+
+
+# ---------------------------------------------------------------------------
+# 1) D3a — store-level namespace filtering
+# ---------------------------------------------------------------------------
+
+
+def test_search_namespace_filter_fts(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    assert store._fts_available  # this test exercises the FTS5 path
+    _seed_namespaced(store)
+
+    all_hits = store.search("gravity apples")
+    assert len(all_hits) == 3  # None = unfiltered (today's behavior)
+
+    alpha = store.search("gravity apples", namespace=["projects/alpha"])
+    assert [r["namespace"] for r in alpha] == ["projects/alpha"]
+
+    # "" in the filter matches UN-namespaced rows alongside the named scope.
+    with_blank = store.search("gravity apples", namespace=["projects/alpha", ""])
+    assert {r["namespace"] for r in with_blank} == {"projects/alpha", None}
+
+    # Empty list = no predicate (same as None), not "match nothing".
+    assert len(store.search("gravity apples", namespace=[])) == 3
+
+
+def test_search_namespace_filter_like_fallback(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    _seed_namespaced(store)
+    store._fts_available = False  # force the LIKE fallback path
+
+    alpha = store.search("gravity apples", namespace=["projects/alpha"])
+    assert [r["namespace"] for r in alpha] == ["projects/alpha"]
+    with_blank = store.search("gravity apples", namespace=["projects/beta", ""])
+    assert {r["namespace"] for r in with_blank} == {"projects/beta", None}
+
+
+def test_hybrid_search_namespace_filters_vector_ranking(tmp_path):
+    """A vector-only hit outside the scope must not leak through RRF fusion."""
+    from knowledge.hybrid_store import HybridKnowledgeStore
+
+    store = HybridKnowledgeStore(tmp_path / "kb.db", embed_fn=lambda text: [1.0, 0.0])
+    _seed_namespaced(store)
+
+    hits = store.search("gravity apples", namespace=["projects/alpha"])
+    assert hits and {r["namespace"] for r in hits} == {"projects/alpha"}
+
+
+# ---------------------------------------------------------------------------
+# 1b) D3a — middleware passes the filter through (and only when configured)
+# ---------------------------------------------------------------------------
+
+
+class _CapturingStore:
+    """Stub store recording the search kwargs the middleware passes."""
+
+    def __init__(self, results=None, accepts_namespace=True):
+        self.calls: list[dict] = []
+        self._results = results or []
+        self._accepts_namespace = accepts_namespace
+
+    def search(self, query, k=5, **kwargs):
+        if not self._accepts_namespace and "namespace" in kwargs:
+            raise TypeError("search() got an unexpected keyword argument 'namespace'")
+        self.calls.append({"query": query, "k": k, **kwargs})
+        return self._results
+
+
+def _mw(store, **kw):
+    mw = KnowledgeMiddleware(knowledge_store=store, **kw)
+    # Pin the prior-sessions cache fresh so before_model never reads real disk.
+    import time
+
+    mw._prior_sessions_cache = ""
+    mw._prior_sessions_loaded_at = time.monotonic()
+    return mw
+
+
+def test_middleware_omits_namespace_when_unconfigured():
+    store = _CapturingStore()
+    mw = _mw(store)  # inject_namespaces default = unfiltered
+    mw.before_model({"messages": [HumanMessage(content="q")]}, runtime=None)
+    assert store.calls and "namespace" not in store.calls[0]
+
+
+def test_middleware_passes_namespace_when_configured():
+    store = _CapturingStore()
+    mw = _mw(store, inject_namespaces=["projects/alpha", ""])
+    mw.before_model({"messages": [HumanMessage(content="q")]}, runtime=None)
+    assert store.calls[0]["namespace"] == ["projects/alpha", ""]
+
+
+def test_middleware_post_filters_for_legacy_backend():
+    """A backend whose search() predates the namespace kwarg still gets the
+    configured scope enforced — via retry + post-filter on the hit's field."""
+    in_scope = {"table": "chunks", "preview": "in", "id": 1, "namespace": "projects/alpha"}
+    out_of_scope = {"table": "chunks", "preview": "out", "id": 2, "namespace": "projects/beta"}
+    store = _CapturingStore(results=[in_scope, out_of_scope], accepts_namespace=False)
+    mw = _mw(store, inject_namespaces=["projects/alpha"])
+    result = mw.before_model({"messages": [HumanMessage(content="q")]}, runtime=None)
+    assert "in" in result["context"] and "out" not in result["context"]
+
+
+# ---------------------------------------------------------------------------
+# 2) D3b — incognito: no persistence, no injection (skills still inject)
+# ---------------------------------------------------------------------------
+
+
+def test_incognito_skips_session_persistence(tmp_path, monkeypatch):
+    import graph.middleware.memory as memmod
+
+    monkeypatch.setenv("MEMORY_PATH", str(tmp_path))
+    monkeypatch.setattr(memmod, "_PERSISTENCE_DISABLED", False, raising=False)
+
+    state = {
+        "session_id": "sess-incog",
+        "incognito": True,
+        "messages": [HumanMessage(content="secret question")],
+    }
+    memmod._persist_session(state, trace_id="t1")
+    assert not any(f.endswith(".json") for f in os.listdir(tmp_path))
+
+    # Sanity: the same state WITHOUT the flag persists (the skip is the flag,
+    # not some other precondition).
+    memmod._persist_session({**state, "incognito": False}, trace_id="t1")
+    assert any("sess-incog" in f for f in os.listdir(tmp_path))
+
+
+class _FakeSkillsIndex:
+    def skill_summaries(self, limit=5):
+        return [{"name": "triage", "description": "triage things"}]
+
+    def discoverable_count(self):
+        return 1
+
+
+def test_incognito_skips_injection_but_keeps_skills(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("deploys go out Fridays", domain="hot")
+    store.add_chunk("gravity pulls apples")
+    mw = _mw(store, skills_index=_FakeSkillsIndex())
+    mw._prior_sessions_cache = "<prior_sessions>\n  x\n</prior_sessions>"
+
+    normal = mw.before_model({"messages": [HumanMessage(content="gravity apples")]}, runtime=None)
+    assert "<injected_memory>" in normal["context"]
+
+    incog = mw.before_model(
+        {"messages": [HumanMessage(content="gravity apples")], "incognito": True}, runtime=None
+    )
+    assert "<injected_memory>" not in incog["context"]
+    assert "<prior_sessions>" not in incog["context"]
+    assert "hot memory" not in incog["context"]
+    assert "<available_skills>" in incog["context"]  # capability, not memory
+
+
+@pytest.mark.asyncio
+async def test_incognito_end_to_end_real_graph(tmp_path, monkeypatch):
+    """Drive the REAL agent graph with incognito in the turn input (as the chat
+    entry paths stamp it) and assert both middlewares honored it — proving the
+    state channel plumbs through LangGraph, not just the hooks."""
+    from unittest.mock import patch
+
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+    from langchain_core.messages import AIMessage
+    from langgraph.checkpoint.memory import MemorySaver
+
+    import graph.agent as agentmod
+    import graph.middleware.memory as memmod
+    from graph.config import LangGraphConfig
+
+    class _Fake(GenericFakeChatModel):
+        def bind_tools(self, tools, **kwargs):
+            return self
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    monkeypatch.setenv("MEMORY_PATH", str(memory_dir))
+    monkeypatch.setattr(memmod, "_PERSISTENCE_DISABLED", False, raising=False)
+    monkeypatch.setattr(agentmod, "SessionSummaryMiddleware", memmod.SessionSummaryMiddleware, raising=False)
+
+    store = KnowledgeStore(str(tmp_path / "kb.db"))
+    store.add_chunk("deploys go out Fridays", domain="hot")
+
+    with patch("graph.agent.create_llm", lambda *a, **k: _Fake(messages=iter([AIMessage(content="ok")]))):
+        from graph.agent import create_agent_graph
+
+        g = create_agent_graph(
+            LangGraphConfig(),
+            knowledge_store=store,
+            include_subagents=False,
+            checkpointer=MemorySaver(),
+        )
+    result = await g.ainvoke(
+        {"messages": [HumanMessage(content="hi")], "session_id": "sess-incog", "incognito": True},
+        config={"configurable": {"thread_id": "sess-incog"}},
+    )
+    assert "<injected_memory>" not in (result.get("context") or "")
+    assert not os.listdir(memory_dir), "incognito turn must not persist a session summary"
+
+
+# ---------------------------------------------------------------------------
+# 3) D6 — the injection record + its read route
+# ---------------------------------------------------------------------------
+
+
+def test_injection_log_records_attributed_ids(tmp_path, monkeypatch):
+    from observability.injection_log import injection_log
+
+    # Prior-sessions digest from a real summary file so digest ids are exercised.
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / "sess-prev.json").write_text(
+        json.dumps(
+            {
+                "session_id": "sess-prev",
+                "messages": [{"role": "user", "content": "earlier topic"}],
+                "timestamp": "2026-07-01T00:00:00+00:00",
+            }
+        )
+    )
+    monkeypatch.setenv("MEMORY_PATH", str(memory_dir))
+
+    store = KnowledgeStore(tmp_path / "kb.db")
+    hot_id = store.add_chunk("deploys go out Fridays", domain="hot")
+    rag_id = store.add_chunk("gravity pulls apples")
+
+    mw = KnowledgeMiddleware(knowledge_store=store)
+    result = mw.before_model(
+        {"messages": [HumanMessage(content="gravity apples")], "session_id": "sess-now"}, runtime=None
+    )
+    assert "<injected_memory>" in result["context"]
+
+    rows = injection_log().recent()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["session_id"] == "sess-now"
+    assert row["digest_session_ids"] == ["sess-prev"]
+    assert row["hot_chunk_ids"] == [hot_id]
+    assert row["rag_chunk_ids"] == [rag_id]
+    assert row["approx_tokens"] >= 1
+    assert row["ts"]
+
+
+def test_incognito_writes_no_injection_row(tmp_path):
+    from observability.injection_log import injection_log
+
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("deploys go out Fridays", domain="hot")
+    mw = _mw(store)
+    mw.before_model(
+        {"messages": [HumanMessage(content="q")], "session_id": "s", "incognito": True}, runtime=None
+    )
+    assert injection_log().recent() == []
+
+
+def _injections_client():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from operator_api.injection_routes import register_injection_routes
+
+    app = FastAPI()
+    register_injection_routes(app)
+    return TestClient(app)
+
+
+def test_injections_route_newest_first_and_filters():
+    from observability.injection_log import injection_log
+
+    log = injection_log()
+    log.record(session_id="sess-a", rag_chunk_ids=[1], approx_tokens=10)
+    log.record(session_id="sess-b", hot_chunk_ids=[7], approx_tokens=20)
+    log.record(session_id="", digest_session_ids=["old"], approx_tokens=5)  # no identity
+
+    c = _injections_client()
+
+    # Empty session_id (omitted or blank) = no filter, newest-first.
+    body = c.get("/api/memory/injections").json()
+    assert [r["session_id"] for r in body["injections"]] == ["", "sess-b", "sess-a"]
+    assert body["injections"][1]["hot_chunk_ids"] == [7]  # JSON columns decoded
+    blank = c.get("/api/memory/injections", params={"session_id": "  "}).json()
+    assert len(blank["injections"]) == 3
+
+    # Filtered to one session.
+    only_a = c.get("/api/memory/injections", params={"session_id": "sess-a"}).json()
+    assert [r["session_id"] for r in only_a["injections"]] == ["sess-a"]
+    assert only_a["injections"][0]["rag_chunk_ids"] == [1]
+
+    # Limit clamps to at least 1 and applies newest-first.
+    limited = c.get("/api/memory/injections", params={"limit": 1}).json()
+    assert [r["session_id"] for r in limited["injections"]] == [""]
+
+
+def test_injections_route_empty_log():
+    body = _injections_client().get("/api/memory/injections").json()
+    assert body == {"injections": []}

--- a/tests/test_memory_load.py
+++ b/tests/test_memory_load.py
@@ -350,6 +350,7 @@ async def test_abefore_model_runs_search_off_event_loop():
 
     store = MagicMock()
     store.get_hot_memory.return_value = ""
+    store.get_hot_memory_entries.return_value = []
 
     def _slow_search(query, k=5):
         seen_threads.append(threading.current_thread())
@@ -492,6 +493,7 @@ def test_envelope_wraps_memory_parts_not_skills(tmp_path):
 
     store = MagicMock()
     store.get_hot_memory.return_value = "coffee is a Gibraltar"
+    store.get_hot_memory_entries.return_value = [(1, "coffee is a Gibraltar")]
     store.search.return_value = [{"table": "chunks", "preview": "rag hit"}]
     mw = KnowledgeMiddleware(store, top_k=5, skills_index=_skills_index_mock())
     import time
@@ -520,6 +522,7 @@ def test_no_envelope_without_memory_parts():
 
     store = MagicMock()
     store.get_hot_memory.return_value = ""
+    store.get_hot_memory_entries.return_value = []
     store.search.return_value = []
     mw = KnowledgeMiddleware(store, top_k=5, skills_index=_skills_index_mock())
     import time


### PR DESCRIPTION
Round 2 of the memory delivery layer ([ADR 0069](docs/adr/0069-memory-delivery-layer.md)) — the backend halves of lanes **R2a (D3 scope filters + incognito)** and **R2b (D6 per-turn injection record)** from `docs/dev/memory-hardening-tasklist.md`. Console UI (thread toggle, inspector panel) rides later lanes.

## D3a — namespace-scoped auto-injection

- New config key **`knowledge.inject_namespaces`** (`string_list`, default empty = unfiltered — box-commons sharing does not silently break). When set, the per-turn auto-injected RAG recall only considers chunks whose `namespace` matches a listed value; `""` in the list matches un-namespaced chunks.
- `KnowledgeStore.search()` / `HybridKnowledgeStore.search()` / `LayeredKnowledgeStore.search()` gain a `namespace: str | list[str] | None` kwarg. The hybrid store filters **both** the FTS5 and vector rankings, so an RRF-fused hit can never come from outside the scope. One shared `_namespace_clause` helper builds the predicate.
- The middleware passes the filter through only when configured; a plugin backend whose `search()` predates the kwarg gets a retry-without + post-filter on each hit's `namespace` field, so the scope holds either way.
- Deliberately gates **only what enters the prompt unasked** — tool-driven `memory_recall` stays unscoped (out-of-scope knowledge remains reachable with the model's intent visible as a tool call).
- Golden-test flow (#1538): dataclass field + `from_dict` parse line + FIELDS entry (+ Recall subsection) + ONE golden map entry.

## D3b — incognito threads

- Per-message flag on both chat entry paths: **`POST /api/chat`** body field `incognito: bool = false` (additive, backward-compatible), and **A2A message metadata** `incognito: true` on the streaming path (read in `_run_native_turn` alongside `model`/`reasoning_effort`).
- Carried in graph state (`ProtoAgentState.incognito`, mirroring `session_id` — `current_session_id()` is empty in tool bodies, state is the reliable carrier). Stamped **explicitly every turn**: the channel persists in the checkpointer, so an omitted key would silently inherit the previous turn's value.
- `SessionSummaryMiddleware._persist_session` skips (no summary file → nothing to surface in later threads' digest); `KnowledgeMiddleware.before_model` skips the digest/hot/RAG injection while the **skill index still injects** (capability, not memory). No injection-log row is written for incognito turns.

## D6 — per-turn injection record

- New **`observability/injection_log.py`**: instance-scoped append-only SQLite (`instance_paths().store("memory-injections.db")`, WAL + `busy_timeout=5000`, TelemetryStore conventions). One row per model call that had memory injected: `ts`, `session_id`, `digest_session_ids` (JSON), `hot_chunk_ids` (JSON), `rag_chunk_ids` (JSON), `approx_tokens`.
- Emitted best-effort from `KnowledgeMiddleware.before_model` (graph → observability is layering-clean; `lint-imports` green). Digest ids come from the new `load_prior_sessions_digest()` (returns `(block, ids)`; `load_prior_sessions` delegates so the two can't drift); hot chunk ids from the new id-attributed `KnowledgeStore.get_hot_memory_entries()` (which `get_hot_memory` now joins — one source of truth).
- Read route: **`GET /api/memory/injections?session_id=&limit=`** in **new** `operator_api/injection_routes.py` (its own file — the sibling lane owns `operator_api/memory_routes.py`), newest-first, empty/omitted `session_id` = all sessions, limit clamped 1–500.
- Test hygiene: `PROTOAGENT_INJECTION_LOG` env override + an autouse conftest fixture point the lazy singleton at a per-test temp DB, so test runs never append rows to a developer's real instance store.

## Tests

- Store-level namespace filtering (FTS5, LIKE fallback, hybrid vector ranking), middleware pass-through when configured / absent when null, legacy-backend post-filter.
- Incognito: persist skipped (and the same state without the flag persists), memory injection skipped while `<available_skills>` survives, **end-to-end through the real agent graph** (state plumbing, not just the hooks), `/api/chat` flag pass-through, no injection row.
- Injection log: id-attributed rows (digest/hot/RAG ids + tokens), route newest-first, session filter, empty-session-id edge, empty log.
- Config golden + drift guards green; envelope/hot-memory mocks updated for the new reader.

## Gates

- `ruff check .` ✓ · `lint-imports` ✓ (3 contracts kept) · `python -m pytest tests/ -q` ✓ (2643 passed, 5 skipped) · `python scripts/live_smoke.py` ✓ · `npm run docs:build` ✓ (docs touched: knowledge guide gains a "Memory delivery controls" section; no new page → no nav regen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)