### PR TITLE
fix(chat): code-block header gap, lighter well colour, no panel-stretch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer auto-merge and freeze the Pages deploy.
 
 ### Fixed
+- **Chat code blocks: no empty header gap, a distinct lighter well, and no panel-stretch.**
+  A fenced block with no language no longer renders an empty ~32px header band (the copy
+  action now floats over the code's top-right); the code well is lifted onto the lighter
+  `--pl-color-bg-raised` token so it reads distinctly from system-message/report cards and
+  select inputs (which use the darkest `--pl-color-bg-inset`); and the block + assistant
+  markdown column are hard-capped to the message width so a long unwrapped line scrolls
+  inside the block instead of widening the chat panel.
 - **Chat session-identity hygiene** ([ADR 0069](docs/adr/0069-memory-delivery-layer.md) D4).
   Omitting `session_id` on `POST /api/chat` now mints a unique per-call id instead of
   pooling every caller into one shared `api-default` thread; an empty session id skips

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -28,6 +28,33 @@
   min-height: 0;
 }
 
+/* ── Assistant markdown code blocks ─────────────────────────────────────────────
+   Polish for the DS streamdown code block inside chat:
+   1. Overflow — hard-cap the block (and the markdown root) to the message width so a
+      long unwrapped line SCROLLS inside the block (the DS gives the body overflow-x:auto)
+      instead of stretching the whole chat panel past its column.
+   2. Empty header — a fenced block with no language renders an empty ~32px header band
+      (an ugly gap). Hide it and float the copy action over the code's top-right instead
+      of reserving a header row (the block is position:relative, so the action anchors to it).
+   3. Colour — the DS default well is --pl-color-bg-inset (the DARKEST token, shared with
+      system-message/report cards and select inputs). Lift code blocks onto the lighter
+      --pl-color-bg-raised so they read as a distinct "code well". */
+/* Constrain the assistant content column (NOT the user bubble, which keeps its
+   max-width:80%) + the markdown root, so a code block can't push either wide. */
+.chat-session-slot .pl-message:not(.pl-message--user) .pl-message__content { min-width: 0; max-width: 100%; }
+.chat-session-slot .pl-markdown { min-width: 0; max-width: 100%; }
+.chat-session-slot .pl-markdown [data-streamdown="code-block"] {
+  max-width: 100%;
+  background: var(--pl-color-bg-raised);
+}
+.chat-session-slot .pl-markdown [data-streamdown="code-block-header"][data-language=""] { display: none; }
+.chat-session-slot .pl-markdown [data-streamdown="code-block-header"][data-language=""] + div {
+  margin-top: 0;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+}
+
 /* The tab-bar wrapper exists only to scope the right-click context menu (ADR 0036) to the
    tab strip — it generates no box, so the DS TabBar stays the flex child it was. */
 .chat-tabbar-wrap {


### PR DESCRIPTION
**Draft** — console UX (local-test gate); please eyeball on your live app, especially the overflow (see caveat below). Addresses the three code-block issues you flagged.

## What's fixed (CSS-only, scoped to `.chat-session-slot .pl-markdown`)

**1. Empty header gap** ✅ *verified* — a no-language fence (` ``` `) renders an empty ~32px `code-block-header` band (the "ugly gap"). Hidden via `[data-language=""]`; the copy action now floats over the code's top-right instead of reserving a header row. Language blocks (` ```js `) keep their label.

**2. Lighter, distinct well colour** ✅ — the DS default is `--pl-color-bg-inset` (**#060608**, the *darkest* token — exactly what system-message/report cards + select inputs use, which is why they all looked the same). Lifted to `--pl-color-bg-raised` (**#131316**) so the code well reads distinctly. *(It's a subtle lift — say the word and I'll bump to `--pl-color-bg-subtle` #1c1c22 for more contrast.)*

**3. Overflow / panel-stretch** ⚠️ *needs your confirm* — hard-capped the code block + assistant content column to the message width so a long line scrolls inside the block (the DS gives the body `overflow-x:auto`) instead of widening the panel.

## Honest caveat on the overflow
I **could not reproduce the panel-stretch in isolation**. I rendered the real DS `<Conversation>`/`<Message>`/`<Markdown>` chain with a long code line and it scrolled correctly — every element in the DS chain is already correctly constrained (`.pl-appshell__col` has `min-width:0`+`overflow:hidden`, `.pl-message__body` has `min-width:0`, the code-block body has `overflow-x:auto`), **identical between DS 0.52 and 0.53**. So the clamp here is a best-effort hard stop (helps if the cause is `content-visibility` intrinsic-size or an unconstrained ancestor).

Two things worth checking on your side:
- **Your app is on DS 0.52.0; origin/main resolves 0.53.0** (the known skew). If your running build is stale, a fresh `npm ci` + rebuild may itself resolve the overflow. Worth confirming what your live app actually ships.
- If it still overflows after this, I'll need to inspect your **running** DOM (the trigger is live-turn state I can't replicate) — happy to walk the element chain with you.

## Verification
- Full `vite build` clean.
- A rendered-DOM probe (real DS `<Markdown>`) confirms: empty header `display:none`, copy button present, `js` header kept, well computes to `#131316`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)