### PR TITLE
feat(knowledge): supersede-don't-delete staleness — invalidated_at + recency-surfaced retrieval (ADR 0069 R3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Supersede-don't-delete staleness** ([ADR 0069](docs/adr/0069-memory-delivery-layer.md)
+  D9). The `chunks` table gains a nullable `invalidated_at` column (additive
+  migration, namespace precedent): when the session-end fact pass extracts a
+  fact that *revises* a stored one (same subject, changed details — a
+  deterministic token-overlap band, never an LLM freshness judgment), the old
+  row is stamped `invalidated_at` and the new row inserted — history kept for
+  audit, nothing updated in place or deleted. Default retrieval excludes
+  invalidated rows everywhere (plain/hybrid/layered `search` — both hybrid
+  rankings — `list_chunks`, hot-memory injection, `memory_recall`), with an
+  `include_invalidated=True` escape hatch for audit tooling. Auto-injected RAG
+  lines now end with the chunk's stored date (`(stored 2026-07-01)`) as a
+  deterministic in-context recency signal. Operator deletes (`forget_memory`,
+  the inspector's DELETE routes) stay **hard** deletes — explicit intent beats
+  history-keeping. See [the knowledge guide](docs/guides/knowledge.md#staleness-supersede-dont-delete).
 - **Namespace-scoped auto-injection** (`knowledge.inject_namespaces`,
   [ADR 0069](docs/adr/0069-memory-delivery-layer.md) D3a). When set, the per-turn
   auto-injected RAG recall only considers chunks in the listed namespaces (`""`

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -59,7 +59,7 @@ When a knowledge store is wired, the agent gets these (operator-curatable under
 | `memory_recall(query, k=5)` | search long-term memory (hybrid, or FTS5 if the breaker is open) |
 | `memory_list(domain?, limit=10)` | browse recent chunks (used by `/dream` consolidation) |
 | `memory_stats()` | per-domain chunk counts |
-| `forget_memory(chunk_id, reason?)` | delete one chunk by id (targeted) |
+| `forget_memory(chunk_id, reason?)` | **hard-delete** one chunk by id (targeted; see [staleness](#staleness-supersede-dont-delete) — explicit deletes are real deletes) |
 
 `GET /api/runtime/status` reports the store status; `GET /api/knowledge/search`
 backs the console browser.
@@ -67,7 +67,7 @@ backs the console browser.
 ## Memory delivery controls (ADR 0069)
 
 What the store *holds* and what gets *pushed into the prompt each turn* are separate
-surfaces ([ADR 0069](/adr/0069-memory-delivery-layer)). Three controls gate and audit
+surfaces ([ADR 0069](/adr/0069-memory-delivery-layer)). These controls gate and audit
 the delivery side:
 
 ### Scope the auto-inject to namespaces
@@ -123,6 +123,28 @@ GET /api/memory/injections?session_id=<id>&limit=50
 returns `{"injections": [...]}` newest-first — omit `session_id` for all sessions.
 Each row: `ts`, `session_id`, `digest_session_ids`, `hot_chunk_ids`,
 `rag_chunk_ids`, `approx_tokens`.
+
+### Staleness: supersede, don't delete
+
+LLMs demonstrably can't self-adjudicate freshness, so protoAgent handles
+staleness **deterministically at retrieval time** ([ADR 0069](/adr/0069-memory-delivery-layer)
+D9) instead of judging it with a model at write time:
+
+- **Facts are superseded, never silently replaced.** When the session-end fact
+  pass extracts a fact that *revises* one already stored (same subject, changed
+  details — detected by a deterministic token-overlap band, no LLM involved),
+  the old row is stamped `invalidated_at` and the new row inserted. History is
+  kept for audit; nothing is updated in place or deleted.
+- **Retrieval excludes invalidated rows by default.** `search`/`list_chunks`
+  on all three stores (plain, hybrid — both rankings — and layered), hot-memory
+  injection, and `memory_recall` only surface valid rows. Audit tooling can
+  pass `include_invalidated=True` (store API) to see the full history.
+- **Recency is surfaced in-context.** Each auto-injected RAG line ends with the
+  chunk's stored date — `(stored 2026-07-01)` — and `memory_recall` cites dates
+  per hit, so the model weighs freshness from explicit timestamps.
+- **Operator deletes stay hard deletes.** `forget_memory` and the memory
+  inspector's DELETE routes remove rows outright — explicit operator intent
+  beats history-keeping. Supersession is only for the *automatic* write paths.
 
 ## Sharing knowledge across a fleet (the commons)
 

--- a/graph/memory_facts.py
+++ b/graph/memory_facts.py
@@ -12,8 +12,13 @@ Two rules from the ADR:
   pleasantries are dropped; a chatty turn with nothing durable yields ``[]``.
 - **Consolidate.** Before inserting, near-identical facts already in the store
   (scoped to the same ``namespace``) are skipped, so memory doesn't accrete
-  duplicates. (Superseding an *outdated* fact with a newer one is an LLM-judged
-  refinement left for a follow-up; v1 dedups conservatively.)
+  duplicates.
+- **Supersede, don't delete** (ADR 0069 D9). A new fact that *revises* an
+  existing one — same subject, changed details, detected by a deterministic
+  token-overlap band, never an LLM freshness judgment (Mem0's 2026 reversal +
+  arXiv 2606.01435) — marks the old row ``invalidated_at=now`` and inserts the
+  new row. History is kept for audit; retrieval excludes invalidated rows by
+  default. Nothing here UPDATEs content in place or DELETEs.
 
 Facts carry a ``namespace`` so per-project/owner scoping (ADR 0007) is a filter
 later, not a migration.
@@ -32,9 +37,15 @@ log = logging.getLogger(__name__)
 _MAX_FACTS = 12
 _MAX_FACT_CHARS = 300
 # ≥ this token-overlap (Jaccard) with an existing fact ⇒ treat as a duplicate and
-# skip. Intentionally conservative for v1 (only near-identical facts are deduped);
-# LLM-judged supersession of *outdated* facts is the follow-up noted in ADR 0021.
+# skip. Intentionally conservative (only near-identical facts are deduped).
 _DEDUP_JACCARD = 0.85
+# Token-overlap band [_SUPERSEDE_JACCARD, _DEDUP_JACCARD) ⇒ the new fact is a
+# *revision* of the existing one (same subject, changed details): the old row is
+# marked invalidated_at=now and the new row inserted (ADR 0069 D9 — supersede,
+# don't delete). The comparison is purely deterministic — token sets plus
+# "the incoming fact is newer by construction" — never an LLM freshness call
+# (Mem0's 2026 reversal + arXiv 2606.01435 are the ADR's basis for that rule).
+_SUPERSEDE_JACCARD = 0.6
 
 _FACTS_PROMPT = (
     "Extract durable, reusable FACTS from this conversation — things worth "
@@ -102,29 +113,53 @@ def consolidate_and_store(
     source: str | None = None,
 ) -> dict:
     """Store ``facts`` as ``finding_type="fact"``, skipping near-duplicates of
-    facts already present in the same ``namespace``. Returns counts.
+    facts already present in the same ``namespace`` and SUPERSEDING revised
+    ones (ADR 0069 D9). Returns counts
+    (``added`` / ``skipped`` / ``superseded``).
+
+    A new fact whose token overlap with an existing valid fact lands in the
+    supersede band (``_SUPERSEDE_JACCARD`` ≤ Jaccard < ``_DEDUP_JACCARD``)
+    replaces it: the old row gets ``invalidated_at=now`` (kept for audit —
+    never UPDATE-in-place, never DELETE) and the new row is inserted. The
+    incoming fact wins purely because it is newer — deterministic
+    timestamps/ids, no LLM freshness judging. ``list_chunks`` excludes
+    invalidated rows by default, so comparisons only ever run against
+    currently-valid facts.
 
     ``source`` is the originating session/thread id (provenance, ADR 0069 D5);
     when the caller has none it falls back to the legacy ``"harvest"`` literal
     rather than an empty source.
 
     Best-effort: a store that lacks ``list_chunks`` (e.g. a minimal test stub)
-    degrades to add-only. Never raises.
+    degrades to add-only, and one without ``invalidate_chunk`` skips the
+    invalidation half of a supersede. Never raises.
     """
-    counts = {"added": 0, "skipped": 0}
+    counts = {"added": 0, "skipped": 0, "superseded": 0}
     if not facts:
         return counts
     try:
         existing = knowledge_store.list_chunks(domain="fact", namespace=namespace, limit=500)
-        existing_tokens = [_tokens(c.content) for c in existing]
+        # (chunk id, token set) per valid fact — ids so a supersede can target
+        # the exact row; id None marks batch-local entries (nothing to invalidate).
+        candidates: list[tuple[int | None, set[str]]] = [(c.id, _tokens(c.content)) for c in existing]
     except Exception:  # noqa: BLE001 — minimal stub or read failure ⇒ add-only
-        existing_tokens = []
+        candidates = []
 
+    invalidate = getattr(knowledge_store, "invalidate_chunk", None)
     for fact in facts:
         ft = _tokens(fact)
-        if any(_jaccard(ft, et) >= _DEDUP_JACCARD for et in existing_tokens):
+        scored = [(_jaccard(ft, toks), i) for i, (_, toks) in enumerate(candidates)]
+        best, best_idx = max(scored, default=(0.0, -1))
+        if best >= _DEDUP_JACCARD:
             counts["skipped"] += 1
             continue
+        if best >= _SUPERSEDE_JACCARD:
+            # Revision of an existing fact: invalidate the single best match,
+            # then insert the new row below (supersede, don't delete).
+            old_id = candidates[best_idx][0]
+            if old_id is not None and callable(invalidate) and invalidate(old_id):
+                counts["superseded"] += 1
+                del candidates[best_idx]  # no longer valid — drop from comparisons
         # Facts live in their own domain (not "finding") so retrieval + the Store
         # view can distinguish semantic facts from other chunk types.
         rid = knowledge_store.add_chunk(
@@ -137,7 +172,7 @@ def consolidate_and_store(
         )
         if rid is not None:
             counts["added"] += 1
-            existing_tokens.append(ft)  # dedup within this batch too
+            candidates.append((rid, ft))  # dedup/supersede within this batch too
     return counts
 
 
@@ -154,15 +189,19 @@ async def extract_and_store_facts(
     store. Never raises — fact capture is best-effort and must not block thread
     retirement."""
     if knowledge_store is None or not transcript.strip():
-        return {"added": 0, "skipped": 0}
+        return {"added": 0, "skipped": 0, "superseded": 0}
     try:
         facts = await extractor(transcript, config)
     except Exception:  # noqa: BLE001
         log.exception("[memory] fact extraction failed")
-        return {"added": 0, "skipped": 0}
+        return {"added": 0, "skipped": 0, "superseded": 0}
     counts = consolidate_and_store(knowledge_store, facts, namespace=namespace, source=source)
     if counts["added"] or counts["skipped"]:
         log.info(
-            "[memory] facts: +%d new, %d dup-skipped (ns=%s)", counts["added"], counts["skipped"], namespace or "-"
+            "[memory] facts: +%d new, %d dup-skipped, %d superseded (ns=%s)",
+            counts["added"],
+            counts["skipped"],
+            counts["superseded"],
+            namespace or "-",
         )
     return counts

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -248,9 +248,16 @@ class KnowledgeMiddleware(AgentMiddleware):
             if last_human and self._store is not None:
                 results = self._search_scoped(last_human)
                 if results:
+                    # Each hit carries its stored date (ADR 0069 D9) — a
+                    # deterministic recency signal in-context, so the model can
+                    # weigh freshness itself instead of any LLM freshness judge.
                     context_parts = ["[Relevant knowledge from previous sessions:]"]
                     for r in results:
-                        context_parts.append(f"- [{r['table']}] {r['preview']}")
+                        line = f"- [{r['table']}] {r['preview']}"
+                        stored = str(r.get("created_at") or "")[:10]
+                        if stored:
+                            line += f" (stored {stored})"
+                        context_parts.append(line)
                         if r.get("id") is not None:
                             rag_ids.append(r["id"])
                     memory_parts.append("\n".join(context_parts))

--- a/knowledge/hybrid_store.py
+++ b/knowledge/hybrid_store.py
@@ -263,6 +263,7 @@ class HybridKnowledgeStore(KnowledgeStore):
         k: int,
         domain: str | None,
         namespace: str | list[str] | None = None,
+        include_invalidated: bool = False,
     ) -> list[int]:
         """Return chunk ids ranked by cosine similarity (brute force)."""
         db = self._get_db()
@@ -270,6 +271,8 @@ class HybridKnowledgeStore(KnowledgeStore):
             return []
         where: list[str] = []
         params: list = []
+        if not include_invalidated:
+            where.append("c.invalidated_at IS NULL")
         if domain:
             where.append("c.domain = ?")
             params.append(domain)
@@ -314,23 +317,29 @@ class HybridKnowledgeStore(KnowledgeStore):
         *,
         domain: str | None = None,
         namespace: str | list[str] | None = None,
+        include_invalidated: bool = False,
     ) -> list[dict]:
         """RRF-fuse the FTS5 ranking with a vector ranking.
 
         Falls back to pure FTS5 when embeddings are unavailable (no embed_fn,
         circuit open, or the query fails to embed) — same shape, never raises.
         ``namespace`` (ADR 0069 D3a) filters BOTH rankings, so a fused hit can
-        never come from outside the requested scope.
+        never come from outside the requested scope. Superseded rows
+        (``invalidated_at``, ADR 0069 D9) are likewise excluded from BOTH
+        rankings by default; ``include_invalidated=True`` is the audit escape
+        hatch.
         """
         if not query or not query.strip():
             return []
 
-        base = super().search(query, k=self._vector_k, domain=domain, namespace=namespace)
+        base = super().search(
+            query, k=self._vector_k, domain=domain, namespace=namespace, include_invalidated=include_invalidated
+        )
         query_vec = self._embed(query)
         if query_vec is None:
             return base[:k]
 
-        vec_ids = self._vector_search(query_vec, self._vector_k, domain, namespace)
+        vec_ids = self._vector_search(query_vec, self._vector_k, domain, namespace, include_invalidated)
         if not vec_ids:
             return base[:k]
 

--- a/knowledge/layered.py
+++ b/knowledge/layered.py
@@ -53,13 +53,15 @@ class LayeredKnowledgeStore:
         *,
         domain: str | None = None,
         namespace: str | list[str] | None = None,
+        include_invalidated: bool = False,
     ) -> list[dict]:
         """Top-k across BOTH tiers, fused by RRF over each tier's rank, tier-tagged.
         A chunk promoted into the commons (same content as its private original) is
         de-duped — the private record wins (it's editable) but keeps the summed score.
-        ``namespace`` (ADR 0069 D3a) is passed through to both tiers."""
-        priv = self._private.search(query, k, domain=domain, namespace=namespace)
-        comm = self._commons.search(query, k, domain=domain, namespace=namespace)
+        ``namespace`` (ADR 0069 D3a) and ``include_invalidated`` (ADR 0069 D9 —
+        superseded rows are excluded by default) are passed through to both tiers."""
+        priv = self._private.search(query, k, domain=domain, namespace=namespace, include_invalidated=include_invalidated)
+        comm = self._commons.search(query, k, domain=domain, namespace=namespace, include_invalidated=include_invalidated)
 
         fused: dict[str, dict] = {}
         scores: dict[str, float] = {}

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -87,6 +87,7 @@ class Chunk:
     created_at: str
     updated_at: str
     namespace: str | None = None
+    invalidated_at: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -100,6 +101,7 @@ class Chunk:
             "namespace": self.namespace,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
+            "invalidated_at": self.invalidated_at,
         }
 
 
@@ -211,7 +213,8 @@ CREATE TABLE IF NOT EXISTS chunks (
     finding_type  TEXT,
     namespace     TEXT,
     created_at    TEXT NOT NULL,
-    updated_at    TEXT NOT NULL
+    updated_at    TEXT NOT NULL,
+    invalidated_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_chunks_domain     ON chunks(domain);
@@ -319,6 +322,16 @@ class KnowledgeStore:
                 db.execute("CREATE INDEX IF NOT EXISTS idx_chunks_namespace ON chunks(namespace)")
             except sqlite3.DatabaseError as exc:
                 log.debug("[knowledge] namespace migration skipped: %s", exc)
+            # Migration: add the invalidated_at column (ADR 0069 D9 — supersede,
+            # don't delete). Same additive+nullable pattern as namespace; NULL =
+            # the row is valid, an ISO timestamp = superseded by a newer row.
+            try:
+                cols = {r[1] for r in db.execute("PRAGMA table_info(chunks)")}
+                if "invalidated_at" not in cols:
+                    db.execute("ALTER TABLE chunks ADD COLUMN invalidated_at TEXT")
+                db.execute("CREATE INDEX IF NOT EXISTS idx_chunks_invalidated_at ON chunks(invalidated_at)")
+            except sqlite3.DatabaseError as exc:
+                log.debug("[knowledge] invalidated_at migration skipped: %s", exc)
             self._fts_available = _has_fts5(db)
             if self._fts_available:
                 db.executescript(_FTS_SCHEMA)
@@ -573,6 +586,7 @@ class KnowledgeStore:
         *,
         domain: str | None = None,
         namespace: str | list[str] | None = None,
+        include_invalidated: bool = False,
     ) -> list[dict[str, Any]]:
         """Top-k chunks matching ``query``. Shape matches what the
         ``KnowledgeMiddleware`` consumes: each result has ``table``,
@@ -583,6 +597,10 @@ class KnowledgeStore:
         ``namespace`` (ADR 0069 D3a) optionally restricts hits to the given
         namespace value(s) — see :func:`_namespace_clause` for the ``""``
         (un-namespaced rows) convention. ``None`` = unfiltered.
+
+        Superseded rows (``invalidated_at`` set — ADR 0069 D9) are excluded
+        by default; ``include_invalidated=True`` is the escape hatch for
+        audit tooling that needs the full history.
         """
         if not query or not query.strip():
             return []
@@ -591,9 +609,9 @@ class KnowledgeStore:
             return []
         try:
             rows = (
-                self._search_fts(db, query, k, domain, namespace)
+                self._search_fts(db, query, k, domain, namespace, include_invalidated)
                 if self._fts_available
-                else self._search_like(db, query, k, domain, namespace)
+                else self._search_like(db, query, k, domain, namespace, include_invalidated)
             )
         except sqlite3.DatabaseError as exc:
             log.warning("[knowledge] search failed: %s", exc)
@@ -620,6 +638,7 @@ class KnowledgeStore:
         k: int,
         domain: str | None,
         namespace: str | list[str] | None = None,
+        include_invalidated: bool = False,
     ) -> list[sqlite3.Row]:
         # Sanitize to FTS5-safe tokens; OR them so a multi-word query
         # matches any of the keywords (closer to LIKE behaviour).
@@ -633,6 +652,8 @@ class KnowledgeStore:
         match = " OR ".join(_fts_quote(t) for t in tokens)
         where = ["chunks_fts MATCH ?"]
         params: list[Any] = [match]
+        if not include_invalidated:
+            where.append("c.invalidated_at IS NULL")
         if domain:
             where.append("c.domain = ?")
             params.append(domain)
@@ -656,6 +677,7 @@ class KnowledgeStore:
         k: int,
         domain: str | None,
         namespace: str | list[str] | None = None,
+        include_invalidated: bool = False,
     ) -> list[sqlite3.Row]:
         tokens = [t for t in re.findall(r"[\w']+", query) if t]
         if not tokens:
@@ -672,6 +694,8 @@ class KnowledgeStore:
             needle = f"%{_escape_like(t)}%"
             params.extend([needle, _LIKE_ESCAPE, needle, _LIKE_ESCAPE])
         sql = f"SELECT *, ({like_clauses}) AS score FROM chunks WHERE score > 0"
+        if not include_invalidated:
+            sql += " AND invalidated_at IS NULL"
         if domain:
             sql += " AND domain = ?"
             params.append(domain)
@@ -689,15 +713,22 @@ class KnowledgeStore:
         limit: int = 50,
         *,
         namespace: str | None = None,
+        include_invalidated: bool = False,
     ) -> list[Chunk]:
         """Most-recent-first chunk listing. Used by ``memory_list`` and the
         fact consolidator. ``namespace`` (ADR 0021) optionally scopes to one
-        per-project/owner bucket."""
+        per-project/owner bucket.
+
+        Superseded rows (ADR 0069 D9) are excluded by default — so hot-memory
+        injection, ``memory_list``, and the fact consolidator only see valid
+        rows. ``include_invalidated=True`` is the audit escape hatch."""
         db = self._get_db()
         if db is None:
             return []
         clauses: list[str] = []
         params: list[Any] = []
+        if not include_invalidated:
+            clauses.append("invalidated_at IS NULL")
         if domain:
             clauses.append("domain = ?")
             params.append(domain)
@@ -716,8 +747,11 @@ class KnowledgeStore:
         return [Chunk(**dict(r)) for r in rows]
 
     def delete_by_id(self, chunk_id: int) -> bool:
-        """Delete one chunk by id. Used by the fact consolidator to replace a
-        superseded fact (ADR 0021). Returns True if a row was removed."""
+        """HARD-delete one chunk by id. This is the operator-intent path
+        (``forget_memory``, the inspector's DELETE routes) — an explicit
+        delete removes the row outright, history-keeping notwithstanding.
+        Automatic supersession uses :meth:`invalidate_chunk` instead
+        (ADR 0069 D9). Returns True if a row was removed."""
         db = self._get_db()
         if db is None:
             return False
@@ -731,14 +765,40 @@ class KnowledgeStore:
         finally:
             db.close()
 
+    def invalidate_chunk(self, chunk_id: int) -> bool:
+        """Mark one chunk superseded (ADR 0069 D9): set ``invalidated_at`` to
+        now, keeping the row for audit/history. Invalidated rows drop out of
+        ``search``/``list_chunks``/hot memory by default but stay reachable via
+        the ``include_invalidated`` escape hatch. Idempotent-safe: returns True
+        only when a VALID row was invalidated (already-invalidated or unknown
+        ids return False)."""
+        db = self._get_db()
+        if db is None:
+            return False
+        try:
+            now = _now_iso()
+            cur = db.execute(
+                "UPDATE chunks SET invalidated_at = ?, updated_at = ? WHERE id = ? AND invalidated_at IS NULL",
+                (now, now, int(chunk_id)),
+            )
+            db.commit()
+            return cur.rowcount > 0
+        except sqlite3.DatabaseError:
+            log.exception("[knowledge] invalidate_chunk failed")
+            return False
+        finally:
+            db.close()
+
     def get_hot_memory_entries(self, max_chars: int = 6000) -> list[tuple[int, str]]:
         """The ``(chunk_id, formatted piece)`` pairs behind :meth:`get_hot_memory`.
 
         Id-attributed so the per-turn injection record (ADR 0069 D6) can name
         exactly which hot chunks entered a model call. Same selection/budget
         semantics as ``get_hot_memory`` (one source of truth — it joins this).
+        Superseded chunks never inject: ``list_chunks`` excludes
+        ``invalidated_at`` rows by default (ADR 0069 D9).
         """
-        chunks = self.list_chunks(domain="hot", limit=100)  # newest-first
+        chunks = self.list_chunks(domain="hot", limit=100)  # newest-first, valid-only
         entries: list[tuple[int, str]] = []
         total = 0
         for c in chunks:  # newest-first → oldest trimmed when over budget

--- a/operator_api/memory_routes.py
+++ b/operator_api/memory_routes.py
@@ -179,6 +179,9 @@ def register_memory_routes(app) -> None:
 
     @app.delete("/api/memory/hot/{chunk_id}")
     async def _api_memory_hot_delete(chunk_id: int):
+        # Deliberately a HARD delete (ADR 0069 D9): automatic supersession keeps
+        # invalidated rows for audit, but an operator delete is explicit intent
+        # and removes the row outright.
         store = STATE.knowledge_store
         if store is None:
             return {"enabled": False, "deleted": False}

--- a/runtime/context.py
+++ b/runtime/context.py
@@ -75,11 +75,15 @@ def _format_skills(summaries: list[dict], total: int) -> str:
 
 
 def _format_knowledge(results) -> str:
-    # Mirrors KnowledgeMiddleware's block ({table, preview}) so an external brain sees
-    # exactly what the native loop would inject.
+    # Mirrors KnowledgeMiddleware's block ({table, preview} + stored date, ADR 0069
+    # D9) so an external brain sees exactly what the native loop would inject.
     lines = ["[Relevant knowledge from previous sessions:]"]
     for r in results:
-        lines.append(f"- [{r.get('table', '')}] {r.get('preview', '')}")
+        line = f"- [{r.get('table', '')}] {r.get('preview', '')}"
+        stored = str(r.get("created_at") or "")[:10]
+        if stored:
+            line += f" (stored {stored})"
+        lines.append(line)
     return "\n".join(lines)
 
 

--- a/tests/test_memory_facts.py
+++ b/tests/test_memory_facts.py
@@ -47,7 +47,7 @@ def test_parse_facts_drops_blank_and_caps_length():
 def test_facts_stored_with_namespace_and_type(tmp_path):
     store = KnowledgeStore(tmp_path / "kb.db")
     counts = consolidate_and_store(store, ["operator deploys on Fridays"], namespace="proj-a")
-    assert counts == {"added": 1, "skipped": 0}
+    assert counts == {"added": 1, "skipped": 0, "superseded": 0}
     facts = store.list_chunks(domain="fact", limit=10)
     assert len(facts) == 1
     assert facts[0].finding_type == "fact"
@@ -59,7 +59,7 @@ def test_near_duplicate_facts_are_skipped(tmp_path):
     consolidate_and_store(store, ["The operator prefers metric units"], namespace="p")
     # Re-running with a near-identical fact must not append a second copy.
     counts = consolidate_and_store(store, ["The operator prefers metric units"], namespace="p")
-    assert counts == {"added": 0, "skipped": 1}
+    assert counts == {"added": 0, "skipped": 1, "superseded": 0}
     assert len(store.list_chunks(domain="fact", limit=10)) == 1
 
 
@@ -70,7 +70,7 @@ def test_distinct_facts_are_added(tmp_path):
         ["The gateway alias is protolabs/reasoning", "Releases are cut manually"],
         namespace="p",
     )
-    assert counts == {"added": 2, "skipped": 0}
+    assert counts == {"added": 2, "skipped": 0, "superseded": 0}
 
 
 def test_namespace_scopes_dedup(tmp_path):
@@ -78,7 +78,7 @@ def test_namespace_scopes_dedup(tmp_path):
     store = KnowledgeStore(tmp_path / "kb.db")
     consolidate_and_store(store, ["deploys on Fridays"], namespace="proj-a")
     counts = consolidate_and_store(store, ["deploys on Fridays"], namespace="proj-b")
-    assert counts == {"added": 1, "skipped": 0}
+    assert counts == {"added": 1, "skipped": 0, "superseded": 0}
     assert len(store.list_chunks(domain="fact", namespace="proj-a")) == 1
     assert len(store.list_chunks(domain="fact", namespace="proj-b")) == 1
 
@@ -121,4 +121,4 @@ def test_extract_and_store_facts_end_to_end(tmp_path):
 
 def test_extract_noop_without_store():
     counts = asyncio.run(extract_and_store_facts("x", knowledge_store=None, config=object()))
-    assert counts == {"added": 0, "skipped": 0}
+    assert counts == {"added": 0, "skipped": 0, "superseded": 0}

--- a/tests/test_memory_staleness.py
+++ b/tests/test_memory_staleness.py
@@ -1,0 +1,255 @@
+"""ADR 0069 D9 — deterministic staleness: supersede, don't delete.
+
+Facts that revise existing facts mark the old row ``invalidated_at`` (kept for
+audit) instead of updating in place or deleting; every default retrieval path
+(search across all three stores, hot memory, memory_recall) excludes
+invalidated rows, with ``include_invalidated=True`` as the audit escape hatch;
+auto-injected RAG lines carry the chunk's stored date as a deterministic
+recency signal. No LLM freshness judging anywhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+from langchain_core.messages import HumanMessage
+
+from graph.memory_facts import consolidate_and_store
+from graph.middleware.knowledge import KnowledgeMiddleware
+from knowledge.hybrid_store import HybridKnowledgeStore
+from knowledge.layered import LayeredKnowledgeStore
+from knowledge.store import KnowledgeStore
+from tools.lg_tools import _build_memory_tools
+
+
+# ── migration: pre-existing DBs gain invalidated_at, idempotently ───────────
+
+
+_OLD_SCHEMA = """
+CREATE TABLE chunks (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    content       TEXT NOT NULL,
+    domain        TEXT NOT NULL DEFAULT 'general',
+    heading       TEXT,
+    source        TEXT,
+    source_type   TEXT,
+    finding_type  TEXT,
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+"""
+
+
+def test_migration_adds_invalidated_at_to_preexisting_db(tmp_path):
+    """A DB created before the column existed is migrated in place (ALTER TABLE
+    + index, the namespace precedent) and its rows stay valid + searchable."""
+    db_path = tmp_path / "old.db"
+    db = sqlite3.connect(str(db_path))
+    db.executescript(_OLD_SCHEMA)  # pre-namespace, pre-invalidated_at era
+    db.execute(
+        "INSERT INTO chunks (content, domain, created_at, updated_at) VALUES (?, ?, ?, ?)",
+        ("legacy fact about the gateway", "fact", "2026-01-01T00:00:00+00:00", "2026-01-01T00:00:00+00:00"),
+    )
+    db.commit()
+    db.close()
+
+    store = KnowledgeStore(db_path)
+    db = sqlite3.connect(str(db_path))
+    cols = {r[1] for r in db.execute("PRAGMA table_info(chunks)")}
+    indexes = {r[1] for r in db.execute("PRAGMA index_list(chunks)")}
+    db.close()
+    assert "invalidated_at" in cols
+    assert "idx_chunks_invalidated_at" in indexes
+    # The migrated row is NULL-invalidated (valid) and still retrievable.
+    hits = store.search("legacy gateway")
+    assert hits and hits[0]["invalidated_at"] is None
+
+    # Idempotent: re-opening the migrated DB is a no-op, nothing lost.
+    KnowledgeStore(db_path)
+    assert KnowledgeStore(db_path).search("legacy gateway")
+
+
+# ── invalidate_chunk ─────────────────────────────────────────────────────────
+
+
+def test_invalidate_chunk_stamps_and_keeps_the_row(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    cid = store.add_chunk("deploys go out Fridays", domain="fact")
+    assert store.invalidate_chunk(cid) is True
+    # The row survives (audit history) — it is not deleted.
+    row = store.get_chunk(cid)
+    assert row is not None and row["invalidated_at"]
+    # Already-invalidated and unknown ids report False (nothing changed).
+    assert store.invalidate_chunk(cid) is False
+    assert store.invalidate_chunk(99999) is False
+
+
+# ── default retrieval excludes; include_invalidated is the escape hatch ─────
+
+
+def test_search_excludes_invalidated_by_default(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    cid = store.add_chunk("the gateway alias is protolabs/reasoning", domain="fact")
+    assert store.search("gateway alias")  # valid → found
+    store.invalidate_chunk(cid)
+    assert store.search("gateway alias") == []  # superseded → hidden
+    hits = store.search("gateway alias", include_invalidated=True)  # audit hatch
+    assert len(hits) == 1 and hits[0]["invalidated_at"]
+
+
+def test_like_fallback_excludes_invalidated(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    cid = store.add_chunk("the gateway alias is protolabs/reasoning", domain="fact")
+    store.invalidate_chunk(cid)
+    store._fts_available = False  # force the LIKE path
+    assert store.search("gateway alias") == []
+    assert len(store.search("gateway alias", include_invalidated=True)) == 1
+
+
+def test_list_chunks_excludes_invalidated_by_default(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    keep = store.add_chunk("releases are cut manually", domain="fact")
+    gone = store.add_chunk("releases are automated", domain="fact")
+    store.invalidate_chunk(gone)
+    ids = {c.id for c in store.list_chunks(domain="fact")}
+    assert ids == {keep}
+    all_ids = {c.id for c in store.list_chunks(domain="fact", include_invalidated=True)}
+    assert all_ids == {keep, gone}
+
+
+def test_hybrid_vector_ranking_excludes_invalidated(tmp_path):
+    """A vector-only hit (no shared tokens with the query) must also honor
+    invalidated_at — both rankings are filtered, not just FTS5."""
+    store = HybridKnowledgeStore(str(tmp_path / "kb.db"), embed_fn=lambda text: [1.0, 0.0])
+    cid = store.add_chunk("alpha beta gamma", domain="general")
+    assert any(r["id"] == cid for r in store.search("zzzzz", k=5))  # vector-only hit
+    store.invalidate_chunk(cid)
+    assert store.search("zzzzz", k=5) == []
+    assert any(r["id"] == cid for r in store.search("zzzzz", k=5, include_invalidated=True))
+
+
+def test_layered_search_passes_include_invalidated_to_both_tiers(tmp_path):
+    private = KnowledgeStore(tmp_path / "private.db")
+    commons = KnowledgeStore(tmp_path / "commons.db")
+    cid = private.add_chunk("the operator prefers metric units", domain="fact")
+    private.invalidate_chunk(cid)
+    layered = LayeredKnowledgeStore(private, commons)
+    assert layered.search("metric units") == []
+    assert layered.search("metric units", include_invalidated=True)
+
+
+def test_hot_memory_excludes_invalidated(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    cid = store.add_chunk("operator prefers metric units", domain="hot", heading="prefs")
+    assert "metric units" in store.get_hot_memory()
+    store.invalidate_chunk(cid)
+    assert store.get_hot_memory() == ""
+    assert store.get_hot_memory_entries() == []
+
+
+def test_memory_recall_excludes_invalidated(tmp_path):
+    """#1579 cited dates on recall; superseded rows must no longer appear."""
+    store = KnowledgeStore(tmp_path / "kb.db")
+    cid = store.add_chunk("the deploy day is Friday", domain="fact", source="a2a:chat-1")
+    recall = next(t for t in _build_memory_tools(store) if t.name == "memory_recall")
+    assert "Friday" in asyncio.run(recall.ainvoke({"query": "deploy day"}))
+    store.invalidate_chunk(cid)
+    assert asyncio.run(recall.ainvoke({"query": "deploy day"})) == "No matches."
+
+
+# ── supersede semantics in fact consolidation ────────────────────────────────
+
+
+def test_revised_fact_supersedes_old_row(tmp_path):
+    """A revised fact (same subject, changed details — token overlap in the
+    supersede band) invalidates the old row and inserts the new one. The old
+    row is kept (never deleted, never updated in place)."""
+    store = KnowledgeStore(tmp_path / "kb.db")
+    consolidate_and_store(store, ["The operator's preferred deploy day is Friday"], namespace="p")
+    counts = consolidate_and_store(store, ["The operator's preferred deploy day is Monday"], namespace="p")
+    assert counts == {"added": 1, "skipped": 0, "superseded": 1}
+
+    valid = store.list_chunks(domain="fact")
+    assert [c.content for c in valid] == ["The operator's preferred deploy day is Monday"]
+    everything = store.list_chunks(domain="fact", include_invalidated=True)
+    assert len(everything) == 2  # history kept
+    old = next(c for c in everything if "Friday" in c.content)
+    new = next(c for c in everything if "Monday" in c.content)
+    assert old.invalidated_at and new.invalidated_at is None
+    # Retrieval now only surfaces the current fact.
+    hits = store.search("preferred deploy day")
+    assert len(hits) == 1 and "Monday" in hits[0]["content"]
+
+
+def test_supersede_applies_within_one_batch(tmp_path):
+    """The batch-local bookkeeping supersedes too: a later fact in the same
+    call revises an earlier one."""
+    store = KnowledgeStore(tmp_path / "kb.db")
+    counts = consolidate_and_store(
+        store,
+        [
+            "The operator's preferred deploy day is Friday",
+            "The operator's preferred deploy day is Monday",
+        ],
+        namespace="p",
+    )
+    assert counts == {"added": 2, "skipped": 0, "superseded": 1}
+    assert [c.content for c in store.list_chunks(domain="fact")] == ["The operator's preferred deploy day is Monday"]
+
+
+def test_unrelated_facts_do_not_supersede(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    consolidate_and_store(store, ["The gateway alias is protolabs/reasoning"], namespace="p")
+    counts = consolidate_and_store(store, ["Releases are cut manually"], namespace="p")
+    assert counts == {"added": 1, "skipped": 0, "superseded": 0}
+    assert len(store.list_chunks(domain="fact")) == 2
+
+
+def test_consolidate_degrades_without_invalidate_chunk(tmp_path):
+    """A minimal backend without invalidate_chunk still gets the new fact
+    (add-only degrade — never raises, never blocks the write)."""
+
+    class MinimalStore:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def list_chunks(self, **kwargs):
+            kwargs.pop("include_invalidated", None)
+            return self._inner.list_chunks(**kwargs)
+
+        def add_chunk(self, *args, **kwargs):
+            return self._inner.add_chunk(*args, **kwargs)
+
+    inner = KnowledgeStore(tmp_path / "kb.db")
+    store = MinimalStore(inner)
+    consolidate_and_store(store, ["The operator's preferred deploy day is Friday"], namespace="p")
+    counts = consolidate_and_store(store, ["The operator's preferred deploy day is Monday"], namespace="p")
+    assert counts["added"] == 1 and counts["superseded"] == 0  # no invalidation half
+    assert len(inner.list_chunks(domain="fact")) == 2  # both rows remain valid
+
+
+# ── recency surfaced in the auto-injected context ────────────────────────────
+
+
+def test_injected_rag_lines_carry_stored_date(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("the gateway alias is protolabs/reasoning", domain="fact")
+    stored_date = store.list_chunks(limit=1)[0].created_at[:10]
+
+    km = KnowledgeMiddleware(knowledge_store=store)
+    km._prior_sessions_cache = ""  # skip session loading
+    result = km.before_model({"messages": [HumanMessage(content="what is the gateway alias?")]}, runtime=None)
+    assert result is not None
+    assert f"(stored {stored_date})" in result["context"]
+
+
+def test_injection_skips_invalidated_chunks(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    cid = store.add_chunk("the gateway alias is protolabs/reasoning", domain="fact")
+    store.invalidate_chunk(cid)
+
+    km = KnowledgeMiddleware(knowledge_store=store)
+    km._prior_sessions_cache = ""
+    result = km.before_model({"messages": [HumanMessage(content="what is the gateway alias?")]}, runtime=None)
+    assert result is None or "protolabs/reasoning" not in result.get("context", "")

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -837,10 +837,15 @@ def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None)
 
     @tool
     async def forget_memory(chunk_id: int, reason: str = "") -> str:
-        """Delete ONE long-term-memory chunk by id (the `#<id>` shown by
+        """HARD-delete ONE long-term-memory chunk by id (the `#<id>` shown by
         memory_list). The consolidation/forgetting half of a `/dream` pass: use
         it to remove a fact that is stale, superseded, or a duplicate — ideally
         after `memory_ingest`-ing the corrected/merged version first.
+
+        This is a real delete, not a supersede: automatic fact consolidation
+        marks replaced rows `invalidated_at` and keeps them for audit (ADR
+        0069 D9), but an explicit forget is operator intent and removes the
+        row outright — history-keeping does not override it.
 
         Targeted and deliberate by design: it deletes exactly the one id you
         pass (no bulk/wildcard delete), so review with memory_list and forget


### PR DESCRIPTION
## Lane R3b — deterministic staleness: supersede, don't delete ([ADR 0069](docs/adr/0069-memory-delivery-layer.md) D9)

LLMs can't self-adjudicate freshness (Mem0's 2026 write-time-reconciliation reversal + arXiv 2606.01435), so staleness is handled **deterministically at retrieval**: facts get superseded — never LLM-judged, never silently replaced, never deleted by an automatic path — and the model sees explicit timestamps in-context.

### Schema
- `chunks.invalidated_at TEXT NULL` + `idx_chunks_invalidated_at`, added via the same additive `ALTER TABLE` migration pattern as the `namespace` column (`knowledge/store.py::_init_db`). `NULL` = valid; an ISO timestamp = superseded. Migration is idempotent and tested against a pre-existing (pre-namespace-era) DB.

### Supersede semantics (`graph/memory_facts.py`)
- `consolidate_and_store` now has three outcomes per extracted fact, all deterministic (token sets + "the incoming fact is newer by construction"):
  - Jaccard ≥ 0.85 → near-duplicate, **skipped** (unchanged);
  - 0.6 ≤ Jaccard < 0.85 → *revision* of an existing fact: old row stamped `invalidated_at=now` via the new `KnowledgeStore.invalidate_chunk()`, new row inserted — no UPDATE-in-place, no DELETE;
  - below the band → plain add.
- Counts gain a `superseded` key; bookkeeping supersedes within one batch too. A backend without `invalidate_chunk` degrades to add-only (never raises).

### Retrieval excludes invalidated by default
- `search` on **all three stores** — plain (`FTS5` + `LIKE` fallback), hybrid (**both** the FTS and vector rankings, so a fused hit can't resurrect a superseded row), layered (both tiers) — plus `list_chunks`, hot-memory injection (`get_hot_memory`/`get_hot_memory_entries`), and `memory_recall` (#1579's cited recall no longer surfaces invalidated rows; tested).
- `include_invalidated=True` is the escape hatch for audit tooling.

### Recency surfaced in-context
- The auto-injected RAG lines in `KnowledgeMiddleware.before_model` (and their `runtime/context.py` mirror for external brains) now end with the chunk's stored date: `- [chunks] … (stored 2026-07-01)`.

### Operator delete stays HARD
- `forget_memory` and the memory inspector's DELETE routes still remove rows outright — explicit operator intent beats history-keeping. Stated in the tool docstring, `delete_by_id` docstring, route comment, and the knowledge guide.

### Docs & tests
- Knowledge guide: new [Staleness: supersede, don't delete](docs/guides/knowledge.md) section under Memory delivery controls; `forget_memory` table row flags the hard delete.
- `tests/test_memory_staleness.py` (15 tests): migration idempotence, invalidate semantics, default-exclude/escape-hatch across plain/hybrid-vector/layered/LIKE paths, hot-memory + recall exclusion, supersede (cross-call and batch-local), unrelated facts untouched, add-only degrade, stored dates in injected context.
- CHANGELOG entry under [Unreleased].

### Gates
- `ruff check .` ✓ · `lint-imports` ✓ (3 contracts kept) · `python -m pytest tests/ -q` ✓ (2674 passed, 5 skipped) · `python scripts/live_smoke.py` ✓ · `npm run docs:build` ✓

Note for the follow-up ranking lane: `search` signatures gained only the trailing `include_invalidated` kwarg; namespace filtering (#1592) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)