### PR TITLE
feat(console): memory inspector surface + incognito threads (ADR 0069 D7/D3b UI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Memory inspector console surface** — a new core "Memory" rail view
+  ([ADR 0069](docs/adr/0069-memory-delivery-layer.md) D7, console half) over the
+  `/api/memory/*` REST surface: **Sessions** (the summaries behind the
+  `<prior_sessions>` digest — row click opens the full `recall_session` render in
+  the document viewer; per-row delete with confirm + toast), **Hot memory** (the
+  always-on `domain="hot"` chunks — edit/delete per row), and **Injections** (the
+  per-turn D6 record: which digest sessions / hot chunks / RAG chunks entered
+  which model call, filterable by session — the poisoning-forensics readout; a
+  session row jumps straight to its filtered injections).
+- **Incognito thread toggle in the console** (ADR 0069 D3b, console half) — a
+  per-chat-tab incognito mode that stamps `incognito` into the A2A message
+  metadata on **every** send while ON (the backend flag is per-message; a mixed
+  thread would leak earlier incognito content into a later turn's summary — the
+  desktop non-streaming `/api/chat` fallback carries it too). Toggle via the
+  `/incognito` slash command or the chat-tab context menu ("Turn incognito
+  on/off"); start a thread private via "New incognito chat"; while ON the tab
+  shows an eye-off glyph and the composer a clickable "incognito" chip (click to
+  turn off). Persisted with the session.
 - **Namespace-scoped auto-injection** (`knowledge.inject_namespaces`,
   [ADR 0069](docs/adr/0069-memory-delivery-layer.md) D3a). When set, the per-turn
   auto-injected RAG recall only considers chunks in the listed namespaces (`""`
@@ -95,6 +113,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer auto-merge and freeze the Pages deploy.
 
 ### Fixed
+- **Settings `string_list` fields can now carry an empty-string entry** — a
+  literal `""` (or `''`) token in the comma-separated editor parses to the empty
+  string and round-trips back as `""`. Needed for
+  `knowledge.inject_namespaces`, where the `""` sentinel means "the
+  un-namespaced rows" (ADR 0069 D3a); previously the editor silently dropped it.
 - **Chat session-identity hygiene** ([ADR 0069](docs/adr/0069-memory-delivery-layer.md) D4).
   Omitting `session_id` on `POST /api/chat` now mints a unique per-call id instead of
   pooling every caller into one shared `api-default` thread; an empty session id skips

--- a/apps/web/e2e/commands.spec.ts
+++ b/apps/web/e2e/commands.spec.ts
@@ -6,7 +6,7 @@ import { SLASH_COMMANDS } from "./fixtures.mjs";
 // (GET /api/chat/commands) and autocompletes them as you type "/name".
 
 // Deterministic client-side commands (ADR 0057) surface FIRST, then the server skills.
-const CLIENT_SLASH = ["/new", "/clear", "/compact", "/effort", "/bypass"];
+const CLIENT_SLASH = ["/new", "/clear", "/compact", "/effort", "/incognito", "/bypass"];
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -689,6 +689,69 @@ export const KNOWLEDGE_CHUNKS = [
   },
 ];
 
+// Memory inspector (ADR 0069 D7) — session-summary digest rows, hot-memory chunks,
+// and the per-turn injection record the Memory surface renders.
+export const MEMORY_SESSIONS = [
+  {
+    session_id: "chat-1750000000000-abc123",
+    timestamp: "2026-06-30T18:00:00+00:00",
+    surface: "chat",
+    topic: "plan the memory hardening rollout",
+    message_count: 12,
+    size_bytes: 2048,
+  },
+  {
+    session_id: "sched-hourly-report",
+    timestamp: "2026-06-30T17:00:00+00:00",
+    surface: "background",
+    topic: "compile the hourly ops report",
+    message_count: 4,
+    size_bytes: 512,
+  },
+];
+
+export const MEMORY_SESSION_RENDERED =
+  '<session id="chat-1750000000000-abc123" timestamp="2026-06-30T18:00:00+00:00">\n' +
+  "  <messages>\n" +
+  "    <user>plan the memory hardening rollout</user>\n" +
+  "    <assistant>Here is the phased plan…</assistant>\n" +
+  "  </messages>\n" +
+  "</session>";
+
+export const MEMORY_HOT = [
+  {
+    id: 31, heading: "Operator timezone", content: "The operator works in US/Pacific.",
+    preview: "The operator works in US/Pacific.",
+    domain: "hot", source: "chat-1750000000000-abc123", source_type: "extracted", finding_type: null,
+    created_at: "2026-06-29T10:00:00+00:00",
+  },
+  {
+    id: 32, heading: "", content: "Weekly report goes out Fridays at 9am.",
+    preview: "Weekly report goes out Fridays at 9am.",
+    domain: "hot", source: "console", source_type: "operator", finding_type: null,
+    created_at: "2026-06-28T09:00:00+00:00",
+  },
+];
+
+export const MEMORY_INJECTIONS = [
+  {
+    ts: "2026-06-30T18:05:00+00:00",
+    session_id: "chat-1750000000000-abc123",
+    digest_session_ids: ["sched-hourly-report"],
+    hot_chunk_ids: [31, 32],
+    rag_chunk_ids: [11],
+    approx_tokens: 420,
+  },
+  {
+    ts: "2026-06-30T17:01:00+00:00",
+    session_id: "sched-hourly-report",
+    digest_session_ids: [],
+    hot_chunk_ids: [31],
+    rag_chunk_ids: [],
+    approx_tokens: 120,
+  },
+];
+
 // Delegate registry (ADR 0025) — types schema + a sample roster for the panel.
 export const DELEGATE_TYPES = {
   types: [

--- a/apps/web/e2e/incognito.spec.ts
+++ b/apps/web/e2e/incognito.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+// Incognito threads (ADR 0069 D3b): while a tab's toggle is ON, EVERY message it
+// sends carries metadata.incognito — the backend flag is per-message, so a single
+// missed send would leak that turn into memory. Asserted at the WIRE level by
+// capturing the /a2a request bodies.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+});
+
+function captureA2ABodies(page: import("@playwright/test").Page): { metadata?: Record<string, unknown> }[] {
+  const messages: { metadata?: Record<string, unknown> }[] = [];
+  page.on("request", (req) => {
+    if (!req.url().endsWith("/a2a") || req.method() !== "POST") return;
+    try {
+      const body = JSON.parse(req.postData() || "{}");
+      if (body?.method === "SendStreamingMessage") messages.push(body.params?.message ?? {});
+    } catch {
+      // non-JSON /a2a traffic — not a chat turn
+    }
+  });
+  return messages;
+}
+
+test("/incognito toggles the tab: chip shows, every send carries metadata.incognito, off stops stamping", async ({ page }) => {
+  const sent = captureA2ABodies(page);
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+
+  // Turn incognito ON via the slash command (bare /incognito toggles). The system
+  // note confirms the local action took effect.
+  await composer.fill("/incognito");
+  await composer.press("Enter"); // picks the highlighted client command → runs it
+  await expect(page.locator(".chat-note", { hasText: "Incognito ON" })).toBeVisible();
+  // The composer chip is the persistent visual indicator while ON.
+  await expect(page.locator(".composer-incognito-toggle")).toBeVisible();
+
+  // BOTH messages sent while ON carry the flag (per-message contract).
+  await composer.fill("first private message");
+  await composer.press("Enter");
+  await expect(page.locator(".pl-message--user", { hasText: "first private message" })).toBeVisible();
+  await expect(page.locator(".pl-message--assistant").first()).toBeVisible();
+  await composer.fill("second private message");
+  await composer.press("Enter");
+  await expect(page.locator(".pl-message--user", { hasText: "second private message" })).toBeVisible();
+  await expect.poll(() => sent.length).toBe(2);
+  expect(sent[0].metadata?.incognito).toBe(true);
+  expect(sent[1].metadata?.incognito).toBe(true);
+
+  // Clicking the chip turns incognito OFF; the next send carries NO incognito flag.
+  await page.locator(".composer-incognito-toggle").click();
+  await expect(page.locator(".composer-incognito-toggle")).toHaveCount(0);
+  await composer.fill("back to normal");
+  await composer.press("Enter");
+  await expect(page.locator(".pl-message--user", { hasText: "back to normal" })).toBeVisible();
+  await expect.poll(() => sent.length).toBe(3);
+  expect(sent[2].metadata?.incognito).toBeUndefined();
+});
+
+test("the chat-tab context menu offers New incognito chat + a per-tab toggle", async ({ page }) => {
+  const tabs = page.locator(".pl-tabbar__tab");
+  const menu = page.locator(".pl-menu");
+
+  // Right-click the current tab → toggle incognito on from the menu.
+  await tabs.first().click({ button: "right" });
+  await expect(menu).toBeVisible();
+  await menu.getByText("Turn incognito on", { exact: true }).click();
+  await expect(page.locator(".composer-incognito-toggle")).toBeVisible();
+  // The tab itself shows the incognito glyph while ON.
+  await expect(page.locator(".session-incognito-icon")).toBeVisible();
+
+  // Re-open the menu: the entry now offers to turn it off.
+  await tabs.first().click({ button: "right" });
+  await menu.getByText("Turn incognito off", { exact: true }).click();
+  await expect(page.locator(".composer-incognito-toggle")).toHaveCount(0);
+
+  // "New incognito chat" opens a NEW tab already in incognito.
+  await tabs.first().click({ button: "right" });
+  await menu.getByText("New incognito chat", { exact: true }).click();
+  await expect(tabs).toHaveCount(2);
+  await expect(page.locator(".composer-incognito-toggle")).toBeVisible();
+  await expect(page.locator(".session-incognito-icon")).toBeVisible();
+});

--- a/apps/web/e2e/memory-inspector.spec.ts
+++ b/apps/web/e2e/memory-inspector.spec.ts
@@ -63,6 +63,23 @@ test("Hot memory panel lists always-on chunks; delete confirms and toasts", asyn
   await expect(surface.getByText("Weekly report goes out Fridays at 9am.")).toHaveCount(0);
 });
 
+test("editing a hot-memory entry saves via PUT, toasts, and shows the revision", async ({ page }) => {
+  const surface = page.getByTestId("memory-surface");
+  await surface.getByRole("tab", { name: "Hot memory" }).click();
+
+  await surface.getByLabel("edit hot entry 31").click();
+  const field = surface.getByLabel("hot entry 31 content");
+  await expect(field).toHaveValue("The operator works in US/Pacific.");
+  await field.fill("The operator works in US/Eastern.");
+  await surface.getByRole("button", { name: "Save", exact: true }).click();
+
+  await expect(page.locator(".pl-toast", { hasText: "Hot-memory entry updated." })).toBeVisible();
+  // The list refetches and shows the new revision (the backend re-adds + deletes,
+  // pinning domain="hot" — the row content is what must survive).
+  await expect(surface.getByText("The operator works in US/Eastern.")).toBeVisible();
+  await expect(surface.getByText("The operator works in US/Pacific.")).toHaveCount(0);
+});
+
 test("Injections panel shows the per-turn record and filters by session id", async ({ page }) => {
   const surface = page.getByTestId("memory-surface");
   await surface.getByRole("tab", { name: "Injections" }).click();

--- a/apps/web/e2e/memory-inspector.spec.ts
+++ b/apps/web/e2e/memory-inspector.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "@playwright/test";
+
+// Memory inspector (ADR 0069 D7): the rail surface auditing the memory DELIVERY
+// layer — session-summary digest rows, hot memory, and the per-turn injection
+// record — with delete flows that confirm + toast.
+
+// The delete tests MUTATE the shared mock (a session row / hot chunk is removed),
+// so run serially and reset the memory fixtures before each test — the same
+// hermeticity guard the knowledge spec uses.
+test.describe.configure({ mode: "serial" });
+test.beforeEach(async ({ page }) => {
+  await page.request.post("/api/__test__/memory/reset");
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Memory" }).click();
+  await expect(page.getByTestId("memory-surface")).toBeVisible();
+});
+
+test("Sessions panel lists digest rows and opens the full summary in the reader", async ({ page }) => {
+  const surface = page.getByTestId("memory-surface");
+
+  // Digest-derived rows: id, surface badge, topic, message count.
+  await expect(surface.getByText("chat-1750000000000-abc123")).toBeVisible();
+  await expect(surface.getByText("plan the memory hardening rollout")).toBeVisible();
+  await expect(surface.getByText("background", { exact: true })).toBeVisible();
+  await expect(surface.getByText(/12 msgs/)).toBeVisible();
+
+  // Row click → the document viewer shows the FULL rendered summary (verbatim pre).
+  await surface.getByText("plan the memory hardening rollout").click();
+  const pre = page.locator(".memory-session-pre");
+  await expect(pre).toBeVisible();
+  await expect(pre).toContainText('<session id="chat-1750000000000-abc123"');
+  await expect(pre).toContainText("<user>plan the memory hardening rollout</user>");
+});
+
+test("deleting a session summary confirms, toasts, and drops the row", async ({ page }) => {
+  const surface = page.getByTestId("memory-surface");
+
+  await surface.getByLabel("delete session sched-hourly-report").click();
+  const dialog = page.getByRole("dialog", { name: "Delete this session summary?" });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Delete summary" }).click();
+
+  // Transient result feedback rides a DS toast (console convention).
+  await expect(page.locator(".pl-toast", { hasText: "Session summary sched-hourly-report deleted." })).toBeVisible();
+  await expect(surface.getByText("sched-hourly-report")).toHaveCount(0);
+});
+
+test("Hot memory panel lists always-on chunks; delete confirms and toasts", async ({ page }) => {
+  const surface = page.getByTestId("memory-surface");
+  await surface.getByRole("tab", { name: "Hot memory" }).click();
+
+  await expect(surface.getByText("The operator works in US/Pacific.")).toBeVisible();
+  await expect(surface.getByText("Weekly report goes out Fridays at 9am.")).toBeVisible();
+  // Provenance badge (ADR 0069 D5): the source session that wrote the row.
+  await expect(surface.getByText("chat-1750000000000-abc123")).toBeVisible();
+
+  await surface.getByLabel("delete hot entry 32").click();
+  const dialog = page.getByRole("dialog", { name: "Delete this hot-memory entry?" });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Delete entry" }).click();
+
+  await expect(page.locator(".pl-toast", { hasText: "Hot-memory entry deleted." })).toBeVisible();
+  await expect(surface.getByText("Weekly report goes out Fridays at 9am.")).toHaveCount(0);
+});
+
+test("Injections panel shows the per-turn record and filters by session id", async ({ page }) => {
+  const surface = page.getByTestId("memory-surface");
+  await surface.getByRole("tab", { name: "Injections" }).click();
+
+  // Both fixture rows, with their injected ids visible.
+  const table = surface.locator(".memory-injections");
+  await expect(table.locator("tbody tr")).toHaveCount(2);
+  await expect(table.getByText("31, 32")).toBeVisible(); // hot chunk ids
+  await expect(table.getByText("sched-hourly-report").first()).toBeVisible();
+
+  // Filtering to one session narrows the table.
+  await surface.getByLabel("filter injections by session id").fill("sched-hourly-report");
+  await expect(table.locator("tbody tr")).toHaveCount(1);
+  await expect(table.getByText("chat-1750000000000-abc123")).toHaveCount(0);
+});
+
+test("a session row's injections jump pre-filters the Injections panel", async ({ page }) => {
+  const surface = page.getByTestId("memory-surface");
+  await surface.getByLabel("injections for chat-1750000000000-abc123").click();
+
+  // Landed on the Injections tab, filter applied, only that session's rows shown.
+  await expect(surface.getByLabel("filter injections by session id")).toHaveValue(
+    "chat-1750000000000-abc123",
+  );
+  await expect(surface.locator(".memory-injections tbody tr")).toHaveCount(1);
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -31,6 +31,10 @@ import {
   SLASH_COMMANDS,
   PLAYBOOKS,
   KNOWLEDGE_CHUNKS,
+  MEMORY_HOT,
+  MEMORY_INJECTIONS,
+  MEMORY_SESSIONS,
+  MEMORY_SESSION_RENDERED,
   SUBAGENTS,
   TELEMETRY_INSIGHTS,
   TELEMETRY_SUMMARY,
@@ -94,6 +98,15 @@ let playbooks = clonePlaybooks();
 // knowledge test resets via POST /api/__test__/knowledge/reset.
 const cloneKnowledge = () => JSON.parse(JSON.stringify(KNOWLEDGE_CHUNKS));
 let knowledgeChunks = cloneKnowledge();
+
+// Memory inspector (ADR 0069 D7) — sessions + hot chunks are MUTATED by the delete
+// specs, so serve working copies each memory test resets via
+// POST /api/__test__/memory/reset.
+const cloneMemory = () => ({
+  sessions: JSON.parse(JSON.stringify(MEMORY_SESSIONS)),
+  hot: JSON.parse(JSON.stringify(MEMORY_HOT)),
+});
+let memory = cloneMemory();
 
 // Fleet state is the one slice of the mock backend the specs MUTATE (create /
 // stop / rename / add-remote). Isolate it PER SPEC so parallel files and serial-
@@ -410,6 +423,26 @@ const server = createServer(async (req, res) => {
     if (req.method === "GET") {
       // Mid-turn steering: turn-end reconcile reads the still-queued items.
       if (/^\/api\/chat\/sessions\/[^/]+\/steer$/.test(pathname)) return sendJson(res, { pending: [] });
+      // Memory inspector (ADR 0069 D7) — needs the query string (injections filter),
+      // so it's handled here rather than in the pathname-only handleApiGet switch.
+      if (pathname === "/api/memory/sessions") return sendJson(res, { sessions: memory.sessions });
+      {
+        const m = pathname.match(/^\/api\/memory\/sessions\/([^/]+)$/);
+        if (m) {
+          const sid = decodeURIComponent(m[1]);
+          const s = memory.sessions.find((x) => x.session_id === sid);
+          if (!s) return sendJson(res, { detail: "no session summary with that id" }, 404);
+          return sendJson(res, { session: { ...s, trace_id: null, rendered: MEMORY_SESSION_RENDERED } });
+        }
+      }
+      if (pathname === "/api/memory/hot") return sendJson(res, { enabled: true, chunks: memory.hot });
+      if (pathname === "/api/memory/injections") {
+        const sid = url.searchParams.get("session_id") || "";
+        const rows = sid
+          ? MEMORY_INJECTIONS.filter((r) => r.session_id === sid)
+          : MEMORY_INJECTIONS;
+        return sendJson(res, { injections: rows });
+      }
       const payload = handleApiGet(pathname, fleetFor(req));
       if (payload !== null) return sendJson(res, payload);
       return sendJson(res, { detail: "not mocked" }, 404);
@@ -472,6 +505,38 @@ const server = createServer(async (req, res) => {
     if (pathname === "/api/__test__/knowledge/reset" && req.method === "POST") {
       knowledgeChunks = cloneKnowledge();
       return sendJson(res, { ok: true });
+    }
+    if (pathname === "/api/__test__/memory/reset" && req.method === "POST") {
+      memory = cloneMemory();
+      return sendJson(res, { ok: true });
+    }
+    // Memory inspector writes (ADR 0069 D7): delete a session summary / edit + delete
+    // a hot chunk — mutate the working copy so the panels visibly update.
+    {
+      const m = pathname.match(/^\/api\/memory\/sessions\/([^/]+)$/);
+      if (m && req.method === "DELETE") {
+        const sid = decodeURIComponent(m[1]);
+        const i = memory.sessions.findIndex((x) => x.session_id === sid);
+        if (i < 0) return sendJson(res, { detail: "no session summary with that id" }, 404);
+        memory.sessions.splice(i, 1);
+        return sendJson(res, { deleted: true, session_id: sid });
+      }
+      const h = pathname.match(/^\/api\/memory\/hot\/(\d+)$/);
+      if (h && req.method === "DELETE") {
+        const id = Number(h[1]);
+        const i = memory.hot.findIndex((x) => x.id === id);
+        if (i < 0) return sendJson(res, { detail: "no hot-memory chunk with that id" }, 404);
+        memory.hot.splice(i, 1);
+        return sendJson(res, { enabled: true, deleted: true });
+      }
+      if (h && req.method === "PUT") {
+        const id = Number(h[1]);
+        const c = memory.hot.find((x) => x.id === id);
+        if (!c) return sendJson(res, { detail: "no hot-memory chunk with that id" }, 404);
+        c.content = String(body.content || "");
+        c.preview = c.content;
+        return sendJson(res, { enabled: true, id: id + 100, replaced: true });
+      }
     }
     if (req.method === "POST" && /^\/api\/knowledge\/\d+\/promote$/.test(pathname)) {
       const id = Number(pathname.split("/").at(-2));

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -77,6 +77,7 @@ import { InboxWidget } from "../inbox/InboxWidget";
 import { ChatSlot } from "./ChatSlot";
 import { chatStore, useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
+import { MemorySurface } from "../memory/MemorySurface";
 import { SettingsOverlay } from "../settings/SettingsOverlay";
 import { PluginSettingsDialog } from "../plugins/PluginSettingsDialog";
 import { PluginRailManage } from "../plugins/PluginRailManage";
@@ -593,6 +594,10 @@ export function App() {
       // Settings ▸ Workspace ▸ Memory (ADR 0048 S-C).
       case "knowledge":
         return <KnowledgeStore />;
+      // Memory inspector (ADR 0069 D7) — the delivery-layer audit surface: session
+      // digests, hot memory, per-turn injection record.
+      case "memory":
+        return <MemorySurface />;
       // Settings is no longer a rail surface (2026-06 consolidation) — it's a utility-bar
       // pill opening the settings dialog (SettingsOverlay). Notes is the first-party `notes`
       // plugin (ADR 0034 S4) — rendered via the default

--- a/apps/web/src/app/coreSurfaces.tsx
+++ b/apps/web/src/app/coreSurfaces.tsx
@@ -2,7 +2,7 @@
 // desktop quick-launcher (ADR 0057) build their command lists from the SAME source —
 // add a core surface here and it shows up in both the rail and ⌘K / the launcher.
 import type { ReactNode } from "react";
-import { BookMarked, LayoutDashboard, MessageSquare } from "lucide-react";
+import { BookMarked, Brain, LayoutDashboard, MessageSquare } from "lucide-react";
 
 export type CoreSurface = { id: string; label: string; icon: ReactNode };
 
@@ -15,6 +15,9 @@ export const CORE_SURFACES: CoreSurface[] = [
   // widget; "agent" folded into Settings ▸ Workspace; "plugins" into Settings ▸ Plugins.
   { id: "work", label: "Work", icon: <LayoutDashboard size={18} /> },
   { id: "knowledge", label: "Knowledge", icon: <BookMarked size={18} /> },
+  // Memory inspector (ADR 0069 D7): the delivery-layer audit surface — session-summary
+  // digest sources, hot memory, and the per-turn injection record.
+  { id: "memory", label: "Memory", icon: <Brain size={18} /> },
   // Settings moved off the rail into a utility-bar pill (2026-06 consolidation) → the
   // settings dialog. It's still a valid ⌘K "go to" via the global deep-links.
 ];

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -3,7 +3,7 @@ import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { Switch } from "@protolabsai/ui/forms";
 import { Conversation, Message, PromptInput } from "@protolabsai/ui/ai";
 import { TabBar } from "@protolabsai/ui/navigation";
-import { Check, TerminalSquare } from "lucide-react";
+import { Check, EyeOff, TerminalSquare } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -162,9 +162,13 @@ export function ChatSurface({
   // (the hook gives us the id) but only to fire the editor.
   function onTabContextMenu(id: string, e: ReactMouseEvent) {
     const tabEl = (e.target as HTMLElement).closest(".pl-tabbar__tab") as HTMLElement | null;
+    const target = chat.sessions.find((s) => s.id === id);
     openContextMenu("chat-tab", e, {
       sessionId: id,
+      incognito: !!target?.incognito,
       onNew: () => chatStore.createSession(),
+      onNewIncognito: () => chatStore.createSession({ incognito: true }),
+      onToggleIncognito: () => chatStore.setSessionIncognito(id, !target?.incognito),
       onRename: () => tabEl?.dispatchEvent(new MouseEvent("dblclick", { bubbles: true })),
       onClose: () => setPendingClose(id),
     });
@@ -174,7 +178,10 @@ export function ChatSurface({
   // owns per-tab; this catches the background only, and bails on tab hits so the two never both fire.
   function onTabBarBackgroundContextMenu(e: ReactMouseEvent) {
     if ((e.target as HTMLElement).closest(".pl-tabbar__tab")) return; // a tab — onTabContextMenu owns it
-    openContextMenu("chat-tab", e, { onNew: () => chatStore.createSession() });
+    openContextMenu("chat-tab", e, {
+      onNew: () => chatStore.createSession(),
+      onNewIncognito: () => chatStore.createSession({ incognito: true }),
+    });
   }
 
   return (
@@ -198,7 +205,16 @@ export function ChatSurface({
             return {
               id: session.id,
               label: session.title,
-              icon: <span className={`session-dot ${status}`} title={status} />,
+              // Incognito rides the icon slot next to the status dot — the tab-level
+              // "this thread leaves no memory" indicator (ADR 0069 D3b).
+              icon: session.incognito ? (
+                <span className="session-tab-icons">
+                  <span className={`session-dot ${status}`} title={status} />
+                  <EyeOff size={12} className="session-incognito-icon" aria-label="incognito" />
+                </span>
+              ) : (
+                <span className={`session-dot ${status}`} title={status} />
+              ),
             };
           })}
           onSelect={(id) => chatStore.switchSession(id)}
@@ -1237,6 +1253,10 @@ function ChatSessionSlot({
         // Read live (not the render-closure session) so an "Approve & don't ask again" that
         // flips bypass on right before this resume turn is carried by it.
         bypassPermissions: chatStore.getSnapshot().sessions.find((s) => s.id === session.id)?.bypassPermissions,
+        // Incognito (ADR 0069 D3b) — per-MESSAGE server-side, so read live and stamp
+        // EVERY send while the tab's toggle is on (a mixed thread would leak earlier
+        // incognito content into a later non-incognito turn's summary).
+        incognito: chatStore.getSnapshot().sessions.find((s) => s.id === session.id)?.incognito,
       });
       chatStore.setSessionStatus(session.id, "idle");
       setStatusMessage("idle");
@@ -1430,6 +1450,18 @@ function ChatSessionSlot({
                 </Button>
               ))}
               <ComposerModelSelect />
+              {session?.incognito ? (
+                <button
+                  type="button"
+                  className="composer-incognito-toggle"
+                  title="Incognito is ON for this tab — turns leave no memory (no session summary, no harvest) and inject none. Click to turn it off."
+                  onClick={() => chatStore.setSessionIncognito(session.id, false)}
+                >
+                  <Badge status="neutral">
+                    <EyeOff size={12} /> incognito
+                  </Badge>
+                </button>
+              ) : null}
               {session?.bypassPermissions ? (
                 <button
                   type="button"

--- a/apps/web/src/chat/chat-store.test.ts
+++ b/apps/web/src/chat/chat-store.test.ts
@@ -391,3 +391,43 @@ describe("cross-tab persistence", () => {
     expect(chatStore.getSnapshot().sessions.map((s) => s.id)).toEqual(before);
   });
 });
+
+// Incognito threads (ADR 0069 D3b): the flag lives ON the session (persisted with it)
+// so ChatSurface can stamp metadata.incognito onto EVERY send while it's on — the
+// backend flag is per-message, and a mixed thread would leak earlier incognito content
+// into a later non-incognito turn's summary.
+describe("incognito sessions", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.resetModules(); // fresh module-level store per test
+  });
+
+  it("createSession({incognito:true}) marks the new session; default stays unmarked", async () => {
+    const { chatStore } = await import("./chat-store");
+    const plain = chatStore.createSession();
+    expect(plain.incognito).toBeUndefined();
+    const priv = chatStore.createSession({ incognito: true });
+    expect(priv.incognito).toBe(true);
+    const snap = chatStore.getSnapshot();
+    expect(snap.sessions.find((s) => s.id === priv.id)?.incognito).toBe(true);
+    expect(snap.currentSessionId).toBe(priv.id); // new tab becomes current, as always
+  });
+
+  it("setSessionIncognito toggles on and off (off drops the key entirely)", async () => {
+    const { chatStore } = await import("./chat-store");
+    const s = chatStore.createSession();
+    chatStore.setSessionIncognito(s.id, true);
+    expect(chatStore.getSnapshot().sessions.find((x) => x.id === s.id)?.incognito).toBe(true);
+    chatStore.setSessionIncognito(s.id, false);
+    expect(chatStore.getSnapshot().sessions.find((x) => x.id === s.id)?.incognito).toBeUndefined();
+  });
+
+  it("the incognito flag persists with the session (survives a reload)", async () => {
+    const first = await import("./chat-store");
+    const s = first.chatStore.createSession({ incognito: true });
+    first.flushChatPersist();
+    vi.resetModules(); // "reload": a fresh module re-reads localStorage
+    const second = await import("./chat-store");
+    expect(second.chatStore.getSnapshot().sessions.find((x) => x.id === s.id)?.incognito).toBe(true);
+  });
+});

--- a/apps/web/src/chat/chat-store.ts
+++ b/apps/web/src/chat/chat-store.ts
@@ -22,6 +22,11 @@ export type ChatSession = {
   // metadata.bypass_permissions so the server auto-approves run_command (no HITL gate). A
   // deliberately dangerous escape hatch — default OFF; the composer shows a loud chip while on.
   bypassPermissions?: boolean;
+  // Per-tab incognito mode (ADR 0069 D3b): while ON, EVERY message sent from this tab
+  // carries metadata.incognito — the server skips memory persistence AND injection for
+  // that turn. The flag is per-MESSAGE server-side, so it must ride every send: a mixed
+  // thread would leak earlier incognito content into a later non-incognito turn's summary.
+  incognito?: boolean;
 };
 
 // Reasoning is ON by default in the console (auto-enable) — a fresh tab thinks at
@@ -76,7 +81,7 @@ function titleFromMessages(messages: ChatMessage[]) {
   return text.length > 52 ? `${text.slice(0, 49)}...` : text;
 }
 
-function createSession(): ChatSession {
+function createSession(opts: { incognito?: boolean } = {}): ChatSession {
   const now = Date.now();
   return {
     id: id("chat"),
@@ -84,6 +89,7 @@ function createSession(): ChatSession {
     messages: [],
     createdAt: now,
     updatedAt: now,
+    ...(opts.incognito ? { incognito: true } : {}),
   };
 }
 
@@ -351,8 +357,8 @@ export const chatStore = {
     return state;
   },
 
-  createSession() {
-    const session = createSession();
+  createSession(opts: { incognito?: boolean } = {}) {
+    const session = createSession(opts);
     setState((current) => {
       // New tabs append to the RIGHT; cap at MAX_SESSIONS by dropping the oldest (left).
       const sessions = [...current.sessions, session].slice(-MAX_SESSIONS);
@@ -489,6 +495,17 @@ export const chatStore = {
       ...current,
       sessions: current.sessions.map((session) =>
         session.id === sessionId ? { ...session, bypassPermissions: on || undefined } : session,
+      ),
+    }));
+  },
+
+  // Per-tab incognito toggle (ADR 0069 D3b). Persisted with the session so the mode
+  // survives reload — every send while ON carries metadata.incognito.
+  setSessionIncognito(sessionId: string, on: boolean) {
+    setState((current) => ({
+      ...current,
+      sessions: current.sessions.map((session) =>
+        session.id === sessionId ? { ...session, incognito: on || undefined } : session,
       ),
     }));
   },

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -154,8 +154,10 @@
 }
 
 /* Bypass-permissions indicator in the composer toolbar — a DS warning Badge (outline tone) in a
-   bare button so clicking it turns bypass off (same as `/bypass off`). The Badge owns the styling. */
-.composer-bypass-toggle {
+   bare button so clicking it turns bypass off (same as `/bypass off`). The Badge owns the styling.
+   The incognito chip (ADR 0069 D3b) mirrors it: clicking turns incognito off. */
+.composer-bypass-toggle,
+.composer-incognito-toggle {
   display: inline-flex;
   align-items: center;
   padding: 0;
@@ -174,6 +176,17 @@
   background-color: currentColor;
   -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M9 3v1H4v2h16V4h-5V3H9zM6 7l1 13h10l1-13H6z'/%3E%3C/svg%3E") center / contain no-repeat;
   mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M9 3v1H4v2h16V4h-5V3H9zM6 7l1 13h10l1-13H6z'/%3E%3C/svg%3E") center / contain no-repeat;
+}
+
+/* Incognito tab indicator (ADR 0069 D3b): the EyeOff glyph rides the icon slot
+   beside the status dot while the thread's toggle is on. */
+.session-tab-icons {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.session-incognito-icon {
+  opacity: 0.75;
 }
 
 .chat-session-slot {

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -131,6 +131,28 @@ registerSlashCommand({
 });
 
 registerSlashCommand({
+  name: "incognito",
+  description: "Incognito for this tab: turns leave no memory and inject none",
+  usage: "/incognito on|off",
+  run: (ctx) => {
+    if (!ctx.sessionId) return false;
+    const arg = ctx.rest.trim().toLowerCase();
+    const session = chatStore.getSnapshot().sessions.find((s) => s.id === ctx.sessionId);
+    const cur = !!session?.incognito;
+    const next = arg === "on" ? true : arg === "off" ? false : !cur; // bare /incognito toggles
+    chatStore.setSessionIncognito(ctx.sessionId, next);
+    ctx.noteToThread(
+      next
+        ? "**Incognito ON** for this tab — every message now carries `incognito`: no session summary, no memory harvest, no memory injection, until you turn it off with `/incognito off`. Messages already sent before this were NOT incognito."
+        : "Incognito **off** — turns persist to memory and receive memory again.",
+      { tone: "info" },
+    );
+    ctx.focusComposer();
+    return true;
+  },
+});
+
+registerSlashCommand({
   name: "bypass",
   description: "DANGER: auto-approve tool permissions (run_command) for this tab",
   usage: "/bypass on|off",

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -203,24 +203,41 @@ registerContextMenu({
   },
 });
 
-// Right-click a chat session tab → New chat / Rename / Close (ADR 0036). ChatSurface owns the
-// behavior and passes it in `ctx` as closures: Close reuses its confirm-dialog flow, Rename
-// triggers the DS TabBar's inline editor (a synthetic dblclick on the tab). Right-clicking empty
-// tab-bar space carries only `onNew`. (The DS TabBar exposes no per-tab context-menu hook — a
-// DS gap noted for contribute-back; ChatSurface delegates from the tab-bar wrapper meanwhile.)
+// Right-click a chat session tab → New chat / New incognito chat / Rename / Incognito toggle /
+// Close (ADR 0036). ChatSurface owns the behavior and passes it in `ctx` as closures: Close
+// reuses its confirm-dialog flow, Rename triggers the DS TabBar's inline editor (a synthetic
+// dblclick on the tab), the incognito entries flip the per-thread flag (ADR 0069 D3b — every
+// send while ON carries metadata.incognito). Right-clicking empty tab-bar space carries only
+// the `onNew*` closures. (The DS TabBar exposes no per-tab context-menu hook — a DS gap noted
+// for contribute-back; ChatSurface delegates from the tab-bar wrapper meanwhile.)
 registerContextMenu({
   type: "chat-tab",
   items: (ctx: {
     sessionId?: string;
+    incognito?: boolean;
     onNew?: () => void;
+    onNewIncognito?: () => void;
+    onToggleIncognito?: () => void;
     onRename?: () => void;
     onClose?: () => void;
   }): MenuEntry[] => {
     const out: MenuEntry[] = [
       { id: "new", label: "New chat", icon: <Plus size={14} />, run: () => ctx?.onNew?.() },
+      {
+        id: "new-incognito",
+        label: "New incognito chat",
+        icon: <EyeOff size={14} />,
+        run: () => ctx?.onNewIncognito?.(),
+      },
     ];
     if (ctx?.sessionId) {
       out.push({ id: "rename", label: "Rename", icon: <Pencil size={14} />, run: () => ctx.onRename?.() });
+      out.push({
+        id: "incognito",
+        label: ctx.incognito ? "Turn incognito off" : "Turn incognito on",
+        icon: ctx.incognito ? <Eye size={14} /> : <EyeOff size={14} />,
+        run: () => ctx.onToggleIncognito?.(),
+      });
       out.push({ id: "tab-div", divider: true });
       out.push({ id: "close", label: "Close chat", icon: <X size={14} />, danger: true, run: () => ctx.onClose?.() });
     }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -25,6 +25,8 @@ import type {
   PluginInstallSummary,
   PluginUpdate,
   KnowledgeChunk,
+  MemoryInjectionRow,
+  MemorySessionDigest,
   RuntimeStatus,
   ScheduledJob,
   SetupStatus,
@@ -771,6 +773,45 @@ export const api = {
     }>("/api/knowledge/ingest", form);
   },
 
+  // --- Memory inspector (ADR 0069 D7) — the delivery-layer audit surface -----
+  // Session summaries: the files behind the <prior_sessions> digest.
+  memorySessions() {
+    return request<{ sessions: MemorySessionDigest[] }>("/api/memory/sessions");
+  },
+  memorySession(sessionId: string) {
+    return request<{ session: MemorySessionDigest }>(
+      `/api/memory/sessions/${encodeURIComponent(sessionId)}`,
+    );
+  },
+  deleteMemorySession(sessionId: string) {
+    return request<{ deleted: boolean; session_id: string }>(
+      `/api/memory/sessions/${encodeURIComponent(sessionId)}`,
+      { method: "DELETE" },
+    );
+  },
+  // Hot memory: the domain="hot" chunks injected every turn.
+  memoryHot() {
+    return request<{ enabled: boolean; chunks: KnowledgeChunk[] }>("/api/memory/hot");
+  },
+  updateMemoryHot(chunkId: number, body: { content: string; heading?: string }) {
+    return request<{ enabled: boolean; id: number | null; replaced: boolean }>(
+      `/api/memory/hot/${chunkId}`,
+      { method: "PUT", body },
+    );
+  },
+  deleteMemoryHot(chunkId: number) {
+    return request<{ enabled: boolean; deleted: boolean }>(`/api/memory/hot/${chunkId}`, {
+      method: "DELETE",
+    });
+  },
+  // Injection record (ADR 0069 D6): which memory entered which turn.
+  memoryInjections(sessionId = "", limit = 50) {
+    const q = new URLSearchParams();
+    if (sessionId) q.set("session_id", sessionId);
+    q.set("limit", String(limit));
+    return request<{ injections: MemoryInjectionRow[] }>(`/api/memory/injections?${q}`);
+  },
+
   // Chat attachment — extract + TIER a dropped file (FormData: `file` + `session_id`).
   // Returns a ready-to-prepend `context` block (full text for small docs, a lede +
   // retrieval note for large docs indexed under the session) so a big doc never
@@ -1244,6 +1285,10 @@ export const api = {
       model?: string;
       reasoningEffort?: string;
       bypassPermissions?: boolean;
+      // Incognito thread (ADR 0069 D3b): the flag is PER MESSAGE server-side, so the
+      // console stamps it on EVERY send while the thread's toggle is on — a mixed
+      // thread would leak earlier incognito content into a later turn's summary.
+      incognito?: boolean;
     } = {},
   ) {
     // One A2A SendStreamingMessage body + one frame dispatcher, shared by the desktop
@@ -1263,13 +1308,15 @@ export const api = {
           messageId: rpcId,
           contextId: sessionId,
           // Per-turn overrides ride the A2A message metadata (server/chat.py reads them):
-          // the tab's chosen model + the /effort reasoning level.
-          ...((opts.model || opts.reasoningEffort || opts.bypassPermissions)
+          // the tab's chosen model + the /effort reasoning level + incognito (ADR 0069 D3b —
+          // per-message server-side, stamped on every send while the thread toggle is on).
+          ...((opts.model || opts.reasoningEffort || opts.bypassPermissions || opts.incognito)
             ? {
                 metadata: {
                   ...(opts.model ? { model: opts.model } : {}),
                   ...(opts.reasoningEffort ? { reasoning_effort: opts.reasoningEffort } : {}),
                   ...(opts.bypassPermissions ? { bypass_permissions: true } : {}),
+                  ...(opts.incognito ? { incognito: true } : {}),
                 },
               }
             : {}),
@@ -1356,7 +1403,14 @@ export const api = {
           method: "POST",
           headers: applyAuth(new Headers({ "Content-Type": "application/json" })),
           signal: handlers.signal,
-          body: JSON.stringify({ message, session_id: sessionId, ...(opts.model ? { model: opts.model } : {}) }),
+          body: JSON.stringify({
+            message,
+            session_id: sessionId,
+            ...(opts.model ? { model: opts.model } : {}),
+            // The non-streaming fallback must carry incognito too — dropping it here
+            // would silently persist a thread the operator marked private.
+            ...(opts.incognito ? { incognito: true } : {}),
+          }),
         });
         if (!res.ok) {
           let detail = `${res.status} ${res.statusText}`;

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -27,6 +27,11 @@ export const queryKeys = {
   playbooks: ["playbooks"] as const,
   knowledge: ["knowledge"] as const,
   flags: ["flags"] as const,
+  // Memory inspector (ADR 0069 D7) — subtree so one invalidate refreshes all panels.
+  memory: ["memory"] as const,
+  memorySessions: ["memory", "sessions"] as const,
+  memoryHot: ["memory", "hot"] as const,
+  memoryInjections: ["memory", "injections"] as const,
 };
 
 // The fleet of workspace agents (ADR 0042). `running` is a live-pid probe, so poll

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -717,6 +717,33 @@ export type KnowledgeChunk = {
   tier?: "private" | "commons" | null;
 };
 
+// Memory inspector (ADR 0069 D7) — the delivery-layer audit surface.
+// One session-summary digest row (GET /api/memory/sessions) — the same
+// derivation the <prior_sessions> digest injects, so the list can't drift
+// from what the agent is actually told.
+export type MemorySessionDigest = {
+  session_id: string;
+  timestamp: string;
+  surface: string; // chat | background | a2a | …
+  topic: string;
+  message_count: number;
+  size_bytes?: number;
+  // Detail-only fields (GET /api/memory/sessions/{id}):
+  trace_id?: string | null;
+  rendered?: string; // the full render recall_session returns
+};
+
+// One per-model-call injection record (GET /api/memory/injections, ADR 0069 D6):
+// which memory items entered which turn — the poisoning-forensics trail.
+export type MemoryInjectionRow = {
+  ts: string;
+  session_id: string;
+  digest_session_ids: string[];
+  hot_chunk_ids: number[];
+  rag_chunk_ids: number[];
+  approx_tokens: number;
+};
+
 // Delegate registry (ADR 0025) — the agents & endpoints the agent can talk to.
 export type DelegateFieldSpec = {
   key: string;

--- a/apps/web/src/memory/MemorySurface.tsx
+++ b/apps/web/src/memory/MemorySurface.tsx
@@ -1,0 +1,400 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Alert } from "@protolabsai/ui/data";
+import { Input, Textarea } from "@protolabsai/ui/forms";
+import { PanelHeader, Tabs } from "@protolabsai/ui/navigation";
+import { ConfirmDialog, useToast } from "@protolabsai/ui/overlays";
+import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
+import { Flame, History, Pencil, Syringe, Trash2 } from "lucide-react";
+
+import { RefreshButton } from "../app/ui-kit";
+import { openDocument } from "../docviewer";
+import { api } from "../lib/api";
+import { ago, errMsg } from "../lib/format";
+import { queryKeys } from "../lib/queries";
+import type { KnowledgeChunk, MemorySessionDigest } from "../lib/types";
+
+import "./memory.css";
+
+// Memory inspector (ADR 0069 D7) — the audit surface over the memory DELIVERY
+// layer: which session summaries feed the <prior_sessions> digest, which hot
+// chunks ride every turn, and (D6) exactly which memory items entered which
+// turn. A security control first — SpAIware-class memory poisoning gets
+// *detected* here — UX second, so the panels favor raw ids/timestamps over
+// polish. Distinct from Knowledge → Store (the whole KB): this is only what
+// auto-injects.
+
+type MemoryTab = "sessions" | "hot" | "injections";
+
+const TABS: { id: MemoryTab; label: string; icon: React.ReactNode }[] = [
+  { id: "sessions", label: "Sessions", icon: <History size={15} /> },
+  { id: "hot", label: "Hot memory", icon: <Flame size={15} /> },
+  { id: "injections", label: "Injections", icon: <Syringe size={15} /> },
+];
+
+export function MemorySurface() {
+  const [tab, setTab] = useState<MemoryTab>("sessions");
+  // Set by a session row's "injections" jump — pre-filters the Injections panel.
+  const [injectionFilter, setInjectionFilter] = useState("");
+
+  return (
+    <section className="panel stage-panel" data-testid="memory-surface">
+      <PanelHeader
+        title="Memory"
+        kicker="what auto-injects into the agent's turns — inspect, audit, prune"
+      />
+      {/* Not `responsive`: this surface lives on the main stage (wide), and the
+          deterministic role="tab" strip keeps the e2e + a11y contract simple. */}
+      <Tabs
+        active={tab}
+        onSelect={(t) => setTab(t as MemoryTab)}
+        items={TABS.map((t) => ({ id: t.id, label: t.label, icon: t.icon }))}
+      />
+      <div className="stage-body">
+        {tab === "sessions" ? (
+          <SessionsPanel
+            onShowInjections={(sid) => {
+              setInjectionFilter(sid);
+              setTab("injections");
+            }}
+          />
+        ) : tab === "hot" ? (
+          <HotMemoryPanel />
+        ) : (
+          <InjectionsPanel filter={injectionFilter} setFilter={setInjectionFilter} />
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ── Sessions — the summaries behind the <prior_sessions> digest ───────────────
+
+function SessionsPanel({ onShowInjections }: { onShowInjections: (sid: string) => void }) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  const { data, isFetching, error, refetch } = useQuery({
+    queryKey: queryKeys.memorySessions,
+    queryFn: () => api.memorySessions(),
+  });
+  const sessions = data?.sessions ?? [];
+  const [pendingDelete, setPendingDelete] = useState<MemorySessionDigest | null>(null);
+
+  const del = useMutation({
+    mutationFn: (sid: string) => api.deleteMemorySession(sid),
+    onSuccess: (_r, sid) => {
+      toast({ tone: "success", title: "Memory", message: `Session summary ${sid} deleted.` });
+      void qc.invalidateQueries({ queryKey: queryKeys.memorySessions });
+    },
+    onError: (e) => toast({ tone: "error", title: "Memory", message: errMsg(e) }),
+  });
+
+  // Open the FULL summary (the render recall_session returns) in the document
+  // viewer. It's the raw <session> record — show it verbatim in a <pre>, never
+  // as markdown (an ingested summary could otherwise smuggle live HTML).
+  async function openSession(row: MemorySessionDigest) {
+    try {
+      const r = await api.memorySession(row.session_id);
+      openDocument({
+        title: row.session_id,
+        subtitle: `${row.surface} · ${row.timestamp} · ${row.message_count} msgs`,
+        render: () => <pre className="memory-session-pre">{r.session.rendered || "(empty summary)"}</pre>,
+      });
+    } catch (e) {
+      toast({ tone: "error", title: "Memory", message: errMsg(e) });
+    }
+  }
+
+  return (
+    <>
+      <div className="memory-panel-head">
+        <p className="memory-panel-hint">
+          Persisted session summaries — each is one line of the <code>&lt;prior_sessions&gt;</code>{" "}
+          digest the agent sees every turn. Click a row for the full summary
+          (what <code>recall_session</code> returns); delete to forget a session.
+        </p>
+        <RefreshButton onClick={() => void refetch()} busy={isFetching} />
+      </div>
+      {error ? <Alert status="error">Couldn't list session summaries — {errMsg(error)}</Alert> : null}
+      {!error && sessions.length === 0 ? (
+        <Empty
+          title="No session summaries"
+          description="finished sessions persist a summary here; the digest stays empty until then."
+        />
+      ) : (
+        <ul className="playbook-list memory-list">
+          {sessions.map((s) => (
+            <li key={s.session_id} className="playbook-card memory-row">
+              <button
+                type="button"
+                className="memory-row-main"
+                title="Open the full summary in the reader"
+                onClick={() => void openSession(s)}
+              >
+                <span className="memory-row-title">
+                  <Badge status="neutral">{s.surface}</Badge>
+                  <code>{s.session_id}</code>
+                </span>
+                <span className="memory-row-topic">{s.topic || "(no user message)"}</span>
+                <span className="memory-row-meta">
+                  {s.timestamp !== "unknown" ? ago(s.timestamp) : "unknown"} · {s.message_count} msgs
+                </span>
+              </button>
+              <span className="knowledge-chunk-actions">
+                <Button
+                  icon
+                  variant="ghost"
+                  type="button"
+                  title="Show what this session's turns injected"
+                  aria-label={`injections for ${s.session_id}`}
+                  onClick={() => onShowInjections(s.session_id)}
+                >
+                  <Syringe size={14} />
+                </Button>
+                <Button
+                  icon
+                  variant="ghost"
+                  type="button"
+                  title="Delete this session summary (drops it from the digest)"
+                  aria-label={`delete session ${s.session_id}`}
+                  onClick={() => setPendingDelete(s)}
+                >
+                  <Trash2 size={14} />
+                </Button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete this session summary?"
+        confirmLabel="Delete summary"
+        destructive
+        onConfirm={() => {
+          if (pendingDelete) del.mutate(pendingDelete.session_id);
+          setPendingDelete(null);
+        }}
+        onClose={() => setPendingDelete(null)}
+      >
+        {pendingDelete
+          ? `"${pendingDelete.session_id}" leaves the <prior_sessions> digest and recall_session — the agent will no longer know of this session. This can't be undone.`
+          : undefined}
+      </ConfirmDialog>
+    </>
+  );
+}
+
+// ── Hot memory — the domain="hot" chunks injected every turn ─────────────────
+
+function HotMemoryPanel() {
+  const qc = useQueryClient();
+  const toast = useToast();
+  const { data, isFetching, error, refetch } = useQuery({
+    queryKey: queryKeys.memoryHot,
+    queryFn: () => api.memoryHot(),
+  });
+  const enabled = data?.enabled ?? true;
+  const chunks = data?.chunks ?? [];
+  const [pendingDelete, setPendingDelete] = useState<KnowledgeChunk | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [draft, setDraft] = useState("");
+  const invalidate = () => void qc.invalidateQueries({ queryKey: queryKeys.memoryHot });
+
+  const del = useMutation({
+    mutationFn: (id: number) => api.deleteMemoryHot(id),
+    onSuccess: () => {
+      toast({ tone: "success", title: "Memory", message: "Hot-memory entry deleted." });
+      invalidate();
+    },
+    onError: (e) => toast({ tone: "error", title: "Memory", message: errMsg(e) }),
+  });
+
+  const save = useMutation({
+    mutationFn: ({ id, content }: { id: number; content: string }) =>
+      api.updateMemoryHot(id, { content }),
+    onSuccess: () => {
+      toast({ tone: "success", title: "Memory", message: "Hot-memory entry updated." });
+      setEditingId(null);
+      setDraft("");
+      invalidate();
+    },
+    onError: (e) => toast({ tone: "error", title: "Memory", message: errMsg(e) }),
+  });
+
+  return (
+    <>
+      <div className="memory-panel-head">
+        <p className="memory-panel-hint">
+          Always-on memory — every entry here is injected into <em>every</em> turn. Keep it
+          small; anything wrong or planted here steers the agent until it's removed.
+        </p>
+        <RefreshButton onClick={() => void refetch()} busy={isFetching} />
+      </div>
+      {error ? <Alert status="error">Couldn't list hot memory — {errMsg(error)}</Alert> : null}
+      {!enabled ? (
+        <Empty>
+          The knowledge store is off (enable <code>middleware.knowledge</code>).
+        </Empty>
+      ) : !error && chunks.length === 0 ? (
+        <Empty
+          title="No hot memory"
+          description="the agent (or you, via the Knowledge surface with domain 'hot') hasn't pinned any always-on memory."
+        />
+      ) : (
+        <ul className="playbook-list memory-list">
+          {chunks.map((c) => (
+            <li key={c.id} className="playbook-card memory-row">
+              {editingId === c.id ? (
+                <div className="memory-edit-form">
+                  <Textarea
+                    rows={3}
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    aria-label={`hot entry ${c.id} content`}
+                  />
+                  <div className="memory-edit-actions">
+                    <Button
+                      type="button"
+                      variant="primary"
+                      size="sm"
+                      disabled={save.isPending || !draft.trim()}
+                      onClick={() => save.mutate({ id: c.id, content: draft })}
+                    >
+                      Save
+                    </Button>
+                    <Button type="button" variant="ghost" size="sm" onClick={() => setEditingId(null)}>
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="memory-row-main memory-row-static">
+                    <span className="memory-row-title">
+                      {c.heading ? <strong>{c.heading}</strong> : null}
+                      {c.source ? (
+                        <span title="provenance — the session/source that wrote this row">
+                          <Badge status="neutral">{c.source}</Badge>
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="memory-row-topic">{c.content || c.preview}</span>
+                    <span className="memory-row-meta">{ago(c.created_at)}</span>
+                  </div>
+                  <span className="knowledge-chunk-actions">
+                    <Button
+                      icon
+                      variant="ghost"
+                      type="button"
+                      title="Edit this hot-memory entry"
+                      aria-label={`edit hot entry ${c.id}`}
+                      onClick={() => {
+                        setEditingId(c.id);
+                        setDraft(c.content || "");
+                      }}
+                    >
+                      <Pencil size={14} />
+                    </Button>
+                    <Button
+                      icon
+                      variant="ghost"
+                      type="button"
+                      title="Delete this hot-memory entry (stops injecting immediately)"
+                      aria-label={`delete hot entry ${c.id}`}
+                      onClick={() => setPendingDelete(c)}
+                    >
+                      <Trash2 size={14} />
+                    </Button>
+                  </span>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete this hot-memory entry?"
+        confirmLabel="Delete entry"
+        destructive
+        onConfirm={() => {
+          if (pendingDelete) del.mutate(pendingDelete.id);
+          setPendingDelete(null);
+        }}
+        onClose={() => setPendingDelete(null)}
+      >
+        {pendingDelete
+          ? `"${(pendingDelete.heading || pendingDelete.content || pendingDelete.preview || "").slice(0, 80)}" stops injecting into every turn. This can't be undone.`
+          : undefined}
+      </ConfirmDialog>
+    </>
+  );
+}
+
+// ── Injections — which memory entered which turn (ADR 0069 D6) ───────────────
+
+function InjectionsPanel({ filter, setFilter }: { filter: string; setFilter: (v: string) => void }) {
+  const { data, isFetching, error, refetch } = useQuery({
+    queryKey: [...queryKeys.memoryInjections, filter] as const,
+    queryFn: () => api.memoryInjections(filter, 100),
+  });
+  const rows = data?.injections ?? [];
+
+  const idList = (ids: Array<string | number>) =>
+    ids.length ? <code>{ids.join(", ")}</code> : <span className="memory-none">—</span>;
+
+  return (
+    <>
+      <div className="memory-panel-head">
+        <p className="memory-panel-hint">
+          The per-turn injection record — which digest sessions, hot chunks, and RAG chunks
+          entered each model call. This is the "why did it say that?" / poisoning-forensics
+          trail.
+        </p>
+        <RefreshButton onClick={() => void refetch()} busy={isFetching} />
+      </div>
+      <Input
+        type="search"
+        placeholder="Filter by session id (blank = all sessions)…"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        aria-label="filter injections by session id"
+      />
+      {error ? <Alert status="error">Couldn't read the injection log — {errMsg(error)}</Alert> : null}
+      {!error && rows.length === 0 ? (
+        <Empty
+          title="No injection records"
+          description={filter ? "no recorded turns for that session id." : "records appear as turns run."}
+        />
+      ) : (
+        <table className="memory-injections">
+          <thead>
+            <tr>
+              <th>when</th>
+              <th>session</th>
+              <th>digest sessions</th>
+              <th>hot chunks</th>
+              <th>RAG chunks</th>
+              <th>~tokens</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={`${r.ts}-${i}`}>
+                <td title={r.ts}>{ago(r.ts)}</td>
+                <td>
+                  <code>{r.session_id}</code>
+                </td>
+                <td>{idList(r.digest_session_ids)}</td>
+                <td>{idList(r.hot_chunk_ids)}</td>
+                <td>{idList(r.rag_chunk_ids)}</td>
+                <td>{r.approx_tokens}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/memory/memory.css
+++ b/apps/web/src/memory/memory.css
@@ -1,0 +1,120 @@
+/* Memory inspector (ADR 0069 D7). Reuses the playbook-list/card shell for rows;
+   these are only the inspector-specific bits. Comments here must never glue a
+   star to a slash mid-comment — the minifier trap (#888). */
+
+.memory-panel-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.memory-panel-hint {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--pl-color-text-muted, #8a8f98);
+}
+
+.memory-list {
+  margin-top: 0.5rem;
+}
+
+.memory-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+/* The clickable session row body — a button styled as content, not chrome. */
+.memory-row-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.memory-row-static {
+  cursor: default;
+}
+
+.memory-row-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.memory-row-title code {
+  font-size: 0.8rem;
+  overflow-wrap: anywhere;
+}
+
+.memory-row-topic {
+  font-size: 0.85rem;
+  overflow-wrap: anywhere;
+}
+
+.memory-row-meta {
+  font-size: 0.75rem;
+  color: var(--pl-color-text-muted, #8a8f98);
+}
+
+.memory-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex: 1;
+}
+
+.memory-edit-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+/* The full-summary reader body: verbatim <session> record, never markdown. */
+.memory-session-pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+/* Injection-record table — a forensics readout, clarity over polish. */
+.memory-injections {
+  width: 100%;
+  margin-top: 0.6rem;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+
+.memory-injections th,
+.memory-injections td {
+  text-align: left;
+  vertical-align: top;
+  padding: 0.35rem 0.5rem;
+  border-bottom: 1px solid var(--pl-color-border, rgba(128, 128, 128, 0.25));
+}
+
+.memory-injections th {
+  font-weight: 600;
+  color: var(--pl-color-text-muted, #8a8f98);
+}
+
+.memory-injections code {
+  font-size: 0.75rem;
+  overflow-wrap: anywhere;
+}
+
+.memory-none {
+  color: var(--pl-color-text-muted, #8a8f98);
+}

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -430,20 +430,34 @@ function SettingRow({
 // Parsed → a clean string[] on every change; re-syncs from `value` on an external change
 // (discard / reset / load).
 // Split a string-list text field into clean items: comma OR newline separated, trimmed,
-// empties dropped — so "a, b", "a\nb", and "a , , b\n" all yield ["a","b"].
+// empties dropped — so "a, b", "a\nb", and "a , , b\n" all yield ["a","b"]. A quoted empty
+// token — `""` — survives as the empty string: some lists use "" as a sentinel (e.g.
+// knowledge.inject_namespaces, where "" means the un-namespaced rows), and blank-between-
+// separators must still be droppable noise, so the sentinel needs an explicit spelling.
 export function parseStringList(text: string): string[] {
-  return text.split(/[,\n]/).map((s) => s.trim()).filter(Boolean);
+  return text
+    .split(/[,\n]/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => (s === '""' || s === "''" ? "" : s));
+}
+
+// The inverse: render items for the text field, spelling the empty-string entry as `""`
+// so it survives the round-trip (join would otherwise emit a bare separator that the
+// parse drops).
+export function formatStringList(items: string[]): string {
+  return items.map((s) => (s === "" ? '""' : s)).join(", ");
 }
 
 function StringListInput({ id, value, onChange }: { id: string; value: unknown; onChange: (v: unknown) => void }) {
   const items = Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
-  const [text, setText] = useState(items.join(", "));
+  const [text, setText] = useState(formatStringList(items));
   const lastParsed = useRef(items);
   useEffect(() => {
     // Adopt the parent value only when it changed to something we didn't just emit
     // (e.g. Discard reverted it) — otherwise leave the user's in-progress text alone.
     if (JSON.stringify(items) !== JSON.stringify(lastParsed.current)) {
-      setText(items.join(", "));
+      setText(formatStringList(items));
       lastParsed.current = items;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -454,7 +468,7 @@ function StringListInput({ id, value, onChange }: { id: string; value: unknown; 
       className="setting-input setting-textarea"
       rows={2}
       value={text}
-      placeholder="comma-separated (e.g. owner/repo, owner/repo2)"
+      placeholder={'comma-separated (e.g. owner/repo, owner/repo2 — "" for an empty entry)'}
       onChange={(e) => {
         setText(e.target.value);
         const parsed = parseStringList(e.target.value);

--- a/apps/web/src/settings/stringList.test.ts
+++ b/apps/web/src/settings/stringList.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseStringList } from "./SettingsCategory";
+import { formatStringList, parseStringList } from "./SettingsCategory";
 
 describe("parseStringList", () => {
   it("splits on commas", () => {
@@ -14,5 +14,24 @@ describe("parseStringList", () => {
   });
   it("is empty for blank input", () => {
     expect(parseStringList("   ")).toEqual([]);
+  });
+  // The empty-string SENTINEL (ADR 0069 D3a): knowledge.inject_namespaces uses a literal
+  // "" entry to mean "the un-namespaced rows". Bare separators stay droppable noise; the
+  // sentinel is spelled with quotes.
+  it('keeps a quoted "" token as the empty-string entry', () => {
+    expect(parseStringList('workspace, ""')).toEqual(["workspace", ""]);
+    expect(parseStringList("''")).toEqual([""]);
+  });
+});
+
+describe("formatStringList", () => {
+  it("joins with commas", () => {
+    expect(formatStringList(["a", "b"])).toBe("a, b");
+  });
+  it('spells the empty-string entry as "" (round-trips through parse)', () => {
+    const items = ["workspace", ""];
+    const text = formatStringList(items);
+    expect(text).toBe('workspace, ""');
+    expect(parseStringList(text)).toEqual(items);
   });
 });

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -148,7 +148,7 @@ type UIState = {
 // persisted `railOrder` is missing it (see the action). Keep ids in sync with
 // CORE_SURFACES (apps/web/src/app/coreSurfaces.tsx).
 const DEFAULT_RAIL_ORDER: { left: string[]; right: string[]; bottom: string[]; hidden: string[] } = {
-  left: ["chat", "knowledge"],
+  left: ["chat", "knowledge", "memory"],
   right: ["work"],
   bottom: [],
   hidden: [],

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -67,7 +67,7 @@ backs the console browser.
 ## Memory delivery controls (ADR 0069)
 
 What the store *holds* and what gets *pushed into the prompt each turn* are separate
-surfaces ([ADR 0069](/adr/0069-memory-delivery-layer)). Three controls gate and audit
+surfaces ([ADR 0069](/adr/0069-memory-delivery-layer)). Four controls gate and audit
 the delivery side:
 
 ### Scope the auto-inject to namespaces
@@ -103,10 +103,16 @@ summarized into the knowledge store).
   default `false`).
 - **A2A / console streaming path** — set `incognito: true` in the message
   **metadata** (alongside `model` / `reasoning_effort`).
+- **Console** — toggle a chat tab incognito with the `/incognito` slash command
+  or the tab's right-click menu ("Turn incognito on/off"; "New incognito chat"
+  starts a thread private). While ON the tab shows an eye-off glyph and the
+  composer an `incognito` chip (click it to turn off), and the console stamps
+  the metadata flag onto **every** message it sends from that tab.
 
 The flag is per-message and stamped explicitly on every turn, so a thread is only
-as incognito as its latest message — send the flag on each turn of a thread you
-want kept out of memory. (A console thread toggle rides a later UI lane.)
+as incognito as its latest message — a raw API caller must send the flag on each
+turn of a thread it wants kept out of memory (the console toggle does exactly
+that for you).
 
 ### The per-turn injection record
 
@@ -123,6 +129,21 @@ GET /api/memory/injections?session_id=<id>&limit=50
 returns `{"injections": [...]}` newest-first — omit `session_id` for all sessions.
 Each row: `ts`, `session_id`, `digest_session_ids`, `hot_chunk_ids`,
 `rag_chunk_ids`, `approx_tokens`.
+
+### The Memory inspector (console)
+
+The **Memory** rail view is the operator half of all of the above — a security
+control first (SpAIware-class memory poisoning gets *detected* here), UX second:
+
+- **Sessions** — the persisted summaries behind the `<prior_sessions>` digest,
+  one row per session (id · surface · topic · message count). Click a row to
+  read the full summary (exactly what `recall_session` returns) in the document
+  viewer; delete a row to forget that session.
+- **Hot memory** — the always-on `domain="hot"` chunks injected into every turn,
+  with their provenance (`source` = the session that wrote them); edit or delete
+  per row. Deleting stops the injection immediately.
+- **Injections** — the per-turn record above, filterable by session id; a
+  session row's syringe button jumps straight to its filtered record.
 
 ## Sharing knowledge across a fleet (the commons)
 


### PR DESCRIPTION
The console half of the [ADR 0069](docs/adr/0069-memory-delivery-layer.md) memory delivery layer — final wave, UI lane. Backend halves already merged: inspector REST `/api/memory/sessions|hot` (#1590), injection log `/api/memory/injections` + per-message incognito (#1592).

> **DRAFT under the console local-test gate** — layout/UX work is operator-triaged locally before merge; do not auto-merge on green.

## Memory inspector (D7, console)

A new core **Memory** rail view (registered like Knowledge: `CORE_SURFACES` + default rail order + reconcile self-heal), `apps/web/src/memory/MemorySurface.tsx`:

- **Sessions** — digest rows (`session_id · surface · topic · msgs`, same derivation the agent sees). Row click fetches `GET /api/memory/sessions/{id}` and opens the full `recall_session` render in the **document viewer** (ADR 0062) as a verbatim `<pre>` — deliberately not markdown, so an ingested summary can't smuggle live HTML into the reader. Per-row delete with confirm + success toast; per-row jump to that session's filtered injections.
- **Hot memory** — `GET /api/memory/hot` rows with provenance (`source`) badges; inline edit (`PUT`, content pinned to `domain="hot"` server-side) and delete, both toasting.
- **Injections** — the D6 per-turn record (`ts`, session, digest session ids, hot chunk ids, RAG chunk ids, ~tokens) as a plain forensics table, filterable by session id. Clarity over polish, per the ADR: this is how SpAIware-class poisoning gets detected.

All reads/writes ride the existing authed `request()` helpers in `src/lib/api.ts` (bearer + fleet slug routing for free).

## Incognito thread toggle (D3b, console)

The backend flag is **per-message** (`server/chat.py` reads `metadata.incognito`), and a mixed thread leaks earlier incognito content into a later non-incognito turn's summary — so the console persists the toggle on the session (`chat-store`) and stamps `metadata.incognito` onto **every** send while ON, including the desktop non-streaming `/api/chat` fallback body.

- Toggle: `/incognito` slash command (bare toggles, `on|off` explicit), chat-tab context menu ("Turn incognito on/off"), and **"New incognito chat"** for private-from-birth threads (tab menu + tab-bar background menu).
- Indicators: eye-off glyph on the tab strip + a clickable `incognito` composer chip (click = off), plus a system note on toggle.

## Settings `string_list` round-trip fix (D3a follow-through)

`knowledge.inject_namespaces` uses a literal `""` entry to mean "the un-namespaced rows" — but `parseStringList` dropped empties (`filter(Boolean)`), so the Settings editor silently discarded the sentinel. Fixed minimally: a quoted `""` (or `''`) token parses to the empty string, and `formatStringList` spells empty entries back as `""`; bare separators stay droppable noise. Unit-tested both ways.

## Tests & gates

- `npm run test:unit` — 257 passed (adds chat-store incognito + string_list round-trip suites).
- `npm run build` — tsc + vite green (`check-css-comments` prebuild included).
- `npm run test:e2e` — new `memory-inspector.spec.ts` (5 tests incl. `.pl-toast` assertions on both delete flows + mock-server `/api/memory/*` routes/fixtures) and `incognito.spec.ts` (wire-level: captures `/a2a` bodies and asserts `metadata.incognito` on every send while ON and absent after OFF; context-menu flow). Full suite: 168/169 per run with one **pre-existing parallel flake** rotating between `chat-input-history` / `fleet` specs — both pass in isolation and are untouched by this diff (CI retries cover it).
- Docs touched (`docs/guides/knowledge.md` — console inspector + thread-toggle sections, removes the stale "later UI lane" note) → `npm run docs:build` green. No Python touched.
- CHANGELOG entry under [Unreleased].

🤖 Generated with [Claude Code](https://claude.com/claude-code)