### PR TITLE
feat(knowledge): trust-tiered injection + hot-memory write visibility (ADR 0069 R3a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Trust-tiered injection** ([ADR 0069](docs/adr/0069-memory-delivery-layer.md)
+  D8). Every knowledge chunk now ranks into a deterministic trust tier by its
+  `source_type` (`knowledge/trust.py`): 3 = operator-authored (console
+  routes), 2 = agent-derived (extracted facts, harvest summaries,
+  `memory_ingest`, compaction archives — the agent write paths now stamp
+  themselves), 1 = ingested/external (web, YouTube, PDF, media) **and
+  unknown/unstamped**. The per-turn auto-injected RAG recall down-weights low
+  tiers (stable post-score sort — a low-trust hit never outranks a
+  higher-trust one, in-tier relevance preserved), and a new
+  `knowledge.inject_min_trust` key (default `1` = nothing excluded) can
+  exclude tiers from auto-injection entirely (`2` drops ingested/external
+  content, `3` = operator rows only). The tier is visible everywhere: injected
+  lines and `memory_recall`/`memory_list` citations carry a
+  `trust: operator|agent|external` label, and tool-driven recall is never
+  gated — excluded content stays reachable on demand. See
+  [the knowledge guide](docs/guides/knowledge.md#trust-tiers-adr-0069-d8).
+- **Hot-memory write visibility** (ADR 0069 D8). Every write that creates a
+  `domain="hot"` chunk (injected in front of the model *every* turn) now
+  emits a `memory.hot_written` event on the plugin event bus (ADR 0039) with
+  `{chunk_id, source, source_type, preview}` — agent tool, operator route, or
+  plugin SDK alike — so the console notification path and any bus subscriber
+  can surface it. An optional confirm gate, `knowledge.hot_write_confirm`
+  (default `false`), makes the agent's own `memory_ingest` refuse hot writes
+  with instructions to ask the operator; operator console surfaces are
+  unaffected.
 - **Supersede-don't-delete staleness** ([ADR 0069](docs/adr/0069-memory-delivery-layer.md)
   D9). The `chunks` table gains a nullable `invalidated_at` column (additive
   migration, namespace precedent): when the session-end fact pass extracts a

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -102,6 +102,18 @@ knowledge:
   # inject_namespaces:
   #   - "projects/alpha"
   #   - ""
+  # Trust floor for the per-turn AUTO-INJECTED recall (ADR 0069 D8). Chunks rank
+  # into deterministic trust tiers by source_type: 3 = operator-authored, 2 =
+  # agent-derived (extracted facts, harvest, memory_ingest), 1 = ingested/external
+  # (web, YouTube, PDFs, media) and unknown. 1 (default) excludes nothing — low
+  # tiers are only ranked below higher ones; 2 drops external content from
+  # auto-injection; 3 = operator rows only. memory_recall is never gated.
+  # inject_min_trust: 1
+  # Hot-memory write confirm gate (ADR 0069 D8). When true, the agent's
+  # memory_ingest refuses domain="hot" writes (it must ask the operator);
+  # operator surfaces are unaffected. Every hot write emits a
+  # `memory.hot_written` bus event either way.
+  # hot_write_confirm: false
   # Document chunking on ingest (ADR 0021) — large bodies (conversation
   # summaries, pasted docs) are split into overlapping passages BEFORE
   # embedding, so each passage gets its own vector instead of one diluted

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -124,6 +124,67 @@ returns `{"injections": [...]}` newest-first — omit `session_id` for all sessi
 Each row: `ts`, `session_id`, `digest_session_ids`, `hot_chunk_ids`,
 `rag_chunk_ids`, `approx_tokens`.
 
+### Trust tiers (ADR 0069 D8)
+
+Not everything in the store deserves the same seat at the table. Every chunk's
+`source_type` names the write path that created it, and those paths rank into
+**three deterministic trust tiers** (`knowledge/trust.py` — a code-level map,
+not config):
+
+| Tier | Label | Write paths |
+|---|---|---|
+| 3 | `operator` | console knowledge browser add/edit, memory-inspector hot edit (`source_type: operator`/`manual`) |
+| 2 | `agent` | extracted facts (`extracted`), harvest summaries (`harvest`), `memory_ingest` + compaction archives (`conversation`), findings (`chat`) |
+| 1 | `external` | everything ingested: web pages (`html`), YouTube transcripts, PDFs, transcribed media, pasted docs — **and any unknown/unstamped `source_type`** (least trust by default, incl. rows written before stamping existed) |
+
+Two things happen with the tier:
+
+- **Auto-injection down-weights low tiers, always.** The per-turn RAG hits are
+  stable-sorted by tier after retrieval — an external/ingested hit never
+  outranks an operator- or agent-authored one; relevance order is preserved
+  within a tier. Deterministic and post-score, so it behaves identically on
+  the plain, hybrid, and layered stores.
+- **A trust floor can exclude tiers entirely:**
+
+```yaml
+knowledge:
+  inject_min_trust: 1   # default: nothing excluded (down-weighting only)
+  # inject_min_trust: 2 # exclude ingested/external content from auto-injection
+  # inject_min_trust: 3 # auto-inject operator-authored rows only
+```
+
+The floor gates **only the automatic injection** — like `inject_namespaces`,
+tool-driven recall (`memory_recall`) is never gated, so excluded content stays
+reachable on demand with the model's intent visible as a tool call. The tier is
+visible everywhere it travels: auto-injected lines end with
+`(stored 2026-07-01; trust: external)`, and `memory_recall` / `memory_list`
+citations carry the same `trust:` label.
+
+### Hot-memory write visibility (ADR 0069 D8)
+
+`domain="hot"` chunks are injected in front of the model **every turn**, which
+makes a silent hot write the highest-leverage poisoning move there is. Two
+controls:
+
+- **Every hot write is a visible event.** Any write that creates a hot chunk —
+  the agent's `memory_ingest`, the console routes, a plugin via the SDK —
+  emits `memory.hot_written` on the plugin event bus ([ADR 0039](/adr/0039-plugin-event-bus))
+  with `{chunk_id, source, source_type, preview}`. Consoles and plugins can
+  subscribe (`HOST.on("memory.hot_written", …)`) to toast/log it.
+- **An optional confirm gate** for multi-user or higher-paranoia setups:
+
+```yaml
+knowledge:
+  hot_write_confirm: false  # default: agent hot writes allowed (single-operator flow)
+  # hot_write_confirm: true # memory_ingest REFUSES domain="hot" writes with a clear
+                            # error telling the model to ask you; only the console
+                            # (Knowledge → Store / memory inspector) writes hot memory
+```
+
+The gate binds the **agent's own write path** (`memory_ingest`) — the simple
+mechanism: a refusal with instructions, nothing is parked or half-stored.
+Operator console surfaces stamp `source_type: operator` and are unaffected.
+
 ### Staleness: supersede, don't delete
 
 LLMs demonstrably can't self-adjudicate freshness, so protoAgent handles

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -99,6 +99,7 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
                 skills_index=_skills_index,
                 skills_top_k=config.skills_top_k,
                 inject_namespaces=config.knowledge_inject_namespaces,
+                inject_min_trust=config.knowledge_inject_min_trust,
             )
         )
 

--- a/graph/compaction_op.py
+++ b/graph/compaction_op.py
@@ -160,6 +160,9 @@ async def compact_thread(
             full_transcript,
             domain="conversation",
             heading=f"Conversation archive ({session_id})",
+            # Agent-derived trust tier (ADR 0069 D8) — the archive is the
+            # operator's own conversation, not ingested third-party content.
+            source_type="conversation",
             namespace=f"chat-archive:{session_id}",
         )
     except Exception:

--- a/graph/config.py
+++ b/graph/config.py
@@ -430,6 +430,22 @@ class LangGraphConfig:
     # are auto-injected; include "" to also match un-namespaced chunks. Gates
     # only what enters the prompt unasked — memory_recall stays unscoped.
     knowledge_inject_namespaces: list[str] = field(default_factory=list)
+    # Trust floor for the AUTO-INJECT RAG hits (ADR 0069 D8). Rows rank into
+    # deterministic trust tiers by source_type (knowledge/trust.py): 3 =
+    # operator-authored, 2 = agent-derived (extracted facts, harvest,
+    # memory_ingest), 1 = ingested/external (web, YouTube, PDF, media) and
+    # unknown. 1 (default) excludes nothing — low tiers are only down-weighted
+    # (ranked below higher tiers); 2 drops external/ingested content from
+    # auto-injection; 3 auto-injects operator-authored rows only. memory_recall
+    # is never gated — excluded content stays reachable on demand.
+    knowledge_inject_min_trust: int = 1
+    # Hot-memory write confirm gate (ADR 0069 D8). When True, the agent's own
+    # write path (memory_ingest) refuses domain="hot" writes with an error
+    # telling it to ask the operator — only operator surfaces (console
+    # knowledge/memory routes) put facts in front of the model every turn.
+    # Default False: single-operator boxes keep the frictionless flow; every
+    # hot write emits a `memory.hot_written` bus event either way.
+    knowledge_hot_write_confirm: bool = False
     # Hybrid-retrieval tuning (HybridKnowledgeStore knobs, ADR 0021) — surfaced so
     # they're tunable without editing the store / via the retrieval eval:
     #   vector_k  — FTS5 + vector candidates fused per query (the RRF pool).
@@ -919,6 +935,8 @@ class LangGraphConfig:
             knowledge_embeddings=knowledge.get("embeddings", cls.knowledge_embeddings),
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),
             knowledge_inject_namespaces=list(knowledge.get("inject_namespaces", []) or []),
+            knowledge_inject_min_trust=knowledge.get("inject_min_trust", cls.knowledge_inject_min_trust),
+            knowledge_hot_write_confirm=knowledge.get("hot_write_confirm", cls.knowledge_hot_write_confirm),
             knowledge_vector_k=knowledge.get("vector_k", cls.knowledge_vector_k),
             knowledge_rrf_k=knowledge.get("rrf_k", cls.knowledge_rrf_k),
             knowledge_min_score=knowledge.get("min_score", cls.knowledge_min_score),

--- a/graph/conversation_harvest.py
+++ b/graph/conversation_harvest.py
@@ -124,7 +124,8 @@ async def harvest_thread(
 
         # source=<thread_id> is the machine-readable provenance link (ADR 0069
         # D5) — the heading carries it for humans, but recall/audit key on the
-        # row's source column.
+        # row's source column. source_type="harvest" ranks the rows in the
+        # agent-derived trust tier (ADR 0069 D8).
         chunk_ids = await asyncio.to_thread(
             add_document,
             knowledge_store,
@@ -132,6 +133,7 @@ async def harvest_thread(
             domain="conversation",
             heading=f"Conversation summary ({thread_id})",
             source=thread_id,
+            source_type="harvest",
             namespace=namespace,
         )
         chunk_id = chunk_ids[0] if chunk_ids else None

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -79,10 +79,19 @@ class KnowledgeMiddleware(AgentMiddleware):
         skills_index: "SkillsIndex | None" = None,
         skills_top_k: int = 5,
         inject_namespaces: list[str] | None = None,
+        inject_min_trust: int = 1,
     ):
         super().__init__()
         self._store = knowledge_store
         self._top_k = top_k
+        # Trust floor for the auto-inject RAG hits (ADR 0069 D8,
+        # `knowledge.inject_min_trust`). 1 (the default) excludes nothing —
+        # low-trust hits are only DOWN-WEIGHTED (ranked below higher tiers);
+        # 2 drops ingested/web/external content from auto-injection entirely;
+        # 3 auto-injects operator-authored rows only. Tool-driven recall
+        # (memory_recall) is never gated — excluded content stays reachable
+        # on demand, with the tier visible in the tool output.
+        self._inject_min_trust = max(1, int(inject_min_trust))
         self._skills_index = skills_index
         # Max skills listed in the always-on <available_skills> index (the rest
         # are reachable via list_skills). The model loads any one's full body on
@@ -246,17 +255,22 @@ class KnowledgeMiddleware(AgentMiddleware):
                     break
 
             if last_human and self._store is not None:
-                results = self._search_scoped(last_human)
+                results = self._rank_by_trust(self._search_scoped(last_human))
                 if results:
                     # Each hit carries its stored date (ADR 0069 D9) — a
                     # deterministic recency signal in-context, so the model can
-                    # weigh freshness itself instead of any LLM freshness judge.
+                    # weigh freshness itself instead of any LLM freshness judge —
+                    # and its trust tier (ADR 0069 D8): operator-authored vs
+                    # agent-derived vs external/ingested content.
+                    from knowledge.trust import trust_label
+
                     context_parts = ["[Relevant knowledge from previous sessions:]"]
                     for r in results:
                         line = f"- [{r['table']}] {r['preview']}"
                         stored = str(r.get("created_at") or "")[:10]
-                        if stored:
-                            line += f" (stored {stored})"
+                        meta = [f"stored {stored}"] if stored else []
+                        meta.append(f"trust: {trust_label(r.get('source_type'))}")
+                        line += f" ({'; '.join(meta)})"
                         context_parts.append(line)
                         if r.get("id") is not None:
                             rag_ids.append(r["id"])
@@ -278,15 +292,37 @@ class KnowledgeMiddleware(AgentMiddleware):
         """The auto-inject RAG search, namespace-scoped when configured (ADR
         0069 D3a). A backend whose ``search`` predates the ``namespace`` kwarg
         gets the unfiltered call and a post-filter on each hit's ``namespace``
-        field, so the configured scope holds either way."""
+        field, so the configured scope holds either way.
+
+        When a trust floor is active (``inject_min_trust`` > 1, ADR 0069 D8)
+        the candidate pool is over-fetched (3×) so hits the floor will drop
+        don't leave the injection thin when trusted matches ranked just below
+        them — ``_rank_by_trust`` filters then trims back to ``top_k``."""
+        k = self._top_k if self._inject_min_trust <= 1 else self._top_k * 3
         if not self._inject_namespaces:
-            return self._store.search(query, k=self._top_k)
+            return self._store.search(query, k=k)
         try:
-            return self._store.search(query, k=self._top_k, namespace=self._inject_namespaces)
+            return self._store.search(query, k=k, namespace=self._inject_namespaces)
         except TypeError:
             allowed = set(self._inject_namespaces)
-            results = self._store.search(query, k=self._top_k)
+            results = self._store.search(query, k=k)
             return [r for r in results if (r.get("namespace") or "") in allowed]
+
+    def _rank_by_trust(self, results: list[dict]) -> list[dict]:
+        """Apply the trust policy to the RAG candidates (ADR 0069 D8).
+
+        Deterministic, post-score: hits below ``inject_min_trust`` are dropped
+        (default floor 1 = nothing dropped), then the survivors are STABLE-sorted
+        by tier descending — a low-trust hit never outranks a higher-trust one,
+        while relevance order is preserved within a tier. Runs after retrieval
+        (never re-scores it), so it behaves identically across the plain FTS5,
+        hybrid-RRF, and layered backends. Trimmed to ``top_k`` (the pool is
+        over-fetched when a floor is active — see ``_search_scoped``)."""
+        from knowledge.trust import trust_tier
+
+        kept = [r for r in results if trust_tier(r.get("source_type")) >= self._inject_min_trust]
+        kept.sort(key=lambda r: -trust_tier(r.get("source_type")))  # stable — keeps in-tier relevance order
+        return kept[: self._top_k]
 
     def _record_injection(
         self,

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -253,6 +253,33 @@ FIELDS: list[Field] = [
         "per line; an empty line matches un-namespaced chunks. Empty = no filter (everything "
         "is eligible, today's behavior). Tool-driven recall (memory_recall) is not affected.",
     ),
+    # Trust floor for the auto-inject RAG hits (ADR 0069 D8).
+    Field(
+        "knowledge.inject_min_trust",
+        "knowledge_inject_min_trust",
+        "Auto-inject trust floor",
+        "number",
+        "Knowledge",
+        "Minimum trust tier a knowledge chunk needs to be auto-injected into the prompt. "
+        "1 = everything (low-trust hits are only ranked below higher tiers); 2 = exclude "
+        "ingested/external content (web, YouTube, PDFs, media); 3 = operator-authored rows "
+        "only. Tool-driven recall (memory_recall) is never gated — excluded content stays "
+        "reachable on demand, tier visible.",
+        minimum=1,
+        maximum=3,
+    ),
+    # Hot-memory write confirm gate (ADR 0069 D8).
+    Field(
+        "knowledge.hot_write_confirm",
+        "knowledge_hot_write_confirm",
+        "Confirm agent hot-memory writes",
+        "bool",
+        "Knowledge",
+        "When on, the agent's memory_ingest tool refuses to write always-on hot memory "
+        "(domain \"hot\") and instructs the model to ask you instead — only operator "
+        "surfaces (the knowledge browser / memory inspector) can put facts in front of the "
+        "model every turn. Every hot write emits a memory.hot_written event either way.",
+    ),
     # Tier (ADR 0041 / bd-2wu) — mirrors `skills.scope`; the commons lives at `commons.path`.
     Field(
         "knowledge.scope",
@@ -717,6 +744,8 @@ _KNOWLEDGE_SUBSECTION = {
     # Recall — what the agent retrieves into context, and how.
     "knowledge.top_k": "Recall",
     "knowledge.inject_namespaces": "Recall",
+    "knowledge.inject_min_trust": "Recall",
+    "knowledge.hot_write_confirm": "Recall",
     "knowledge.scope": "Recall",
     "knowledge.embeddings": "Recall",
     "knowledge.embed_model": "Recall",

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -140,6 +140,39 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+# Preview length in the hot-write event payload — enough for a console toast /
+# Activity line to be meaningful, small enough to never bloat the bus.
+_HOT_EVENT_PREVIEW_CHARS = 160
+
+
+def _publish_hot_write(chunk_id: int, source: str | None, source_type: str | None, content: str) -> None:
+    """Emit ``memory.hot_written`` on the plugin event bus (ADR 0069 D8).
+
+    ``domain="hot"`` chunks are injected in front of the model EVERY turn, so a
+    write to that domain must be visible, not silent — this is how the console
+    notification path (and any ADR 0039 subscriber) learns one landed, whoever
+    wrote it (agent tool, operator route, plugin SDK). Best-effort via the
+    late-bound ``HOST.publish`` seam (same pattern as ``tasks/store.py``): a
+    missing bus (unit tests, standalone use) or a bus hiccup must never break
+    a store write. The lazy import keeps ``knowledge`` free of a hard ``graph``
+    dependency."""
+    try:
+        from graph.plugins.host import HOST
+
+        if HOST.publish:
+            HOST.publish(
+                "memory.hot_written",
+                {
+                    "chunk_id": chunk_id,
+                    "source": source or "",
+                    "source_type": source_type or "",
+                    "preview": (content or "")[:_HOT_EVENT_PREVIEW_CHARS],
+                },
+            )
+    except Exception:  # noqa: BLE001 — visibility must never break a write
+        log.debug("[knowledge] hot-write event publish failed", exc_info=True)
+
+
 # LIKE escaping — sqlite treats ``%`` and ``_`` as wildcards in LIKE
 # patterns. Without escaping, a search for ``"100%"`` matches every row
 # starting with ``"100"`` instead of literal "100%". We escape them
@@ -430,7 +463,13 @@ class KnowledgeStore:
                 (content, domain, heading, source, source_type, finding_type, namespace, now, now),
             )
             db.commit()
-            return int(cur.lastrowid)
+            chunk_id = int(cur.lastrowid)
+            # Hot-memory write visibility (ADR 0069 D8): every write funnels
+            # through here, so this one hook covers every writer of the
+            # always-on domain — agent tool, operator routes, plugin SDK.
+            if domain == "hot":
+                _publish_hot_write(chunk_id, source, source_type, content)
+            return chunk_id
         except sqlite3.DatabaseError:
             log.exception("[knowledge] add_chunk failed")
             return None

--- a/knowledge/trust.py
+++ b/knowledge/trust.py
@@ -1,0 +1,87 @@
+"""Trust tiers for knowledge-store rows (ADR 0069 D8).
+
+Every chunk carries a ``source_type`` naming the write path that created it.
+This module ranks those write paths into three deterministic trust tiers, so
+the delivery layer can down-weight (or, via ``knowledge.inject_min_trust``,
+exclude) low-trust content from the per-turn auto-injection while keeping it
+reachable on demand through ``memory_recall`` — with the tier visible either
+way.
+
+The tiers (higher = more trusted):
+
+- **3 — operator.** The operator wrote it deliberately through a console
+  surface (knowledge browser add/edit, memory-inspector hot edit). These rows
+  are direct operator intent.
+- **2 — agent.** The agent derived it from conversation with the operator:
+  extracted facts, harvest summaries, compaction archives, ``memory_ingest``
+  notes. Trustworthy in the main, but a model can be induced to write them —
+  the MINJA-style poisoning surface.
+- **1 — external.** Ingested third-party content: web pages, YouTube
+  transcripts, PDFs, transcribed media, pasted documents. The OWASP ASI06
+  memory-poisoning surface — nothing here was authored by the operator or
+  the agent.
+
+An **unknown or missing** ``source_type`` maps to tier 1: a write path that
+doesn't identify itself gets the least trust, not the benefit of the doubt
+(this also covers rows written before source stamping existed, and plugin
+SDK writes that don't stamp one).
+
+The map is deliberately a code-level constant, not config: the tier of a
+write path is a property of the architecture (who can reach that path), not
+an operator preference. What IS config is the delivery policy built on it
+(``knowledge.inject_min_trust``).
+"""
+
+from __future__ import annotations
+
+# Lowest tier — unknown/unstamped source types land here (least trust by default).
+DEFAULT_TRUST_TIER = 1
+
+# source_type → tier. Keys are every value the in-tree writers stamp (audited
+# 2026-07 across graph/, tools/, knowledge/, ingestion/, operator_api/) plus
+# the generic aliases the ADR names (manual/harvest/web/ingest/external) so
+# forks using those spellings rank sensibly too.
+TRUST_TIERS: dict[str, int] = {
+    # Tier 3 — operator-authored (console routes stamp "operator").
+    "operator": 3,
+    "manual": 3,
+    # Tier 2 — agent-derived from conversation.
+    "extracted": 2,  # graph/memory_facts.py — session-end fact extraction
+    "harvest": 2,  # graph/conversation_harvest.py — retired-thread summaries
+    "conversation": 2,  # memory_ingest tool + compaction archives
+    "chat": 2,  # knowledge/store.add_finding default
+    # Tier 1 — ingested / third-party content (ingestion/engine.py source types).
+    "text": 1,
+    "markdown": 1,
+    "pdf": 1,
+    "html": 1,
+    "audio": 1,
+    "video": 1,
+    "image": 1,
+    "youtube": 1,
+    "web": 1,
+    "ingest": 1,
+    "external": 1,
+}
+
+# Tier → the short label shown in recall/injection lines. Kept to one word so
+# the in-context cost is negligible.
+TIER_LABELS: dict[int, str] = {3: "operator", 2: "agent", 1: "external"}
+
+
+def trust_tier(source_type: str | None) -> int:
+    """The trust tier for a row's ``source_type`` (deterministic — a plain
+    dict lookup, case-insensitive, unknown/empty → ``DEFAULT_TRUST_TIER``)."""
+    if not source_type:
+        return DEFAULT_TRUST_TIER
+    return TRUST_TIERS.get(str(source_type).strip().lower(), DEFAULT_TRUST_TIER)
+
+
+def tier_label(tier: int) -> str:
+    """Human label for a tier (unknown tiers clamp to the external label)."""
+    return TIER_LABELS.get(int(tier), TIER_LABELS[DEFAULT_TRUST_TIER])
+
+
+def trust_label(source_type: str | None) -> str:
+    """Shorthand: the label for a ``source_type``'s tier."""
+    return tier_label(trust_tier(source_type))

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -117,6 +117,8 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "knowledge_embeddings": True,
     "knowledge_facts": True,
     "knowledge_inject_namespaces": [],
+    "knowledge_inject_min_trust": 1,
+    "knowledge_hot_write_confirm": False,
     "knowledge_middleware": True,
     "knowledge_top_k": 5,
     "knowledge_vector_k": 20,

--- a/tests/test_conversation_harvest.py
+++ b/tests/test_conversation_harvest.py
@@ -28,9 +28,16 @@ class _FakeKnowledge:
     def __init__(self):
         self.chunks = []
 
-    def add_chunk(self, content, domain=None, heading=None, *, source=None, namespace=None, **kw):
+    def add_chunk(self, content, domain=None, heading=None, *, source=None, source_type=None, namespace=None, **kw):
         self.chunks.append(
-            {"content": content, "domain": domain, "heading": heading, "source": source, "namespace": namespace}
+            {
+                "content": content,
+                "domain": domain,
+                "heading": heading,
+                "source": source,
+                "source_type": source_type,
+                "namespace": namespace,
+            }
         )
         return f"chunk-{len(self.chunks)}"
 
@@ -74,6 +81,8 @@ def test_harvest_thread_summarizes_into_knowledge(tmp_path):
     assert "teal" in kb.chunks[0]["content"]
     # Provenance (ADR 0069 D5): the row links back to the retired thread.
     assert kb.chunks[0]["source"] == "a2a:chat-1"
+    # Trust tier (ADR 0069 D8): harvest rows rank agent-derived.
+    assert kb.chunks[0]["source_type"] == "harvest"
 
 
 def test_harvest_extracts_facts_when_enabled(tmp_path):

--- a/tests/test_knowledge_trust.py
+++ b/tests/test_knowledge_trust.py
@@ -1,0 +1,332 @@
+"""ADR 0069 D8 — trust-tiered injection + hot-memory write visibility.
+
+Covers the four pieces this round adds:
+
+  1. The deterministic tier map (``knowledge/trust.py``): every source_type
+     the in-tree writers stamp ranks into the right tier; unknown/unstamped
+     values land in the lowest tier (least trust by default, not benefit of
+     the doubt).
+  2. Auto-inject delivery policy (``KnowledgeMiddleware``): low tiers are
+     DOWN-WEIGHTED (stable-sorted below higher tiers, in-tier relevance
+     preserved), ``knowledge.inject_min_trust`` EXCLUDES tiers below the
+     floor (default 1 = nothing excluded), the candidate pool over-fetches
+     only when a floor is active, and every injected line carries its tier
+     label. ``memory_recall`` / ``memory_list`` cite the tier too.
+  3. Hot-memory write visibility: any write that creates a ``domain="hot"``
+     chunk emits ``memory.hot_written`` on the plugin event bus (ADR 0039
+     HOST seam) — whoever wrote it.
+  4. The optional confirm gate (``knowledge.hot_write_confirm``): when on,
+     the agent's ``memory_ingest`` refuses hot writes with a clear error;
+     off (default) keeps today's behavior; non-hot domains are never gated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from langchain_core.messages import HumanMessage
+
+from graph.middleware.knowledge import KnowledgeMiddleware
+from knowledge.store import KnowledgeStore
+from knowledge.trust import DEFAULT_TRUST_TIER, tier_label, trust_label, trust_tier
+from tools.lg_tools import _build_memory_tools
+
+
+def _by_name(tools):
+    return {t.name: t for t in tools}
+
+
+def _mw(store, **kw):
+    mw = KnowledgeMiddleware(knowledge_store=store, **kw)
+    mw._prior_sessions_cache = ""  # pin fresh so before_model never reads real disk
+    import time
+
+    mw._prior_sessions_loaded_at = time.monotonic()
+    return mw
+
+
+# ---------------------------------------------------------------------------
+# 1) The tier map — every discovered writer source_type ranks deterministically
+# ---------------------------------------------------------------------------
+
+
+def test_trust_tier_map_covers_every_writer_source_type():
+    # Tier 3 — operator surfaces (operator_api knowledge/memory routes).
+    assert trust_tier("operator") == 3
+    assert trust_tier("manual") == 3
+    # Tier 2 — agent-derived writers: graph/memory_facts.py ("extracted"),
+    # graph/conversation_harvest.py ("harvest"), memory_ingest + compaction
+    # archives ("conversation"), knowledge/store.add_finding default ("chat").
+    for st in ("extracted", "harvest", "conversation", "chat"):
+        assert trust_tier(st) == 2, st
+    # Tier 1 — every ingestion/engine.py extraction type + the generic aliases.
+    for st in ("text", "markdown", "pdf", "html", "audio", "video", "image", "youtube", "web", "ingest", "external"):
+        assert trust_tier(st) == 1, st
+
+
+def test_unknown_or_missing_source_type_gets_least_trust():
+    assert DEFAULT_TRUST_TIER == 1
+    assert trust_tier(None) == 1
+    assert trust_tier("") == 1
+    assert trust_tier("some-fork-invented-this") == 1
+
+
+def test_tier_lookup_is_case_and_whitespace_insensitive():
+    assert trust_tier("Operator") == 3
+    assert trust_tier("  EXTRACTED ") == 2
+
+
+def test_tier_labels():
+    assert trust_label("operator") == "operator"
+    assert trust_label("extracted") == "agent"
+    assert trust_label("youtube") == "external"
+    assert trust_label(None) == "external"
+    assert tier_label(99) == "external"  # unknown tier clamps to the low label
+
+
+# ---------------------------------------------------------------------------
+# 2) Auto-inject policy — down-weighting, the min-trust floor, visible tiers
+# ---------------------------------------------------------------------------
+
+
+def _seed_three_tiers(store: KnowledgeStore) -> None:
+    # Insertion order is LOW trust first, so a pass-through order would put
+    # external content on top — the down-weighting must flip it.
+    store.add_chunk("gravity fact from a youtube transcript", source_type="youtube")
+    store.add_chunk("gravity fact the agent extracted", source_type="extracted")
+    store.add_chunk("gravity fact the operator wrote", source_type="operator")
+
+
+def _context(mw, query="gravity fact"):
+    result = mw.before_model({"messages": [HumanMessage(content=query)]}, runtime=None)
+    return (result or {}).get("context", "")
+
+
+def test_injection_down_weights_low_tiers(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    _seed_three_tiers(store)
+    ctx = _context(_mw(store))
+    op = ctx.index("operator wrote")
+    ag = ctx.index("agent extracted")
+    ext = ctx.index("youtube transcript")
+    assert op < ag < ext  # higher trust always ranks above lower
+
+
+def test_down_weighting_is_stable_within_a_tier(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    # Two same-tier hits: retrieval order between them must be preserved.
+    store.add_chunk("gravity fact alpha from the operator", source_type="operator")
+    store.add_chunk("gravity fact beta from the operator", source_type="operator")
+    raw = store.search("gravity fact")
+    ctx = _context(_mw(store))
+    first, second = raw[0]["content"], raw[1]["content"]
+    assert ctx.index(first[:30]) < ctx.index(second[:30])
+
+
+def test_inject_min_trust_default_excludes_nothing(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    _seed_three_tiers(store)
+    ctx = _context(_mw(store))  # default floor = 1
+    assert "youtube transcript" in ctx and "agent extracted" in ctx and "operator wrote" in ctx
+
+
+def test_inject_min_trust_2_excludes_ingested_content(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    _seed_three_tiers(store)
+    store.add_chunk("gravity fact with no source stamp")  # unknown → tier 1
+    ctx = _context(_mw(store, inject_min_trust=2))
+    assert "operator wrote" in ctx and "agent extracted" in ctx
+    assert "youtube transcript" not in ctx
+    assert "no source stamp" not in ctx  # unknown is excluded like external
+
+
+def test_inject_min_trust_3_keeps_operator_rows_only(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    _seed_three_tiers(store)
+    ctx = _context(_mw(store, inject_min_trust=3))
+    assert "operator wrote" in ctx
+    assert "agent extracted" not in ctx and "youtube transcript" not in ctx
+
+
+def test_min_trust_never_gates_memory_recall(tmp_path):
+    """Excluded-from-injection content stays reachable on demand via the tool."""
+    store = KnowledgeStore(tmp_path / "kb.db")
+    _seed_three_tiers(store)
+    recall = _by_name(_build_memory_tools(store))["memory_recall"]
+    out = asyncio.run(recall.ainvoke({"query": "gravity fact"}))
+    assert "youtube transcript" in out  # tier 1 still recallable
+
+
+class _CapturingStore:
+    def __init__(self, results=None):
+        self.calls: list[dict] = []
+        self._results = results or []
+
+    def search(self, query, k=5, **kwargs):
+        self.calls.append({"query": query, "k": k, **kwargs})
+        return self._results
+
+
+def test_pool_over_fetches_only_when_a_floor_is_active():
+    store = _CapturingStore()
+    _context(_mw(store, top_k=4))  # floor 1 → plain top_k (today's behavior)
+    assert store.calls[0]["k"] == 4
+    store2 = _CapturingStore()
+    _context(_mw(store2, top_k=4, inject_min_trust=2))  # floor → 3× pool
+    assert store2.calls[0]["k"] == 12
+
+
+def test_filtered_pool_still_trims_to_top_k():
+    hits = [
+        {"table": "chunks", "preview": f"hit {i}", "id": i, "source_type": "operator"} for i in range(6)
+    ]
+    store = _CapturingStore(results=hits)
+    ctx = _context(_mw(store, top_k=2, inject_min_trust=2))
+    assert "hit 0" in ctx and "hit 1" in ctx and "hit 2" not in ctx
+
+
+# ---------------------------------------------------------------------------
+# 2b) The tier is visible — injected lines + memory_recall / memory_list
+# ---------------------------------------------------------------------------
+
+
+def test_injected_lines_carry_trust_label(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    _seed_three_tiers(store)
+    ctx = _context(_mw(store))
+    assert "trust: operator" in ctx
+    assert "trust: agent" in ctx
+    assert "trust: external" in ctx
+
+
+def test_memory_recall_and_list_cite_trust_label(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("the deploy day is Friday", domain="fact", source_type="extracted")
+    tools = _by_name(_build_memory_tools(store))
+    out = asyncio.run(tools["memory_recall"].ainvoke({"query": "deploy day"}))
+    assert "trust: agent" in out
+    listed = asyncio.run(tools["memory_list"].ainvoke({}))
+    assert "trust: agent" in listed
+
+
+def test_memory_ingest_stamps_conversation_source_type(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    ingest = _by_name(_build_memory_tools(store))["memory_ingest"]
+    out = asyncio.run(ingest.ainvoke({"content": "operator takes coffee black"}))
+    assert out.startswith("Stored chunk")
+    row = store.list_chunks(limit=1)[0]
+    assert row.source_type == "conversation"  # agent-derived tier, not unknown
+    assert trust_tier(row.source_type) == 2
+
+
+# ---------------------------------------------------------------------------
+# 3) Hot-memory write visibility — memory.hot_written on the bus
+# ---------------------------------------------------------------------------
+
+
+def _capture_bus(monkeypatch):
+    from graph.plugins.host import HOST
+
+    events: list[tuple[str, dict]] = []
+    monkeypatch.setattr(HOST, "publish", lambda topic, data: events.append((topic, data)))
+    return events
+
+
+def test_hot_write_emits_bus_event(tmp_path, monkeypatch):
+    events = _capture_bus(monkeypatch)
+    store = KnowledgeStore(tmp_path / "kb.db")
+    cid = store.add_chunk("always-on fact", "hot", heading="pin", source="console", source_type="operator")
+    assert cid is not None
+    assert len(events) == 1
+    topic, data = events[0]
+    assert topic == "memory.hot_written"
+    assert data["chunk_id"] == cid
+    assert data["source"] == "console"
+    assert data["source_type"] == "operator"
+    assert data["preview"].startswith("always-on fact")
+
+
+def test_non_hot_write_emits_nothing(tmp_path, monkeypatch):
+    events = _capture_bus(monkeypatch)
+    store = KnowledgeStore(tmp_path / "kb.db")
+    assert store.add_chunk("a normal fact", "general") is not None
+    assert events == []
+
+
+def test_hot_write_survives_missing_bus(tmp_path, monkeypatch):
+    """No wired publisher (unit tests / standalone use) must never break a write."""
+    from graph.plugins.host import HOST
+
+    monkeypatch.setattr(HOST, "publish", None)
+    store = KnowledgeStore(tmp_path / "kb.db")
+    assert store.add_chunk("always-on fact", "hot") is not None
+
+
+def test_hot_write_survives_raising_bus(tmp_path, monkeypatch):
+    from graph.plugins.host import HOST
+
+    def _boom(topic, data):
+        raise RuntimeError("bus down")
+
+    monkeypatch.setattr(HOST, "publish", _boom)
+    store = KnowledgeStore(tmp_path / "kb.db")
+    assert store.add_chunk("always-on fact", "hot") is not None  # write still lands
+
+
+def test_agent_tool_hot_write_emits_event(tmp_path, monkeypatch):
+    """The choke point is store-level, so the agent's tool path emits too."""
+    events = _capture_bus(monkeypatch)
+    store = KnowledgeStore(tmp_path / "kb.db")
+    ingest = _by_name(_build_memory_tools(store))["memory_ingest"]
+    out = asyncio.run(ingest.ainvoke({"content": "pin this", "domain": "hot"}))
+    assert out.startswith("Stored chunk")
+    assert [t for t, _ in events] == ["memory.hot_written"]
+    assert events[0][1]["source_type"] == "conversation"
+
+
+# ---------------------------------------------------------------------------
+# 4) The confirm gate — knowledge.hot_write_confirm
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_gate_off_by_default_agent_hot_write_lands(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    ingest = _by_name(_build_memory_tools(store, graph_config=SimpleNamespace(knowledge_hot_write_confirm=False)))[
+        "memory_ingest"
+    ]
+    out = asyncio.run(ingest.ainvoke({"content": "pin this", "domain": "hot"}))
+    assert out.startswith("Stored chunk")
+    assert store.list_chunks(domain="hot", limit=5)
+
+
+def test_confirm_gate_on_refuses_agent_hot_write_with_clear_error(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    ingest = _by_name(_build_memory_tools(store, graph_config=SimpleNamespace(knowledge_hot_write_confirm=True)))[
+        "memory_ingest"
+    ]
+    out = asyncio.run(ingest.ainvoke({"content": "pin this", "domain": "hot"}))
+    assert out.startswith("Error:")
+    assert "operator" in out  # tells the model to ask, not to retry
+    assert store.list_chunks(domain="hot", limit=5) == []  # nothing parked/stored
+
+
+def test_confirm_gate_on_leaves_other_domains_alone(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    ingest = _by_name(_build_memory_tools(store, graph_config=SimpleNamespace(knowledge_hot_write_confirm=True)))[
+        "memory_ingest"
+    ]
+    out = asyncio.run(ingest.ainvoke({"content": "a general note", "domain": "general"}))
+    assert out.startswith("Stored chunk")
+
+
+def test_confirm_gate_on_operator_route_still_writes(tmp_path, monkeypatch):
+    """The gate binds the AGENT's write path only — the operator's console
+    routes call the store directly (stamping source_type="operator") and must
+    keep working, event still emitted."""
+    events = _capture_bus(monkeypatch)
+    store = KnowledgeStore(tmp_path / "kb.db")
+    # What operator_api/memory_routes.py's hot edit does, minus the HTTP shell.
+    cid = store.add_chunk("operator pin", "hot", source="console", source_type="operator")
+    assert cid is not None
+    assert [t for t, _ in events] == ["memory.hot_written"]

--- a/tests/test_memory_staleness.py
+++ b/tests/test_memory_staleness.py
@@ -241,7 +241,9 @@ def test_injected_rag_lines_carry_stored_date(tmp_path):
     km._prior_sessions_cache = ""  # skip session loading
     result = km.before_model({"messages": [HumanMessage(content="what is the gateway alias?")]}, runtime=None)
     assert result is not None
-    assert f"(stored {stored_date})" in result["context"]
+    # The stored date leads the hit's metadata suffix; the trust tier label
+    # rides the same parens (ADR 0069 D8).
+    assert f"(stored {stored_date};" in result["context"]
 
 
 def test_injection_skips_invalidated_chunks(tmp_path):

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -544,10 +544,17 @@ def _memory_citation(
     source: str | None = None,
     created_at: str | None = None,
     namespace: str | None = None,
+    source_type: str | None = ...,
 ) -> str:
     """Compact provenance suffix for a memory row (ADR 0069 D5), e.g.
-    ``" (src: a2a:chat-42, 2026-07-01, ns: proj-x)"``. Empty when there's
-    nothing to cite; ``created_at`` is trimmed to date precision."""
+    ``" (src: a2a:chat-42, 2026-07-01, ns: proj-x, trust: agent)"``. Empty when
+    there's nothing to cite; ``created_at`` is trimmed to date precision.
+
+    ``source_type`` (ADR 0069 D8) appends the row's trust-tier label —
+    operator / agent / external — so recall output always shows how much the
+    content should be trusted. Pass the row's value (``None`` included: an
+    unstamped row is labeled ``external`` by design); omit the kwarg entirely
+    (the ``...`` sentinel) to skip the trust part."""
     parts: list[str] = []
     if source:
         parts.append(f"src: {source}")
@@ -555,6 +562,10 @@ def _memory_citation(
         parts.append(str(created_at)[:10])
     if namespace:
         parts.append(f"ns: {namespace}")
+    if source_type is not ...:
+        from knowledge.trust import trust_label
+
+        parts.append(f"trust: {trust_label(source_type)}")
     return f" ({', '.join(parts)})" if parts else ""
 
 
@@ -593,10 +604,30 @@ def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None)
 
         Returns ``"Stored chunk N in 'domain'."`` on success.
         """
+        # Hot-memory confirm gate (ADR 0069 D8): domain="hot" chunks are
+        # injected in front of the model EVERY turn, so when the operator has
+        # turned the gate on, this (the agent's own write path) refuses hot
+        # writes with instructions to ask — only operator surfaces (console
+        # knowledge/memory routes) may promote content to always-on.
+        if (domain or "").strip().lower() == "hot" and getattr(graph_config, "knowledge_hot_write_confirm", False):
+            return (
+                "Error: hot-memory writes need operator confirmation on this instance "
+                "(knowledge.hot_write_confirm is on). Ask the operator to add it via the "
+                "console (Knowledge → Store or the Memory inspector), or store it in a "
+                "regular domain instead."
+            )
         # add_chunk embeds over HTTP on hybrid stores — keep it off the loop.
+        # source_type="conversation" ranks the row in the agent-derived trust
+        # tier (ADR 0069 D8) — this write path is model-driven, not operator-.
         import asyncio
 
-        chunk_id = await asyncio.to_thread(knowledge_store.add_chunk, content, domain=domain, heading=heading)
+        def _write():
+            try:
+                return knowledge_store.add_chunk(content, domain=domain, heading=heading, source_type="conversation")
+            except TypeError:  # plugin backend predating the source_type kwarg
+                return knowledge_store.add_chunk(content, domain=domain, heading=heading)
+
+        chunk_id = await asyncio.to_thread(_write)
         if chunk_id is None:
             return "Error: failed to store chunk (knowledge store unavailable)."
         return f"Stored chunk {chunk_id} in {domain!r}."
@@ -758,7 +789,12 @@ def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None)
             return "No matches."
         lines = [
             f"[{r.get('domain', '?')}] {r['preview']}"
-            + _memory_citation(source=r.get("source"), created_at=r.get("created_at"), namespace=r.get("namespace"))
+            + _memory_citation(
+                source=r.get("source"),
+                created_at=r.get("created_at"),
+                namespace=r.get("namespace"),
+                source_type=r.get("source_type"),
+            )
             for r in results
         ]
         return "\n".join(lines)
@@ -817,8 +853,9 @@ def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None)
             preview = (c.content or "")[:200]
             # Lead with the chunk id so a caller (e.g. the `dream` consolidation
             # pass) can target a stale/superseded fact with `forget_memory`.
-            # created_at already leads the line, so the citation adds src/ns only.
-            cite = _memory_citation(source=c.source, namespace=c.namespace)
+            # created_at already leads the line, so the citation adds
+            # src/ns/trust only.
+            cite = _memory_citation(source=c.source, namespace=c.namespace, source_type=c.source_type)
             lines.append(f"#{c.id} {c.created_at} {head} {preview}{cite}")
         return "\n".join(lines)
 


### PR DESCRIPTION
Final wave of the [ADR 0069](docs/adr/0069-memory-delivery-layer.md) memory delivery layer — lane **R3a (D8: trust tiers + hot-memory write visibility)**. Branches from `origin/main` after R3b (#1595, `invalidated_at`).

## Trust tiers (D8)

- **Audit → deterministic tier map** (`knowledge/trust.py`). Audited every `source_type` the in-tree writers stamp and ranked them:
  - **3 `operator`** — console routes (`operator`, plus the `manual` alias)
  - **2 `agent`** — `extracted` (memory_facts), `harvest` (conversation_harvest), `conversation` (memory_ingest + compaction archives, both now stamp themselves), `chat` (add_finding default)
  - **1 `external`** — every ingestion type (`html`/`youtube`/`pdf`/`text`/`markdown`/`audio`/`video`/`image`, plus `web`/`ingest`/`external` aliases) **and unknown/unstamped** — a write path that doesn't identify itself gets the least trust, not the benefit of the doubt.
  - Code-level map, not config — the tier of a write path is an architectural property; the *policy* on top of it is the config.
- **Auto-inject down-weighting, always on.** `KnowledgeMiddleware` stable-sorts the RAG candidates by tier after retrieval (post-score, so it behaves identically across plain/hybrid/layered backends — same threading as the #1592 namespace filter): an external hit never outranks an operator/agent one; in-tier relevance order is preserved.
- **`knowledge.inject_min_trust`** (int, default `1` = current behavior, nothing excluded): `2` excludes ingested/web content from auto-injection entirely, `3` = operator rows only. The candidate pool over-fetches 3× only when a floor is active, so exclusions don't leave the injection thin. `memory_recall` is deliberately never gated — excluded content stays reachable on demand, intent visible as a tool call.
- **Tier visible everywhere:** injected lines end `(stored 2026-07-01; trust: external)`; `memory_recall`/`memory_list` citations append `trust: operator|agent|external`.

## Hot-memory write visibility (D8)

- **`memory.hot_written` bus event** (ADR 0039 conventions, best-effort via the late-bound `HOST.publish` seam — same pattern as `tasks/store.py`) on every write that creates a `domain="hot"` chunk. Emitted at the `KnowledgeStore.add_chunk` choke point, so agent tool, operator route, and plugin-SDK writers are all covered. Payload: `{chunk_id, source, source_type, preview}`.
- **Optional confirm gate `knowledge.hot_write_confirm`** (bool, default `false`): when on, the agent's own write path (`memory_ingest`) **refuses** `domain="hot"` writes with a clear error instructing it to ask the operator (the simpler mechanism — nothing parked or half-stored, documented in the guide); operator console surfaces stamp `source_type="operator"` and are unaffected. Every hot write emits the event either way.

## Config / docs / tests

- Two new config keys ride the #1538 golden flow (`FROM_YAML_EXAMPLE_FIELDS` updated, `settings_schema` fields under Knowledge ▸ Recall, example YAML commented).
- Knowledge guide: new **Trust tiers** + **Hot-memory write visibility** sections; CHANGELOG under [Unreleased].
- Tests (`tests/test_knowledge_trust.py`, 22 new): tier map coverage for every discovered source_type incl. unknown/case handling; down-weight ordering + in-tier stability; `inject_min_trust` exclusion at 2 and 3 + default-excludes-nothing; over-fetch only when a floor is active; recall never gated; tier labels in injected lines + tool output; `memory_ingest` stamps `conversation`; hot-write event (agent path, operator path, non-hot silence, missing/raising bus safety); confirm gate on/off/other-domain/operator-route. Harvest provenance test now asserts the `harvest` stamp.

## Gates

- `ruff check .` ✓ · `lint-imports` ✓ (3 contracts kept) · `python -m pytest tests/ -q` ✓ (2706 passed, 5 skipped) · `python scripts/live_smoke.py` ✓ · `npm run docs:build` ✓

Draft per lane rules — the review lane closes out; no automerge armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)