### PR TITLE
chore: release v0.79.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.79.0] - 2026-07-01
+
 ### Added
 - **Memory-regression evals** (`memory-regression` category,
   [ADR 0069](docs/adr/0069-memory-delivery-layer.md) D10) — three ADR 0012

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.78.0"
+version = "0.79.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,43 @@
 [
   {
+    "version": "v0.79.0",
+    "date": "2026-07-01",
+    "changes": [
+      "Memory-regression evals",
+      "Memory inspector console surface",
+      "Incognito thread toggle in the console",
+      "Trust-tiered injection",
+      "Hot-memory write visibility",
+      "Supersede-don't-delete staleness",
+      "Namespace-scoped auto-injection",
+      "Incognito threads",
+      "Per-turn memory-injection record",
+      "Memory-inspector REST surface",
+      "recall_session(session_id) starter tool",
+      "Knowledge Base view — collapsible source grouping + Shift+click quick-delete.",
+      "One-command install",
+      "Agent archetypes are a data-driven registry",
+      "CI workflows are fork-friendly",
+      "Fleet \"New agent\" now applies the archetype's persona",
+      "Cross-session memory injection is now an attributed digest inside an untrusted-reference envelope",
+      "Memory rows carry provenance.",
+      "The docs build now gates every PR.",
+      "Settings string_list fields can now carry an empty-string entry",
+      "Chat code blocks: no empty header gap, a distinct lighter well, and no panel-stretch.",
+      "Chat session-identity hygiene",
+      "Artifact plugin (0.15.0) — pointer lock now works in games/canvas/3D artifacts.",
+      "Artifact plugin (0.15.0) — SVG / Mermaid now render crisply instead of pixelating on zoom.",
+      "Artifact plugin (0.15.0) — the selected artifact + version now survive a tab switch.",
+      "A stale untracked plugin copy no longer shadows a newer bundled one.",
+      "Plugin install git clone --no-hardlinks",
+      "Console dev server no longer defaults to the prod backend.",
+      "Removed the broken built-in \"Project Manager\" archetype.",
+      "Instance collision warning no longer false-alarms on a shared box root",
+      "Setup wizard: the archetype bundle-install result is no longer swallowed.",
+      "Setup wizard: picking a persona-less archetype no longer blanks the editor."
+    ]
+  },
+  {
     "version": "v0.78.0",
     "date": "2026-07-01",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.79.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.79.0 -m 'Release v0.79.0' && git push origin v0.79.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).