### PR TITLE
fix(fleet): frozen-sidecar member spawn + surface boot failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer auto-merge and freeze the Pages deploy.
 
 ### Fixed
+- **Fleet agents now actually start in the desktop app, and a boot failure tells
+  you why.** Creating a new agent (the ADR 0042 new-agent flow) silently produced
+  a dead member in the frozen desktop build: members were spawned as
+  `<sys.executable> -m server …`, but in the PyInstaller sidecar `sys.executable`
+  *is* the server entrypoint, so every spawn died at argparse with
+  `unrecognized arguments: -m server` — visible only in the workspace's
+  `agent.log`, which nothing surfaced. The spawn (and the workspace bundle
+  installer) is now frozen-aware, and `supervisor.start()` watches the fresh
+  process: if it exits during boot, the state entry is reaped and the API returns
+  a readable 400 carrying the exit code + the fresh `agent.log` tail (the console
+  already toasts it; `fleet up` prints it per-member and keeps going).
 - **Settings `string_list` fields can now carry an empty-string entry** — a
   literal `""` (or `''`) token in the comma-separated editor parses to the empty
   string and round-trips back as `""`. Needed for

--- a/graph/fleet/cli.py
+++ b/graph/fleet/cli.py
@@ -34,10 +34,15 @@ def run_fleet_cli(argv: list[str]) -> int:
             rows = supervisor.up(args.names or None)
             if not rows:
                 print("(no workspaces — create one: python -m server workspace new <name>)")
+            failed = False
             for r in rows:
+                if r.get("error"):  # died at boot — start() surfaced the log tail
+                    failed = True
+                    print(f"  ✗ {r['name']:16} {r['error']}", file=sys.stderr)
+                    continue
                 tag = "already running" if r.get("already") else "started"
                 print(f"  ✓ {r['name']:16} {tag} (:{r.get('port')}, pid {r.get('pid')})")
-            return 0
+            return 1 if failed else 0
         if args.cmd == "down":
             rows = supervisor.down(args.names or None)
             if not rows:

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -129,9 +129,47 @@ def is_running(ident: str) -> bool:
     return bool(rec) and _alive(rec.get("pid"))
 
 
+def _port_listening(port: int | None, timeout: float = 0.25) -> bool:
+    """Is something accepting connections on localhost:``port``? The member binds its
+    HTTP port early in boot, so this is the cheap 'it came up' signal."""
+    if not port:
+        return False
+    import socket
+
+    try:
+        with socket.create_connection(("127.0.0.1", int(port)), timeout=timeout):
+            return True
+    except (OSError, OverflowError, ValueError):  # unreachable, or a nonsense port record
+        return False
+
+
+def _log_tail_since(log_path: Path, offset: int, limit: int = 500) -> str:
+    """The last ``limit`` chars the child wrote past ``offset`` (the log is opened
+    append — earlier runs' output stays; only this boot's lines are the reason)."""
+    try:
+        with open(log_path, "rb") as f:
+            f.seek(offset)
+            fresh = f.read().decode("utf-8", errors="replace").strip()
+        return fresh[-limit:]
+    except OSError:
+        return ""
+
+
+# How long start() watches a fresh spawn for insta-death before returning. It returns
+# EARLY on either signal (port bound → up, process exited → raise), so a healthy boot
+# pays only its own bind latency and only a hung-but-not-listening child waits it out.
+_BOOT_WATCH_SECONDS = 10.0
+
+
 def start(ident: str) -> dict:
     """Spawn the workspace's agent (by id or display name) as a detached background
-    process. No-op (returns the live record) if it's already running."""
+    process. No-op (returns the live record) if it's already running.
+
+    Raises ``FleetError`` (with the fresh ``agent.log`` tail) when the child exits
+    during the boot watch — a member that dies at boot (broken spawn, bad config,
+    taken port) used to report ``running: true`` and just show up dead on the next
+    poll, with the reason buried in a log nothing surfaced (#1565 fallout).
+    """
     ws = manager._find(manager._safe(ident))
     if ws is None:
         raise FleetError(f"no workspace {ident!r} — create it: workspace new {ident}")
@@ -147,6 +185,7 @@ def start(ident: str) -> dict:
         full_env = {**os.environ, **env}
         log_path = _log_path(ws)
         log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_offset = log_path.stat().st_size if log_path.exists() else 0
         logf = open(log_path, "a")  # noqa: SIM115 — handed to the child; closed on its exit
         # start_new_session detaches it from this CLI's process group so it survives exit.
         proc = subprocess.Popen(argv, env=full_env, stdout=logf, stderr=logf, start_new_session=True)
@@ -167,6 +206,28 @@ def start(ident: str) -> dict:
         }
         state[wid] = rec
         _save_state(state)
+
+    # Boot watch — OUTSIDE the lock (like stop()'s kill) so other state ops can't freeze
+    # behind it. NOTE: blocks up to _BOOT_WATCH_SECONDS; call off the event loop
+    # (``asyncio.to_thread``) — the routes do.
+    deadline = time.monotonic() + _BOOT_WATCH_SECONDS
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:  # died at boot — reap the entry + surface the reason
+            with _state_lock():
+                state = _load_state()
+                if (state.get(wid) or {}).get("pid") == proc.pid:
+                    state.pop(wid, None)
+                    _save_state(state)
+            tail = _log_tail_since(log_path, log_offset)
+            log.error("[fleet] %s exited during boot (code %s): %s", name, proc.returncode, tail)
+            raise FleetError(
+                f"{name!r} exited during boot (exit code {proc.returncode})."
+                + (f" Log tail: {tail}" if tail else "")
+                + f" Full log: {log_path}"
+            )
+        if _port_listening(rec["port"]):
+            break
+        time.sleep(0.2)
     log.info("[fleet] started %s (pid %d, :%s)", name, proc.pid, rec["port"])
     return {**rec, "name": name, "running": True, "already": False}
 
@@ -471,9 +532,16 @@ def status() -> list[dict]:
 
 
 def up(names: list[str] | None = None) -> list[dict]:
-    """Start a set of agents (named, or all workspaces)."""
-    targets = names or [w["name"] for w in manager.list_workspaces()]
-    return [start(n) for n in targets]
+    """Start a set of agents (named, or all workspaces). One member dying at boot
+    (start() now raises on that) doesn't abort the rest — it's reported as its own
+    ``{running: False, error}`` row instead."""
+    out = []
+    for n in names or [w["name"] for w in manager.list_workspaces()]:
+        try:
+            out.append(start(n))
+        except FleetError as exc:
+            out.append({"name": n, "running": False, "error": str(exc)})
+    return out
 
 
 def down(names: list[str] | None = None) -> list[dict]:

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -427,6 +427,16 @@ def _stamp_identity(cfg: Path, name: str, shared_skills: bool, *, instance_id: s
     save_yaml_doc(doc, cfg)
 
 
+def _server_argv() -> list[str]:
+    """Argv prefix that re-invokes THIS server binary. A source checkout launches
+    ``python -m server``; in the frozen desktop sidecar ``sys.executable`` *is* the
+    server entrypoint, and passing ``-m server`` to it dies at argparse with
+    "unrecognized arguments" — the fleet's created-agents never booted there."""
+    if getattr(sys, "frozen", False):  # PyInstaller sidecar — entrypoint is already `-m server`
+        return [sys.executable]
+    return [sys.executable, "-m", "server"]
+
+
 def _install_bundle_into(ws: Path, bundle: str) -> list[str]:
     """Install a bundle (or plugin) into the workspace via a scoped subprocess —
     ``PROTOAGENT_HOME=<ws>`` makes the workspace the installer's instance root, so
@@ -436,7 +446,7 @@ def _install_bundle_into(ws: Path, bundle: str) -> list[str]:
         "PROTOAGENT_HOME": str(ws),
     }
     proc = subprocess.run(
-        [sys.executable, "-m", "server", "plugin", "install", bundle],
+        [*_server_argv(), "plugin", "install", bundle],
         env=env,
         capture_output=True,
         text=True,
@@ -471,7 +481,7 @@ def run_exec(ident: str, passthrough: list[str]) -> tuple[dict, list[str]]:
         "PROTOAGENT_HOME": str(ws),
         "PROTOAGENT_INSTANCE": str(rec.get("id", ident)),
     }
-    argv = [sys.executable, "-m", "server", "--port", str(rec.get("port", PORT_BASE + 1)), *passthrough]
+    argv = [*_server_argv(), "--port", str(rec.get("port", PORT_BASE + 1)), *passthrough]
     return env, argv
 
 

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -20,12 +20,19 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr(supervisor, "_alive", lambda pid: int(pid) in alive if pid else False)
 
     class FakeProc:
+        returncode = None
+
         def __init__(self, *a, **k):
             self.pid = 4242
             alive.add(4242)
 
+        def poll(self):  # boot watch: still running
+            return None
+
     monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
     monkeypatch.setattr(supervisor, "_is_our_agent", lambda pid: True)
+    # Fake spawns never bind a port — short-circuit the boot watch to "it's up".
+    monkeypatch.setattr(supervisor, "_port_listening", lambda port, timeout=0.25: True)
     monkeypatch.setattr(supervisor.os, "kill", lambda pid, sig: alive.discard(int(pid)))
 
     app = FastAPI()

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+import os
+import signal
+import socket
+import time
+
 import pytest
 
 from graph.workspaces import manager
 from graph.fleet import supervisor
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
 
 
 @pytest.fixture
@@ -15,12 +26,19 @@ def fleet(tmp_path, monkeypatch):
     monkeypatch.setattr(supervisor, "_alive", lambda pid: int(pid) in alive if pid else False)
 
     class FakeProc:
+        returncode = None
+
         def __init__(self, *a, **k):
             self.pid = 99001
             alive.add(99001)
 
+        def poll(self):  # boot watch: still running
+            return None
+
     monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
     monkeypatch.setattr(supervisor, "_is_our_agent", lambda pid: True)
+    # Fake spawns never bind a port — short-circuit the boot watch to "it's up".
+    monkeypatch.setattr(supervisor, "_port_listening", lambda port, timeout=0.25: True)
 
     def fake_kill(pid, sig):  # SIGTERM/SIGKILL "kills" the fake process
         alive.discard(int(pid))
@@ -65,13 +83,19 @@ def test_keep_n_warm_evicts_lru(tmp_path, monkeypatch):
     monkeypatch.setattr(supervisor, "_alive", lambda pid: int(pid) in alive if pid else False)
 
     class FakeProc:
+        returncode = None
+
         def __init__(self, *a, **k):
             seq["n"] += 1
             self.pid = seq["n"]
             alive.add(self.pid)
 
+        def poll(self):  # boot watch: still running
+            return None
+
     monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
     monkeypatch.setattr(supervisor, "_is_our_agent", lambda pid: True)
+    monkeypatch.setattr(supervisor, "_port_listening", lambda port, timeout=0.25: True)
     monkeypatch.setattr(supervisor.os, "kill", lambda pid, sig: alive.discard(int(pid)))
 
     ids = {}
@@ -308,13 +332,19 @@ def _multi_fleet(tmp_path, monkeypatch):
     monkeypatch.setattr(supervisor, "_alive", lambda pid: int(pid) in alive if pid else False)
 
     class FakeProc:
+        returncode = None
+
         def __init__(self, *a, **k):
             seq["n"] += 1
             self.pid = seq["n"]
             alive.add(self.pid)
 
+        def poll(self):  # boot watch: still running
+            return None
+
     monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
     monkeypatch.setattr(supervisor, "_is_our_agent", lambda pid: True)
+    monkeypatch.setattr(supervisor, "_port_listening", lambda port, timeout=0.25: True)
 
     def fake_kill(pid, sig):
         killed.append((int(pid), int(sig)))
@@ -364,13 +394,19 @@ def test_shutdown_all_sigkills_straggler(tmp_path, monkeypatch):
     monkeypatch.setattr(supervisor, "_alive", lambda pid: int(pid) in alive if pid else False)
 
     class FakeProc:
+        returncode = None
+
         def __init__(self, *a, **k):
             seq["n"] += 1
             self.pid = seq["n"]
             alive.add(self.pid)
 
+        def poll(self):  # boot watch: still running
+            return None
+
     monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
     monkeypatch.setattr(supervisor, "_is_our_agent", lambda pid: True)
+    monkeypatch.setattr(supervisor, "_port_listening", lambda port, timeout=0.25: True)
 
     def stubborn_kill(pid, sig):  # ignores SIGTERM; dies only on SIGKILL
         sigs.append(int(sig))
@@ -445,3 +481,65 @@ def test_reconcile_on_boot_stamps_and_returns_previous(tmp_path, monkeypatch):
     monkeypatch.setattr(paths_mod, "package_version", lambda: "0.2.0")
     assert supervisor.reconcile_on_boot() == "0.1.0"  # the update is visible once…
     assert supervisor._version_stamp_path().read_text().strip() == "0.2.0"  # …then re-stamped
+
+
+# ── boot-failure feedback (#1565 fallout) ─────────────────────────────────────
+# A member that dies at boot used to report `running: true` (the pid existed for a
+# moment) and just show up dead on the next poll — the reason lived only in
+# agent.log, which nothing surfaced. start() now watches the fresh spawn and raises
+# with the log tail; these run REAL subprocesses (no FakeProc) to prove it.
+
+
+def _real_spawn_env(tmp_path, monkeypatch, argv):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    monkeypatch.setattr(manager, "run_exec", lambda ident, passthrough: ({}, argv))
+
+
+def test_start_surfaces_boot_death(tmp_path, monkeypatch):
+    import sys
+
+    _real_spawn_env(
+        tmp_path,
+        monkeypatch,
+        [sys.executable, "-c", "import sys; sys.stderr.write('kaboom: unrecognized arguments'); sys.exit(3)"],
+    )
+    ws = manager.create("dies", port=_free_port())  # free port — nothing binds it; the child exits first
+    with pytest.raises(supervisor.FleetError) as exc:
+        supervisor.start("dies")
+    msg = str(exc.value)
+    assert "exit code 3" in msg and "kaboom" in msg  # the reason, not a generic failure
+    assert not supervisor.is_running("dies")  # the dead entry was reaped, not left as a zombie
+    assert (tmp_path / "ws" / ws["id"] / "agent.log").exists()
+
+
+def test_start_returns_once_port_binds(tmp_path, monkeypatch):
+    import sys
+
+    port = _free_port()  # a genuinely free port for the fake member to bind
+    child = (
+        "import socket,time\n"
+        f"s=socket.socket(); s.bind(('127.0.0.1',{port})); s.listen(1)\n"
+        "time.sleep(30)\n"
+    )
+    _real_spawn_env(tmp_path, monkeypatch, [sys.executable, "-c", child])
+    manager.create("binds", port=port)
+    t0 = time.monotonic()
+    try:
+        rec = supervisor.start("binds")
+        assert rec["running"] and not rec["already"]
+        assert time.monotonic() - t0 < supervisor._BOOT_WATCH_SECONDS  # early exit on bind, not the full watch
+    finally:
+        try:
+            os.kill(rec["pid"], signal.SIGKILL)
+        except (OSError, UnboundLocalError):
+            pass
+
+
+def test_up_reports_boot_death_and_continues(tmp_path, monkeypatch):
+    import sys
+
+    _real_spawn_env(tmp_path, monkeypatch, [sys.executable, "-c", "raise SystemExit(2)"])
+    manager.create("brokey", port=_free_port())
+    rows = supervisor.up(["brokey"])  # must not raise — the row carries the error
+    assert rows[0]["name"] == "brokey" and rows[0]["running"] is False
+    assert "exit code 2" in rows[0]["error"]

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -238,3 +238,26 @@ def test_apply_bundle_config_defaults_noop_without_config(root):
     (ws / "plugins.lock").write_text(json.dumps({"bundles": [{"id": "stack", "plugins": ["a"]}]}))
     assert manager._apply_bundle_config_defaults(cfg, ws / "plugins.lock") == {}
     assert cfg.read_text() == before  # untouched
+
+
+def test_server_argv_frozen_vs_source(monkeypatch):
+    """The spawn prefix must adapt to the frozen desktop sidecar: there
+    ``sys.executable`` IS the server entrypoint, and a ``-m server`` prefix dies at
+    argparse with "unrecognized arguments" — created agents never booted in the
+    desktop app (#1565 fallout)."""
+    import sys
+
+    assert manager._server_argv() == [sys.executable, "-m", "server"]  # source checkout
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    assert manager._server_argv() == [sys.executable]
+
+
+def test_run_exec_frozen_argv(root, monkeypatch):
+    """In a frozen build the member launches as ``<sidecar> --port …`` directly."""
+    import sys
+
+    manager.create("gamma")
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    _, argv = manager.run_exec("gamma", ["--ui", "none"])
+    assert argv[0] == sys.executable and "-m" not in argv
+    assert argv[1] == "--port" and argv[-2:] == ["--ui", "none"]


### PR DESCRIPTION
## Why

Creating a new agent from the console (the ADR 0042 new-agent flow, #1565) **silently fails in the desktop app**: the member never comes up and the operator gets zero feedback. Live repro on a desktop box — the workspace's `agent.log` shows the child dying instantly, three times:

```
python -m server: error: unrecognized arguments: -m server
```

Two stacked defects:

1. **Frozen-sidecar spawn bug.** `manager.run_exec()` (and `_install_bundle_into()`) spawn `<sys.executable> -m server …`. In a source checkout that's `python -m server`; in the PyInstaller sidecar `sys.executable` *is* the server entrypoint (`server/__main__.py` is the freeze entry), so `-m server` lands in argparse as unrecognized arguments and the child exits immediately. Same latent break for bundle-archetype installs in the desktop app.
2. **No feedback.** `supervisor.start()` returned `running: true` as soon as the pid existed. A boot death (this bug, a bad config, a taken port) reported success to `/api/fleet` create/start/activate, then just showed a dead member on the next poll — the reason lived only in `agent.log`, which nothing surfaces.

## What

- `graph/workspaces/manager.py` — new `_server_argv()`: `[sys.executable]` when frozen (`sys.frozen`, same idiom as `infra/paths.py` / the plugin installer), `[sys.executable, "-m", "server"]` otherwise. Used by `run_exec()` and `_install_bundle_into()` (subcommand dispatch keys on `argv[1]`, so `<sidecar> plugin install <url>` works as-is).
- `graph/fleet/supervisor.py` — `start()` now watches the fresh spawn **outside the state lock** for up to 10s, returning early the moment the member's port is listening. If the process exits during the watch, the registry entry is reaped and `FleetError` carries the exit code + the log tail written **by this boot** (offset-tracked, capped at 500 chars) + the full log path. The fleet routes already catch `FleetError` → HTTP 400, and the console new-agent panel already toasts that detail — so create-from-picker now shows *why* it failed. `up()` reports a per-member `{running: false, error}` row instead of aborting the batch; the `fleet up` CLI prints ✗ rows and exits 1.
- `_port_listening()` tolerates nonsense port records (`OverflowError`/`ValueError` → not listening).

## Tests

- `test_server_argv_frozen_vs_source`, `test_run_exec_frozen_argv` — the argv contract both ways.
- `test_start_surfaces_boot_death` — a **real** child that exits 3: `FleetError` carries "exit code 3" + the stderr tail; the dead entry is reaped.
- `test_start_returns_once_port_binds` — a real child that binds the workspace port: `start()` returns well before the watch cap.
- `test_up_reports_boot_death_and_continues` — batch start doesn't raise; the row carries the error.
- Existing fake-Popen fixtures gained `poll()` + a `_port_listening` short-circuit.

Gates: `ruff check .` ✓, `lint-imports` (3 kept / 0 broken) ✓, `python -m pytest tests/ -q` → 2719 passed, 5 skipped.

## Follow-up (not this PR)

The slug-navigation `activate` path stays fire-and-forget by design; the App boot-gate's "agent down" recovery card could render the new 400 detail so a dead member explains itself on navigation too, not just at create time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)