### PR TITLE
feat(background): push-resume to origin session, KB-indexed reports, disposable workers (ADR 0070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   safe: A2A turns serialize per thread. **(D2)** a substantial completed report
   (> 800 chars) is **indexed into the knowledge store** keyed to the origin
   session (`source_type: background_report`, trust tier 2 — agent-derived;
-  chunked by `add_document`), and the drain notification shrinks (cap 6 000 →
+  chunked by `add_document`; never for incognito-spawned or chained
+  background-origin jobs — a worker identity is never memory), and the drain
+  notification shrinks (cap 6 000 →
   3 000 chars) with a pointer to `memory_recall` + the console report card.
   **(D3)** worker transcripts are **disposable**: `background:*` sessions skip
   session-summary persistence, the `<prior_sessions>` digest filters worker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Background results are pushed, indexed, and worker-disposable**
+  ([ADR 0070](docs/adr/0070-background-results-push-resume.md), backend). When a
+  background job (ADR 0050) reaches a terminal state: **(D1)** the server
+  **push-resumes the origin session** — a terse self-A2A nudge turn (the
+  spawner's self-POST mechanics, factored into a shared
+  `BackgroundManager._send_a2a_message`) whose drain attaches the pending
+  `<task-notification>`, so the agent reviews the report and briefs the operator
+  immediately instead of the report waiting for the session's next manual turn.
+  New config `background.auto_resume` (default on; Settings ▸ Background).
+  Guarded: never for canceled jobs, `background:*` origins (no resume chains),
+  or incognito-spawned jobs; never-raises — a delivery failure falls back to the
+  ADR 0050 Activity idle-wake and the report still drains exactly-once on the
+  next manual turn. When the resume fires, the Activity wake is skipped (one
+  briefing turn, in the right place — never both). A mid-turn origin session is
+  safe: A2A turns serialize per thread. **(D2)** a substantial completed report
+  (> 800 chars) is **indexed into the knowledge store** keyed to the origin
+  session (`source_type: background_report`, trust tier 2 — agent-derived;
+  chunked by `add_document`), and the drain notification shrinks (cap 6 000 →
+  3 000 chars) with a pointer to `memory_recall` + the console report card.
+  **(D3)** worker transcripts are **disposable**: `background:*` sessions skip
+  session-summary persistence, the `<prior_sessions>` digest filters worker
+  files (legacy ones included), and retirement harvest skips worker threads —
+  the jobs DB is the system of record. The `task`/`task_batch` tools propagate
+  the turn's **incognito** flag onto the job row (new `origin_incognito`
+  column, migrated in place). New `GET /api/background/{job_id}` returns one
+  job's full row (strict `bg-<12 hex>` id validation) for the console report
+  card.
+
 ## [0.79.0] - 2026-07-01
 
 ### Added

--- a/background/manager.py
+++ b/background/manager.py
@@ -96,14 +96,21 @@ class BackgroundManager:
         subagent_type: str,
         description: str,
         prompt: str,
+        origin_incognito: bool = False,
     ) -> str:
-        """Register a job and fire it detached. Returns the opaque job id immediately."""
+        """Register a job and fire it detached. Returns the opaque job id immediately.
+
+        ``origin_incognito`` records that the spawning thread was incognito (ADR 0069
+        D3b → ADR 0070): the completion then skips the push-resume nudge and the
+        knowledge-store indexing — no memory trail — while the report still lives in
+        the jobs DB and drains into the origin session normally."""
         job_id = self.store.create(
             agent_name=self.agent_name,
             origin_session=origin_session or "",
             subagent_type=subagent_type,
             description=description,
             prompt=prompt,
+            origin_incognito=origin_incognito,
         )
         fired_prompt = _build_fired_prompt(subagent_type, description, prompt)
         t = asyncio.create_task(self._fire(job_id, fired_prompt), name=f"background.fire.{job_id}")
@@ -124,6 +131,7 @@ class BackgroundManager:
         description: str,
         work,
         detail: str = "",
+        origin_incognito: bool = False,
     ) -> str:
         """Register and run a deterministic background job — a plain coroutine, NOT an
         LLM subagent turn — through the same durable store + concurrency cap + event
@@ -141,6 +149,7 @@ class BackgroundManager:
             subagent_type=kind,
             description=description,
             prompt=detail,
+            origin_incognito=origin_incognito,
         )
         t = asyncio.create_task(
             self._run_work(job_id, kind, description, origin_session or "", work),
@@ -250,11 +259,7 @@ class BackgroundManager:
 
         import httpx
 
-        headers = {"Content-Type": "application/json", "A2A-Version": "1.0"}
-        if self._bearer:
-            headers["Authorization"] = f"Bearer {self._bearer}"
-        if self._api_key:
-            headers["X-API-Key"] = self._api_key
+        headers = self._a2a_headers()
         body = {
             "jsonrpc": "2.0",
             "id": str(uuid.uuid4()),
@@ -280,23 +285,26 @@ class BackgroundManager:
         )
         return {"ok": ok, "status": "canceled", "detail": f"Canceled {job_id}."}
 
-    async def _fire(self, job_id: str, prompt: str) -> None:
-        """POST the job to our own /a2a as a turn in a dedicated background context.
+    # ── self-POST mechanics (shared by _fire and resume_origin — ADR 0050/0070) ─
 
-        On any delivery failure (non-2xx / network / timeout), mark the job failed —
-        but only if the terminal hook hasn't already settled it (mark_complete is a
-        no-op on an already-terminal row), so a slow-turn timeout can't clobber a
-        result that actually landed.
-        """
-        import httpx
-
-        # A2A 1.0 wire shape (matches scheduler/local.py:_fire): SendMessage, ROLE_USER,
-        # {text} parts, contextId + metadata on the message, A2A-Version header.
+    def _a2a_headers(self) -> dict:
         headers = {"Content-Type": "application/json", "A2A-Version": "1.0"}
         if self._bearer:
             headers["Authorization"] = f"Bearer {self._bearer}"
         if self._api_key:
             headers["X-API-Key"] = self._api_key
+        return headers
+
+    async def _send_a2a_message(self, *, context_id: str, text: str, metadata: dict) -> None:
+        """POST one ``SendMessage`` turn to our own ``/a2a`` and hold the connection
+        open until the turn finishes (the A2A handler runs it synchronously).
+
+        A2A 1.0 wire shape (matches scheduler/local.py:_fire): SendMessage, ROLE_USER,
+        ``{text}`` parts, contextId + metadata on the message, A2A-Version header.
+        Raises on a non-2xx response or any network/timeout error — callers decide
+        what a delivery failure means (a job fire marks the row failed; a push-resume
+        nudge just logs and lets the drain deliver on the next manual turn)."""
+        import httpx
 
         message_id = str(uuid.uuid4())
         body = {
@@ -306,39 +314,90 @@ class BackgroundManager:
             "params": {
                 "message": {
                     "role": "ROLE_USER",
-                    "parts": [{"text": prompt}],
+                    "parts": [{"text": text}],
                     "messageId": message_id,
-                    # Dedicated, isolated context per job — keeps the background turn's
-                    # history out of the originating chat thread; the job id rides in
-                    # the context so the terminal hook can map back without metadata.
-                    "contextId": f"background:{job_id}",
-                    "metadata": {
-                        "origin": "background",
-                        "trigger": job_id,
-                        "background_job_id": job_id,
-                    },
+                    "contextId": context_id,
+                    "metadata": metadata,
                 },
             },
         }
+        async with httpx.AsyncClient(timeout=self._fire_timeout_s) as client:
+            r = await client.post(f"{self._invoke_url}/a2a", headers=self._a2a_headers(), json=body)
+        if r.status_code >= 400:
+            raise RuntimeError(f"HTTP {r.status_code}: {r.text[:200]}")
+
+    async def _fire(self, job_id: str, prompt: str) -> None:
+        """POST the job to our own /a2a as a turn in a dedicated background context.
+
+        On any delivery failure (non-2xx / network / timeout), mark the job failed —
+        but only if the terminal hook hasn't already settled it (mark_complete is a
+        no-op on an already-terminal row), so a slow-turn timeout can't clobber a
+        result that actually landed.
+        """
         # Gate the actual self-POST on the concurrency semaphore so a fan-out can't open more
         # than ``_max_concurrency`` full turns at once. The slot is held for the WHOLE turn —
         # the A2A handler runs the turn synchronously before the POST returns — which is
         # exactly the bound we want (concurrent running turns, not just in-flight requests).
         async with self._sem:
             try:
-                async with httpx.AsyncClient(timeout=self._fire_timeout_s) as client:
-                    r = await client.post(f"{self._invoke_url}/a2a", headers=headers, json=body)
-                if r.status_code >= 400:
-                    log.error(
-                        "[background] fire failed for %s: HTTP %d %s",
-                        job_id,
-                        r.status_code,
-                        r.text[:200],
-                    )
-                    self.store.mark_complete(job_id, "failed", f"Background turn failed to start: HTTP {r.status_code}.")
+                await self._send_a2a_message(
+                    # Dedicated, isolated context per job — keeps the background turn's
+                    # history out of the originating chat thread; the job id rides in
+                    # the context so the terminal hook can map back without metadata.
+                    context_id=f"background:{job_id}",
+                    text=prompt,
+                    metadata={
+                        "origin": "background",
+                        "trigger": job_id,
+                        "background_job_id": job_id,
+                    },
+                )
             except Exception as exc:  # noqa: BLE001
-                log.exception("[background] fire exception for %s", job_id)
+                log.exception("[background] fire failed for %s", job_id)
                 self.store.mark_complete(job_id, "failed", f"Background turn delivery error: {exc}")
+
+    async def resume_origin(self, job) -> bool:
+        """Push-resume (ADR 0070 D1): submit a terse self-A2A nudge INTO the job's
+        origin session, so the origin agent runs a turn NOW — the notified-gated
+        drain (``server/chat.py``) attaches the actual ``<task-notification>`` to
+        that turn, and the agent briefs the operator against the new data.
+
+        Deliberately NOT gated on the concurrency semaphore: this is an
+        origin-session turn, not a background job — queuing the briefing behind
+        the very jobs it reports on would deadlock a full fan-out. A mid-turn
+        origin session is safe: the A2A server serializes turns per thread_id
+        (``server/chat.py:_thread_lock``), so the nudge queues and runs after the
+        in-flight turn. Never raises; returns whether the nudge was delivered.
+        On failure nothing is lost — ``notified`` is untouched, so the report
+        still drains on the session's next manual turn."""
+        verb = "failed" if job.status == "failed" else "finished"
+        text = (
+            f"[background job {job.id} ({job.description}) {verb} — its report notification "
+            "is attached to this turn; review it and brief the operator]"
+        )
+        try:
+            await self._send_a2a_message(
+                context_id=job.origin_session,
+                text=text,
+                metadata={
+                    # NOT "background": the terminal hook routes origin=="background"
+                    # turns back into _handle_background_terminal — the nudge turn is
+                    # an ordinary origin-session turn with its own provenance.
+                    "origin": "background-resume",
+                    "trigger": job.id,
+                    "background_job_id": job.id,
+                },
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 — push-resume is best-effort by contract
+            log.warning(
+                "[background] push-resume for %s into %s failed (%s) — the report will "
+                "drain on that session's next turn",
+                job.id,
+                job.origin_session,
+                exc,
+            )
+            return False
 
 
 def _build_fired_prompt(subagent_type: str, description: str, prompt: str) -> str:

--- a/background/store.py
+++ b/background/store.py
@@ -36,6 +36,10 @@ class BackgroundJob:
     created_at: str
     completed_at: str | None
     a2a_task_id: str = ""  # the detached turn's A2A task id — the handle for stop_task
+    # The spawning thread was incognito (ADR 0069 D3b → ADR 0070): the completion
+    # must leave NO memory trail — no push-resume nudge, no knowledge-store indexing.
+    # The report still lives here (jobs.db) and drains into the origin session normally.
+    origin_incognito: bool = False
 
     def to_dict(self) -> dict:
         return {
@@ -50,6 +54,7 @@ class BackgroundJob:
             "created_at": self.created_at,
             "completed_at": self.completed_at,
             "a2a_task_id": self.a2a_task_id,
+            "origin_incognito": self.origin_incognito,
         }
 
 
@@ -68,6 +73,7 @@ def _row_to_job(row: sqlite3.Row) -> BackgroundJob:
         created_at=row["created_at"],
         completed_at=row["completed_at"],
         a2a_task_id=(row["a2a_task_id"] if "a2a_task_id" in keys else "") or "",
+        origin_incognito=bool(row["origin_incognito"] if "origin_incognito" in keys else 0),
     )
 
 
@@ -101,7 +107,8 @@ class BackgroundStore:
                     notified       INTEGER NOT NULL DEFAULT 0,
                     created_at     TEXT NOT NULL,
                     completed_at   TEXT,
-                    a2a_task_id    TEXT
+                    a2a_task_id    TEXT,
+                    origin_incognito INTEGER NOT NULL DEFAULT 0
                 )
                 """
             )
@@ -109,6 +116,9 @@ class BackgroundStore:
             cols = {r[1] for r in db.execute("PRAGMA table_info(background_jobs)").fetchall()}
             if "a2a_task_id" not in cols:
                 db.execute("ALTER TABLE background_jobs ADD COLUMN a2a_task_id TEXT")
+            # Migrate a pre-ADR-0070 DB: incognito propagation (existing rows default 0).
+            if "origin_incognito" not in cols:
+                db.execute("ALTER TABLE background_jobs ADD COLUMN origin_incognito INTEGER NOT NULL DEFAULT 0")
             db.execute(
                 "CREATE INDEX IF NOT EXISTS ix_bg_session_pending ON background_jobs(origin_session, status, notified)"
             )
@@ -127,6 +137,7 @@ class BackgroundStore:
         subagent_type: str,
         description: str,
         prompt: str,
+        origin_incognito: bool = False,
         now: datetime | None = None,
     ) -> str:
         """Insert a ``running`` job and return its opaque id (``bg-<uuid12>``)."""
@@ -137,9 +148,18 @@ class BackgroundStore:
             db.execute(
                 "INSERT INTO background_jobs "
                 "(id, agent_name, origin_session, subagent_type, description, prompt, "
-                " status, result, notified, created_at, completed_at, a2a_task_id) "
-                "VALUES (?, ?, ?, ?, ?, ?, 'running', '', 0, ?, NULL, '')",
-                (job_id, agent_name, origin_session, subagent_type, description, prompt, created),
+                " status, result, notified, created_at, completed_at, a2a_task_id, origin_incognito) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'running', '', 0, ?, NULL, '', ?)",
+                (
+                    job_id,
+                    agent_name,
+                    origin_session,
+                    subagent_type,
+                    description,
+                    prompt,
+                    created,
+                    1 if origin_incognito else 0,
+                ),
             )
             db.commit()
         finally:

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -234,6 +234,13 @@ checkpoint:
   # checkpoints. Needs the knowledge middleware enabled.
   harvest_enabled: true
 
+# Background jobs (ADR 0050/0070) — delegations fired with run_in_background.
+# auto_resume: when a job finishes, immediately run a turn in the session that
+# spawned it so the agent reviews the report and briefs the operator; false
+# restores pull-only delivery (the report drains on that session's next turn).
+background:
+  auto_resume: true
+
 # Model routing / failover.
 #   aux_model: ONE cheap/fast alias for the non-reasoning calls — context
 #     summarization, goal verification, and subagent delegation all fall back

--- a/docs/guides/subagents.md
+++ b/docs/guides/subagents.md
@@ -167,9 +167,24 @@ like any other; the `deep-research` recipe just wires them into a DAG.
 A delegation can run **detached** so it never blocks the turn: `task(run_in_background=true)`
 (or `task_batch`) fires the subagent, returns a `bg-…` job id immediately, and the result is
 drained back into the conversation when it finishes — with a live card on the console's
-background-jobs surface and an autonomous idle-wake
-([ADR 0050](/adr/0050-background-subagents-reactive-notifications)). Durable (survives restart),
-concurrency-capped (`BACKGROUND_MAX_CONCURRENCY`), and cancellable.
+background-jobs surface ([ADR 0050](/adr/0050-background-subagents-reactive-notifications)).
+Durable (survives restart), concurrency-capped (`BACKGROUND_MAX_CONCURRENCY`), and cancellable.
+
+**Completion is a push, not mail waiting for pickup**
+([ADR 0070](/adr/0070-background-results-push-resume)). When a job finishes, the server
+**resumes the origin session** with a nudge turn: the pending `<task-notification>` drains into
+that turn and the agent briefs the operator right where the work was requested (config
+`background.auto_resume`, on by default; `false` restores pull-only delivery on the session's
+next manual turn — the ADR 0050 Activity idle-wake then covers autonomous reaction instead).
+A **substantial report** (> ~800 chars) is also **indexed into the knowledge store** at
+completion, keyed to the origin session (`source_type: background_report`, trust tier 2 —
+agent-derived), so only a 3 000-char excerpt rides in-context while the full text stays
+searchable via `memory_recall` and openable from the console report card
+(`GET /api/background/{job_id}`). Worker transcripts are **disposable**: `background:*`
+sessions are excluded from session-summary persistence, the `<prior_sessions>` digest, and
+retirement harvest — the jobs DB is the system of record. Jobs spawned from an **incognito**
+thread inherit the no-memory-trail contract: no auto-resume, no indexing; the report still
+drains normally.
 
 **Reuse it from your own code — `BackgroundManager.spawn_work(...)`.** Not every long job is an
 LLM turn. A *deterministic* pipeline — media transcription, a bulk import, a crawl — shouldn't

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -429,6 +429,19 @@ checkpoint:
 | `prune_interval_hours` | `6` | How often the background pruner runs. |
 | `harvest_enabled` | `true` | On thread retire, harvest its history into the knowledge store before purging. |
 
+## `background`
+
+Background subagent jobs (`task(run_in_background=true)`, [ADR 0050](/adr/0050-background-subagents-reactive-notifications)) and how their results are delivered ([ADR 0070](/adr/0070-background-results-push-resume)).
+
+```yaml
+background:
+  auto_resume: true
+```
+
+| Key | Default | What |
+|---|---|---|
+| `auto_resume` | `true` | When a background job finishes, immediately run a turn in the session that spawned it — its `<task-notification>` drains into that turn and the agent briefs the operator. `false` restores pull-only delivery (the report waits for the session's next manual turn; the ADR 0050 Activity idle-wake covers autonomous reaction instead). Never fires for canceled jobs, incognito-spawned jobs, or jobs spawned from another background turn. |
+
 ## `workflows`
 
 Declarative multi-step recipes over subagents ([ADR 0002](../adr/0002-reusable-subagent-workflows.md)) — the `run_workflow` / `save_workflow` tools.

--- a/docs/reference/operator-api.md
+++ b/docs/reference/operator-api.md
@@ -52,6 +52,7 @@ is a map — `operator_api/*.py` is the source of truth for exact request/respon
 | Method | Path | Purpose |
 |---|---|---|
 | GET | `/api/background` | Background subagent jobs |
+| GET | `/api/background/{job_id}` | One job's full row by id (full result text; ADR 0070) |
 | POST | `/api/background/{job_id}/cancel` · `/api/background/clear` | Cancel one / clear finished |
 | DELETE | `/api/background/{job_id}` | Remove a job row |
 | GET · POST | `/api/scheduler/jobs` | List / create scheduled jobs |

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -179,6 +179,14 @@ def _resolve_aux_model(config, specific: str = "") -> str | None:
     return None
 
 
+def _incognito_from(state: Any) -> bool:
+    """Whether the CURRENT turn is incognito, read from injected graph state (the
+    same source ``_session_id_from`` uses — the tracing contextvar is not visible
+    in tool bodies). Propagated onto spawned background jobs (ADR 0070) so their
+    completions honor the no-memory-trail contract (ADR 0069 D3b)."""
+    return bool(state.get("incognito")) if isinstance(state, dict) else False
+
+
 def _auto_background_seconds() -> float:
     """Time budget (seconds) after which a *foreground* ``task`` delegation transparently
     detaches to the background (ADR 0051). ``BACKGROUND_AUTO_S`` env; 0 (default) = off."""
@@ -498,11 +506,15 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
             # Resolve the originating session from injected graph state, not the
             # tracing contextvar — the contextvar reads empty in a tool body, so
             # the completion could never drain back to the spawning chat (ADR 0050).
+            # The state's incognito flag rides along (ADR 0070): a job spawned from
+            # an incognito thread must leave no memory trail at completion (no
+            # push-resume, no knowledge indexing) — the report still drains here.
             job_id = await background_mgr.spawn(
                 origin_session=_session_id_from(state),
                 subagent_type=subagent_type,
                 description=description,
                 prompt=prompt,
+                origin_incognito=_incognito_from(state),
             )
             return job_id
 
@@ -670,6 +682,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
                     subagent_type=st,
                     description=desc,
                     prompt=prm,
+                    origin_incognito=_incognito_from(state),
                 )
                 started += 1
                 lines.append(f"Task {i}: {job_id} ({st}: {desc})")

--- a/graph/config.py
+++ b/graph/config.py
@@ -512,6 +512,11 @@ class LangGraphConfig:
     # Background subagent threads (a2a:background:*) get a tighter cap — we only
     # resume-from-latest, never time-travel, so retaining more than 1 is waste.
     checkpoint_background_keep: int = 1
+    # Push-resume (ADR 0070 D1): when a background job finishes, self-submit a nudge
+    # turn into the session that spawned it, so its <task-notification> drains
+    # immediately and the agent briefs the operator — instead of the report waiting
+    # for that session's next manual turn. False restores pull-only delivery.
+    background_auto_resume: bool = True
     checkpoint_max_age_days: int = 30
     checkpoint_prune_interval_hours: int = 6
     # When a session is retired (aged out or deleted), summarize it into the
@@ -919,6 +924,7 @@ class LangGraphConfig:
             checkpoint_background_keep=data.get("checkpoint", {}).get(
                 "background_keep", cls.checkpoint_background_keep
             ),
+            background_auto_resume=data.get("background", {}).get("auto_resume", cls.background_auto_resume),
             checkpoint_max_age_days=data.get("checkpoint", {}).get("max_age_days", cls.checkpoint_max_age_days),
             checkpoint_prune_interval_hours=data.get("checkpoint", {}).get(
                 "prune_interval_hours", cls.checkpoint_prune_interval_hours

--- a/graph/conversation_harvest.py
+++ b/graph/conversation_harvest.py
@@ -93,6 +93,14 @@ async def harvest_thread(
     """
     if knowledge_store is None:
         return None
+    # Background worker thread (ADR 0070 D3): its transcript is disposable — the
+    # report was already delivered to (and indexed under) the ORIGIN session at
+    # completion, so harvesting the worker would duplicate the report into the KB
+    # under the worker's identity. Mirrors the incognito skip below; string-matched
+    # so legacy retired threads are covered too.
+    if thread_id.startswith("background:") or ":background:" in thread_id:
+        log.info("[harvest] thread %s is a background worker — skipping harvest", thread_id)
+        return None
     try:
         tup = await checkpointer.aget_tuple({"configurable": {"thread_id": thread_id}})
         if tup is None:

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -96,6 +96,14 @@ def _persist_session(state: dict, trace_id: str) -> None:
         # injected everywhere via <prior_sessions>.
         log.warning("[memory] no session_id resolved — skipping session persistence")
         return
+    if session_id.startswith("background:"):
+        # Background worker turn (ADR 0070 D3): the worker's transcript is
+        # disposable — the report is delivered to the ORIGIN session (drain +
+        # push-resume) and indexed to it in the knowledge store; a summary file
+        # here would leak the full report into every thread's digest under the
+        # worker's identity. The jobs DB is the system of record.
+        log.debug("[memory] background worker session %s — skipping session persistence", session_id)
+        return
     messages_raw: list = state.get("messages", []) or []
 
     # --- Extract user-visible messages ---
@@ -345,6 +353,11 @@ def load_prior_sessions_digest(
         entries: list[tuple[float, str]] = []
         for fname in os.listdir(memory_dir):
             if not fname.endswith(".json"):
+                continue
+            if fname.startswith("background:"):
+                # Background worker summaries are disposable (ADR 0070 D3). The
+                # writer no longer produces them; this read-side filter also
+                # keeps LEGACY files already on disk out of the digest.
                 continue
             fpath = os.path.join(memory_dir, fname)
             try:

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -609,6 +609,17 @@ FIELDS: list[Field] = [
     # A plugin's Settings group is declared by its manifest (ADR 0019) and rendered
     # via the plugin-fields path in build_schema — same for bundled or external
     # plugins; the generic Test button + guide link come from the manifest (ADR 0059).
+    # ── Background jobs (ADR 0050/0070) ──────────────────────────────────────
+    Field(
+        "background.auto_resume",
+        "background_auto_resume",
+        "Push-resume on completion",
+        "bool",
+        "Background",
+        "When a background job finishes, immediately run a turn in the session that "
+        "spawned it so the agent reviews the report and briefs the operator (ADR 0070). "
+        "Off = the report waits for that session's next manual turn.",
+    ),
     # ── Runtime (restart) ────────────────────────────────────────────────────
     Field(
         "runtime.autostart_on_boot",
@@ -843,6 +854,7 @@ _SECTION_CATEGORY = {
     "Goal mode": "Behavior",
     "Compaction": "Behavior",
     "Middleware": "Behavior",
+    "Background": "Behavior",
     "Runtime": "Behavior",
     # Capabilities — the sharing/tier knobs for what the agent is wired to (the rich
     # Tools/MCP/Skills/Subagents/Delegates managers are bespoke console panels).

--- a/knowledge/trust.py
+++ b/knowledge/trust.py
@@ -50,6 +50,7 @@ TRUST_TIERS: dict[str, int] = {
     "harvest": 2,  # graph/conversation_harvest.py — retired-thread summaries
     "conversation": 2,  # memory_ingest tool + compaction archives
     "chat": 2,  # knowledge/store.add_finding default
+    "background_report": 2,  # server/a2a.py — background job reports indexed at completion (ADR 0070 D2)
     # Tier 1 — ingested / third-party content (ingestion/engine.py source types).
     "text": 1,
     "markdown": 1,

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -244,6 +244,30 @@ def register_operator_routes(
         except Exception as exc:
             raise _http_error(exc) from exc
 
+    @app.get("/api/background/{job_id}")
+    async def _background_job(job_id: str):
+        """One background job's full row by id (ADR 0070 D4) — the console report
+        card fetches this instead of list-and-filter, and it carries the FULL result
+        (the ``background.completed`` bus event only carries a preview). Job ids are
+        strictly ``bg-<12 hex>`` (background/store.py), so anything else is rejected
+        before it reaches the store."""
+        import re as _re
+
+        from runtime.state import STATE
+
+        if not _re.fullmatch(r"bg-[a-f0-9]{12}", job_id or ""):
+            raise HTTPException(status_code=400, detail="Invalid background job id.")
+        mgr = getattr(STATE, "background_mgr", None)
+        if mgr is None:
+            raise HTTPException(status_code=404, detail="Background jobs are not available.")
+        try:
+            job = await asyncio.to_thread(mgr.store.get, job_id)
+        except Exception as exc:
+            raise _http_error(exc) from exc
+        if job is None:
+            raise HTTPException(status_code=404, detail=f"No background job {job_id}.")
+        return job.to_dict()
+
     @app.post("/api/background/{job_id}/cancel")
     async def _background_cancel(job_id: str):
         """Stop a running background job (ADR 0051) — cancels its detached A2A turn."""

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -25,9 +25,14 @@ from server import _event_bus, agent_name
 
 log = logging.getLogger("protoagent.server")
 
-# Holds the fire-and-forget background-wake tasks (ADR 0050 Phase 2) so they aren't
-# GC'd mid-flight; the done callback discards each on completion.
+# Holds the fire-and-forget background-wake/-resume/-index tasks (ADR 0050 Phase 2,
+# ADR 0070) so they aren't GC'd mid-flight; the done callback discards each on completion.
 _BG_WAKE_TASKS: set = set()
+
+# ADR 0070 D2 — results at or under this size just drain inline; anything bigger is
+# also indexed into the knowledge store so the full report stays searchable after
+# the drain notification truncates it.
+_BG_INDEX_MIN_CHARS = 800
 
 
 def _background_wake_enabled() -> bool:
@@ -35,6 +40,30 @@ def _background_wake_enabled() -> bool:
     Phase 2). On by default; ``BACKGROUND_WAKE=0`` opts out (parity with
     ``BACKGROUND_DISABLED``)."""
     return os.environ.get("BACKGROUND_WAKE", "1").strip().lower() not in ("0", "false", "no")
+
+
+def _background_auto_resume_enabled() -> bool:
+    """Whether a finished background job push-resumes its origin session (ADR 0070 D1).
+    Config ``background.auto_resume``; default on. ``false`` restores pull-only delivery
+    (the drain on the origin session's next manual turn)."""
+    cfg = STATE.graph_config
+    return bool(getattr(cfg, "background_auto_resume", True)) if cfg is not None else True
+
+
+def _should_auto_resume(job) -> bool:
+    """The ADR 0070 D1 guards: push-resume a completed/failed job into its origin
+    session unless the feature is off, the job was canceled (the operator already
+    intervened), there is no origin chat session or it is itself a background
+    context (no resume chains), or the spawning thread was incognito (no memory
+    trail — the report still drains normally)."""
+    if job.status == "canceled":
+        return False
+    origin = job.origin_session or ""
+    if not origin or origin.startswith("background:"):
+        return False
+    if getattr(job, "origin_incognito", False):
+        return False
+    return _background_auto_resume_enabled()
 
 
 def _background_wake_text(job) -> str:
@@ -87,6 +116,84 @@ def _spawn_background_wake(job) -> None:
             await _background_wake(job)
         except Exception:  # noqa: BLE001 — best-effort; never breaks the terminal hook
             log.exception("[background] wake fire failed for %s", getattr(job, "id", "?"))
+
+    t = loop.create_task(_go())
+    _BG_WAKE_TASKS.add(t)
+    t.add_done_callback(_BG_WAKE_TASKS.discard)
+
+
+def _spawn_background_resume(mgr, job) -> None:
+    """Schedule the push-resume nudge (ADR 0070 D1) fire-and-forget on the running
+    loop. When the nudge can't be delivered, fall back to the ADR 0050 Phase 2
+    Activity wake (when enabled) so the completion still reaches the agent somewhere;
+    either way ``notified`` is untouched — the report itself always drains into the
+    origin session's next turn, exactly once. No-op off-loop."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+
+    async def _go() -> None:
+        try:
+            delivered = await mgr.resume_origin(job)
+        except Exception:  # noqa: BLE001 — resume_origin is never-raises by contract; belt and braces
+            log.exception("[background] push-resume failed for %s", getattr(job, "id", "?"))
+            delivered = False
+        if not delivered and _background_wake_enabled():
+            try:
+                await _background_wake(job)
+            except Exception:  # noqa: BLE001 — best-effort fallback
+                log.exception("[background] wake fallback failed for %s", getattr(job, "id", "?"))
+
+    t = loop.create_task(_go())
+    _BG_WAKE_TASKS.add(t)
+    t.add_done_callback(_BG_WAKE_TASKS.discard)
+
+
+def _should_index_report(job) -> bool:
+    """The ADR 0070 D2 guards: index a *completed* job's report when it is substantial
+    (> ``_BG_INDEX_MIN_CHARS`` — smaller results just drain inline), the knowledge
+    store is up, and the spawning thread wasn't incognito (no memory trail)."""
+    if job is None or job.status != "completed":
+        return False
+    if getattr(job, "origin_incognito", False):
+        return False
+    if len(job.result or "") <= _BG_INDEX_MIN_CHARS:
+        return False
+    return STATE.knowledge_store is not None
+
+
+def _spawn_report_index(job) -> None:
+    """Index a finished job's FULL report into the knowledge store (ADR 0070 D2),
+    fire-and-forget. Keyed to the ORIGIN session (``source=origin_session``) with
+    ``source_type="background_report"`` (trust tier 2 — agent-derived, ADR 0069 D8),
+    so ``memory_recall`` surfaces it with provenance + trust citations after the
+    drain notification truncates the in-context copy. ``add_document`` chunks
+    document-sized reports with the shared ingestion chunker (knowledge/chunking.py).
+    Best-effort; never raises into the terminal hook. No-op off-loop."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+
+    async def _go() -> None:
+        try:
+            from knowledge import add_document
+
+            # add_document does blocking gateway work per chunk (embed + optional
+            # contextual enrichment) — keep it off the event loop.
+            chunk_ids = await asyncio.to_thread(
+                add_document,
+                STATE.knowledge_store,
+                job.result,
+                domain="conversation",
+                heading=f"Background report: {job.description} ({job.id})",
+                source=job.origin_session or f"background:{job.id}",
+                source_type="background_report",
+            )
+            log.info("[background] indexed report for %s → %d chunk(s)", job.id, len(chunk_ids or []))
+        except Exception:  # noqa: BLE001 — indexing is best-effort; jobs.db stays the record
+            log.exception("[background] report indexing failed for %s", getattr(job, "id", "?"))
 
     t = loop.create_task(_go())
     _BG_WAKE_TASKS.add(t)
@@ -492,10 +599,20 @@ def _handle_background_terminal(outcome) -> None:
             "result": result_preview,
         },
     )
-    # Autonomous idle-wake (ADR 0050 Phase 2): fire an Activity turn so the agent reacts
-    # to the result on its own, instead of only learning on the spawning session's next
-    # turn. Gated + storm-guarded; needs the full job row for the stimulus.
-    if job is not None and _background_wake_enabled():
+    # Index the full report into the knowledge store (ADR 0070 D2) BEFORE any resume
+    # turn runs, so the drained notification's "searchable via memory_recall" pointer
+    # is already true when the agent reads it.
+    if _should_index_report(job):
+        _spawn_report_index(job)
+    # Delivery (ADR 0070 D1): push-resume the ORIGIN session — the nudge turn's drain
+    # injects the <task-notification> and the agent briefs the operator right where
+    # the work was requested. That one turn IS the reaction, so the ADR 0050 Phase 2
+    # Activity wake only fires when the resume doesn't apply (feature off, canceled,
+    # incognito, no/background origin) or couldn't be delivered (fallback inside
+    # _spawn_background_resume) — never both for one completion.
+    if job is not None and _should_auto_resume(job):
+        _spawn_background_resume(mgr, job)
+    elif job is not None and _background_wake_enabled():
         _spawn_background_wake(job)
 
 
@@ -504,9 +621,10 @@ def _surface_resumed_chat_turn(outcome) -> None:
     that landed in a CHAT session — not the Activity thread — on the event bus so an
     open chat tab shows the resumed turn LIVE (bd-k02). The browser only renders
     turns it streamed, so a server-fired resume is otherwise invisible until the
-    next interaction. Mirrors the ADR 0050 background path. Only scheduler-origin
-    turns qualify; an operator/A2A chat turn the browser already streamed does not."""
-    if getattr(outcome, "origin", "") != "scheduler":
+    next interaction. Mirrors the ADR 0050 background path. Only server-fired
+    origins qualify — scheduler resumes and ADR 0070 push-resume briefings; an
+    operator/A2A chat turn the browser already streamed does not."""
+    if getattr(outcome, "origin", "") not in ("scheduler", "background-resume"):
         return
     text = extract_output(outcome.text) or outcome.text
     if not text.strip():

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -158,6 +158,14 @@ def _should_index_report(job) -> bool:
         return False
     if getattr(job, "origin_incognito", False):
         return False
+    # A CHAINED job — spawned from another background worker's turn — is never
+    # indexed: its origin is a disposable worker identity (D3 — worker sessions are
+    # never memory), its content flows into the parent worker's own report (which is
+    # indexed, or not, under the REAL origin session's rules), and the worker turn
+    # runs non-incognito so an incognito root's no-memory-trail contract (ADR 0069
+    # D3b) would otherwise leak transitively through the chain.
+    if (job.origin_session or "").startswith("background:"):
+        return False
     if len(job.result or "") <= _BG_INDEX_MIN_CHARS:
         return False
     return STATE.knowledge_store is not None

--- a/server/chat.py
+++ b/server/chat.py
@@ -58,10 +58,15 @@ def _drain_background_messages(session_id: str) -> list:
         result = j.result or ""
         if len(result) > _BG_RESULT_CAP:
             # Completed, non-incognito reports this size were indexed at completion
-            # (ADR 0070 D2) — say so; incognito/failed ones only live in the jobs DB.
+            # (ADR 0070 D2) — say so; incognito/failed/chained (background-origin)
+            # ones only live in the jobs DB.
             searchable = (
                 " — the full report is indexed and searchable via memory_recall"
-                if j.status == "completed" and not getattr(j, "origin_incognito", False)
+                if (
+                    j.status == "completed"
+                    and not getattr(j, "origin_incognito", False)
+                    and not (j.origin_session or "").startswith("background:")
+                )
                 else ""
             )
             result = result[:_BG_RESULT_CAP] + (
@@ -841,7 +846,10 @@ def _thread_lock(thread_id: str) -> asyncio.Lock:
 # Live operator turns carry an empty origin (they keep parking — a human is watching);
 # inbound `a2a` calls are excluded too, because the remote caller can itself resume the
 # input-required task. For everything here, we auto-answer the interrupt instead of parking.
-_AUTONOMOUS_ORIGINS = frozenset({"scheduler", "inbox", "webhook", "background"})
+# "background-resume" is the ADR 0070 push-resume nudge — server-fired like the rest
+# (the manager discards the A2A response), so a briefing turn that asks a question
+# must auto-answer, not park.
+_AUTONOMOUS_ORIGINS = frozenset({"scheduler", "inbox", "webhook", "background", "background-resume"})
 
 # What we resume an autonomous turn's HITL interrupt with, so the agent stops waiting and
 # finishes the turn instead of deadlocking. Bounded by the cap below so a model that keeps

--- a/server/chat.py
+++ b/server/chat.py
@@ -26,7 +26,11 @@ from runtime.state import STATE
 log = logging.getLogger("protoagent.server")
 
 
-_BG_RESULT_CAP = 6000  # chars of a background result injected into the spawning turn
+# Chars of a background result injected into the spawning turn. Shrunk 6000 → 3000
+# (ADR 0070 D2): a substantial report is now ALSO indexed into the knowledge store at
+# completion, so the notification carries a summary-sized excerpt plus a pointer to
+# the searchable full text instead of a third of the context window.
+_BG_RESULT_CAP = 3000
 
 
 def _drain_background_messages(session_id: str) -> list:
@@ -53,7 +57,17 @@ def _drain_background_messages(session_id: str) -> list:
     for j in jobs:
         result = j.result or ""
         if len(result) > _BG_RESULT_CAP:
-            result = result[:_BG_RESULT_CAP] + f"\n\n…[truncated to {_BG_RESULT_CAP} chars]"
+            # Completed, non-incognito reports this size were indexed at completion
+            # (ADR 0070 D2) — say so; incognito/failed ones only live in the jobs DB.
+            searchable = (
+                " — the full report is indexed and searchable via memory_recall"
+                if j.status == "completed" and not getattr(j, "origin_incognito", False)
+                else ""
+            )
+            result = result[:_BG_RESULT_CAP] + (
+                f"\n\n…[truncated to {_BG_RESULT_CAP} chars{searchable}; the operator can open "
+                f"the full text from the console background report card (job id {j.id})]"
+            )
         body = (
             "<task-notification>\n"
             "A background agent finished a task you delegated earlier:\n"

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -593,9 +593,11 @@ class _ToolFake(GenericFakeChatModel):
 class _RecordingBG:
     def __init__(self):
         self.seen_origin = "__unset__"
+        self.seen_incognito = None
 
-    async def spawn(self, *, origin_session, subagent_type, description, prompt):
+    async def spawn(self, *, origin_session, subagent_type, description, prompt, origin_incognito=False):
         self.seen_origin = origin_session
+        self.seen_incognito = origin_incognito
         return "bg-test-1"
 
 
@@ -652,7 +654,7 @@ class _RecordingBatchBG:
     def __init__(self):
         self.spawns: list[dict] = []
 
-    async def spawn(self, *, origin_session, subagent_type, description, prompt):
+    async def spawn(self, *, origin_session, subagent_type, description, prompt, origin_incognito=False):
         self.spawns.append({"origin": origin_session, "subagent_type": subagent_type, "description": description})
         return f"bg-{len(self.spawns)}"
 

--- a/tests/test_background_results.py
+++ b/tests/test_background_results.py
@@ -1,0 +1,604 @@
+"""ADR 0070 — background results: push-resume, indexed reports, disposable workers.
+
+Covers the completion-moment behaviors added on top of ADR 0050's registry/drain:
+
+- D1 push-resume: exactly one nudge into the ORIGIN session on completion, none
+  when disabled / canceled / background-origin / incognito; delivery failure falls
+  back to the Phase-2 wake and leaves ``notified`` untouched (drain still delivers).
+- D2 report indexing: substantial completed results land in the knowledge store
+  keyed to the origin session (source_type="background_report", trust tier 2);
+  small / failed / incognito results don't; the drain notification carries a
+  pointer to the searchable full text once truncated.
+- D3 disposable workers: no session-summary persistence for ``background:*``
+  sessions, legacy worker files are filtered out of the digest, and retirement
+  harvest skips worker threads.
+- Incognito propagation onto the job row (``origin_incognito`` column + migration).
+- The ``GET /api/background/{job_id}`` by-id route.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from background.manager import BackgroundManager
+from background.store import BackgroundStore
+
+# ── helpers (mirroring tests/test_background.py) ─────────────────────────────
+
+
+def _store(tmp_path: Path) -> BackgroundStore:
+    return BackgroundStore(str(tmp_path / "background" / "jobs.db"))
+
+
+def _manager(tmp_path: Path, **kw) -> BackgroundManager:
+    return BackgroundManager(
+        agent_name="a",
+        invoke_url="http://127.0.0.1:7870",
+        store=_store(tmp_path),
+        api_key="k",
+        bearer_token="b",
+        **kw,
+    )
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, text: str = ""):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeClient:
+    """Captures the POST and returns a canned response (stubs httpx.AsyncClient)."""
+
+    captured: dict = {}
+
+    def __init__(self, response, raise_exc=None, **_kw):
+        self._response = response
+        self._raise = raise_exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def post(self, url, headers=None, json=None):
+        _FakeClient.captured = {"url": url, "headers": headers, "json": json}
+        if self._raise:
+            raise self._raise
+        return self._response
+
+
+async def _settle_bg_tasks() -> None:
+    """Let the terminal hook's fire-and-forget resume/index/wake tasks finish."""
+    import server.a2a as a2a
+
+    for _ in range(200):
+        if not a2a._BG_WAKE_TASKS:
+            return
+        await asyncio.sleep(0.01)
+
+
+def _outcome(job_id: str, state: str = "completed", text: str = "the report"):
+    from a2a_impl.executor import TurnOutcome
+
+    return TurnOutcome(
+        task_id="t1",
+        context_id=f"background:{job_id}",
+        state=state,
+        text=text,
+        origin="background",
+        trigger=job_id,
+    )
+
+
+@pytest.fixture
+def hook_env(monkeypatch):
+    """Neutral STATE + bus for exercising ``_handle_background_terminal`` directly."""
+    import server.a2a as a2a
+    from graph.config import LangGraphConfig
+    from runtime.state import STATE
+
+    monkeypatch.setattr(STATE, "graph_config", LangGraphConfig(), raising=False)
+    monkeypatch.setattr(STATE, "knowledge_store", None, raising=False)
+    monkeypatch.delenv("BACKGROUND_WAKE", raising=False)
+    published: list = []
+    monkeypatch.setattr(a2a._event_bus, "publish", lambda t, d=None: published.append((t, d)))
+    return published
+
+
+# ── incognito column + migration ─────────────────────────────────────────────
+
+
+class TestStoreIncognito:
+    def test_create_default_not_incognito(self, tmp_path):
+        s = _store(tmp_path)
+        jid = s.create(agent_name="a", origin_session="s1", subagent_type="researcher", description="d", prompt="p")
+        job = s.get(jid)
+        assert job.origin_incognito is False
+        assert job.to_dict()["origin_incognito"] is False
+
+    def test_create_incognito_roundtrips(self, tmp_path):
+        s = _store(tmp_path)
+        jid = s.create(
+            agent_name="a",
+            origin_session="s1",
+            subagent_type="researcher",
+            description="d",
+            prompt="p",
+            origin_incognito=True,
+        )
+        assert s.get(jid).origin_incognito is True
+        assert s.get(jid).to_dict()["origin_incognito"] is True
+
+    def test_migration_adds_column_to_legacy_db(self, tmp_path):
+        """A pre-ADR-0070 DB (no origin_incognito column) migrates in place; legacy
+        rows read origin_incognito=False."""
+        db_path = tmp_path / "jobs.db"
+        db = sqlite3.connect(str(db_path))
+        db.execute(
+            """
+            CREATE TABLE background_jobs (
+                id TEXT PRIMARY KEY, agent_name TEXT NOT NULL, origin_session TEXT NOT NULL,
+                subagent_type TEXT NOT NULL, description TEXT NOT NULL, prompt TEXT NOT NULL,
+                status TEXT NOT NULL, result TEXT, notified INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL, completed_at TEXT, a2a_task_id TEXT
+            )
+            """
+        )
+        db.execute(
+            "INSERT INTO background_jobs (id, agent_name, origin_session, subagent_type, description, "
+            "prompt, status, result, notified, created_at, completed_at, a2a_task_id) "
+            "VALUES ('bg-aaaaaaaaaaaa', 'a', 's1', 'researcher', 'd', 'p', 'running', '', 0, 't', NULL, '')"
+        )
+        db.commit()
+        db.close()
+
+        s = BackgroundStore(str(db_path))
+        legacy = s.get("bg-aaaaaaaaaaaa")
+        assert legacy is not None and legacy.origin_incognito is False
+        # new inserts carry the flag
+        jid = s.create(
+            agent_name="a", origin_session="s2", subagent_type="researcher", description="d", prompt="p",
+            origin_incognito=True,
+        )
+        assert s.get(jid).origin_incognito is True
+
+    def test_migration_is_idempotent(self, tmp_path):
+        path = str(tmp_path / "jobs.db")
+        s1 = BackgroundStore(path)
+        jid = s1.create(
+            agent_name="a", origin_session="s1", subagent_type="researcher", description="d", prompt="p",
+            origin_incognito=True,
+        )
+        s2 = BackgroundStore(path)  # re-init on an already-migrated DB must not error
+        assert s2.get(jid).origin_incognito is True
+
+
+# ── D1: the manager's push-resume nudge ──────────────────────────────────────
+
+
+class TestResumeOrigin:
+    async def test_posts_nudge_into_origin_session(self, tmp_path, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _FakeClient(_FakeResponse(200)))
+        mgr = _manager(tmp_path)
+        jid = mgr.store.create(
+            agent_name="a", origin_session="chat-42", subagent_type="researcher", description="dig", prompt="p"
+        )
+        mgr.store.mark_complete(jid, "completed", "found it")
+        assert await mgr.resume_origin(mgr.store.get(jid)) is True
+        cap = _FakeClient.captured
+        assert cap["url"] == "http://127.0.0.1:7870/a2a"
+        msg = cap["json"]["params"]["message"]
+        assert msg["contextId"] == "chat-42"  # the ORIGIN session, not a background context
+        assert msg["metadata"]["origin"] == "background-resume"  # NOT "background" — no terminal-hook loop
+        assert msg["metadata"]["trigger"] == jid
+        text = msg["parts"][0]["text"]
+        assert jid in text and "dig" in text and "brief the operator" in text and "finished" in text
+
+    async def test_failed_job_nudge_says_failed(self, tmp_path, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _FakeClient(_FakeResponse(200)))
+        mgr = _manager(tmp_path)
+        jid = mgr.store.create(
+            agent_name="a", origin_session="chat-42", subagent_type="researcher", description="d", prompt="p"
+        )
+        mgr.store.mark_complete(jid, "failed", "boom")
+        assert await mgr.resume_origin(mgr.store.get(jid)) is True
+        assert "failed" in _FakeClient.captured["json"]["params"]["message"]["parts"][0]["text"]
+
+    async def test_delivery_failure_never_raises_and_leaves_row(self, tmp_path, monkeypatch):
+        """A failed nudge changes NOTHING: status stays terminal, notified stays 0 —
+        the report still drains exactly-once on the session's next manual turn."""
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _FakeClient(_FakeResponse(500, "down")))
+        mgr = _manager(tmp_path)
+        jid = mgr.store.create(
+            agent_name="a", origin_session="chat-42", subagent_type="researcher", description="d", prompt="p"
+        )
+        mgr.store.mark_complete(jid, "completed", "the answer")
+        assert await mgr.resume_origin(mgr.store.get(jid)) is False
+        job = mgr.store.get(jid)
+        assert job.status == "completed" and job.result == "the answer" and job.notified is False
+        assert [j.id for j in mgr.store.drain_pending("chat-42")] == [jid]
+        assert mgr.store.drain_pending("chat-42") == []  # still exactly-once
+
+
+# ── D1: the terminal hook's resume/wake routing ──────────────────────────────
+
+
+class TestTerminalHookResume:
+    def _wire(self, tmp_path, monkeypatch, *, origin="chat-42", incognito=False):
+        import server.a2a as a2a
+        from runtime.state import STATE
+
+        mgr = _manager(tmp_path)
+        jid = mgr.store.create(
+            agent_name="a",
+            origin_session=origin,
+            subagent_type="researcher",
+            description="dig",
+            prompt="p",
+            origin_incognito=incognito,
+        )
+        monkeypatch.setattr(STATE, "background_mgr", mgr, raising=False)
+        resumes: list = []
+
+        async def fake_resume(job):
+            resumes.append(job.id)
+            return True
+
+        monkeypatch.setattr(mgr, "resume_origin", fake_resume)
+        wakes: list = []
+        monkeypatch.setattr(a2a, "_spawn_background_wake", lambda job: wakes.append(job.id))
+        return a2a, mgr, jid, resumes, wakes
+
+    async def test_completion_fires_exactly_one_nudge_and_no_wake(self, tmp_path, monkeypatch, hook_env):
+        a2a, mgr, jid, resumes, wakes = self._wire(tmp_path, monkeypatch)
+        a2a._handle_background_terminal(_outcome(jid))
+        await _settle_bg_tasks()
+        assert resumes == [jid]
+        assert wakes == []  # the resume turn IS the reaction — never both
+
+    async def test_drain_still_exactly_once_after_nudge(self, tmp_path, monkeypatch, hook_env):
+        a2a, mgr, jid, resumes, wakes = self._wire(tmp_path, monkeypatch)
+        a2a._handle_background_terminal(_outcome(jid))
+        await _settle_bg_tasks()
+        # the nudge itself never flips notified — the origin session's (nudge) turn drains it once
+        assert [j.id for j in mgr.store.drain_pending("chat-42")] == [jid]
+        assert mgr.store.drain_pending("chat-42") == []
+
+    async def test_disabled_config_restores_wake(self, tmp_path, monkeypatch, hook_env):
+        from graph.config import LangGraphConfig
+        from runtime.state import STATE
+
+        a2a, mgr, jid, resumes, wakes = self._wire(tmp_path, monkeypatch)
+        monkeypatch.setattr(STATE, "graph_config", LangGraphConfig(background_auto_resume=False), raising=False)
+        a2a._handle_background_terminal(_outcome(jid))
+        await _settle_bg_tasks()
+        assert resumes == []
+        assert wakes == [jid]
+
+    async def test_canceled_job_never_resumes(self, tmp_path, monkeypatch, hook_env):
+        a2a, mgr, jid, resumes, wakes = self._wire(tmp_path, monkeypatch)
+        a2a._handle_background_terminal(_outcome(jid, state="canceled"))
+        await _settle_bg_tasks()
+        assert resumes == []
+        assert wakes == [jid]  # pre-ADR-0070 wake behavior preserved
+
+    async def test_background_origin_never_resumes(self, tmp_path, monkeypatch, hook_env):
+        """No resume chains: a job spawned FROM a background turn must not nudge the
+        worker context (which would spiral turn-on-turn)."""
+        a2a, mgr, jid, resumes, wakes = self._wire(tmp_path, monkeypatch, origin="background:bg-parentparent")
+        a2a._handle_background_terminal(_outcome(jid))
+        await _settle_bg_tasks()
+        assert resumes == []
+        assert wakes == [jid]
+
+    async def test_incognito_origin_never_resumes(self, tmp_path, monkeypatch, hook_env):
+        a2a, mgr, jid, resumes, wakes = self._wire(tmp_path, monkeypatch, incognito=True)
+        a2a._handle_background_terminal(_outcome(jid))
+        await _settle_bg_tasks()
+        assert resumes == []
+
+    async def test_failed_delivery_falls_back_to_wake(self, tmp_path, monkeypatch, hook_env):
+        import server.a2a as a2a_mod
+        from runtime.state import STATE
+
+        mgr = _manager(tmp_path)
+        jid = mgr.store.create(
+            agent_name="a", origin_session="chat-42", subagent_type="researcher", description="d", prompt="p"
+        )
+        monkeypatch.setattr(STATE, "background_mgr", mgr, raising=False)
+
+        async def failing_resume(job):
+            return False
+
+        monkeypatch.setattr(mgr, "resume_origin", failing_resume)
+        woke: list = []
+
+        async def fake_wake(job):
+            woke.append(job.id)
+            return True
+
+        monkeypatch.setattr(a2a_mod, "_background_wake", fake_wake)
+        a2a_mod._handle_background_terminal(_outcome(jid))
+        await _settle_bg_tasks()
+        assert woke == [jid]
+
+
+# ── D2: report indexing ──────────────────────────────────────────────────────
+
+
+class _FakeKnowledgeStore:
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    def add_document(self, content, **kwargs):
+        self.calls.append((content, kwargs))
+        return [1, 2]
+
+
+class TestReportIndexing:
+    def _wire(self, tmp_path, monkeypatch, *, incognito=False):
+        import server.a2a as a2a
+        from graph.config import LangGraphConfig
+        from runtime.state import STATE
+
+        mgr = _manager(tmp_path)
+        jid = mgr.store.create(
+            agent_name="a",
+            origin_session="chat-42",
+            subagent_type="researcher",
+            description="dig",
+            prompt="p",
+            origin_incognito=incognito,
+        )
+        monkeypatch.setattr(STATE, "background_mgr", mgr, raising=False)
+        # pull-only so the resume path stays out of these assertions
+        monkeypatch.setattr(STATE, "graph_config", LangGraphConfig(background_auto_resume=False), raising=False)
+        monkeypatch.setattr(a2a, "_spawn_background_wake", lambda job: None)
+        fake = _FakeKnowledgeStore()
+        monkeypatch.setattr(STATE, "knowledge_store", fake, raising=False)
+        return a2a, jid, fake
+
+    async def test_substantial_result_indexed_with_provenance(self, tmp_path, monkeypatch, hook_env):
+        a2a, jid, fake = self._wire(tmp_path, monkeypatch)
+        report = "finding line\n" * 100  # > 800 chars
+        a2a._handle_background_terminal(_outcome(jid, text=report))
+        await _settle_bg_tasks()
+        assert len(fake.calls) == 1
+        content, kwargs = fake.calls[0]
+        assert content == report.strip() or content == report  # full report, not the preview
+        assert kwargs["source"] == "chat-42"  # keyed to the ORIGIN session
+        assert kwargs["source_type"] == "background_report"
+        assert kwargs["heading"] == f"Background report: dig ({jid})"
+
+    async def test_small_result_not_indexed(self, tmp_path, monkeypatch, hook_env):
+        a2a, jid, fake = self._wire(tmp_path, monkeypatch)
+        a2a._handle_background_terminal(_outcome(jid, text="short answer"))
+        await _settle_bg_tasks()
+        assert fake.calls == []
+
+    async def test_failed_job_not_indexed(self, tmp_path, monkeypatch, hook_env):
+        a2a, jid, fake = self._wire(tmp_path, monkeypatch)
+        a2a._handle_background_terminal(_outcome(jid, state="failed", text="x" * 2000))
+        await _settle_bg_tasks()
+        assert fake.calls == []
+
+    async def test_incognito_job_not_indexed(self, tmp_path, monkeypatch, hook_env):
+        a2a, jid, fake = self._wire(tmp_path, monkeypatch, incognito=True)
+        a2a._handle_background_terminal(_outcome(jid, text="x" * 2000))
+        await _settle_bg_tasks()
+        assert fake.calls == []
+
+    def test_background_report_is_agent_trust_tier(self):
+        from knowledge.trust import trust_label, trust_tier
+
+        assert trust_tier("background_report") == 2
+        assert trust_label("background_report") == "agent"
+
+
+# ── D2: the drain notification's pointer line ────────────────────────────────
+
+
+class TestDrainPointer:
+    def _drained_body(self, tmp_path, monkeypatch, *, result: str, incognito=False, status="completed") -> str:
+        from runtime.state import STATE
+        from server.chat import _drain_background_messages
+
+        mgr = _manager(tmp_path)
+        monkeypatch.setattr(STATE, "background_mgr", mgr, raising=False)
+        jid = mgr.store.create(
+            agent_name="a",
+            origin_session="sess-P",
+            subagent_type="researcher",
+            description="d",
+            prompt="p",
+            origin_incognito=incognito,
+        )
+        mgr.store.mark_complete(jid, status, result)
+        msgs = _drain_background_messages("sess-P")
+        assert len(msgs) == 1
+        return msgs[0].content
+
+    def test_truncated_notification_points_at_memory_recall(self, tmp_path, monkeypatch):
+        from server.chat import _BG_RESULT_CAP
+
+        assert _BG_RESULT_CAP == 3000  # ADR 0070 D2 shrank the inline cap
+        body = self._drained_body(tmp_path, monkeypatch, result="x" * (_BG_RESULT_CAP + 500))
+        assert "memory_recall" in body
+        assert "report card" in body
+        assert "job id bg-" in body
+
+    def test_small_result_carries_no_pointer(self, tmp_path, monkeypatch):
+        body = self._drained_body(tmp_path, monkeypatch, result="tiny result")
+        assert "memory_recall" not in body
+        assert "tiny result" in body
+
+    def test_incognito_truncation_does_not_claim_searchability(self, tmp_path, monkeypatch):
+        """An incognito job's report is NOT indexed — the notification must not
+        point the model at a memory_recall hit that doesn't exist."""
+        from server.chat import _BG_RESULT_CAP
+
+        body = self._drained_body(tmp_path, monkeypatch, result="x" * (_BG_RESULT_CAP + 500), incognito=True)
+        assert "memory_recall" not in body
+        assert "report card" in body  # jobs.db still has the full text
+
+
+# ── D3: disposable workers ───────────────────────────────────────────────────
+
+
+class TestDisposableWorkers:
+    def test_persist_session_skips_background_sessions(self, tmp_path, monkeypatch):
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        from graph.middleware.memory import _persist_session
+
+        monkeypatch.setenv("MEMORY_PATH", str(tmp_path))
+        msgs = [HumanMessage(content="do the research"), AIMessage(content="the full report")]
+        _persist_session({"session_id": "background:bg-abcabcabcabc", "messages": msgs}, "trace-1")
+        assert list(tmp_path.iterdir()) == []  # nothing written
+        # control: an ordinary chat session still persists
+        _persist_session({"session_id": "chat-77", "messages": msgs}, "trace-1")
+        assert (tmp_path / "chat-77.json").exists()
+
+    def test_digest_loader_skips_legacy_background_files(self, tmp_path):
+        from graph.middleware.memory import load_prior_sessions
+
+        summary = {
+            "session_id": "chat-1",
+            "messages": [{"role": "user", "content": "plan the sprint"}],
+            "timestamp": "2026-07-01T00:00:00+00:00",
+        }
+        (tmp_path / "chat-1.json").write_text(json.dumps(summary))
+        legacy = dict(summary, session_id="background:bg-abcabcabcabc")
+        legacy["messages"] = [{"role": "user", "content": "SECRET WORKER REPORT"}]
+        (tmp_path / "background:bg-abcabcabcabc.json").write_text(json.dumps(legacy))
+
+        block = load_prior_sessions(memory_dir=str(tmp_path))
+        assert "chat-1" in block
+        assert "background:bg-abcabcabcabc" not in block
+        assert "SECRET WORKER REPORT" not in block
+
+    async def test_harvest_skips_background_threads(self):
+        from graph.conversation_harvest import harvest_thread
+
+        class _RecordingCheckpointer:
+            calls: list = []
+
+            async def aget_tuple(self, cfg):
+                self.calls.append(cfg)
+                return None
+
+        cp = _RecordingCheckpointer()
+        for tid in ("a2a:background:bg-abcabcabcabc", "background:bg-abcabcabcabc"):
+            out = await harvest_thread(tid, checkpointer=cp, knowledge_store=object(), config=None)
+            assert out is None
+        assert cp.calls == []  # early-returned before touching the checkpointer
+
+
+# ── incognito propagation from the task tool ─────────────────────────────────
+
+
+class TestIncognitoPropagation:
+    def test_incognito_from_state(self):
+        from graph.agent import _incognito_from
+
+        assert _incognito_from({"incognito": True}) is True
+        assert _incognito_from({"incognito": False}) is False
+        assert _incognito_from({}) is False
+        assert _incognito_from(None) is False
+
+    async def test_task_tool_stamps_incognito_on_the_job(self, tmp_path, monkeypatch):
+        import httpx
+
+        from graph.agent import _build_task_tools
+        from graph.config import LangGraphConfig
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _FakeClient(_FakeResponse(200)))
+        mgr = _manager(tmp_path)
+        tools = _build_task_tools(LangGraphConfig(), [], background_mgr=mgr)
+        task = next(t for t in tools if t.name == "task")
+        await task.ainvoke(
+            {
+                "name": "task",
+                "type": "tool_call",
+                "id": "tc1",
+                "args": {
+                    "description": "dig",
+                    "prompt": "p",
+                    "subagent_type": "researcher",
+                    "run_in_background": True,
+                    "state": {"session_id": "chat-9", "incognito": True},
+                },
+            }
+        )
+        jobs = mgr.store.list()
+        assert len(jobs) == 1
+        assert jobs[0].origin_session == "chat-9"
+        assert jobs[0].origin_incognito is True
+
+
+# ── the by-id route ──────────────────────────────────────────────────────────
+
+
+class TestBackgroundByIdRoute:
+    def _client(self, monkeypatch, mgr):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from operator_api.routes import register_operator_routes
+        from runtime.state import STATE
+
+        app = FastAPI()
+
+        async def _run(_payload):
+            return ""
+
+        register_operator_routes(
+            app,
+            runtime_status=lambda: {},
+            subagent_list=lambda: [],
+            subagent_run=_run,
+            subagent_batch=_run,
+        )
+        monkeypatch.setattr(STATE, "background_mgr", mgr, raising=False)
+        return TestClient(app)
+
+    def test_happy_path_returns_full_row(self, tmp_path, monkeypatch):
+        mgr = _manager(tmp_path)
+        jid = mgr.store.create(
+            agent_name="a", origin_session="chat-42", subagent_type="researcher", description="dig", prompt="p"
+        )
+        mgr.store.mark_complete(jid, "completed", "the FULL report " * 500)
+        client = self._client(monkeypatch, mgr)
+        r = client.get(f"/api/background/{jid}")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["id"] == jid
+        assert body["origin_session"] == "chat-42"
+        assert body["result"].startswith("the FULL report")  # full text, not a preview
+        assert body["origin_incognito"] is False
+
+    def test_unknown_id_is_404(self, tmp_path, monkeypatch):
+        client = self._client(monkeypatch, _manager(tmp_path))
+        assert client.get("/api/background/bg-abcdefabcdef").status_code == 404
+
+    @pytest.mark.parametrize("bad", ["bg-XYZ", "notajob", "bg-abc", "bg-ABCDEFABCDEF", "bg-abcdefabcdef0"])
+    def test_malformed_id_is_400(self, tmp_path, monkeypatch, bad):
+        client = self._client(monkeypatch, _manager(tmp_path))
+        assert client.get(f"/api/background/{bad}").status_code == 400
+
+    def test_disabled_manager_is_404(self, monkeypatch):
+        client = self._client(monkeypatch, None)
+        assert client.get("/api/background/bg-abcdefabcdef").status_code == 404

--- a/tests/test_background_results.py
+++ b/tests/test_background_results.py
@@ -336,6 +336,59 @@ class TestTerminalHookResume:
         assert woke == [jid]
 
 
+# ── D1: the nudge turn is autonomous (no operator on the wire) ───────────────
+
+
+class _HitlTurnStream:
+    """Stand-in for ``_run_turn_stream`` (mirrors tests/test_hitl_forms.py): yields a
+    HITL interrupt on the first pass, then an answer once resumed."""
+
+    def __init__(self):
+        self.resume_values: list = []
+
+    def __call__(self, message, session_id, config, *, resume_value=None, **_kw):
+        self.resume_values.append(resume_value)
+        first = len(self.resume_values) == 1
+
+        async def _gen():
+            if first:
+                yield ("input_required", {"question": "Should I dig deeper?"})
+            else:
+                yield ("__raw__", "Briefing delivered.")
+
+        return _gen()
+
+
+class TestResumeTurnIsAutonomous:
+    async def test_nudge_turn_auto_answers_hitl_instead_of_parking(self, monkeypatch):
+        """The push-resume nudge is server-fired — the manager discards the A2A
+        response, so nobody can answer a HITL pause. origin="background-resume"
+        must ride the autonomous auto-answer path (like scheduler/background), or a
+        briefing turn that asks a question parks its task in input-required forever."""
+        import importlib
+
+        from runtime.state import STATE
+
+        chat_mod = importlib.import_module("server.chat")
+        monkeypatch.setattr(STATE, "goal_controller", None, raising=False)
+        fake = _HitlTurnStream()
+        monkeypatch.setattr(chat_mod, "_run_turn_stream", fake)
+
+        frames = [
+            frame
+            async for frame in chat_mod._run_native_turn(
+                "[background job bg-abcabcabcabc (dig) finished — brief the operator]",
+                "chat-42",
+                {"configurable": {"thread_id": "a2a:chat-42"}},
+                request_metadata={"origin": "background-resume"},
+            )
+        ]
+        kinds = [k for k, _ in frames]
+        assert "input_required" not in kinds  # never parks
+        assert ("done", "Briefing delivered.") in frames
+        assert chat_mod._AUTONOMOUS_HITL_SENTINEL in fake.resume_values
+
+
 # ── D2: report indexing ──────────────────────────────────────────────────────
 
 
@@ -349,7 +402,7 @@ class _FakeKnowledgeStore:
 
 
 class TestReportIndexing:
-    def _wire(self, tmp_path, monkeypatch, *, incognito=False):
+    def _wire(self, tmp_path, monkeypatch, *, incognito=False, origin="chat-42"):
         import server.a2a as a2a
         from graph.config import LangGraphConfig
         from runtime.state import STATE
@@ -357,7 +410,7 @@ class TestReportIndexing:
         mgr = _manager(tmp_path)
         jid = mgr.store.create(
             agent_name="a",
-            origin_session="chat-42",
+            origin_session=origin,
             subagent_type="researcher",
             description="dig",
             prompt="p",
@@ -401,6 +454,16 @@ class TestReportIndexing:
         await _settle_bg_tasks()
         assert fake.calls == []
 
+    async def test_chained_background_origin_job_not_indexed(self, tmp_path, monkeypatch, hook_env):
+        """A job spawned FROM another background worker's turn is never indexed:
+        its origin is a disposable worker identity (D3), its content flows into the
+        parent's own report, and the worker turn runs non-incognito — indexing here
+        would leak an incognito root's report into the KB transitively."""
+        a2a, jid, fake = self._wire(tmp_path, monkeypatch, origin="background:bg-parentparent")
+        a2a._handle_background_terminal(_outcome(jid, text="x" * 2000))
+        await _settle_bg_tasks()
+        assert fake.calls == []
+
     def test_background_report_is_agent_trust_tier(self):
         from knowledge.trust import trust_label, trust_tier
 
@@ -412,7 +475,9 @@ class TestReportIndexing:
 
 
 class TestDrainPointer:
-    def _drained_body(self, tmp_path, monkeypatch, *, result: str, incognito=False, status="completed") -> str:
+    def _drained_body(
+        self, tmp_path, monkeypatch, *, result: str, incognito=False, status="completed", origin="sess-P"
+    ) -> str:
         from runtime.state import STATE
         from server.chat import _drain_background_messages
 
@@ -420,14 +485,14 @@ class TestDrainPointer:
         monkeypatch.setattr(STATE, "background_mgr", mgr, raising=False)
         jid = mgr.store.create(
             agent_name="a",
-            origin_session="sess-P",
+            origin_session=origin,
             subagent_type="researcher",
             description="d",
             prompt="p",
             origin_incognito=incognito,
         )
         mgr.store.mark_complete(jid, status, result)
-        msgs = _drain_background_messages("sess-P")
+        msgs = _drain_background_messages(origin)
         assert len(msgs) == 1
         return msgs[0].content
 
@@ -453,6 +518,17 @@ class TestDrainPointer:
         body = self._drained_body(tmp_path, monkeypatch, result="x" * (_BG_RESULT_CAP + 500), incognito=True)
         assert "memory_recall" not in body
         assert "report card" in body  # jobs.db still has the full text
+
+    def test_chained_job_truncation_does_not_claim_searchability(self, tmp_path, monkeypatch):
+        """A background-origin (chained) job's report is NOT indexed — mirror of the
+        indexing guard, so the notification never points at a hit that doesn't exist."""
+        from server.chat import _BG_RESULT_CAP
+
+        body = self._drained_body(
+            tmp_path, monkeypatch, result="x" * (_BG_RESULT_CAP + 500), origin="background:bg-parentparent"
+        )
+        assert "memory_recall" not in body
+        assert "report card" in body
 
 
 # ── D3: disposable workers ───────────────────────────────────────────────────

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -67,6 +67,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "audit_middleware": True,
     "autostart_on_boot": False,
     "aux_model": "",
+    "background_auto_resume": True,
     "bind_host": "127.0.0.1",
     "cache_warming_enabled": False,
     "cache_warming_interval_seconds": 3300,

--- a/tests/test_memory_load.py
+++ b/tests/test_memory_load.py
@@ -404,13 +404,19 @@ def test_digest_one_attributed_line_no_assistant_text(tmp_path):
 def test_digest_surface_classification(tmp_path):
     cases = [
         ("chat-1", "chat"),
-        ("background:job-7", "background"),
         ("system:activity", "activity"),
         ("palette-2", "palette"),
         ("someA2Aconsumer", "a2a/other"),
     ]
     for sid, _ in cases:
         _write_session(str(tmp_path), sid, _sample_session(sid))
+    # A background WORKER summary never enters the digest (ADR 0070 D3 — the writer
+    # no longer persists them; the loader filters legacy files). digest_entry itself
+    # still classifies the surface (asserted below) for the memory-inspector API.
+    _write_session(str(tmp_path), "background:job-7", _sample_session("background:job-7"))
+    from graph.middleware.memory import digest_entry
+
+    assert digest_entry(_sample_session("background:job-7"))["surface"] == "background"
 
     from graph.middleware.memory import load_prior_sessions
 
@@ -418,6 +424,7 @@ def test_digest_surface_classification(tmp_path):
     for sid, surface in cases:
         line = next(ln for ln in result.split("\n") if sid in ln)
         assert f" {surface} " in line.replace("·", " "), f"{sid} classified wrong: {line}"
+    assert "background:job-7" not in result
 
 
 def test_digest_topic_truncated(tmp_path):

--- a/tests/test_task_batch.py
+++ b/tests/test_task_batch.py
@@ -159,7 +159,7 @@ class _RecordingBG:
     def __init__(self):
         self.calls: list[dict] = []
 
-    async def spawn(self, *, origin_session, subagent_type, description, prompt):
+    async def spawn(self, *, origin_session, subagent_type, description, prompt, origin_incognito=False):
         self.calls.append(
             {
                 "origin": origin_session,


### PR DESCRIPTION
Implements the backend lane of [ADR 0070 — background results: push-resume, indexed reports, disposable workers](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0070-background-results-push-resume.md) (D1 + D2 + D3 + the by-id route). The D4 report-card console work is a separate lane.

## D1 — push-resume (`background/manager.py`, `server/a2a.py`)

- The spawner's self-POST mechanics are factored into a shared `BackgroundManager._send_a2a_message` (used by `_fire` and the new `resume_origin`; `cancel` shares the header builder) — no copy-paste of the A2A wire shape.
- On terminal completion, after `mark_complete` + the `background.completed` publish, `_handle_background_terminal` schedules `resume_origin(job)`: a terse nudge turn into the **origin session** (`[background job bg-… (desc) finished — its report notification is attached to this turn; review it and brief the operator]`). The existing notified-gated drain (`server/chat.py:_drain_background_messages`, prepended at graph-input assembly in `_run_turn_stream` — the path every A2A turn takes) attaches the actual `<task-notification>` to that turn, preserving exactly-once.
- **Guards:** config `background.auto_resume` (NEW field, default on — golden + settings schema + example yaml + docs); never for canceled jobs; never for empty/`background:*` origins (no resume chains); never for incognito-spawned jobs; never-raises (`log.warning` on delivery failure — `notified` is untouched by the nudge, so the report still drains on the next manual turn).
- **Wake interplay:** when the resume applies, the ADR 0050 Phase-2 Activity wake is **skipped** — one briefing turn, in the right place, never both for one completion (the ADR's "a completed job now costs one extra agent turn"). When the resume doesn't apply (off/canceled/incognito/no-or-background origin) or can't be delivered, the wake fires as before.
- **Mid-turn origins (verified, nothing new built):** concurrent A2A sends on one context serialize via the per-thread lock in `server/chat.py` (`_thread_lock`), so a nudge into a mid-turn session queues and runs after the in-flight turn.
- The nudge turn's metadata is `origin: "background-resume"` (NOT `"background"` — that would route its own terminal back into the background hook). `_surface_resumed_chat_turn` now also pushes `chat.resumed` for that origin, so an open chat tab shows the briefing live (same seam as scheduler resumes, bd-k02).

## D2 — indexed reports (`server/a2a.py`, `knowledge/trust.py`, `server/chat.py`)

- Completed jobs with a substantial result (> 800 chars) are indexed into the knowledge store at completion via `knowledge.add_document` (which chunks with the shared `knowledge/chunking.py` splitter — same path as conversation harvest): `source=origin_session`, `source_type="background_report"`, heading `Background report: {description} ({job_id})`, `domain="conversation"` for read-path parity with harvest rows. Rows get `created_at`/provenance from `add_chunk`, so `memory_recall` cites them (`src: <origin session>, <date>, trust: agent`).
- `"background_report"` added to the trust map at **tier 2** (agent-derived, ADR 0069 D8).
- `_BG_RESULT_CAP` shrinks 6000 → 3000; a truncated notification appends a pointer line (searchable via `memory_recall` — only claimed when the report was actually indexed, i.e. completed + non-incognito — and openable from the console report card by job id).
- Indexing is fire-and-forget on the loop with the embed work in `asyncio.to_thread`; skipped for incognito spawns and failed jobs.

## D3 — disposable workers (`graph/middleware/memory.py`, `graph/conversation_harvest.py`)

- `_persist_session` returns early for `background:*` session ids (log.debug) — no worker summary file, so no full-report leak into `<prior_sessions>` via `final_output`.
- `load_prior_sessions_digest` skips files named `background:*` — covers legacy files already on disk.
- `harvest_thread` returns early for `background:*` / `*:background:*` thread ids (covers `a2a:background:*`), mirroring the incognito skip — no retirement harvest or fact extraction for worker threads. Checkpoints untouched (pruned normally); the jobs DB stays the system of record.

## Incognito propagation (`graph/agent.py`, `background/store.py`)

- `task`/`task_batch` background spawns pass the injected state's `incognito` flag (`_incognito_from`, same injected-state source as `_session_id_from`) into `BackgroundManager.spawn`/`spawn_work` → new `origin_incognito INTEGER NOT NULL DEFAULT 0` column (ALTER TABLE migration following the store's `a2a_task_id` convention; idempotent, legacy rows read false). When set: no D1 resume, no D2 indexing (ADR 0069 D3b semantics); the report still lives in jobs.db and drains normally.

## By-id route (`operator_api/routes.py`)

- `GET /api/background/{job_id}` → the full row dict (full result text — the bus event only carries a preview). Strict `bg-[a-f0-9]{12}` validation (400 otherwise), 404 unknown / manager-disabled. Registered inside `register_operator_routes`, so it sits behind the same `/api/*` bearer middleware as the list route.

## Tests (36 new in `tests/test_background_results.py` + 3 adjusted)

Resume: nudge wire shape (origin context, `background-resume` origin, text), exactly-one-nudge on completion with no wake, none when disabled/canceled/background-origin/incognito, delivery-failure → wake fallback with row + `notified` untouched, drain still exactly-once after the nudge. Indexing: provenance/heading/source_type happy path, small/failed/incognito not indexed, trust tier resolves 2. Drain pointer: cap=3000, pointer present when truncated (and not falsely claiming searchability for incognito), absent for small results. D3: persist skip (+ control), legacy digest filter, harvest skip (checkpointer untouched). Incognito: `_incognito_from` matrix + end-to-end through the real `task` tool. Store: incognito roundtrip, legacy-DB migration, idempotence. Route: happy/404/bad-id/disabled. Existing suites: `_RecordingBG` stubs learned the new kwarg; the digest surface-classification test now asserts worker files are excluded (behavior change is the point of D3).

## Gates

- `ruff check .` ✓ · `lint-imports` ✓ (3 kept) · `python -m pytest tests/ -q` ✓ (2753 passed, 5 skipped) · `python scripts/live_smoke.py` ✓ · `npm run docs:build` ✓ (docs touched: subagents guide, configuration + operator-api reference; no new page → no nav regen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
