### PR TITLE
feat(console): background report card — raised surface, clamped excerpt with fade, Open CTA, by-id fetch (ADR 0070 D4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   link): it's now a raised card — `--pl-color-bg-raised` surface, 1px border,
   real corners, drop shadow — with a header row (report title + "Background
   report"), an excerpt **clamped to ~7 lines with a bottom fade-out mask** (a
-  teaser, not the content), and a clear **"Open report"** CTA into the document
+  teaser, not the content — the fade applies only when the text actually
+  overflows, so a short report's final line stays fully readable), and a clear
+  **"Open report"** CTA into the document
   viewer; the whole card is click-to-open (selection-guarded). The viewer now
   fetches the full report **by id** via the new `GET /api/background/{id}`
   (`api.backgroundJob`), replacing the list-and-filter hack — kept only as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   job's full row (strict `bg-<12 hex>` id validation) for the console report
   card.
 
+### Changed
+- **The background report card is a real card**
+  ([ADR 0070](docs/adr/0070-background-results-push-resume.md) D4, console).
+  A finished background job's report no longer renders as the DS system-message
+  pill (near-black inset fill, 100px radius, a quiet ghost "Read full report"
+  link): it's now a raised card — `--pl-color-bg-raised` surface, 1px border,
+  real corners, drop shadow — with a header row (report title + "Background
+  report"), an excerpt **clamped to ~7 lines with a bottom fade-out mask** (a
+  teaser, not the content), and a clear **"Open report"** CTA into the document
+  viewer; the whole card is click-to-open (selection-guarded). The viewer now
+  fetches the full report **by id** via the new `GET /api/background/{id}`
+  (`api.backgroundJob`), replacing the list-and-filter hack — kept only as a
+  fallback when the by-id route 404s (pre-0070 servers / deleted rows). Card
+  styling uses stacked specificity (`.pl-message--system.chat-report …`) so the
+  DS default can't win by stylesheet load order.
+
 ## [0.79.0] - 2026-07-01
 
 ### Added

--- a/apps/web/e2e/report-card.spec.ts
+++ b/apps/web/e2e/report-card.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+
+// Background report card (ADR 0070 D4). A finished background job's report renders as a
+// real CARD in the spawning chat — raised surface, clamped excerpt with a bottom fade-out,
+// an "Open report" CTA — and the document viewer fetches the FULL report BY ID
+// (GET /api/background/{id}), never via the legacy list-and-filter.
+//
+// Harness: seed an open chat session, replace the mock SSE stream with one that emits a
+// `background.completed` for that session (BackgroundWatch injects the display-only report
+// message), and serve the by-id route with a full result the LIST route does not carry —
+// so the viewer showing the full text proves the by-id fetch.
+
+const JOB_ID = "bg-abcdefabcdef";
+const SESSION = "chat-bg-e2e";
+const TITLE = "Quarterly numbers deep-dive";
+// Long enough that the excerpt must clamp (scrollHeight > clientHeight).
+const PREVIEW = Array.from({ length: 40 }, (_, i) => `Preview line ${i + 1} of the trimmed result.`).join("\n\n");
+const FULL_MARKER = "FULL-REPORT-ONLY-SERVED-BY-ID";
+const FULL = `# ${TITLE}\n\n${FULL_MARKER}\n\nThe untruncated report body.`;
+
+test("report card: clamped fading excerpt, Open CTA → docviewer, fetched by id", async ({ page }) => {
+  // An open chat session whose id matches the job's origin_session — BackgroundWatch
+  // only injects into sessions that are open in this window.
+  await page.addInitScript(
+    ([session]) => {
+      window.localStorage.setItem(
+        "protoagent.chat.sessions",
+        JSON.stringify({
+          version: 1,
+          currentSessionId: session,
+          sessions: [{ id: session, title: "spawner", createdAt: 1, updatedAt: 2, messages: [] }],
+        }),
+      );
+    },
+    [SESSION],
+  );
+
+  // SSE: one background.completed frame for the seeded session. The stream then closes;
+  // EventSource reconnects and replays it — BackgroundWatch dedupes, so the card renders
+  // exactly once even though delivery is repeated.
+  const frame = {
+    topic: "background.completed",
+    data: {
+      job_id: JOB_ID,
+      origin_session: SESSION,
+      status: "completed",
+      description: TITLE,
+      result: PREVIEW, // the truncated preview the bus event carries
+    },
+  };
+  await page.route("**/api/events**", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+      body: `data: ${JSON.stringify(frame)}\n\n`,
+    }),
+  );
+
+  // The by-id route (ADR 0070) carries the FULL result; record its hits.
+  const byIdHits: string[] = [];
+  await page.route(`**/api/background/${JOB_ID}`, (route) => {
+    byIdHits.push(route.request().url());
+    return route.fulfill({
+      json: {
+        id: JOB_ID,
+        status: "completed",
+        subagent_type: "researcher",
+        description: TITLE,
+        origin_session: SESSION,
+        result: FULL,
+      },
+    });
+  });
+  // The LIST route must NOT be the card's source — it answers, but without the report.
+  await page.route("**/api/background", (route) => route.fulfill({ json: { enabled: true, jobs: [] } }));
+
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // The card: raised-card wrapper, header row (title + subtitle), CTA.
+  const card = page.locator(".chat-report-card");
+  await expect(card).toBeVisible({ timeout: 15_000 });
+  await expect(card.locator(".chat-report-title")).toHaveText(TITLE);
+  await expect(card.locator(".chat-report-sub")).toHaveText("Background report");
+
+  // The excerpt is CLAMPED (content overflows the fade window) and carries the
+  // fade-out mask class.
+  const excerpt = card.locator(".chat-report-excerpt");
+  await expect(excerpt).toBeVisible();
+  await expect(excerpt).toContainText("Preview line 1");
+  expect(await excerpt.evaluate((el) => el.scrollHeight > el.clientHeight + 1)).toBe(true);
+  expect(
+    await excerpt.evaluate((el) => {
+      const s = getComputedStyle(el);
+      return s.maskImage || s.webkitMaskImage || "";
+    }),
+  ).toContain("linear-gradient");
+
+  // The CTA opens the document viewer with the FULL report — which only the by-id
+  // route serves, so its presence + the recorded hit prove the fetch path.
+  await card.getByRole("button", { name: "Open report" }).click();
+  const viewer = page.locator(".doc-viewer");
+  await expect(viewer).toBeVisible();
+  await expect(viewer).toContainText(FULL_MARKER);
+  expect(byIdHits.length).toBeGreaterThan(0);
+});

--- a/apps/web/e2e/report-card.spec.ts
+++ b/apps/web/e2e/report-card.spec.ts
@@ -17,6 +17,11 @@ const TITLE = "Quarterly numbers deep-dive";
 const PREVIEW = Array.from({ length: 40 }, (_, i) => `Preview line ${i + 1} of the trimmed result.`).join("\n\n");
 const FULL_MARKER = "FULL-REPORT-ONLY-SERVED-BY-ID";
 const FULL = `# ${TITLE}\n\n${FULL_MARKER}\n\nThe untruncated report body.`;
+// A SHORT report that fits entirely: the fade mask must NOT apply (an unconditional
+// mask would ghost the report's last line into a fake truncation).
+const SHORT_JOB_ID = "bg-abcdefabcd99";
+const SHORT_TITLE = "Quick store check";
+const SHORT_PREVIEW = "All 4 stores match the drive.\n\nNothing to fix.";
 
 test("report card: clamped fading excerpt, Open CTA → docviewer, fetched by id", async ({ page }) => {
   // An open chat session whose id matches the job's origin_session — BackgroundWatch
@@ -35,24 +40,37 @@ test("report card: clamped fading excerpt, Open CTA → docviewer, fetched by id
     [SESSION],
   );
 
-  // SSE: one background.completed frame for the seeded session. The stream then closes;
-  // EventSource reconnects and replays it — BackgroundWatch dedupes, so the card renders
-  // exactly once even though delivery is repeated.
-  const frame = {
-    topic: "background.completed",
-    data: {
-      job_id: JOB_ID,
-      origin_session: SESSION,
-      status: "completed",
-      description: TITLE,
-      result: PREVIEW, // the truncated preview the bus event carries
+  // SSE: two background.completed frames for the seeded session — a long report (must
+  // clamp + fade) and a short one (must NOT fade). The stream then closes; EventSource
+  // reconnects and replays them — BackgroundWatch dedupes, so each card renders exactly
+  // once even though delivery is repeated.
+  const frames = [
+    {
+      topic: "background.completed",
+      data: {
+        job_id: JOB_ID,
+        origin_session: SESSION,
+        status: "completed",
+        description: TITLE,
+        result: PREVIEW, // the truncated preview the bus event carries
+      },
     },
-  };
+    {
+      topic: "background.completed",
+      data: {
+        job_id: SHORT_JOB_ID,
+        origin_session: SESSION,
+        status: "completed",
+        description: SHORT_TITLE,
+        result: SHORT_PREVIEW,
+      },
+    },
+  ];
   await page.route("**/api/events**", (route) =>
     route.fulfill({
       status: 200,
       headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
-      body: `data: ${JSON.stringify(frame)}\n\n`,
+      body: frames.map((f) => `data: ${JSON.stringify(f)}\n\n`).join(""),
     }),
   );
 
@@ -76,24 +94,42 @@ test("report card: clamped fading excerpt, Open CTA → docviewer, fetched by id
 
   await page.goto("/app/", { waitUntil: "load" });
 
-  // The card: raised-card wrapper, header row (title + subtitle), CTA.
-  const card = page.locator(".chat-report-card");
+  // The long-report card: raised-card wrapper, header row (title + subtitle), CTA.
+  const card = page.locator(".chat-report-card").filter({ hasText: TITLE });
   await expect(card).toBeVisible({ timeout: 15_000 });
   await expect(card.locator(".chat-report-title")).toHaveText(TITLE);
   await expect(card.locator(".chat-report-sub")).toHaveText("Background report");
 
   // The excerpt is CLAMPED (content overflows the fade window) and carries the
-  // fade-out mask class.
+  // fade-out mask.
   const excerpt = card.locator(".chat-report-excerpt");
   await expect(excerpt).toBeVisible();
   await expect(excerpt).toContainText("Preview line 1");
   expect(await excerpt.evaluate((el) => el.scrollHeight > el.clientHeight + 1)).toBe(true);
+  await expect(excerpt).toHaveClass(/chat-report-excerpt--clamped/);
   expect(
     await excerpt.evaluate((el) => {
       const s = getComputedStyle(el);
       return s.maskImage || s.webkitMaskImage || "";
     }),
   ).toContain("linear-gradient");
+
+  // The SHORT report fits entirely — no clamp, and crucially NO fade mask (an
+  // unconditional mask would ghost its final line into a fake truncation).
+  const shortExcerpt = page
+    .locator(".chat-report-card")
+    .filter({ hasText: SHORT_TITLE })
+    .locator(".chat-report-excerpt");
+  await expect(shortExcerpt).toBeVisible();
+  await expect(shortExcerpt).toContainText("Nothing to fix.");
+  expect(await shortExcerpt.evaluate((el) => el.scrollHeight > el.clientHeight + 1)).toBe(false);
+  await expect(shortExcerpt).not.toHaveClass(/chat-report-excerpt--clamped/);
+  expect(
+    await shortExcerpt.evaluate((el) => {
+      const s = getComputedStyle(el);
+      return s.maskImage === "none" ? "" : s.maskImage || s.webkitMaskImage || "";
+    }),
+  ).not.toContain("linear-gradient");
 
   // The CTA opens the document viewer with the FULL report — which only the by-id
   // route serves, so its presence + the recorded hit prove the fetch path.

--- a/apps/web/src/app/BackgroundWatch.tsx
+++ b/apps/web/src/app/BackgroundWatch.tsx
@@ -83,9 +83,13 @@ export function BackgroundWatch() {
       const header = failed
         ? `Background agent failed — ${desc}`
         : `Background agent finished — ${desc}`;
+      // The report CARD renders its own header row (title + "Background report",
+      // ADR 0070 D4) — a finished job injects just the result preview as the card's
+      // excerpt so the lede isn't duplicated. Failures keep the explicit failed-lede
+      // (the card header alone doesn't convey the outcome); no result → lede only.
       const injected = appendSystem(
         session,
-        result ? `${header}\n\n${result}` : header,
+        failed && result ? `${header}\n\n${result}` : result || header,
         jobId ? { jobId, title: desc } : undefined,
       );
       toast({

--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -3,6 +3,7 @@ import { Message, MessageAction, MessageActions } from "@protolabsai/ui/ai";
 import { Tooltip } from "@protolabsai/ui/overlays";
 import { Spinner } from "@protolabsai/ui/data";
 import { ArrowDownToLine, Check, Clock, Coins, Copy, FileText, GitBranch, Gauge, History, Maximize2, RotateCcw } from "lucide-react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 import { openDocument } from "../docviewer";
 import { slashCommandName } from "../ext/slashRegistry";
@@ -218,6 +219,22 @@ function BackgroundReportCard({
       subtitle: "Background agent report",
       load: () => loadBackgroundReport(report.jobId),
     });
+  // The bottom fade-out is a CLAMP indicator, not decoration: apply it only when the
+  // excerpt actually overflows its max-height. An unconditional mask scales to the
+  // element's own box, so a SHORT report (which fits entirely) would have its last
+  // line faded toward invisible — the report's conclusion, misread as truncation.
+  // Re-measured on resize (width changes rewrap the text and move the overflow point).
+  const excerptRef = useRef<HTMLDivElement | null>(null);
+  const [clamped, setClamped] = useState(false);
+  useLayoutEffect(() => {
+    const el = excerptRef.current;
+    if (!el) return;
+    const measure = () => setClamped(el.scrollHeight > el.clientHeight + 1);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [message.content]);
   return (
     <Message role={message.role} className="chat-report">
       <div
@@ -235,7 +252,7 @@ function BackgroundReportCard({
           </div>
         </div>
         {message.content ? (
-          <div className="chat-report-excerpt">
+          <div ref={excerptRef} className={`chat-report-excerpt${clamped ? " chat-report-excerpt--clamped" : ""}`}>
             <Markdown>{message.content}</Markdown>
           </div>
         ) : null}

--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -2,11 +2,11 @@ import { Button } from "@protolabsai/ui/primitives";
 import { Message, MessageAction, MessageActions } from "@protolabsai/ui/ai";
 import { Tooltip } from "@protolabsai/ui/overlays";
 import { Spinner } from "@protolabsai/ui/data";
-import { ArrowDownToLine, Check, Clock, Coins, Copy, GitBranch, Gauge, History, Maximize2, RotateCcw } from "lucide-react";
+import { ArrowDownToLine, Check, Clock, Coins, Copy, FileText, GitBranch, Gauge, History, Maximize2, RotateCcw } from "lucide-react";
 
 import { openDocument } from "../docviewer";
 import { slashCommandName } from "../ext/slashRegistry";
-import { api } from "../lib/api";
+import { loadBackgroundReport } from "../lib/api";
 import { useUI } from "../state/uiStore";
 import type { ChatMessage, ChatPart, ContextWindow, TurnUsage } from "../lib/types";
 import { ChatComponent } from "./ChatComponent";
@@ -63,21 +63,26 @@ export function ChatMessageView({
         {text}
       </span>
     );
+  // Background-agent report (ADR 0050 → ADR 0070 D4): a finished job's report renders as a
+  // dedicated CARD — none of the streaming/parts machinery below applies (BackgroundWatch
+  // injects it display-only: role "system", plain content, never streams).
+  if (message.report) {
+    return <BackgroundReportCard message={message} report={message.report} />;
+  }
   return (
     <Message
       role={message.role}
       streaming={streaming}
       className={
-        message.report
-          ? "chat-report"
-          : // Any non-report system message is a local note → compact .chat-note card; the
-            // tone modifier is appended only when set, so neutral notes still get the styling.
-            message.role === "system"
-            ? `chat-note${message.noteTone ? ` chat-note--${message.noteTone}` : ""}`
-            : // An issued slash command → distinct .chat-slash-msg user bubble (#1529).
-              userSlashCmd
-              ? "chat-slash-msg"
-              : undefined
+        // Any system message here is a local note → compact .chat-note card; the tone
+        // modifier is appended only when set, so neutral notes still get the styling.
+        // (Report messages returned above.)
+        message.role === "system"
+          ? `chat-note${message.noteTone ? ` chat-note--${message.noteTone}` : ""}`
+          : // An issued slash command → distinct .chat-slash-msg user bubble (#1529).
+            userSlashCmd
+            ? "chat-slash-msg"
+            : undefined
       }
     >
       {message.reasoning && !(message.parts && message.parts.length) ? (
@@ -161,31 +166,6 @@ export function ChatMessageView({
       {message.components && message.components.length > 0 && !message.parts?.some((p) => p.kind === "component")
         ? message.components.map((spec, i) => <ChatComponent key={i} spec={spec} />)
         : null}
-      {/* Background-agent report (ADR 0050/0062): the bubble shows the server's preview; this
-          opens the FULL report in the full-screen document viewer (fetched by job id). */}
-      {message.report ? (
-        <Button
-          className="chat-report-open"
-          variant="ghost"
-          size="sm"
-          onClick={() =>
-            openDocument({
-              title: message.report!.title,
-              subtitle: "Background agent report",
-              load: () =>
-                api
-                  .background()
-                  .then(
-                    (r) =>
-                      r.jobs.find((j) => j.id === message.report!.jobId)?.result ||
-                      "_The full report is no longer available — it may have been cleared from the Background agents panel._",
-                  ),
-            })
-          }
-        >
-          <Maximize2 size={14} /> Read full report
-        </Button>
-      ) : null}
       {showChatUsage && message.role === "assistant" && !streaming && (message.usage || message.contextWindow) ? (
         <UsageFooter usage={message.usage} context={message.contextWindow} />
       ) : null}
@@ -214,6 +194,64 @@ export function ChatMessageView({
           ) : null}
         </MessageActions>
       ) : null}
+    </Message>
+  );
+}
+
+// The background-report CARD (ADR 0070 D4). A finished job's report is a document, not a
+// status pill: raised surface + shadow (styling in chat.css), a title header, a clamped
+// excerpt that fades out at the bottom (a teaser — the full text lives in the document
+// viewer), and an explicit "Open report" CTA. The full report is fetched BY ID
+// (GET /api/background/{id}); loadBackgroundReport keeps a legacy list-and-filter
+// fallback for pre-ADR-0070 servers. The whole card is click-to-open as a convenience
+// (guarded so a text selection is never stolen); the Button is the accessible control.
+function BackgroundReportCard({
+  message,
+  report,
+}: {
+  message: ChatMessage;
+  report: NonNullable<ChatMessage["report"]>;
+}) {
+  const open = () =>
+    openDocument({
+      title: report.title,
+      subtitle: "Background agent report",
+      load: () => loadBackgroundReport(report.jobId),
+    });
+  return (
+    <Message role={message.role} className="chat-report">
+      <div
+        className="chat-report-card"
+        onClick={() => {
+          // Convenience click-anywhere — but selecting excerpt text must not open.
+          if (window.getSelection()?.isCollapsed !== false) open();
+        }}
+      >
+        <div className="chat-report-head">
+          <FileText size={16} aria-hidden />
+          <div className="chat-report-titles">
+            <span className="chat-report-title">{report.title}</span>
+            <span className="chat-report-sub">Background report</span>
+          </div>
+        </div>
+        {message.content ? (
+          <div className="chat-report-excerpt">
+            <Markdown>{message.content}</Markdown>
+          </div>
+        ) : null}
+        <div className="chat-report-cta">
+          <Button
+            className="chat-report-open"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation(); // the card's own click-to-open would double-fire
+              open();
+            }}
+          >
+            <Maximize2 size={14} /> Open report
+          </Button>
+        </div>
+      </div>
     </Message>
   );
 }

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -122,13 +122,18 @@
   letter-spacing: 0.05em;
   color: var(--pl-color-fg-muted);
 }
-/* The excerpt is a TEASER, not the content: clamp to ~7 text lines and fade the tail
-   out so the text visibly trails off into the card — the full report lives in the
-   document viewer behind the CTA. */
+/* The excerpt is a TEASER, not the content: clamp to ~7 text lines, and when the text
+   actually overflows (the --clamped modifier, measured in ChatMessageView) fade the tail
+   out so it visibly trails off into the card — the full report lives in the document
+   viewer behind the CTA. The mask is NOT unconditional: it scales to the element's own
+   box, so on a short, fully-visible report it would ghost the last line — the report's
+   conclusion — into a fake "there's more" truncation. */
 .chat-report-excerpt {
   margin-top: 10px;
   max-height: 10.5em; /* ≈7 lines at the markdown 1.5 line height */
   overflow: hidden;
+}
+.chat-report-excerpt--clamped {
   -webkit-mask-image: linear-gradient(to bottom, black 55%, transparent 100%);
   mask-image: linear-gradient(to bottom, black 55%, transparent 100%);
 }

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -61,25 +61,83 @@
   display: contents;
 }
 
-/* Background-agent report card (ADR 0050/0062). The DS system message is a de-emphasized
-   centered pill (bg-inset fill); for a report + "Read full report" button that reads wrong.
-   Restyle it as a bordered card sitting on the chat surface: same background as the surface
-   (transparent), a border instead of the fill, de-pilled + left-aligned + readable size. */
+/* Background-agent report card (ADR 0070 D4). The DS system message is a de-emphasized
+   centered near-black pill (bg-inset fill, 100px radius); a finished job's report is a
+   DOCUMENT teaser, not a status blip. The card itself is the bespoke .chat-report-card
+   inside the message content (raised surface, real corners, shadow, header row, clamped
+   fading excerpt, "Open report" CTA — built in ChatMessageView); here we only NEUTRALIZE
+   the DS pill on the content wrapper. Specificity is STACKED on the message root
+   (.pl-message--system.chat-report …) — the .chat-note pattern below — so the DS default
+   (.pl-message--system .pl-message__content, 0-2-0) can never win by load order; the
+   .chat-session-slot-anchored variant (0-4-0) also outranks our own base system-message
+   rule further down (0-3-0), and the bare variant covers a card rendered outside the
+   chat slot (the shared renderer also serves the ⌘K palette chat). */
 .chat-report.pl-message--system {
   justify-content: stretch;
 }
-.chat-report .pl-message__content {
-  background: transparent; /* match the chat surface — no bg-inset fill */
-  border: var(--pl-border-width) solid var(--pl-color-border);
-  border-radius: var(--pl-radius);
+.chat-session-slot .pl-message--system.chat-report .pl-message__content,
+.pl-message--system.chat-report .pl-message__content {
   display: block;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
   text-align: left;
   font-size: 0.9rem;
   color: var(--pl-color-fg);
-  padding: 10px 14px;
 }
-.chat-report-open {
-  margin-top: 8px;
+.chat-report-card {
+  background: var(--pl-color-bg-raised); /* lifted OFF the surface — not the bg-inset well */
+  border: 1px solid var(--pl-color-border);
+  border-radius: var(--pl-radius);
+  /* Raised-element shadow — the DS .pl-convo__jump precedent, same literal fallback for
+     themes that don't define the popover shadow token. */
+  box-shadow: var(--pl-shadow-popover, 0 2px 8px rgba(0, 0, 0, 0.22));
+  padding: 14px 16px;
+  cursor: pointer; /* the whole card opens the report (selection-guarded in JSX) */
+}
+.chat-report-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.chat-report-head > svg {
+  flex: 0 0 auto;
+  color: var(--pl-color-fg-muted);
+}
+.chat-report-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.chat-report-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+.chat-report-sub {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--pl-color-fg-muted);
+}
+/* The excerpt is a TEASER, not the content: clamp to ~7 text lines and fade the tail
+   out so the text visibly trails off into the card — the full report lives in the
+   document viewer behind the CTA. */
+.chat-report-excerpt {
+  margin-top: 10px;
+  max-height: 10.5em; /* ≈7 lines at the markdown 1.5 line height */
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to bottom, black 55%, transparent 100%);
+  mask-image: linear-gradient(to bottom, black 55%, transparent 100%);
+}
+.chat-report-excerpt .markdown > :first-child,
+.chat-report-excerpt .pl-markdown > :first-child {
+  margin-top: 0;
+}
+.chat-report-cta {
+  margin-top: 10px;
 }
 
 /* Per-turn token/cost footer under an assistant answer (#1372) — a quiet, monospace row of

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
   ApiError,
+  api,
   apiUrl,
   drainSseBuffer,
   frameIsForeign,
   isColdStart,
   isAgentNotRunning,
+  loadBackgroundReport,
   textFromParts,
   hitlFromParts,
 } from "./api";
@@ -207,5 +209,87 @@ describe("frameIsForeign — cross-context stream guard (subagent-stream-isolati
   it("never treats an empty / resultless frame as foreign", () => {
     expect(frameIsForeign({}, SESSION)).toBe(false);
     expect(frameIsForeign({ result: {} }, SESSION)).toBe(false);
+  });
+});
+
+// ── Background report by-id fetch (ADR 0070 D4) ────────────────────────────────
+// api.backgroundJob hits GET /api/background/{id} (the only route carrying the FULL
+// result); loadBackgroundReport wraps it for the report card / document viewer with
+// a legacy list-and-filter fallback that fires ONLY on a 404.
+
+const JOB = "bg-abcdefabcdef";
+const GONE = /no longer available/;
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Stub global fetch with a per-URL router; returns the list of requested paths. */
+function stubFetch(route: (path: string) => Response) {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input);
+      calls.push(path);
+      return route(path);
+    }),
+  );
+  return calls;
+}
+
+describe("api.backgroundJob / loadBackgroundReport (ADR 0070 D4)", () => {
+  beforeEach(() => {
+    // The apiUrl slug-routing suite above leaves the jsdom URL focused on a member
+    // (/app/agent/m/) — reset to the host window so paths aren't /agents/m/-prefixed.
+    window.history.replaceState({}, "", "/app/");
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("backgroundJob GETs the by-id route and returns the full row", async () => {
+    const calls = stubFetch(() =>
+      json({ id: JOB, status: "completed", subagent_type: "researcher", description: "dig", result: "the FULL report" }),
+    );
+    const job = await api.backgroundJob(JOB);
+    expect(calls).toEqual([`/api/background/${JOB}`]);
+    expect(job.id).toBe(JOB);
+    expect(job.result).toBe("the FULL report");
+  });
+
+  it("loadBackgroundReport resolves the by-id result without touching the list", async () => {
+    const calls = stubFetch(() => json({ id: JOB, status: "completed", result: "full text" }));
+    await expect(loadBackgroundReport(JOB)).resolves.toBe("full text");
+    expect(calls).toEqual([`/api/background/${JOB}`]);
+  });
+
+  it("falls back to list-and-filter ONLY on a 404 (pre-ADR-0070 server)", async () => {
+    const calls = stubFetch((path) =>
+      path === `/api/background/${JOB}`
+        ? json({ detail: "not found" }, 404)
+        : json({ enabled: true, jobs: [{ id: JOB, status: "completed", result: "from the list" }] }),
+    );
+    await expect(loadBackgroundReport(JOB)).resolves.toBe("from the list");
+    expect(calls).toEqual([`/api/background/${JOB}`, "/api/background"]);
+  });
+
+  it("404 + job absent from the list → the 'no longer available' placeholder", async () => {
+    stubFetch((path) =>
+      path === `/api/background/${JOB}` ? json({ detail: "gone" }, 404) : json({ enabled: true, jobs: [] }),
+    );
+    await expect(loadBackgroundReport(JOB)).resolves.toMatch(GONE);
+  });
+
+  it("a completed row with an empty result also reads as unavailable", async () => {
+    stubFetch(() => json({ id: JOB, status: "completed", result: "" }));
+    await expect(loadBackgroundReport(JOB)).resolves.toMatch(GONE);
+  });
+
+  it("non-404 failures PROPAGATE (no silent fallback that hides a real error)", async () => {
+    const calls = stubFetch(() => json({ detail: "boom" }, 500));
+    await expect(loadBackgroundReport(JOB)).rejects.toMatchObject({ status: 500 });
+    expect(calls).toEqual([`/api/background/${JOB}`]); // never reached the list
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -670,6 +670,13 @@ export const api = {
     return request<{ enabled: boolean; jobs: BackgroundJobDTO[] }>("/api/background");
   },
 
+  // One background job's full row by id (ADR 0070 D4). This is the ONLY place the
+  // FULL result text is fetchable — the `background.completed` bus event and the
+  // drained <task-notification> both carry truncated previews.
+  backgroundJob(jobId: string) {
+    return request<BackgroundJobDTO>(`/api/background/${encodeURIComponent(jobId)}`);
+  },
+
   // Stop a running background job (ADR 0051) — cancels its detached A2A turn.
   stopBackground(jobId: string) {
     return request<{ ok: boolean; status?: string; detail?: string }>(
@@ -1742,3 +1749,24 @@ export const api = {
     return request<DelegateProbe>("/api/delegates/test", { method: "POST", body: entry });
   },
 };
+
+/** Full report body for the chat report card → document viewer (ADR 0070 D4).
+ *
+ *  Fetches the job by id (`GET /api/background/{id}` — the only route that carries the
+ *  untruncated result). Falls back to the legacy list-and-filter ONLY on a 404: a
+ *  pre-ADR-0070 server has no by-id route (its router answers 404), and on a current
+ *  server a 404 means the job row was deleted — which the list fallback resolves to the
+ *  same "no longer available" placeholder. Any other failure (401/500/network) is real
+ *  and propagates so the viewer shows its error state instead of a misleading placeholder. */
+export async function loadBackgroundReport(jobId: string): Promise<string> {
+  const gone =
+    "_The full report is no longer available — it may have been cleared from the Background agents panel._";
+  try {
+    return (await api.backgroundJob(jobId)).result || gone;
+  } catch (err) {
+    if (!(err instanceof ApiError) || err.status !== 404) throw err;
+    // Old server (no by-id route) or deleted row — the list answers both.
+    const listed = await api.background().catch(() => null);
+    return listed?.jobs.find((j) => j.id === jobId)?.result || gone;
+  }
+}


### PR DESCRIPTION
## What

The console half of [ADR 0070](docs/adr/0070-background-results-push-resume.md) (D4), on top of the backend by-id route shipped in #1604. The chat report card for a finished background job becomes a **real card** instead of the restyled DS system-message pill, and the document viewer fetches the full report **by id**.

### Card restyle (`apps/web/src/chat/chat.css`, `ChatMessageView.tsx`)

- **Raised surface** — `--pl-color-bg-raised` (not the near-black `bg-inset` well), 1px `--pl-color-border` border, `--pl-radius` corners (the 100px pill is gone), left-aligned block layout.
- **Drop shadow** — `var(--pl-shadow-popover, 0 2px 8px rgba(0,0,0,0.22))` (the DS `.pl-convo__jump` precedent, same literal fallback).
- **Header row** — report title + "Background report" subtitle, `FileText` glyph.
- **Teaser excerpt** — clamped to ~7 text lines (`max-height` + `overflow: hidden`) with a bottom **fade-out** (`mask-image: linear-gradient(to bottom, black 55%, transparent 100%)`, `-webkit-` prefixed) so the preview visibly trails off. `BackgroundWatch` now injects just the result preview for finished jobs — the card header owns the lede (failures keep the explicit failed-lede).
- **Clear CTA** — an outline DS `Button` "Open report" into the document viewer; the whole card is also click-to-open (`cursor: pointer`, selection-guarded so copying excerpt text never opens the viewer; the Button is the accessible/keyboard control).
- **Load-order-proof selectors** — stacked specificity (`.pl-message--system.chat-report …`, anchored under `.chat-session-slot`), the `.chat-note` pattern, so neither the DS default (`.pl-message--system .pl-message__content`) nor our own base system-message rule can win by stylesheet import order.

### By-id fetch (`apps/web/src/lib/api.ts`)

- New `api.backgroundJob(id)` → `GET /api/background/{id}` (typed `BackgroundJobDTO`) — the only route carrying the untruncated result.
- `loadBackgroundReport(jobId)` feeds the docviewer: by-id first; the legacy list-and-filter survives **only** as a 404 fallback (pre-0070 servers have no by-id route; on current servers a 404 means the row was deleted — the list resolves both to the same "no longer available" placeholder). Non-404 errors propagate so the viewer shows its real error state.

## Tests

- **Unit** (`api.test.ts`, 6 new cases): by-id GET path + full row, by-id-only happy path, 404 → list fallback, 404 + absent → placeholder, empty result → placeholder, 500 propagates without touching the list.
- **E2E** (`e2e/report-card.spec.ts`): seeds an open session, pushes `background.completed` over the mocked SSE stream, and asserts the card renders with the clamped excerpt + fade mask, the header row, and that the "Open report" CTA opens the docviewer showing full-report text served **only** by the by-id route (list route deliberately answers empty).
- Gates: `npm run test:unit` 263 passed · `npm run build` clean · `npm run test:e2e` 173 passed. Python untouched.

## Review notes

Console UX gate: this stays **draft / no automerge** — the operator merges after a local look. Screenshot sanity-checked against the e2e mock server (raised card, fading excerpt, outline CTA, viewer shows the by-id full report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)