### PR TITLE
feat(flags): put /compact behind the chat.compact developer flag (ADR 0068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   job's full row (strict `bg-<12 hex>` id validation) for the console report
   card.
 
+### Changed
+- **`/compact` is now behind the `chat.compact` developer flag** (ADR 0068,
+  first real flag in the registry). The command shipped in #1558 but is still
+  pre-release: on the prod channel it no longer appears in the slash menu and
+  `POST /api/chat/sessions/{id}/compact` refuses with 403; the dev channel (and
+  `PROTOAGENT_FLAG_CHAT_COMPACT=1`, `?flag:chat.compact=on`, or the Settings ▸
+  Developer toggle) keeps it on. The client slash-command seam (ADR 0061) gains
+  an optional `flag:` tag — the host lists and dispatches a tagged command only
+  while its flag resolves ON, so forks can flag-gate their own commands the
+  same way.
+
 ## [0.79.0] - 2026-07-01
 
 ### Added

--- a/apps/web/e2e/commands.spec.ts
+++ b/apps/web/e2e/commands.spec.ts
@@ -27,6 +27,22 @@ test("slash menu opens and lists the client + server commands", async ({ page })
   expect(names).toContain("/research-and-brief");
 });
 
+test("a flag-gated command (/compact, ADR 0068) vanishes when its flag is forced off", async ({ page }) => {
+  // The ?flag: query override is the shareable "try this build" layer — here it turns the
+  // chat.compact flag OFF over the mock server's enabled state, so /compact must not list.
+  await page.goto("/app/?flag:chat.compact=off", { waitUntil: "load" });
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.fill("/");
+
+  const menu = page.locator(".slash-menu");
+  await expect(menu).toBeVisible();
+  const names = await menu.locator(".slash-name").allInnerTexts();
+  expect(names).toEqual([
+    ...CLIENT_SLASH.filter((n) => n !== "/compact"),
+    ...SLASH_COMMANDS.map((c) => `/${c.name}`),
+  ]);
+});
+
 test("filtering narrows the menu and selecting completes the command", async ({ page }) => {
   const composer = page.getByPlaceholder(/Message protoAgent/i);
   await composer.fill("/go");

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -276,6 +276,9 @@ function handleApiGet(pathname, fleet = FLEET) {
         flags: [
           { id: "chat.new_dashboard", description: "Preview of the redesigned dashboard.", tier: "beta", owner: "kj", remove_by: "v1.0", enabled: true, source: "channel" },
           { id: "chat.experimental_widget", description: "An in-progress widget.", tier: "dev", owner: "kj", remove_by: "", enabled: true, source: "channel" },
+          // The REAL chat.compact flag (runtime/flags.py) — enabled so commands.spec sees
+          // /compact in the slash menu; the flag-off path is covered via ?flag:chat.compact=off.
+          { id: "chat.compact", description: "/compact — summarize + archive a chat thread.", tier: "dev", owner: "kj", remove_by: "2026-09-01", enabled: true, source: "channel" },
         ],
       };
     default:

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -24,6 +24,7 @@ import {
 } from "./chat-store";
 import "./coreSlashCommands"; // registers /new, /clear, /effort via the slash-command seam (ADR 0061)
 import { findSlashCommand, registeredSlashCommands, slashTokenAt } from "../ext/slashRegistry";
+import { useFlagPredicate } from "../flags/flags";
 import { registeredComposerActions } from "../ext/composerRegistry";
 import { ChatMessageView } from "./ChatMessageView";
 import { ComposerModelSelect } from "./ComposerModelSelect";
@@ -446,6 +447,10 @@ function ChatSessionSlot({
 
   const slashQuery = slashDismissed ? null : slashCtx?.query ?? null;
 
+  // Developer-flag gate (ADR 0068): a registered command tagged with `flag:` is listed
+  // and dispatched only while its flag resolves ON — flag-off, it's as if unregistered.
+  const flagOn = useFlagPredicate();
+
   const slashMatches = useMemo(() => {
     if (slashQuery === null) return [];
     const q = slashQuery.toLowerCase();
@@ -453,13 +458,15 @@ function ChatSessionSlot({
     // comes from the slash-command registry — core (/new, /clear, /effort) AND any fork-
     // registered commands — so neither is hardcoded here.
     const all: SlashCommand[] = [
-      ...registeredSlashCommands().map((c) => ({ name: c.name, description: c.description, usage: c.usage })),
+      ...registeredSlashCommands()
+        .filter((c) => !c.flag || flagOn(c.flag))
+        .map((c) => ({ name: c.name, description: c.description, usage: c.usage })),
       ...commands,
     ];
     return all.filter(
       (c) => !q || c.name.toLowerCase().includes(q) || c.description.toLowerCase().includes(q),
     );
-  }, [slashQuery, commands]);
+  }, [slashQuery, commands, flagOn]);
 
   const slashActive = slashMatches.length > 0;
   const slashSel = slashActive ? Math.min(slashIndex, slashMatches.length - 1) : 0;
@@ -495,6 +502,7 @@ function ChatSessionSlot({
     const [verb, ...rest] = raw.split(/\s+/);
     const cmd = findSlashCommand(verb);
     if (!cmd) return false;
+    if (cmd.flag && !flagOn(cmd.flag)) return false; // flag-off ⇒ as if unregistered
     return cmd.run({
       rest: rest.join(" ").trim(),
       sessionId: session?.id ?? null,

--- a/apps/web/src/chat/coreSlashCommands.test.ts
+++ b/apps/web/src/chat/coreSlashCommands.test.ts
@@ -17,6 +17,13 @@ describe("core slash commands (dogfood the seam, ADR 0061)", () => {
     expect(findSlashCommand("compact")).toBeTruthy();
   });
 
+  it("/compact is tagged with the chat.compact developer flag (ADR 0068)", () => {
+    // Registration is unconditional; the HOST (ChatSurface) hides + skips dispatch of a
+    // flag-tagged command while its flag is off. The tag is the contract under test here.
+    expect(findSlashCommand("compact")!.flag).toBe("chat.compact");
+    expect(findSlashCommand("new")!.flag).toBeUndefined(); // shipped commands stay untagged
+  });
+
   it("/clear, /effort, /compact are no-ops (return false → fall through) without a session", () => {
     expect(findSlashCommand("clear")!.run(ctx())).toBe(false);
     expect(findSlashCommand("effort")!.run(ctx())).toBe(false);

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -41,6 +41,7 @@ registerSlashCommand({
 registerSlashCommand({
   name: "compact",
   description: "Summarize & archive older history, keeping recent context",
+  flag: "chat.compact", // pre-release (ADR 0068) — hidden + inert while the flag is off
   run: (ctx) => {
     if (!ctx.sessionId) return false; // no session → fall through
     const sessionId = ctx.sessionId;

--- a/apps/web/src/ext/slashRegistry.ts
+++ b/apps/web/src/ext/slashRegistry.ts
@@ -37,6 +37,12 @@ export type ClientSlashCommand = {
   description: string;
   /** Optional usage hint. */
   usage?: string;
+  /** Optional developer-flag id (ADR 0068). When set, the host lists and dispatches the
+   *  command only while the flag resolves ON (`useFlagPredicate`) — a flag-off command
+   *  behaves as if it were never registered (the token falls through to the server /
+   *  draft path). Registration itself is unconditional, so flipping the flag needs no
+   *  re-registration. */
+  flag?: string;
   /** Run when the user picks or submits `/<name>`. Return `true` if handled (the send is
    *  short-circuited + the draft cleared); return `false` to fall through to the default
    *  (insert `/<name> ` into the draft to edit + send). Fire async work and return `true`

--- a/apps/web/src/flags/flags.ts
+++ b/apps/web/src/flags/flags.ts
@@ -7,6 +7,8 @@
 //   ?flag:<id>= query param  >  device-local panel toggle  >  server channel-resolved state
 // (The server has already applied the PROTOAGENT_FLAG_<ID> env override beneath that.)
 
+import { useCallback } from "react";
+
 import { useQuery } from "@tanstack/react-query";
 
 import { createUISlice } from "../ext/uiStateRegistry";
@@ -51,13 +53,26 @@ export function useFlags() {
   return useQuery(flagsQuery());
 }
 
+/** A predicate over ANY flag id, same precedence as `useFlag` — for gating LISTS (e.g.
+ *  flag-tagged slash commands) where calling a per-id hook in a loop is illegal. Stable
+ *  per (server state, overrides) so it's safe in memo deps. Fail-closed like `useFlag`. */
+export function useFlagPredicate(): (id: string) => boolean {
+  const { data } = useFlags();
+  const overrides = useFlagOverrides((s) => s.overrides);
+  return useCallback(
+    (id: string) => {
+      if (id in _queryOverrides) return _queryOverrides[id];
+      const override = overrides[id];
+      if (override !== undefined) return override;
+      return data?.flags.find((f) => f.id === id)?.enabled ?? false;
+    },
+    [data, overrides],
+  );
+}
+
 /** Is a developer flag ON for this session? Fail-closed: an unknown/loading flag is off. */
 export function useFlag(id: string): boolean {
-  const { data } = useFlags();
-  const override = useFlagOverrides((s) => s.overrides[id]);
-  if (id in _queryOverrides) return _queryOverrides[id];
-  if (override !== undefined) return override;
-  return data?.flags.find((f) => f.id === id)?.enabled ?? false;
+  return useFlagPredicate()(id);
 }
 
 /** The runtime channel this instance runs on (prod | beta | dev). */

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -108,7 +108,18 @@ def register_chat_routes(app, ui: str) -> None:
 
         Never-lossy: if there's no store or the archive write yields nothing, the
         checkpoint is left untouched and ``refused`` is true (the console then
-        keeps the full thread rather than dropping anything)."""
+        keeps the full thread rather than dropping anything).
+
+        Pre-release: behind the ``chat.compact`` developer flag (ADR 0068)."""
+        from fastapi import HTTPException
+
+        from runtime.flags import flag_enabled
+
+        if not flag_enabled("chat.compact"):
+            raise HTTPException(
+                status_code=403,
+                detail="/compact is pre-release — enable the chat.compact developer flag (ADR 0068)",
+            )
         return await compact_session(session_id)
 
     @app.post("/api/chat/sessions/{session_id}/rewind")

--- a/runtime/flags.py
+++ b/runtime/flags.py
@@ -43,8 +43,15 @@ class Flag:
 
 
 # The registry — the SINGLE source of truth. Add a flag here; check it with ``flag_enabled``.
-# Empty until a real pre-release feature needs gating (slice 6 dogfoods the first one).
-FLAGS: list[Flag] = []
+FLAGS: list[Flag] = [
+    Flag(
+        id="chat.compact",
+        description="/compact — summarize + archive a chat thread, rewrite the checkpoint (#1527).",
+        tier="dev",
+        owner="kj",
+        remove_by="2026-09-01",
+    ),
+]
 
 
 def _registry() -> dict[str, Flag]:

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -131,9 +131,12 @@ def test_delete_session_harvest_is_opt_in(monkeypatch):
 
 def test_compact_session_route(monkeypatch):
     # The route is a thin pass-through to server.chat.compact_session — forwards the
-    # path session_id and returns the compaction result dict verbatim.
+    # path session_id and returns the compaction result dict verbatim. /compact is
+    # behind the chat.compact developer flag (ADR 0068); force it ON via the env
+    # override so the pass-through is what's under test, not the gate.
     import operator_api.chat_routes as cr
 
+    monkeypatch.setenv("PROTOAGENT_FLAG_CHAT_COMPACT", "1")
     seen: list[str] = []
 
     async def _fake_compact(session_id):
@@ -155,6 +158,28 @@ def test_compact_session_route(monkeypatch):
     assert seen == ["s1"]
     assert body["removed"] == 9 and body["kept"] == 4 and body["archived"] is True
     assert body["message"] == "Compacted this conversation"
+
+
+def test_compact_session_route_refuses_when_flag_off(monkeypatch):
+    # /compact is pre-release (chat.compact developer flag, ADR 0068): on the prod
+    # channel the dev-tier flag resolves OFF, the route 403s, and compact_session is
+    # never reached — the checkpoint can't be touched through a disabled gate.
+    import operator_api.chat_routes as cr
+
+    monkeypatch.delenv("PROTOAGENT_FLAG_CHAT_COMPACT", raising=False)
+    monkeypatch.setenv("PROTOAGENT_CHANNEL", "prod")
+    called: list[str] = []
+
+    async def _fake_compact(session_id):
+        called.append(session_id)
+        return {}
+
+    monkeypatch.setattr(cr, "compact_session", _fake_compact)
+    c = _client(monkeypatch)
+    resp = c.post("/api/chat/sessions/s1/compact")
+    assert resp.status_code == 403
+    assert "chat.compact" in resp.json()["detail"]
+    assert called == []
 
 
 def test_rewind_session_route(monkeypatch):


### PR DESCRIPTION
## What

`/compact` (#1558) is still pre-release, so it becomes the **first real entry** in the `runtime/flags.py` registry — tier `dev`, `remove_by: 2026-09-01` (the ISO date puts it under `test_no_flag_is_past_its_remove_by`'s cleanup guard).

**Effect:** on the prod channel the command no longer appears in the slash menu and the route refuses; on the dev channel (dev sandbox instance, `PROTOAGENT_CHANNEL=dev`, or `developer.channel`) nothing changes. Per-developer escapes: `PROTOAGENT_FLAG_CHAT_COMPACT=1`, `?flag:chat.compact=on`, or the Settings ▸ Developer toggle.

## How

- **Backend** — `POST /api/chat/sessions/{id}/compact` 403s when `flag_enabled("chat.compact")` is false, before `compact_session` is reached, so a disabled gate can never touch the checkpoint. `graph/compaction_op.py` itself is untouched (wrap, don't restructure — ADR 0068).
- **Console** — the client slash-command seam (ADR 0061) gains an optional `flag:` tag on `ClientSlashCommand`. ChatSurface lists **and** dispatches a tagged command only while its flag resolves ON; flag-off, the token behaves as if the command were never registered. Powered by a new `useFlagPredicate()` in `flags/flags.ts` — the list-friendly sibling of `useFlag` with the same `?flag:` query > device override > server-state precedence (`useFlag` is now implemented on top of it). Forks can flag-gate their own commands through the same seam.
- `/compact` registers with `flag: "chat.compact"`; registration stays unconditional so flipping the flag needs no re-registration.

## Tests

- `test_compact_session_route` now forces the flag ON via the env override (the pass-through stays the thing under test); new `test_compact_session_route_refuses_when_flag_off` proves the 403 + that `compact_session` is never called.
- Unit: pins the `flag` tag on `/compact` (and that shipped commands stay untagged).
- E2E: mock server serves the real `chat.compact` flag enabled so the exact `CLIENT_SLASH` listing still covers `/compact`; a new spec loads `?flag:chat.compact=off` and asserts the command vanishes from the menu.

## Gates

- `ruff check .` ✅ · `lint-imports` ✅ (3 kept, 0 broken) · `pytest tests/ -q` ✅ 2762 passed, 5 skipped
- `vitest` ✅ 258 passed · `tsc` ×2 + `vite build` ✅ · Playwright `commands` / `developer-flags` / `chat` specs ✅ 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flag-aware handling for the `/compact` command so it only appears and runs when the feature is enabled.
  * The `/compact` API now returns a clear 403 response when unavailable.

* **Bug Fixes**
  * Prevented hidden commands from showing up in the slash menu when disabled.
  * Ensured the command behavior matches the current feature-flag state across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->