### PR TITLE
fix(fleet): close two remote-member proxy-auth gaps (ADR 0042 §I)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   while its flag resolves ON, so forks can flag-gate their own commands the
   same way.
 
+### Security
+- **Fleet: the hub no longer lends a remote member's token over an unauthenticated
+  WebSocket, and live events now work through a token-gated hub.** Two proxy-auth
+  gaps in remote fleet members (ADR 0042 §I), both only reachable on a non-loopback
+  (tailnet/LAN) hub — a loopback desktop hub was never exposed:
+  - The hub's default-deny auth is an HTTP middleware (Starlette `BaseHTTPMiddleware`
+    skips non-HTTP scopes), so the `/agents/<slug>/*` **WebSocket** proxy route ran
+    with no hub auth. For a *remote* member the hub would attach that member's stored
+    bearer and proxy any caller into its authenticated sockets (e.g. a terminal
+    plugin's PTY). WebSocket proxying to a **remote** member is now refused (close
+    1008); host/local-peer sockets — which carry no hub-stored credential — are
+    unaffected. Live plugin views into a remote member should use `delegate_to` / a
+    direct connection.
+  - The SSE token for `/api/events` was fetched slug-routed (signed by the *member*),
+    but the proxied stream is validated at the **hub's** middleware first — so on a
+    bearer-gated hub, live events 401'd for every non-host member. The console now
+    fetches a **hub-signed** SSE token; the hub validates it, then forwards with the
+    member's own credential so the member accepts it downstream.
+
 ## [0.79.0] - 2026-07-01
 
 ### Added

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -169,6 +169,15 @@ describe("apiUrl — fleet slug routing (ADR 0042)", () => {
     expect(apiUrl("/api/fleet")).not.toContain("/agents/");
     expect(apiUrl("/api/archetypes")).not.toContain("/agents/");
   });
+
+  it("host:true keeps the SSE token on the hub in a member window (proxied /api/events is validated by the HUB key)", () => {
+    // The SSE-token fix: /api/events is proxied and the HUB's auth middleware validates the
+    // ?token= with the HUB's key before forwarding, so the token must be hub-signed. Without
+    // host:true, /api/sse-token would slug-route and be member-signed → 401 at the hub.
+    focus("m");
+    expect(apiUrl("/api/sse-token")).toContain("/agents/m/api/sse-token"); // default: slug-routed (the bug)
+    expect(apiUrl("/api/sse-token", { host: true })).not.toContain("/agents/"); // the fix
+  });
 });
 
 describe("frameIsForeign — cross-context stream guard (subagent-stream-isolation #1394 follow-up)", () => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -642,10 +642,16 @@ export const api = {
   // Short-lived HMAC token for the SSE EventSource, which can't send an
   // Authorization header. Bearer-gated; in open mode the server returns "" and
   // accepts a tokenless /api/events. events.ts fetches this before each
-  // (re)connect. Same slug routing as /api/events so the token is signed by
-  // whichever server actually terminates the stream (host or a proxied member).
+  // (re)connect.
+  //
+  // Signed by the HUB (host:true), NOT slug-routed. The proxied `/api/events`
+  // is validated at the HUB's auth middleware FIRST (before it forwards to the
+  // member), so the token must carry the hub's signature or the stream 401s at
+  // the hub for every non-host member on a bearer-gated hub. The hub then
+  // forwards with the member's own credential attached, so the member accepts it
+  // downstream (its SSE branch falls through to the bearer check).
   sseToken() {
-    return request<{ token: string }>("/api/sse-token");
+    return request<{ token: string }>("/api/sse-token", { host: true });
   },
 
   // Gracefully restart the server process (POST /api/restart) — the server drains and

--- a/graph/fleet/proxy.py
+++ b/graph/fleet/proxy.py
@@ -167,8 +167,27 @@ async def forward_ws(slug: str, ws, path: str) -> None:
     live WS — agent_browser's viewport/feed, say — couldn't traverse the hub: HTTP loaded
     the panel but the socket showed "Disconnected". This resolves the slug → member, opens
     a client WS to it (carrying the bearer + subprotocols), and pumps frames both ways.
+
+    **Remote members are NOT proxied over WS (security).** The hub's default-deny auth is an
+    HTTP middleware (``A2AAuthMiddleware`` is a Starlette ``BaseHTTPMiddleware``, which skips
+    non-HTTP scopes), so this ``@app.websocket`` route runs with NO hub auth. For a local
+    peer/host that's benign — the hub attaches no stored credential, and a browser WS can't
+    carry one — but for a REMOTE member the hub would attach the remote's stored bearer
+    (``_target_for_slug``) and thereby lend an unauthenticated caller a ride into the remote's
+    authed sockets (e.g. a terminal plugin's PTY). Until the caller can be authenticated over
+    the WS handshake, remote-member live sockets don't traverse the hub; use ``delegate_to`` /
+    a direct connection to the remote instead.
     """
     import websockets
+
+    # Refuse WS to a remote member (see docstring). A live LOCAL peer takes precedence over a
+    # same-slug remote in _target_for_slug, so only refuse when the slug resolves to a remote
+    # (not a running local process). host/local peers fall through and proxy as before.
+    live_local = supervisor._load_state().get(slug)
+    if not (live_local and supervisor._alive(live_local.get("pid"))) and supervisor.remote_for_slug(slug):
+        log.info("[fleet] refusing WS proxy to remote member %r (hub auth is HTTP-only)", slug)
+        await ws.close(code=1008, reason="websocket proxying to a remote member is disabled")
+        return
 
     target = _target_for_slug(slug)
     if target is None:

--- a/tests/test_fleet_proxy_ws.py
+++ b/tests/test_fleet_proxy_ws.py
@@ -75,3 +75,44 @@ def test_ws_proxy_rejects_when_agent_not_running(monkeypatch):
     with pytest.raises(WebSocketDisconnect):
         with TestClient(_ws_app()).websocket_connect("/agents/ghost/live"):
             pass
+
+
+def test_ws_proxy_refuses_remote_member(monkeypatch):
+    """Security: the hub's default-deny auth is HTTP-only (BaseHTTPMiddleware skips WS
+    scopes), so a WS proxied to a REMOTE member would lend that member's stored bearer to
+    an unauthenticated caller. forward_ws refuses it (1008) BEFORE opening any upstream —
+    even though a target would resolve. Local peers/host are unaffected (no stored creds)."""
+    from graph.fleet import supervisor
+
+    # Slug resolves to a registered remote (with a stored token) and NOT to a live local peer.
+    monkeypatch.setattr(supervisor, "_load_state", lambda: {})
+    monkeypatch.setattr(
+        supervisor, "remote_for_slug", lambda slug: {"id": slug, "url": "http://100.64.0.9:7870", "token": "sek"}
+    )
+    # If the guard failed to fire, _target_for_slug would hand back the remote target and the
+    # relay would try to dial it — make that loud rather than a silent connect attempt.
+    monkeypatch.setattr(
+        proxy, "_target_for_slug", lambda slug: pytest.fail("must refuse a remote before resolving a target")
+    )
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with TestClient(_ws_app()).websocket_connect("/agents/ava/live"):
+            pass
+    assert exc.value.code == 1008  # policy violation, not a transient "not running"
+
+
+def test_ws_proxy_still_serves_live_local_peer(monkeypatch):
+    """A running LOCAL peer (a live pid in fleet state) still proxies — the remote refusal
+    must not catch same-slug local members."""
+    port, stop = _echo_ws_server()
+    try:
+        from graph.fleet import supervisor
+
+        monkeypatch.setattr(supervisor, "_load_state", lambda: {"peer": {"pid": 4242, "port": port}})
+        monkeypatch.setattr(supervisor, "_alive", lambda pid: True)
+        monkeypatch.setattr(supervisor, "remote_for_slug", lambda slug: None)
+        monkeypatch.setattr(proxy, "_target_for_slug", lambda slug: (f"http://127.0.0.1:{port}", {}))
+        with TestClient(_ws_app()).websocket_connect("/agents/peer/live") as ws:
+            ws.send_text("ping")
+            assert ws.receive_text() == "ping"
+    finally:
+        stop()


### PR DESCRIPTION
## Why

Audit of remote fleet members (ADR 0042 §I) ahead of live testing surfaced two proxy-auth gaps. **Both are only reachable on a non-loopback (tailnet/LAN) hub** — the exact posture remote fleet is documented for (`--host` + `A2A_AUTH_TOKEN`). A loopback desktop hub (open mode) was never exposed by either.

### 1. WebSocket proxy bypassed the hub's auth (the critical one)

The hub's default-deny auth is `A2AAuthMiddleware`, a Starlette `BaseHTTPMiddleware` — which passes non-HTTP scopes straight through without running `dispatch`. So the `@app.websocket("/agents/{slug}/{path:path}")` proxy route ran with **no hub auth at all**. For a **remote** member, `_target_for_slug` attaches the member's *stored bearer*, so the hub would proxy an unauthenticated caller into the remote's authenticated WebSocket endpoints (e.g. a terminal plugin's PTY shell) — the caller never needs the hub's own credential.

The console core opens zero WebSockets; this route exists only for external plugin iframes (agent_browser, terminal). Authenticating a browser WS caller means a query-string token the plugin JS would have to send (browsers can't set WS headers) — cross-repo plumbing. Rather than ship that now, this **refuses WS proxying to a remote member** (close `1008`). Host and local-peer sockets — which carry *no* hub-stored credential — are unchanged, so agent_browser/terminal live views into the host and local peers keep working. Live views into a *remote* member should use `delegate_to` / a direct connection. (This matches the "delegate_to-only if remote" fallback; a follow-up can add token-gated WS if remote live-views are wanted back.)

### 2. SSE cross-key break through the proxy

The console fetched `/api/sse-token` **slug-routed**, so a member window got a *member*-signed token. But the proxied `/api/events` is validated at the **hub's** middleware first (before it forwards), with the *hub's* key — so on a bearer-gated hub, live events 401'd in a permanent reconnect loop for **every non-host member**. Fix: fetch the SSE token from the **hub** (`host: true`); the hub validates it, then forwards with the member's own bearer attached so the member accepts it downstream (its SSE branch falls through to the bearer check). Open-mode hubs are unaffected (token is `""` either way).

## Changes
- `graph/fleet/proxy.py` — `forward_ws` refuses a remote member before resolving a target.
- `apps/web/src/lib/api.ts` — `sseToken()` fetches host-signed (`host: true`), with a comment explaining the hub-validates-first ordering.
- Tests: `tests/test_fleet_proxy_ws.py` (refuse-remote → 1008 before any upstream dial; live local peer still relays); `apps/web/src/lib/api.test.ts` (SSE token stays on the hub in a member window).

## Verification
`ruff` ✓ · import-linter 3 kept/0 broken ✓ · `pytest tests/` → **2764 passed, 5 skipped** · console `test:unit` → **30 passed** · `tsc --noEmit` clean.

## Scope note
This is Phase 1 (security) of the remote-fleet audit. Phase 2 (console operability — manual add-remote-with-token form, token/URL edit, per-remote 401 handling, dead-remote 502 recovery, reachable-vs-stopped state) will follow as a **draft** PR under the console local-test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)