### PR TITLE
feat(fleet): manual add-remote form (URL + token) + honest remote status

### DIFF
--- a/apps/web/src/fleet/fleet.css
+++ b/apps/web/src/fleet/fleet.css
@@ -78,3 +78,37 @@
   padding-top: 12px;
   border-top: 1px solid var(--border);
 }
+
+.fleet-discover-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.fleet-add-remote {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 10px 0 4px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius, 8px);
+  background: var(--pl-color-bg-raised, transparent);
+}
+
+.fleet-add-remote .field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fleet-add-remote .field > span {
+  font-size: 12px;
+  color: var(--pl-color-fg-muted, inherit);
+}
+
+.fleet-add-remote-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1167,8 +1167,11 @@ export const api = {
   },
   addRemoteAgent(body: { name: string; url: string; token?: string }) {
     // Register a remote protoAgent as a SWITCHABLE fleet member (ADR 0042 §I) —
-    // it gets a slug window; the hub reverse-proxies its console + A2A.
-    return request<{ ok: boolean; agent: FleetAgent }>("/api/fleet/remotes", {
+    // it gets a slug window; the hub reverse-proxies its console + A2A. The server
+    // probes it at register time and returns `reachable`/`version` so the caller can
+    // warn up front (registration is NOT rejected for an unreachable peer — deferred
+    // registration is intentional; a peer can come online later).
+    return request<{ ok: boolean; agent: FleetAgent; reachable?: boolean; version?: string }>("/api/fleet/remotes", {
       method: "POST",
       body,
     });

--- a/apps/web/src/settings/FleetManagerPanel.test.ts
+++ b/apps/web/src/settings/FleetManagerPanel.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+
+import { canAddRemote } from "./FleetManagerPanel";
+
+describe("canAddRemote — manual add-remote submit gate (ADR 0042 §I)", () => {
+  it("requires a non-empty name", () => {
+    expect(canAddRemote("", "http://100.64.0.9:7870")).toBe(false);
+    expect(canAddRemote("   ", "http://100.64.0.9:7870")).toBe(false);
+    expect(canAddRemote("ava", "http://100.64.0.9:7870")).toBe(true);
+  });
+
+  it("requires an http(s) URL", () => {
+    expect(canAddRemote("ava", "")).toBe(false);
+    expect(canAddRemote("ava", "100.64.0.9:7870")).toBe(false); // no scheme
+    expect(canAddRemote("ava", "ftp://host")).toBe(false);
+    expect(canAddRemote("ava", "ws://host")).toBe(false); // ws:// isn't the register URL (it's http)
+    expect(canAddRemote("ava", "https://ava.example:7870")).toBe(true);
+  });
+
+  it("trims before validating", () => {
+    expect(canAddRemote("  ava  ", "  http://host:7870  ")).toBe(true);
+  });
+});

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { Alert, StatusDot } from "@protolabsai/ui/data";
-import { EditableText, Switch } from "@protolabsai/ui/forms";
+import { EditableText, Input, SecretInput, Switch } from "@protolabsai/ui/forms";
 import { ConfirmDialog, useToast } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 
@@ -15,6 +15,13 @@ import { api, currentSlug } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { fleetQuery, queryKeys } from "../lib/queries";
 import type { DiscoveredAgent, FleetAgent } from "../lib/types";
+
+/** The manual add-remote form is submittable only with a name and an http(s) URL. Exported
+ * (pure) so the enable rule is unit-tested without rendering the panel. The server does the
+ * authoritative validation (charset, SSRF egress, dedupe); this is just the button gate. */
+export function canAddRemote(name: string, url: string): boolean {
+  return name.trim().length > 0 && /^https?:\/\/.+/.test(url.trim());
+}
 
 // Fleet manager (ADR 0042) — Settings → Agents. Lists the workspace agents with live
 // status (the query polls every 3s, so a crashed agent flips to stopped on its own) and
@@ -128,17 +135,51 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
   // same enable-and-retry path as fleet-row adds.
   const addRemote = (d: DiscoveredAgent) => addDelegate.mutate({ name: d.name, url: `${d.url}/a2a` });
 
+  // A registered member's up-front feedback: the server probes it at register time and
+  // returns `reachable`, so a peer that's offline (or behind a wrong/missing token — the
+  // probe hits its unauthenticated agent-card) is added with an honest "not reachable yet"
+  // warning instead of silently appearing as a dead row.
+  const addedToast = (name: string, reachable?: boolean) =>
+    reachable === false
+      ? toast({
+          tone: "warning",
+          title: `Added ${name}`,
+          message: "Registered, but it isn't reachable yet — it'll connect when it comes online.",
+        })
+      : toast({ tone: "success", title: `Added ${name}`, message: `${name} joined the fleet.` });
+
   // …or join the fleet outright (ADR 0042 §I): the remote becomes a SWITCHABLE member —
-  // a slug window, console + A2A reverse-proxied through this hub. Discovered names can
-  // collide with existing agents (every template fork is "protoagent") — suffix on 400.
+  // a slug window, console + A2A reverse-proxied through this hub.
   const addMember = useMutation({
     mutationFn: (d: DiscoveredAgent) => api.addRemoteAgent({ name: d.name, url: d.url }),
+    onSuccess: (res, d) => addedToast(d.name, res.reachable),
     onError: (e) => toast({ tone: "error", title: "Couldn't add to fleet", message: errMsg(e) }),
     onSettled: () => {
       qc.invalidateQueries({ queryKey: queryKeys.fleet });
       void scan(); // the new member drops out of the discover list
     },
   });
+
+  // Manual add — the ONLY way to register a token-gated remote (discovery can't carry a
+  // credential) or a peer discovery didn't surface (a different subnet, mDNS off). A blank
+  // name defaults to the URL's host:port server-side isn't a thing, so require a name.
+  const [showAdd, setShowAdd] = useState(false);
+  const [addName, setAddName] = useState("");
+  const [addUrl, setAddUrl] = useState("");
+  const [addToken, setAddToken] = useState("");
+  const addManual = useMutation({
+    mutationFn: () => api.addRemoteAgent({ name: addName.trim(), url: addUrl.trim(), token: addToken.trim() }),
+    onSuccess: (res) => {
+      addedToast(addName.trim(), res.reachable);
+      setShowAdd(false);
+      setAddName("");
+      setAddUrl("");
+      setAddToken("");
+    },
+    onError: (e) => toast({ tone: "error", title: "Couldn't add to fleet", message: errMsg(e) }),
+    onSettled: () => qc.invalidateQueries({ queryKey: queryKeys.fleet }),
+  });
+  const canAdd = canAddRemote(addName, addUrl);
   const removeMember = useMutation({
     mutationFn: (a: FleetAgent) => api.removeRemoteAgent(a.id),
     onError: (e) => toast({ tone: "error", title: "Couldn't remove member", message: errMsg(e) }),
@@ -212,9 +253,20 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
               const isActive = (a.host ? "host" : a.id) === slug; // slug = stable id, not name
               return (
                 <li key={a.id} className={`fleet-row${isActive ? " active" : ""}`}>
-                  <span role="img" title={a.running ? "running" : "stopped"} aria-label={a.running ? "running" : "stopped"}>
-                    <StatusDot status={a.running ? "success" : "neutral"} pulse={a.running} />
-                  </span>
+                  {/* A remote's `running` IS its reachability probe (it has no local process),
+                      so an offline remote is "unreachable", not "stopped" — and its dot reads
+                      warning, not neutral, since it's a fault to act on rather than an idle agent. */}
+                  {(() => {
+                    const label = a.running ? "running" : a.remote ? "unreachable" : "stopped";
+                    return (
+                      <span role="img" title={label} aria-label={label}>
+                        <StatusDot
+                          status={a.running ? "success" : a.remote ? "warning" : "neutral"}
+                          pulse={a.running}
+                        />
+                      </span>
+                    );
+                  })()}
                   <div className="fleet-row-main">
                     <span className="fleet-name">
                       {renaming === a.id ? (
@@ -318,9 +370,59 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
         {/* Network discovery — scan the box + LAN for OTHER protoAgents and add one as a remote
             delegate of the focused agent (ADR 0042 §I). */}
         <div className="fleet-discover">
-          <Button variant="ghost" onClick={scan} disabled={scanning}>
-            <Radar size={14} /> {scanning ? "Scanning…" : "Discover agents on the network"}
-          </Button>
+          <div className="fleet-discover-actions">
+            <Button variant="ghost" onClick={scan} disabled={scanning}>
+              <Radar size={14} /> {scanning ? "Scanning…" : "Discover agents on the network"}
+            </Button>
+            {/* Manual add — the only path for a token-gated remote (discovery carries no
+                credential) or one on a subnet the scan can't reach. */}
+            <Button variant="ghost" onClick={() => setShowAdd((v) => !v)} aria-expanded={showAdd}>
+              <Link2 size={14} /> Add a remote by URL
+            </Button>
+          </div>
+          {showAdd ? (
+            <form
+              className="fleet-add-remote"
+              onSubmit={(e) => {
+                e.preventDefault();
+                if (canAdd && !addManual.isPending) addManual.mutate();
+              }}
+            >
+              <label className="field">
+                <span>Name</span>
+                <Input
+                  value={addName}
+                  onChange={(e) => setAddName(e.target.value)}
+                  placeholder="e.g. ava (letters, digits, - and _)"
+                  autoFocus
+                />
+              </label>
+              <label className="field">
+                <span>URL</span>
+                <Input
+                  value={addUrl}
+                  onChange={(e) => setAddUrl(e.target.value)}
+                  placeholder="http://100.x.y.z:7870"
+                />
+              </label>
+              <label className="field">
+                <span>Token (optional)</span>
+                <SecretInput
+                  value={addToken}
+                  onChange={(e) => setAddToken(e.target.value)}
+                  placeholder="the remote's operator token, if it's gated"
+                />
+              </label>
+              <div className="fleet-add-remote-actions">
+                <Button type="button" variant="ghost" onClick={() => setShowAdd(false)}>
+                  Cancel
+                </Button>
+                <Button type="submit" variant="primary" disabled={!canAdd || addManual.isPending}>
+                  {addManual.isPending ? "Adding…" : "Add to fleet"}
+                </Button>
+              </div>
+            </form>
+          ) : null}
           {discovered ? (
             discovered.length === 0 ? (
               <Empty>No other protoAgents found on the network.</Empty>


### PR DESCRIPTION
> **Draft — console UX, under the local-test gate.** CI can't judge UX; please eyeball the form + status wording locally before merge. **Stacked on #1607** (the Phase 1 security fix); review/merge that first — this branches off it, so its diff will shrink once #1607 lands.

## Why

Phase 2 of the remote-fleet audit (operability). The audit's top operability gap: **you can't add a token-gated remote from the console at all** — the only add path was the discovery list, which posts `{name, url}` with no token field, so a gated remote was CLI/curl-only. Secondary: an offline remote rendered as a neutral "stopped" dot (it's unreachable, not stopped), and adds gave no feedback (not even a success toast; the register-time `reachable` the server computes was discarded).

## What

- **Add a remote by URL** (`FleetManagerPanel`): a manual form (name + URL + optional token via `SecretInput`) next to Discover. The submit gate is the pure, unit-tested `canAddRemote(name, url)`; the server keeps doing the authoritative validation (charset, SSRF egress, dedupe). This is the path for a token-gated remote or one discovery can't see.
- **Reachability feedback**: `addRemoteAgent` now surfaces the server's register-time `{ reachable, version }`; both the manual add and the discovery add toast either "Added — not reachable yet, it'll connect when it comes online" (warning) or a success toast. Registration is still never *rejected* for an unreachable peer (deferred registration is intentional).
- **Honest remote status**: an offline remote shows "unreachable" with a warning `StatusDot` instead of a neutral "stopped" — a remote's `running` *is* its reachability probe, and it can't be started/stopped from here.

## Deferred (follow-up)

Not in this PR — they need a new backend endpoint and/or an AuthGate refactor that benefits from your UX input:
- Edit a remote's token/URL in place (today: remove + re-add, which mints a new id/slug).
- Route a proxied-remote **401** to a per-remote "auth failed — update token" state instead of tripping the global hub AuthGate (which currently loops unrecoverably for a wrong remote token).
- Dead-remote **502** → "Return to host" boot recovery in `App.tsx` (the existing recovery only fires on 409, which a remote never returns).

## Verification

`tsc --noEmit` clean · console `test:unit` **262 passed** (new `FleetManagerPanel.test.ts` covers the submit gate) · `npm run build` clean. `dist/` is gitignored (shipped prebuilt, not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)