### PR TITLE
feat(fleet): edit remote members in place + recovery for down/mis-tokened ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Remote fleet members are fully manageable from the console** (ADR 0042 §I).
+  You can now **add a remote by URL** (name + URL + optional token) — the only way
+  to register a token-gated remote, since network discovery can't carry a
+  credential — and **edit a member in place** (its URL, token, or name; the id and
+  slug survive, so open windows don't break), which is how you fix a rotated or
+  wrong token. Adds surface the server's register-time reachability (an offline
+  peer is added with an honest "not reachable yet" toast, not a silent dead row),
+  and an offline remote now reads **"unreachable"** with a warning dot rather than
+  a neutral "stopped" (a remote's `running` *is* its reachability probe). New
+  `PATCH /api/fleet/remotes/{ident}` + `supervisor.update_remote` back it, re-running
+  the same SSRF-egress / collision checks as add and re-probing on save.
+- **A down or mis-tokened fleet agent gives you a way out instead of a boot hang.**
+  A focused member that can't be reached now shows a targeted boot-gate recovery:
+  a **remote whose box is offline** (a 502, which a remote returns instead of the
+  local peer's 409) offers *Return to host* / *Try again*, and a **remote whose
+  stored token is wrong** (a 401) shows *"can't authenticate — update its token in
+  Settings ▸ Agents"* with *Return to host*. Critically, a proxied member's 401 no
+  longer trips the **hub's** global token prompt (which asked for, and would
+  overwrite, the hub's own token) — a member-scoped 401 is recognized as that
+  member's credential problem.
 - **Background results are pushed, indexed, and worker-disposable**
   ([ADR 0070](docs/adr/0070-background-results-push-resume.md), backend). When a
   background job (ADR 0050) reaches a terminal state: **(D1)** the server

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -89,7 +89,17 @@ import {
   type RightPanel,
   type Surface,
 } from "../state/uiStore";
-import { api, apiUrl, authToken, is401, isAgentNotRunning, currentSlug, agentHref, activateSlugAgent } from "../lib/api";
+import {
+  api,
+  apiUrl,
+  authToken,
+  is401,
+  isAgentNotRunning,
+  isAgentUnreachable,
+  currentSlug,
+  agentHref,
+  activateSlugAgent,
+} from "../lib/api";
 import { PluginView, consoleTheme } from "./PluginView";
 import { UtilityWidget } from "./UtilityWidget";
 import { AppShell, Header, UtilityBar } from "@protolabsai/ui/app-shell";
@@ -378,19 +388,26 @@ export function App() {
   // copy/escape-hatch swap. STUCK_AFTER_MS=45s — past it, offer "Continue anyway"
   // so a graph that never compiles can't trap the operator on the loading screen.
   const bootFailed = !runtime && runtimeQ.isError;
-  // Focused fleet agent is DOWN (ADR 0042): a non-host slug whose boot probe keeps 409'ing
-  // ("agent not running") past a normal spawn window — `activate` didn't bring it up (or it
-  // failed to start). Without this the operator waited out the full ~30 retries for a generic
-  // "isn't responding" gate whose "Continue anyway" just opens a 409-broken app. Detect it
+  // Focused fleet agent is DOWN (ADR 0042): a non-host slug whose boot probe keeps failing
+  // past a normal spawn window. Two shapes: a LOCAL peer 409s ("agent not running" — `activate`
+  // didn't bring it up), a REMOTE member 502s (its box is offline / URL wrong — it never 409s,
+  // it isn't a local process). Without this the operator waited out the full ~30 retries for a
+  // generic "isn't responding" gate whose "Continue anyway" just opens a broken app. Detect it
   // early (≥6 retries ≈ ~6s at the 1s delay) and offer targeted recovery: return to the host
-  // console, or try starting the agent again. `failureReason`/`failureCount` are live during
+  // console, or try starting/reaching it again. `failureReason`/`failureCount` are live during
   // retries (TanStack Query v5), so recovery shows before the probe fully gives up.
   const focusedSlug = currentSlug();
   const agentDown =
     focusedSlug !== "host" &&
     !runtime &&
-    isAgentNotRunning(runtimeQ.failureReason) &&
+    (isAgentNotRunning(runtimeQ.failureReason) || isAgentUnreachable(runtimeQ.failureReason)) &&
     runtimeQ.failureCount >= 6;
+  // Focused REMOTE member's stored token is wrong/missing: its proxied boot probe 401s. That's
+  // the MEMBER's credential problem, not the hub's — api.ts already keeps it off the global
+  // AuthGate (which prompts for the HUB token), and the probe's 401 stops the retry loop
+  // immediately (is401), so we surface a targeted "update its token / return to host" recovery
+  // instead of the generic "isn't responding" gate. Host-window 401s stay with the AuthGate.
+  const memberAuthFailed = focusedSlug !== "host" && !runtime && is401(runtimeQ.failureReason);
   // Token-gated first run (#873): the boot probe itself 401s. The BootGate's
   // "Starting… / isn't responding" copy is wrong for that — and its overlay
   // (z-1900) would cover the AuthGate dialog (z-1000) — so the gate yields to
@@ -758,23 +775,41 @@ export function App() {
           <BootGate
             logo={<ProtoLabsIcon variant="outline" size={56} decorative gradientStroke tone="accent" />}
             title={
-              agentDown
-                ? `Agent “${focusedSlug}” isn’t running`
-                : bootFailed
-                  ? `${bootName} isn’t responding`
-                  : `Starting ${bootName}…`
+              memberAuthFailed
+                ? `Can’t authenticate to “${focusedSlug}”`
+                : agentDown
+                  ? isAgentUnreachable(runtimeQ.failureReason)
+                    ? `Agent “${focusedSlug}” is unreachable`
+                    : `Agent “${focusedSlug}” isn’t running`
+                  : bootFailed
+                    ? `${bootName} isn’t responding`
+                    : `Starting ${bootName}…`
             }
             detail={
-              agentDown
-                ? "This fleet agent didn’t start. Return to the host console to keep working, or try starting it again."
-                : bootFailed
-                  ? "The engine didn’t come up in time. It may still be warming up — give it another moment, then retry."
-                  : bootStuck
-                    ? "This is taking longer than usual. The engine may still be compiling, or it may need attention in Settings."
-                    : "Warming up the engine — first launch (and finishing setup) can take up to a minute. Later launches are quick."
+              memberAuthFailed
+                ? "This remote member rejected the hub’s stored token (it’s wrong, missing, or was rotated). Return to the host console and update its token in Settings ▸ Agents."
+                : agentDown
+                  ? isAgentUnreachable(runtimeQ.failureReason)
+                    ? "This remote member didn’t answer. Return to the host console to keep working, or check its URL and token in Settings ▸ Agents."
+                    : "This fleet agent didn’t start. Return to the host console to keep working, or try starting it again."
+                  : bootFailed
+                    ? "The engine didn’t come up in time. It may still be warming up — give it another moment, then retry."
+                    : bootStuck
+                      ? "This is taking longer than usual. The engine may still be compiling, or it may need attention in Settings."
+                      : "Warming up the engine — first launch (and finishing setup) can take up to a minute. Later launches are quick."
             }
             action={
-              agentDown ? (
+              memberAuthFailed ? (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() => {
+                    window.location.href = agentHref("host");
+                  }}
+                >
+                  Return to host
+                </Button>
+              ) : agentDown ? (
                 <div style={{ display: "flex", gap: 8 }}>
                   <Button
                     variant="primary"
@@ -795,7 +830,7 @@ export function App() {
                       })();
                     }}
                   >
-                    Try to start it
+                    {isAgentUnreachable(runtimeQ.failureReason) ? "Try again" : "Try to start it"}
                   </Button>
                 </div>
               ) : bootFailed ? (

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -65,6 +65,7 @@ import { BackgroundWatch } from "./BackgroundWatch";
 import { ChatResumeWatch } from "./ChatResumeWatch";
 import { BackgroundJobs } from "./BackgroundJobs";
 import { ProtoLabsIcon } from "./ProtoLabsIcon";
+import { bootGatePhase } from "./bootGate";
 import { AuthGate } from "./AuthGate";
 import { authRequired, subscribeAuth } from "../lib/auth";
 import { TenantGuard } from "./TenantGuard";
@@ -408,6 +409,7 @@ export function App() {
   // immediately (is401), so we surface a targeted "update its token / return to host" recovery
   // instead of the generic "isn't responding" gate. Host-window 401s stay with the AuthGate.
   const memberAuthFailed = focusedSlug !== "host" && !runtime && is401(runtimeQ.failureReason);
+  const agentUnreachable = isAgentUnreachable(runtimeQ.failureReason); // 502 (remote) vs 409 (local peer)
   // Token-gated first run (#873): the boot probe itself 401s. The BootGate's
   // "Starting… / isn't responding" copy is wrong for that — and its overlay
   // (z-1900) would cover the AuthGate dialog (z-1000) — so the gate yields to
@@ -421,6 +423,8 @@ export function App() {
     const t = window.setTimeout(() => setBootStuck(true), 45_000);
     return () => window.clearTimeout(t);
   }, [bootReady]);
+  // Which recovery the boot gate shows (pure precedence — tested in bootGate.test.ts).
+  const gatePhase = bootGatePhase({ memberAuthFailed, agentDown, unreachable: agentUnreachable, bootFailed, bootStuck });
   const [error, setError] = useState("");
 
   // Clear the stale "Load failed" strip once the engine reports ready. The
@@ -775,31 +779,31 @@ export function App() {
           <BootGate
             logo={<ProtoLabsIcon variant="outline" size={56} decorative gradientStroke tone="accent" />}
             title={
-              memberAuthFailed
+              gatePhase === "memberAuth"
                 ? `Can’t authenticate to “${focusedSlug}”`
-                : agentDown
-                  ? isAgentUnreachable(runtimeQ.failureReason)
-                    ? `Agent “${focusedSlug}” is unreachable`
-                    : `Agent “${focusedSlug}” isn’t running`
-                  : bootFailed
-                    ? `${bootName} isn’t responding`
-                    : `Starting ${bootName}…`
+                : gatePhase === "unreachable"
+                  ? `Agent “${focusedSlug}” is unreachable`
+                  : gatePhase === "notRunning"
+                    ? `Agent “${focusedSlug}” isn’t running`
+                    : gatePhase === "failed"
+                      ? `${bootName} isn’t responding`
+                      : `Starting ${bootName}…`
             }
             detail={
-              memberAuthFailed
+              gatePhase === "memberAuth"
                 ? "This remote member rejected the hub’s stored token (it’s wrong, missing, or was rotated). Return to the host console and update its token in Settings ▸ Agents."
-                : agentDown
-                  ? isAgentUnreachable(runtimeQ.failureReason)
-                    ? "This remote member didn’t answer. Return to the host console to keep working, or check its URL and token in Settings ▸ Agents."
-                    : "This fleet agent didn’t start. Return to the host console to keep working, or try starting it again."
-                  : bootFailed
-                    ? "The engine didn’t come up in time. It may still be warming up — give it another moment, then retry."
-                    : bootStuck
-                      ? "This is taking longer than usual. The engine may still be compiling, or it may need attention in Settings."
-                      : "Warming up the engine — first launch (and finishing setup) can take up to a minute. Later launches are quick."
+                : gatePhase === "unreachable"
+                  ? "This remote member didn’t answer. Return to the host console to keep working, or check its URL and token in Settings ▸ Agents."
+                  : gatePhase === "notRunning"
+                    ? "This fleet agent didn’t start. Return to the host console to keep working, or try starting it again."
+                    : gatePhase === "failed"
+                      ? "The engine didn’t come up in time. It may still be warming up — give it another moment, then retry."
+                      : gatePhase === "stuck"
+                        ? "This is taking longer than usual. The engine may still be compiling, or it may need attention in Settings."
+                        : "Warming up the engine — first launch (and finishing setup) can take up to a minute. Later launches are quick."
             }
             action={
-              memberAuthFailed ? (
+              gatePhase === "memberAuth" ? (
                 <Button
                   variant="primary"
                   size="sm"
@@ -809,7 +813,7 @@ export function App() {
                 >
                   Return to host
                 </Button>
-              ) : agentDown ? (
+              ) : gatePhase === "unreachable" || gatePhase === "notRunning" ? (
                 <div style={{ display: "flex", gap: 8 }}>
                   <Button
                     variant="primary"
@@ -830,14 +834,14 @@ export function App() {
                       })();
                     }}
                   >
-                    {isAgentUnreachable(runtimeQ.failureReason) ? "Try again" : "Try to start it"}
+                    {gatePhase === "unreachable" ? "Try again" : "Try to start it"}
                   </Button>
                 </div>
-              ) : bootFailed ? (
+              ) : gatePhase === "failed" ? (
                 <Button variant="primary" size="sm" onClick={() => void runtimeQ.refetch()}>
                   Retry
                 </Button>
-              ) : bootStuck ? (
+              ) : gatePhase === "stuck" ? (
                 <Button variant="primary" size="sm" onClick={() => setBootOverride(true)}>
                   Continue anyway
                 </Button>

--- a/apps/web/src/app/bootGate.test.ts
+++ b/apps/web/src/app/bootGate.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+
+import { bootGatePhase } from "./bootGate";
+
+const NONE = {
+  memberAuthFailed: false,
+  agentDown: false,
+  unreachable: false,
+  bootFailed: false,
+  bootStuck: false,
+};
+
+describe("bootGatePhase — focused-agent recovery precedence (ADR 0042 §I)", () => {
+  it("no faults → the normal cold-start wait", () => {
+    expect(bootGatePhase(NONE)).toBe("loading");
+  });
+
+  it("a member's bad token (401) wins over everything", () => {
+    // memberAuthFailed must beat agentDown/failed/stuck so the operator gets the
+    // "update its token" recovery, not a generic "isn't responding".
+    expect(bootGatePhase({ ...NONE, memberAuthFailed: true })).toBe("memberAuth");
+    expect(
+      bootGatePhase({ memberAuthFailed: true, agentDown: true, unreachable: true, bootFailed: true, bootStuck: true }),
+    ).toBe("memberAuth");
+  });
+
+  it("agentDown splits on reachability: 502 → unreachable, 409 → notRunning", () => {
+    expect(bootGatePhase({ ...NONE, agentDown: true, unreachable: true })).toBe("unreachable");
+    expect(bootGatePhase({ ...NONE, agentDown: true, unreachable: false })).toBe("notRunning");
+  });
+
+  it("agentDown beats the generic engine states", () => {
+    expect(bootGatePhase({ ...NONE, agentDown: true, unreachable: true, bootFailed: true, bootStuck: true })).toBe(
+      "unreachable",
+    );
+    expect(bootGatePhase({ ...NONE, agentDown: true, bootFailed: true, bootStuck: true })).toBe("notRunning");
+  });
+
+  it("failed beats stuck; stuck beats loading", () => {
+    expect(bootGatePhase({ ...NONE, bootFailed: true, bootStuck: true })).toBe("failed");
+    expect(bootGatePhase({ ...NONE, bootStuck: true })).toBe("stuck");
+  });
+
+  it("unreachable is ignored unless agentDown is set (a stray 502 mid-boot doesn't jump the gun)", () => {
+    // agentDown already encodes the failureCount>=6 guard; `unreachable` alone must not
+    // short-circuit the normal loading state.
+    expect(bootGatePhase({ ...NONE, unreachable: true })).toBe("loading");
+  });
+});

--- a/apps/web/src/app/bootGate.ts
+++ b/apps/web/src/app/bootGate.ts
@@ -1,0 +1,30 @@
+// Boot-gate phase resolution (ADR 0042 §I). The full-screen boot gate shows one of several
+// recovery states for the focused agent; this pure function picks WHICH, in precedence order,
+// from the already-computed booleans off App's runtime probe. Extracted so the decision table
+// is unit-tested without rendering App (the gate covers the whole app, so its logic is
+// high-blast-radius — worth testing in isolation).
+
+export type BootGatePhase =
+  | "memberAuth" // a focused REMOTE member's stored token is wrong/missing (its probe 401s)
+  | "unreachable" // a focused REMOTE member's box is offline / URL wrong (its probe 502s)
+  | "notRunning" // a focused LOCAL peer didn't start (its probe 409s)
+  | "failed" // the engine probe gave up (generic "isn't responding")
+  | "stuck" // still loading past the grace period — offer "Continue anyway"
+  | "loading"; // the normal cold-start wait
+
+export function bootGatePhase(s: {
+  memberAuthFailed: boolean;
+  agentDown: boolean;
+  /** agentDown caused by a 502 (remote unreachable) vs a 409 (local peer not running). */
+  unreachable: boolean;
+  bootFailed: boolean;
+  bootStuck: boolean;
+}): BootGatePhase {
+  // Focused-agent faults win over the generic engine states: a member that's down/mis-tokened
+  // needs its OWN recovery (return-to-host / update-token), not the hub's "isn't responding".
+  if (s.memberAuthFailed) return "memberAuth";
+  if (s.agentDown) return s.unreachable ? "unreachable" : "notRunning";
+  if (s.bootFailed) return "failed";
+  if (s.bootStuck) return "stuck";
+  return "loading";
+}

--- a/apps/web/src/fleet/fleet.css
+++ b/apps/web/src/fleet/fleet.css
@@ -96,6 +96,11 @@
   background: var(--pl-color-bg-raised, transparent);
 }
 
+.fleet-add-remote-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
 .fleet-add-remote .field {
   display: flex;
   flex-direction: column;

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -8,10 +8,12 @@ import {
   isColdStart,
   isAgentNotRunning,
   isAgentUnreachable,
+  isMemberScoped,
   loadBackgroundReport,
   textFromParts,
   hitlFromParts,
 } from "./api";
+import { authRequired, clearAuthRequired } from "./auth";
 
 describe("cold-start detection (ApiError / isColdStart)", () => {
   it("ApiError carries the HTTP status", () => {
@@ -57,6 +59,63 @@ describe("unreachable-remote detection (isAgentUnreachable)", () => {
     expect(isAgentUnreachable(new ApiError(401, "unauthorized"))).toBe(false); // that's a bad token
     expect(isAgentUnreachable(new TypeError("Load failed"))).toBe(false);
     expect(isAgentUnreachable(undefined)).toBe(false);
+  });
+});
+
+describe("isMemberScoped — which 401s belong to a member vs the hub (ADR 0042 §I)", () => {
+  const focus = (slug: string | null) =>
+    window.history.replaceState({}, "", slug ? `/app/agent/${slug}/` : "/app/");
+
+  it("host window: nothing is member-scoped", () => {
+    focus(null);
+    expect(isMemberScoped("/api/runtime/status")).toBe(false);
+    expect(isMemberScoped("/a2a")).toBe(false);
+  });
+
+  it("member window: slug-routed agent paths are member-scoped, hub paths are not", () => {
+    focus("ava");
+    expect(isMemberScoped("/api/runtime/status")).toBe(true); // proxied to the member
+    expect(isMemberScoped("/a2a")).toBe(true);
+    expect(isMemberScoped("/api/fleet")).toBe(false); // hub control-plane — stays on the hub
+    expect(isMemberScoped("/api/runtime/status", true)).toBe(false); // host:true forces the hub
+  });
+});
+
+describe("member-scoped 401 must NOT hijack the hub AuthGate (ADR 0042 §I)", () => {
+  // The load-bearing behavior: a proxied member's bad/rotated token 401s, but that's the
+  // MEMBER's credential problem — tripping the global hub prompt would ask for (and overwrite)
+  // the wrong token. request() suppresses notifyAuthRequired() for member-scoped requests.
+  const focus = (slug: string | null) =>
+    window.history.replaceState({}, "", slug ? `/app/agent/${slug}/` : "/app/");
+  const unauthorized = () =>
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        text: async () => "unauthorized",
+      })),
+    );
+
+  beforeEach(() => clearAuthRequired());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearAuthRequired();
+  });
+
+  it("a HOST-scoped 401 trips the global auth prompt", async () => {
+    focus(null);
+    unauthorized();
+    await expect(api.runtimeStatus()).rejects.toBeInstanceOf(ApiError);
+    expect(authRequired()).toBe(true);
+  });
+
+  it("a MEMBER-scoped 401 does NOT trip it (it's the member's token, not the hub's)", async () => {
+    focus("ava");
+    unauthorized();
+    await expect(api.runtimeStatus()).rejects.toBeInstanceOf(ApiError);
+    expect(authRequired()).toBe(false); // the boot gate / fleet panel own this recovery instead
   });
 });
 

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -7,6 +7,7 @@ import {
   frameIsForeign,
   isColdStart,
   isAgentNotRunning,
+  isAgentUnreachable,
   loadBackgroundReport,
   textFromParts,
   hitlFromParts,
@@ -46,6 +47,16 @@ describe("focused-agent-down detection (isAgentNotRunning)", () => {
     expect(isAgentNotRunning(new ApiError(404, "nope"))).toBe(false);
     expect(isAgentNotRunning(new TypeError("Load failed"))).toBe(false);
     expect(isAgentNotRunning(undefined)).toBe(false);
+  });
+});
+
+describe("unreachable-remote detection (isAgentUnreachable)", () => {
+  it("true ONLY for a 502 (the fleet proxy's 'can't reach the member') — a remote never 409s", () => {
+    expect(isAgentUnreachable(new ApiError(502, "agent is not reachable"))).toBe(true);
+    expect(isAgentUnreachable(new ApiError(409, "not running"))).toBe(false); // that's a local peer
+    expect(isAgentUnreachable(new ApiError(401, "unauthorized"))).toBe(false); // that's a bad token
+    expect(isAgentUnreachable(new TypeError("Load failed"))).toBe(false);
+    expect(isAgentUnreachable(undefined)).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -329,6 +329,23 @@ export function is401(error: unknown): boolean {
   return error instanceof ApiError && error.status === 401;
 }
 
+/** The fleet proxy's "can't reach the member" signal (ADR 0042 §I): a 502 from a
+ *  slug-routed call. A REMOTE member never 409s (it isn't a local process the hub can find
+ *  "not running") — it 502s when its box is offline or its URL is wrong. Distinct from
+ *  `isAgentNotRunning` (409) so the boot gate can offer the same return-to-host recovery for a
+ *  dead remote that it does for a down local peer. */
+export function isAgentUnreachable(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 502;
+}
+
+/** A request is MEMBER-scoped when it's slug-routed to the focused agent (not the hub). A 401
+ *  from one is that member's credential problem — a wrong/missing stored token for a REMOTE —
+ *  NOT the hub's, so it must not trip the global AuthGate (which prompts for, and would
+ *  overwrite, the HUB token). `host:true` and the host window are always hub-scoped. */
+function isMemberScoped(path: string, host?: boolean): boolean {
+  return !host && currentSlug() !== "host" && isAgentPath(path);
+}
+
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const { host, ...init } = options;  // `host` is ours (routing), not a fetch RequestInit field
   const headers = applyAuth(new Headers(init.headers));
@@ -357,7 +374,9 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
     }
     // Wrong/expired/missing bearer on a token-gated deployment — surface the
     // token prompt (#873) instead of leaving per-panel 401 cards as the only signal.
-    if (response.status === 401) notifyAuthRequired();
+    // But a MEMBER-scoped 401 is the focused remote's bad token, not the hub's — don't
+    // hijack the hub AuthGate; the boot gate / fleet panel own that recovery.
+    if (response.status === 401 && !isMemberScoped(path, host)) notifyAuthRequired();
     throw new ApiError(response.status, detail || "request failed");
   }
 
@@ -385,7 +404,7 @@ async function requestForm<T>(path: string, form: FormData, opts: { host?: boole
     } catch {
       detail = raw || detail;
     }
-    if (response.status === 401) notifyAuthRequired();
+    if (response.status === 401 && !isMemberScoped(path, opts.host)) notifyAuthRequired();
     throw new ApiError(response.status, detail || "request failed");
   }
   return (await response.json()) as T;
@@ -1176,6 +1195,15 @@ export const api = {
       body,
     });
   },
+  updateRemoteAgent(ident: string, body: { name?: string; url?: string; token?: string }) {
+    // Edit a remote member in place (ADR 0042 §I) — omitted fields keep their value;
+    // token:"" clears the stored bearer. The id/slug is unchanged, so open windows survive.
+    // The server re-probes and returns fresh {reachable, version}.
+    return request<{ ok: boolean; agent: FleetAgent; reachable?: boolean; version?: string }>(
+      `/api/fleet/remotes/${encodeURIComponent(ident)}`,
+      { method: "PATCH", body },
+    );
+  },
   removeRemoteAgent(ident: string) {
     return request<{ ok: boolean; id: string; name: string }>(`/api/fleet/remotes/${encodeURIComponent(ident)}`, {
       method: "DELETE",
@@ -1462,7 +1490,9 @@ export const api = {
     });
 
     if (!response.ok) {
-      if (response.status === 401) notifyAuthRequired(); // token-gated chat turn (#873)
+      // token-gated chat turn (#873) — but a member-scoped 401 is the focused remote's bad
+      // token, not the hub's, so don't hijack the hub AuthGate (the boot gate owns that).
+      if (response.status === 401 && !isMemberScoped("/a2a")) notifyAuthRequired();
       throw new Error(`${response.status} ${response.statusText}`);
     }
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -341,8 +341,9 @@ export function isAgentUnreachable(error: unknown): boolean {
 /** A request is MEMBER-scoped when it's slug-routed to the focused agent (not the hub). A 401
  *  from one is that member's credential problem — a wrong/missing stored token for a REMOTE —
  *  NOT the hub's, so it must not trip the global AuthGate (which prompts for, and would
- *  overwrite, the HUB token). `host:true` and the host window are always hub-scoped. */
-function isMemberScoped(path: string, host?: boolean): boolean {
+ *  overwrite, the HUB token). `host:true` and the host window are always hub-scoped. Exported
+ *  for unit testing (it gates whether a 401 reaches `notifyAuthRequired`). */
+export function isMemberScoped(path: string, host?: boolean): boolean {
   return !host && currentSlug() !== "host" && isAgentPath(path);
 }
 

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -160,23 +160,51 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
     },
   });
 
-  // Manual add — the ONLY way to register a token-gated remote (discovery can't carry a
-  // credential) or a peer discovery didn't surface (a different subnet, mDNS off). A blank
-  // name defaults to the URL's host:port server-side isn't a thing, so require a name.
+  // The add-a-remote-by-URL form doubles as the EDIT form (`editingId` set). Manual add is the
+  // ONLY way to register a token-gated remote (discovery can't carry a credential) or a peer
+  // discovery didn't surface (a different subnet, mDNS off); edit is how you fix a rotated/
+  // wrong token or a changed URL in place (the id/slug — and open windows — survive).
   const [showAdd, setShowAdd] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null); // null = add mode
   const [addName, setAddName] = useState("");
   const [addUrl, setAddUrl] = useState("");
   const [addToken, setAddToken] = useState("");
-  const addManual = useMutation({
-    mutationFn: () => api.addRemoteAgent({ name: addName.trim(), url: addUrl.trim(), token: addToken.trim() }),
-    onSuccess: (res) => {
-      addedToast(addName.trim(), res.reachable);
-      setShowAdd(false);
-      setAddName("");
-      setAddUrl("");
-      setAddToken("");
+  const resetForm = () => {
+    setShowAdd(false);
+    setEditingId(null);
+    setAddName("");
+    setAddUrl("");
+    setAddToken("");
+  };
+  const openAdd = () => {
+    resetForm();
+    setShowAdd(true);
+  };
+  const openEdit = (a: FleetAgent) => {
+    setEditingId(a.id);
+    setAddName(a.name);
+    setAddUrl(a.url ?? "");
+    setAddToken(""); // blank = keep the stored token (write a new one only to rotate it)
+    setShowAdd(true);
+  };
+  const submitRemote = useMutation({
+    mutationFn: () => {
+      const name = addName.trim();
+      const url = addUrl.trim();
+      const token = addToken.trim();
+      // On edit, a blank token means "keep" (omit it); on add, pass it through.
+      return editingId
+        ? api.updateRemoteAgent(editingId, { name, url, ...(token ? { token } : {}) })
+        : api.addRemoteAgent({ name, url, token });
     },
-    onError: (e) => toast({ tone: "error", title: "Couldn't add to fleet", message: errMsg(e) }),
+    onSuccess: (res) => {
+      const name = addName.trim();
+      if (editingId) toast({ tone: "success", title: `Updated ${name}`, message: res.reachable === false ? "Saved — still not reachable." : "Saved." });
+      else addedToast(name, res.reachable);
+      resetForm();
+    },
+    onError: (e) =>
+      toast({ tone: "error", title: editingId ? "Couldn't update member" : "Couldn't add to fleet", message: errMsg(e) }),
     onSettled: () => qc.invalidateQueries({ queryKey: queryKeys.fleet }),
   });
   const canAdd = canAddRemote(addName, addUrl);
@@ -325,14 +353,22 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                         </Button>
                       )
                     ) : null}
-                    {/* A remote member can't be started/stopped/renamed from here — only
-                        unregistered (the remote agent itself is untouched). */}
+                    {/* A remote member can't be started/stopped from here, but its URL/token/
+                        name ARE editable in place (the id/slug survives) — or unregister it
+                        (the remote agent itself is untouched). */}
                     {a.remote ? (
-                      <Button icon variant="ghost" title="Remove from this fleet (the remote agent is untouched)"
-                        disabled={removeMember.isPending}
-                        onClick={() => removeMember.mutate(a)}>
-                        <Trash2 size={14} />
-                      </Button>
+                      <>
+                        <Button icon variant="ghost" title="Edit this member's URL, token or name"
+                          disabled={submitRemote.isPending}
+                          onClick={() => openEdit(a)}>
+                          <Pencil size={14} />
+                        </Button>
+                        <Button icon variant="ghost" title="Remove from this fleet (the remote agent is untouched)"
+                          disabled={removeMember.isPending}
+                          onClick={() => removeMember.mutate(a)}>
+                          <Trash2 size={14} />
+                        </Button>
+                      </>
                     ) : null}
                     {/* The host serves this console — it can't stop or remove itself; its
                         display name is edited in Settings → Identity instead. */}
@@ -376,7 +412,7 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
             </Button>
             {/* Manual add — the only path for a token-gated remote (discovery carries no
                 credential) or one on a subnet the scan can't reach. */}
-            <Button variant="ghost" onClick={() => setShowAdd((v) => !v)} aria-expanded={showAdd}>
+            <Button variant="ghost" onClick={() => (showAdd ? resetForm() : openAdd())} aria-expanded={showAdd}>
               <Link2 size={14} /> Add a remote by URL
             </Button>
           </div>
@@ -385,9 +421,10 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
               className="fleet-add-remote"
               onSubmit={(e) => {
                 e.preventDefault();
-                if (canAdd && !addManual.isPending) addManual.mutate();
+                if (canAdd && !submitRemote.isPending) submitRemote.mutate();
               }}
             >
+              {editingId ? <span className="fleet-add-remote-title">Edit remote member</span> : null}
               <label className="field">
                 <span>Name</span>
                 <Input
@@ -406,19 +443,25 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                 />
               </label>
               <label className="field">
-                <span>Token (optional)</span>
+                <span>Token{editingId ? "" : " (optional)"}</span>
                 <SecretInput
                   value={addToken}
                   onChange={(e) => setAddToken(e.target.value)}
-                  placeholder="the remote's operator token, if it's gated"
+                  placeholder={editingId ? "•••••••• — leave blank to keep the current token" : "the remote's operator token, if it's gated"}
                 />
               </label>
               <div className="fleet-add-remote-actions">
-                <Button type="button" variant="ghost" onClick={() => setShowAdd(false)}>
+                <Button type="button" variant="ghost" onClick={resetForm}>
                   Cancel
                 </Button>
-                <Button type="submit" variant="primary" disabled={!canAdd || addManual.isPending}>
-                  {addManual.isPending ? "Adding…" : "Add to fleet"}
+                <Button type="submit" variant="primary" disabled={!canAdd || submitRemote.isPending}>
+                  {submitRemote.isPending
+                    ? editingId
+                      ? "Saving…"
+                      : "Adding…"
+                    : editingId
+                      ? "Save changes"
+                      : "Add to fleet"}
                 </Button>
               </div>
             </form>

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -351,26 +351,35 @@ def remote_for_slug(slug: str) -> dict | None:
     return _load_remotes().get(slug)
 
 
+def _normalize_remote_url(url: str) -> str:
+    """Validate + canonicalize a remote member URL (trailing slash trimmed, must be http(s),
+    SSRF-guarded). Shared by add/update. Raises FleetError.
+
+    SSRF guard (#871): the hub reverse-proxies /agents/<slug>/* to this URL, so a registered
+    remote can turn the hub into an internal-network proxy. Fleet remotes ARE normally private
+    (LAN / tailnet / a co-located instance), so allow_private — but ALWAYS block
+    link-local/cloud-metadata (169.254.169.254), multicast, reserved.
+    """
+    u = (url or "").strip().rstrip("/")
+    if not u.startswith(("http://", "https://")):
+        raise FleetError(f"remote url must be http(s), got {u!r}")
+    from security import egress
+
+    if egress.check_url(u, allow_private=True, block_unresolvable=False):
+        raise FleetError(
+            f"remote url {u} is blocked by the egress guard (link-local/metadata/"
+            f"reserved address); allowlist it via egress.allowed_hosts if intentional"
+        )
+    return u
+
+
 def add_remote(name: str, url: str, token: str = "") -> dict:
     """Register a remote protoAgent as a fleet member. Name follows the workspace
     charset + uniqueness rules; the id is opaque like a local agent's (#823)."""
     name = manager._safe(name)
     if name.lower() in manager._RESERVED_NAMES:
         raise FleetError(f"{name!r} is reserved — it's how the fleet addresses this instance")
-    url = (url or "").strip().rstrip("/")
-    if not url.startswith(("http://", "https://")):
-        raise FleetError(f"remote url must be http(s), got {url!r}")
-    # SSRF guard (#871): the hub reverse-proxies /agents/<slug>/* to this URL, so a
-    # registered remote can turn the hub into an internal-network proxy. Fleet remotes
-    # ARE normally private (LAN / tailnet / a co-located instance), so allow_private —
-    # but ALWAYS block link-local/cloud-metadata (169.254.169.254), multicast, reserved.
-    from security import egress
-
-    if egress.check_url(url, allow_private=True, block_unresolvable=False):
-        raise FleetError(
-            f"remote url {url} is blocked by the egress guard (link-local/metadata/"
-            f"reserved address); allowlist it via egress.allowed_hosts if intentional"
-        )
+    url = _normalize_remote_url(url)
     with _remotes_lock():
         remotes = _load_remotes()
         taken = {r["name"] for r in remotes.values()} | {w["name"] for w in manager.list_workspaces()}
@@ -383,6 +392,43 @@ def add_remote(name: str, url: str, token: str = "") -> dict:
         remotes[rid] = rec
         _save_remotes(remotes)
     log.info("[fleet] remote member added: %s (%s)", name, url)
+    return {k: v for k, v in rec.items() if k != "token"}
+
+
+def update_remote(ident: str, *, name: str | None = None, url: str | None = None, token: str | None = None) -> dict:
+    """Edit a registered remote's ``name`` / ``url`` / ``token`` in place (by id or name).
+
+    Only the fields you pass change — a ``None`` field is left as-is, so ``token=None`` KEEPS
+    the stored bearer while ``token=""`` clears it (the recovery path for a rotated/wrong
+    token). The id — and so the URL slug, open windows, and data scope — never changes. Re-runs
+    the same reserved-name / SSRF-egress / collision checks as ``add_remote``. Returns the
+    sanitized record (token stripped). ``FleetError`` if no such remote.
+    """
+    with _remotes_lock():
+        remotes = _load_remotes()
+        rid = ident if ident in remotes else next((k for k, r in remotes.items() if r["name"] == ident), None)
+        if rid is None:
+            raise FleetError(f"no remote member {ident!r}")
+        rec = dict(remotes[rid])
+        if name is not None:
+            new_name = manager._safe(name)
+            if new_name.lower() in manager._RESERVED_NAMES:
+                raise FleetError(f"{new_name!r} is reserved — it's how the fleet addresses this instance")
+            others = {r["name"] for k, r in remotes.items() if k != rid} | {w["name"] for w in manager.list_workspaces()}
+            if new_name in others:
+                raise FleetError(f"an agent named {new_name!r} already exists")
+            rec["name"] = new_name
+        if url is not None:
+            new_url = _normalize_remote_url(url)
+            if any(r["url"] == new_url for k, r in remotes.items() if k != rid):
+                raise FleetError(f"a remote at {new_url} is already in the fleet")
+            rec["url"] = new_url
+        if token is not None:
+            rec["token"] = token
+        remotes[rid] = rec
+        _save_remotes(remotes)
+    _probe_cache.pop(rid, None)  # url/token may have changed reachability — force a fresh probe
+    log.info("[fleet] remote member updated: %s (%s)", rec["name"], rec["url"])
     return {k: v for k, v in rec.items() if k != "token"}
 
 

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -55,6 +55,28 @@ def register_fleet_routes(app) -> None:
         except (supervisor.FleetError, manager.WorkspaceError) as exc:
             raise HTTPException(400, str(exc))
 
+    @app.patch("/api/fleet/remotes/{ident}")
+    async def _update_remote(ident: str, req: dict):
+        """Edit a remote member's ``url`` / ``token`` / display ``name`` in place (ADR 0042 §I).
+
+        Omitted fields are left as-is; ``token: ""`` clears the stored bearer (a rotated/wrong
+        token is fixed by PATCHing the new one — the recovery path when a proxied member 401s).
+        The id — and so the slug + open windows — never changes. Re-probes so the response
+        reports fresh reachability, same shape as add. 400 on a bad url/name/collision."""
+        body = req or {}
+        try:
+            rec = await asyncio.to_thread(
+                supervisor.update_remote,
+                ident,
+                name=body.get("name"),
+                url=body.get("url"),
+                token=body.get("token"),
+            )
+            reachable, version = await asyncio.to_thread(supervisor.probe_remote, rec["id"])
+            return {"ok": True, "agent": rec, "reachable": reachable, "version": version}
+        except (supervisor.FleetError, manager.WorkspaceError) as exc:
+            raise HTTPException(400, str(exc))
+
     @app.delete("/api/fleet/remotes/{ident}")
     async def _remove_remote(ident: str):
         """Unregister a remote member (the remote agent itself is untouched)."""

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -248,6 +248,28 @@ def test_add_remote_unreachable_is_registered_not_rejected(client, monkeypatch):
     assert entry["name"] == "ghosty" and entry["running"] is False
 
 
+def test_patch_remote_edits_and_reprobes(client, monkeypatch):
+    """PATCH /api/fleet/remotes/{ident} edits url/token/name in place (id/slug stable) and
+    re-probes so the response carries fresh reachability. A bad url is a 400, not a 500."""
+    import httpx
+    from graph.fleet import supervisor
+
+    supervisor._probe_cache.clear()
+    monkeypatch.setattr(httpx, "get", lambda url, timeout: type("C", (), {"status_code": 200, "json": lambda s: {}})())
+    rid = client.post("/api/fleet/remotes", json={"name": "ava", "url": "http://1.2.3.4:7871"}).json()["agent"]["id"]
+
+    r = client.patch(f"/api/fleet/remotes/{rid}", json={"url": "http://1.2.3.4:7999", "token": "sek"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True and body["agent"]["url"] == "http://1.2.3.4:7999" and body["reachable"] is True
+    assert "token" not in body["agent"]  # the bearer never comes back out
+    entry = next(a for a in client.get("/api/fleet").json()["agents"] if a.get("remote"))
+    assert entry["id"] == rid and entry["url"] == "http://1.2.3.4:7999"  # same id, new url
+
+    assert client.patch(f"/api/fleet/remotes/{rid}", json={"url": "ftp://nope"}).status_code == 400
+    assert client.patch("/api/fleet/remotes/ghost", json={"token": "x"}).status_code == 400
+
+
 def test_discover_endpoint(client, monkeypatch):
     # /api/fleet/discover returns OTHER protoAgents (mock the scan); the route's host self-exclusion
     # + supervisor scan run, discover() internals are unit-tested elsewhere.

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -155,6 +155,42 @@ def test_remote_name_collides_with_workspace(tmp_path, monkeypatch):
         supervisor.add_remote("alpha", "http://h:1")
 
 
+def test_update_remote_edits_url_token_name_in_place(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    rec = supervisor.add_remote("ava", "http://100.64.0.9:7870", token="old")
+    rid = rec["id"]
+
+    # Only-provided-fields change; the id (slug + data scope) is stable.
+    out = supervisor.update_remote(rid, url="http://100.64.0.9:7999", token="new", name="ava2")
+    assert out["id"] == rid and out["name"] == "ava2" and out["url"] == "http://100.64.0.9:7999"
+    assert "token" not in out  # sanitized — the bearer never leaves via the API
+    stored = supervisor.remote_for_slug(rid)  # proxy-side lookup DOES carry it
+    assert stored["token"] == "new" and stored["url"] == "http://100.64.0.9:7999"
+
+    # token=None keeps the stored bearer; token="" clears it.
+    supervisor.update_remote(rid, url="http://100.64.0.9:8001")  # no token kwarg
+    assert supervisor.remote_for_slug(rid)["token"] == "new"
+    supervisor.update_remote(rid, token="")
+    assert supervisor.remote_for_slug(rid)["token"] == ""
+
+
+def test_update_remote_rejects_bad_url_collision_and_unknown(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    a = supervisor.add_remote("ava", "http://100.64.0.9:7870")
+    supervisor.add_remote("bo", "http://100.64.0.10:7870")
+
+    with pytest.raises(supervisor.FleetError):
+        supervisor.update_remote(a["id"], url="ftp://nope")  # not http(s)
+    with pytest.raises(supervisor.FleetError):
+        supervisor.update_remote(a["id"], url="http://169.254.169.254/")  # SSRF egress guard
+    with pytest.raises(supervisor.FleetError):
+        supervisor.update_remote(a["id"], url="http://100.64.0.10:7870")  # bo's url — collision
+    with pytest.raises(supervisor.FleetError):
+        supervisor.update_remote("ghost", token="x")  # no such remote
+    # Editing to its OWN current url is fine (the collision check excludes self).
+    assert supervisor.update_remote(a["id"], url="http://100.64.0.9:7870")["url"] == "http://100.64.0.9:7870"
+
+
 def test_refresh_remote_probes_ttl(tmp_path, monkeypatch):
     monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
     supervisor._probe_cache.clear()


### PR DESCRIPTION
> **Draft — console UX under the local-test gate.** CI can't judge UX; please eyeball the edit form + the boot-gate recovery copy locally before merge. Round 2 of the remote-fleet audit follow-ups (#1607 security, #1608 add-form both merged).

## Why

The audit left three operability gaps that needed a backend endpoint + an AuthGate refactor:
1. **No way to edit a remote** — a rotated/wrong token or changed URL meant remove + re-add, which mints a new id/slug and breaks open windows.
2. **A wrong remote token hijacked the hub's token prompt** — a proxied member's 401 tripped the *global* AuthGate (asking for, and overwriting, the **hub's** token) in an unrecoverable loop.
3. **A dead remote trapped you on the boot screen** — the return-to-host recovery only fired on 409, but a remote never 409s (it 502s), so an offline member just span through 30 retries into a generic "isn't responding".

## What

**Backend**
- `supervisor.update_remote(ident, name?/url?/token?)` — edits a registered remote in place under the remotes lock: omitted fields kept, `token=""` clears, re-running the same reserved-name / SSRF-egress / collision checks as add (factored into a shared `_normalize_remote_url`) and invalidating the probe cache. New `PATCH /api/fleet/remotes/{ident}` re-probes and returns fresh `{reachable, version}` (400 on bad url/name/collision, never 500).

**Console**
- **Edit form**: the add-a-remote form doubles as an edit form (Pencil on remote rows), pre-filled; blank token = keep the stored one. The id/slug survives, so open windows don't break.
- **Per-member 401**: `request()` / `requestForm()` / the a2a stream now suppress the global AuthGate for slug-routed **member** requests (`isMemberScoped`) — a member's 401 is *its* credential problem, not the hub's.
- **Boot-gate recovery**: a focused member's **502** (unreachable remote) folds into `agentDown` with *Return to host* / *Try again*; a **401** shows *"can't authenticate to X — update its token in Settings ▸ Agents"* with *Return to host*.

## Tests

`update_remote` unit (edit/keep-token/clear-token/collision/SSRF/unknown) + `PATCH` route test + `isAgentUnreachable` predicate. **Full pytest 2767 passed**; console **tsc clean, 269 unit tests, production build clean**. `ruff` + import-linter (3 kept / 0 broken) clean.

This closes out the remote-fleet audit follow-up list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)