### PR TITLE
feat(console): Work surface — card-first overview navigation, live cards + quick-add (no tabs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   card.
 
 ### Changed
+- **The Work surface is card-first — no tabs** (console). The right-rail Work
+  hub drops its Overview/Goals/Watches/Tasks/Schedule tab strip: the landing is
+  always the **Overview**, now four live cards (Goals · **Watches**, previously
+  missing from the roll-up · Tasks · Schedule) in a responsive grid. Each card
+  IS the navigation — whole-card click-through (keyboard-accessible,
+  selection-guarded, raised-card hover like the chat report card) into the
+  unchanged panel under a slim **"← Overview"** back bar (Escape backs out too,
+  when no dialog is open). Cards carry an icon + count Badge header, a muted
+  one-line **pulse** ("2 driving · iteration 3/6", "1 watching · 1 met today",
+  "0 ready · 1 in progress", "next in 25m"), a StatusDot micro-list, and a
+  corner **"+" quick-add** that opens the same creator the panel uses — the
+  Goals inline `<details>` form became a shared `GoalCreateDialog` (one form,
+  two hosts: the panel's new "New goal" header action and the overview
+  quick-add; identical `/api/goals` payload), and `TaskCreateDialog` /
+  `ScheduleModal` are reused directly. Watches has **no** quick-add (watches
+  are agent-created; its empty state says so). Liveness: one surface-level SSE
+  subscription set (`goal.*`, `watch.*`, `task.changed`, `scheduler.fired`)
+  keeps every card fresh whichever view is open, plus a gentle 60s
+  schedule poll while the overview is mounted (the scheduler bus has no push
+  for agent-side add/cancel).
 - **The background report card is a real card**
   ([ADR 0070](docs/adr/0070-background-results-push-resume.md) D4, console).
   A finished background job's report no longer renders as the DS system-message

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -175,6 +175,36 @@ export const GOALS = {
   ],
 };
 
+// Watches (ADR 0067) — varied statuses so the Work overview card renders an active
+// count, a met-today pulse fragment, and tinted status badges. `last_checked` is epoch
+// SECONDS; "met today" derives from the local day, so keep it near now.
+export const WATCHES = {
+  enabled: true,
+  watches: [
+    {
+      id: "watch-1",
+      condition: "CI is green on main",
+      status: "active",
+      verifier: { type: "llm" },
+      last_checked: Math.floor(Date.now() / 1000) - 120,
+    },
+    {
+      id: "watch-2",
+      condition: "The staging deploy finishes",
+      status: "met",
+      verifier: { type: "llm" },
+      last_checked: Math.floor(Date.now() / 1000) - 600,
+    },
+    {
+      id: "watch-3",
+      condition: "Inbox zero before Friday",
+      status: "expired",
+      verifier: { type: "llm" },
+      last_checked: Math.floor(Date.now() / 1000) - 7200,
+    },
+  ],
+};
+
 export const NOTES_WORKSPACE = {
   version: 1,
   workspaceVersion: 1,

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -176,8 +176,10 @@ export const GOALS = {
 };
 
 // Watches (ADR 0067) — varied statuses so the Work overview card renders an active
-// count, a met-today pulse fragment, and tinted status badges. `last_checked` is epoch
-// SECONDS; "met today" derives from the local day, so keep it near now.
+// count, a met-today pulse fragment, and tinted status badges. Times are epoch SECONDS.
+// Mirror the controller's write order: the met path sets `finished_at` and skips the
+// `last_checked` update, so a finished watch's last_checked is the PREVIOUS check.
+// "met today" derives from finished_at on the local day, so keep it near now.
 export const WATCHES = {
   enabled: true,
   watches: [
@@ -193,14 +195,16 @@ export const WATCHES = {
       condition: "The staging deploy finishes",
       status: "met",
       verifier: { type: "llm" },
-      last_checked: Math.floor(Date.now() / 1000) - 600,
+      last_checked: Math.floor(Date.now() / 1000) - 900,
+      finished_at: Math.floor(Date.now() / 1000) - 600,
     },
     {
       id: "watch-3",
       condition: "Inbox zero before Friday",
       status: "expired",
       verifier: { type: "llm" },
-      last_checked: Math.floor(Date.now() / 1000) - 7200,
+      last_checked: Math.floor(Date.now() / 1000) - 7500,
+      finished_at: Math.floor(Date.now() / 1000) - 7200,
     },
   ],
 };

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -39,6 +39,7 @@ import {
   TELEMETRY_INSIGHTS,
   TELEMETRY_SUMMARY,
   TELEMETRY_TURNS,
+  WATCHES,
   WORKFLOW_RUN_RESULT,
   WORKFLOWS,
 } from "./fixtures.mjs";
@@ -148,6 +149,8 @@ function handleApiGet(pathname, fleet = FLEET) {
       return SCHEDULER_JOBS;
     case "/api/goals":
       return GOALS;
+    case "/api/watches":
+      return WATCHES;
     case "/api/notes/workspace":
       return { workspace: NOTES_WORKSPACE };
     case "/api/tasks/status":

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -25,36 +25,35 @@ test("Studio lands directly on Workflows (Run tab removed — run is a chat gest
 });
 
 // The Work hub (2026-06) consolidates the former Tasks / Goals / Schedule rail surfaces
-// into one right-rail "Work" surface with Overview · Goals · Tasks · Schedule tabs.
-// Work is the default-active right panel, so it's already open — clicking its rail icon
-// when active would TOGGLE it closed, so only click when it's not the active surface.
-// In the narrow right panel the DS responsive Tabs collapse the role="tab" strip into a
-// native <select.pl-tabs__select>; pick the tab through it.
-const TAB_VALUE: Record<string, string> = { Overview: "overview", Goals: "goals", Tasks: "tasks", Schedule: "schedule" };
-async function openWorkTab(page, tab: string) {
+// into one right-rail "Work" surface. Card-first navigation (2026-07, no tabs): the
+// landing is the Overview's four cards (Goals · Watches · Tasks · Schedule); clicking a
+// card opens the panel. Work is the default-active right panel, so it's already open —
+// clicking its rail icon when active would TOGGLE it closed, so only click when it's not
+// the active surface.
+async function openWorkView(page, card: string) {
   const workBtn = page.locator(".pl-rail--right").getByRole("button", { name: "Work", exact: true });
   const cls = (await workBtn.getAttribute("class")) ?? "";
   if (!cls.includes("--active")) await workBtn.click();
-  await page.locator(".pl-tabs__select").first().selectOption(TAB_VALUE[tab]);
+  await page.getByTestId(`work-card-${card}`).click();
 }
 
-test("Work → Schedule tab lists scheduled jobs", async ({ page }) => {
-  await openWorkTab(page, "Schedule");
+test("Work → Schedule card opens the panel listing scheduled jobs", async ({ page }) => {
+  await openWorkView(page, "schedule");
   await expect(page.getByRole("heading", { name: "Schedule" })).toBeVisible();
   await expect(page.getByText("Summarize overnight activity")).toBeVisible();
 });
 
-test("Work → Goals tab lists active goals", async ({ page }) => {
-  // Goals folded into the Work hub's Goals tab (still renders the GoalsPanel verbatim).
-  await openWorkTab(page, "Goals");
+test("Work → Goals card opens the panel listing active goals", async ({ page }) => {
+  // Goals folded into the Work hub (still renders the GoalsPanel verbatim).
+  await openWorkView(page, "goals");
   await expect(page.getByRole("heading", { name: "Goals" })).toBeVisible();
   await expect(page.getByText("All tests pass")).toBeVisible();
 });
 
-test("Work → Tasks tab lists tasks issues (query-backed)", async ({ page }) => {
-  // The tab is labeled "Tasks" but the panel content is still Tasks (TanStack Query /
+test("Work → Tasks card opens the panel listing tasks issues (query-backed)", async ({ page }) => {
+  // The card is labeled "Tasks" and the panel is the Tasks board (TanStack Query /
   // Suspense, ADR 0013) — folded into the Work hub.
-  await openWorkTab(page, "Tasks");
+  await openWorkView(page, "tasks");
   await expect(page.getByRole("heading", { name: "Tasks" })).toBeVisible();
   await expect(page.getByText("Wire the telemetry rollup")).toBeVisible();
 });
@@ -181,8 +180,8 @@ test("right-click → Move to bottom dock docks the surface at the bottom", asyn
   // Work now lives in the (icon-only) bottom rail, off the right rail, and its panel opens.
   await expect(bottomRail.getByRole("button", { name: "Work", exact: true })).toBeVisible();
   await expect(rightRail.getByRole("button", { name: "Work", exact: true })).toHaveCount(0);
-  // Its panel renders — the Work hub's Tabs strip is present in the bottom dock.
-  await expect(page.locator(".pl-appshell__bottom .pl-tabs").getByRole("tab", { name: "Overview", exact: true })).toBeVisible();
+  // Its panel renders — the Work hub's overview card grid is present in the bottom dock.
+  await expect(page.locator(".pl-appshell__bottom").getByTestId("work-card-goals")).toBeVisible();
 });
 
 test("right-click a core surface → Hide removes it; Chat offers no Hide (ADR 0035/0036)", async ({ page }) => {

--- a/apps/web/e2e/schedule.spec.ts
+++ b/apps/web/e2e/schedule.spec.ts
@@ -6,13 +6,12 @@ import { expect, test } from "@playwright/test";
 
 async function gotoSchedule(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  // Schedule folded into the Work hub (2026-06): the right-rail Work surface, Schedule tab.
-  // Work is the default-active right panel; in the narrow panel the DS responsive Tabs
-  // collapse the role="tab" strip into a native <select.pl-tabs__select>.
+  // Schedule lives in the Work hub (right rail). Card-first navigation (2026-07, no
+  // tabs): the overview's Schedule card clicks through to the panel.
   const workBtn = page.locator(".pl-rail--right").getByRole("button", { name: "Work", exact: true });
   const cls = (await workBtn.getAttribute("class")) ?? "";
   if (!cls.includes("--active")) await workBtn.click();
-  await page.locator(".pl-tabs__select").first().selectOption("schedule");
+  await page.getByTestId("work-card-schedule").click();
 }
 
 async function openScheduleModal(page) {

--- a/apps/web/e2e/tasks.spec.ts
+++ b/apps/web/e2e/tasks.spec.ts
@@ -8,7 +8,8 @@ async function openTasks(page) {
   const workBtn = page.locator(".pl-rail--right").getByRole("button", { name: "Work", exact: true });
   const cls = (await workBtn.getAttribute("class")) ?? "";
   if (!cls.includes("--active")) await workBtn.click();
-  await page.locator(".pl-tabs__select").first().selectOption("tasks");
+  // Card-first Work hub (2026-07, no tabs): the overview's Tasks card IS the navigation.
+  await page.getByTestId("work-card-tasks").click();
 }
 
 test("New task opens a dialog; submit is gated on a title, then creates", async ({ page }) => {

--- a/apps/web/e2e/work-overview.spec.ts
+++ b/apps/web/e2e/work-overview.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test } from "@playwright/test";
+
+// The Work hub's card-first overview (2026-07, no tabs): the landing is four live cards
+// (Goals · Watches · Tasks · Schedule) that ARE the navigation — whole-card click-through
+// to the nested panel, a "← Overview" back bar, live counts + a pulse line per card, and
+// a corner "+" quick-add that opens the same creator dialog the panel uses (adding never
+// navigates). Watches is the odd one out: agent-created, so no quick-add.
+
+async function openWork(page) {
+  await page.goto("/app/", { waitUntil: "load" });
+  // Work is the default-active right panel — clicking its rail icon when active would
+  // TOGGLE the panel closed, so only click when it's not the active surface.
+  const workBtn = page.locator(".pl-rail--right").getByRole("button", { name: "Work", exact: true });
+  const cls = (await workBtn.getAttribute("class")) ?? "";
+  if (!cls.includes("--active")) await workBtn.click();
+}
+
+test("all four cards render with live counts and pulse lines", async ({ page }) => {
+  await openWork(page);
+
+  const goals = page.getByTestId("work-card-goals");
+  await expect(goals.locator(".work-card-head .pl-badge")).toHaveText("1");
+  await expect(goals.locator(".work-card-pulse")).toHaveText("1 driving · iteration 1/6");
+  await expect(goals.getByText("All tests pass")).toBeVisible();
+
+  const watches = page.getByTestId("work-card-watches");
+  await expect(watches.locator(".work-card-head .pl-badge")).toHaveText("1"); // active only
+  await expect(watches.locator(".work-card-pulse")).toHaveText("1 watching · 1 met today");
+  await expect(watches.getByText("CI is green on main")).toBeVisible();
+  // Non-active watches still list, tinted by status.
+  await expect(watches.locator(".work-row", { hasText: "The staging deploy finishes" }).locator(".pl-badge")).toHaveText("met");
+
+  const tasks = page.getByTestId("work-card-tasks");
+  await expect(tasks.locator(".work-card-head .pl-badge")).toHaveText("1");
+  await expect(tasks.locator(".work-card-pulse")).toHaveText("0 ready · 1 in progress");
+  await expect(tasks.getByText("Wire the telemetry rollup")).toBeVisible();
+
+  const schedule = page.getByTestId("work-card-schedule");
+  await expect(schedule.locator(".work-card-head .pl-badge")).toHaveText("1");
+  await expect(schedule.locator(".work-card-pulse")).toContainText("next");
+  await expect(schedule.getByText("Summarize overnight activity")).toBeVisible();
+});
+
+test("a card clicks through to its panel; ← Overview (and Escape) return", async ({ page }) => {
+  await openWork(page);
+  await page.getByTestId("work-card-goals").click();
+
+  // Nested view: the full Goals panel under the slim back bar.
+  await expect(page.getByRole("heading", { name: "Goals" })).toBeVisible();
+  await expect(page.getByTestId("work-back")).toBeVisible();
+
+  // Back → the overview grid again.
+  await page.getByTestId("work-back").click();
+  await expect(page.getByTestId("work-card-goals")).toBeVisible();
+  await expect(page.getByTestId("work-back")).toHaveCount(0);
+
+  // Escape (focus inside the Work surface, no dialog open) also backs out.
+  await page.getByTestId("work-card-watches").click();
+  await expect(page.getByRole("heading", { name: "Watches" })).toBeVisible();
+  await page.getByTestId("work-back").focus();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("work-card-watches")).toBeVisible();
+});
+
+test("Tasks quick-add opens the create dialog without navigating; creating updates the card", async ({ page }) => {
+  // Stateful tasks feed for THIS page only (the shared mock server's writes are
+  // generic-ok/stateless): after the POST, the list serves one more issue so the
+  // invalidate → refetch visibly updates the card.
+  let created = false;
+  await page.route("**/api/tasks/issues", async (route) => {
+    if (route.request().method() === "POST") {
+      created = true;
+      return route.fulfill({ json: { issue: { id: "task-9", title: "Overview quick-add", status: "open" } } });
+    }
+    const issues = [
+      { id: "bd-1", title: "Wire the telemetry rollup", status: "in_progress", priority: 1, issue_type: "task", created_at: "2026-06-02T09:00:00Z" },
+      ...(created ? [{ id: "task-9", title: "Overview quick-add", status: "open", priority: 2, issue_type: "task", created_at: "2026-07-01T09:00:00Z" }] : []),
+    ];
+    return route.fulfill({ json: { issues } });
+  });
+
+  await openWork(page);
+  const tasks = page.getByTestId("work-card-tasks");
+  await expect(tasks.locator(".work-card-head .pl-badge")).toHaveText("1");
+
+  // The "+" is a quick-add, not a navigation: the dialog opens over the overview.
+  await page.getByTestId("work-add-task").click();
+  await expect(page.getByTestId("task-create-dialog")).toBeVisible();
+  await expect(page.getByTestId("work-back")).toHaveCount(0); // still on the overview
+
+  await page.getByTestId("task-create-title").fill("Overview quick-add");
+  await page.getByTestId("task-create-submit").click();
+  await expect(page.getByTestId("task-create-dialog")).toHaveCount(0);
+
+  // The card updates live: count 1 → 2, and the new row appears.
+  await expect(tasks.locator(".work-card-head .pl-badge")).toHaveText("2");
+  await expect(tasks.getByText("Overview quick-add")).toBeVisible();
+});
+
+test("the Watches card has no quick-add (watches are agent-created)", async ({ page }) => {
+  await openWork(page);
+  const watches = page.getByTestId("work-card-watches");
+  await expect(watches).toBeVisible();
+  await expect(watches.locator(".work-card-foot")).toHaveCount(0);
+  // The other cards do offer one.
+  await expect(page.getByTestId("work-add-goal")).toBeVisible();
+  await expect(page.getByTestId("work-add-task")).toBeVisible();
+  await expect(page.getByTestId("work-add-schedule")).toBeVisible();
+});
+
+test("an empty card shows the DS Empty with the quick-add as its CTA", async ({ page }) => {
+  // No active goals for THIS page → the Goals card renders its empty state.
+  await page.route("**/api/goals", (route) =>
+    route.fulfill({ json: { enabled: true, goals: [] } }),
+  );
+  await openWork(page);
+
+  const goals = page.getByTestId("work-card-goals");
+  await expect(goals.locator(".work-card-head .pl-badge")).toHaveText("0");
+  await expect(goals.getByText("No active goals")).toBeVisible();
+
+  // The Empty's action IS the quick-add — it opens the goal dialog, no navigation.
+  await goals.locator(".pl-empty__action").getByTestId("work-add-goal").click();
+  await expect(page.getByTestId("goal-create-dialog")).toBeVisible();
+  await expect(page.getByTestId("work-back")).toHaveCount(0);
+
+  // Gated on a condition, like the panel host.
+  await expect(page.getByTestId("goal-create-submit")).toBeDisabled();
+  await page.getByTestId("goal-create-condition").fill("Ship the overview");
+  await expect(page.getByTestId("goal-create-submit")).toBeEnabled();
+});
+
+test("watches empty state explains agent-created watches and offers no CTA", async ({ page }) => {
+  await page.route("**/api/watches", (route) =>
+    route.fulfill({ json: { enabled: true, watches: [] } }),
+  );
+  await openWork(page);
+
+  const watches = page.getByTestId("work-card-watches");
+  await expect(watches.getByText(/The agent sets watches/)).toBeVisible();
+  await expect(watches.locator(".pl-empty__action")).toHaveCount(0);
+});

--- a/apps/web/e2e/work-overview.spec.ts
+++ b/apps/web/e2e/work-overview.spec.ts
@@ -130,6 +130,41 @@ test("an empty card shows the DS Empty with the quick-add as its CTA", async ({ 
   await expect(page.getByTestId("goal-create-submit")).toBeEnabled();
 });
 
+test("the Goals PANEL hosts the same create dialog via its New goal header action", async ({ page }) => {
+  // The other host of the lifted GoalCreateDialog (one form, two hosts): the Goals
+  // panel's header action — the replacement for the old inline <details> form. Tasks/
+  // Schedule panel create flows have their own specs; this covers the Goals panel's.
+  let posted: Record<string, unknown> | null = null;
+  await page.route("**/api/goals", async (route) => {
+    if (route.request().method() === "POST") {
+      posted = route.request().postDataJSON();
+      return route.fulfill({ json: { ok: true, message: "goal set" } });
+    }
+    return route.fallback();
+  });
+
+  await openWork(page);
+  await page.getByTestId("work-card-goals").click();
+  await expect(page.getByRole("heading", { name: "Goals" })).toBeVisible();
+
+  await page.getByTestId("goal-new").click();
+  await expect(page.getByTestId("goal-create-dialog")).toBeVisible();
+  await expect(page.getByTestId("goal-create-submit")).toBeDisabled(); // gated on a condition
+  await page.getByTestId("goal-create-condition").fill("All tests pass twice");
+  await page.getByTestId("goal-create-submit").click();
+
+  // Same payload/endpoint as the old inline form; success closes the dialog + toasts.
+  await expect(page.getByTestId("goal-create-dialog")).toHaveCount(0);
+  await expect(page.locator(".pl-toast__title", { hasText: "Goal set" })).toBeVisible();
+  expect(posted).toMatchObject({
+    session_id: "operator",
+    condition: "All tests pass twice",
+    verifier: { type: "llm" },
+  });
+  // Still in the nested Goals view — creating never navigates.
+  await expect(page.getByTestId("work-back")).toBeVisible();
+});
+
 test("watches empty state explains agent-created watches and offers no CTA", async ({ page }) => {
   await page.route("**/api/watches", (route) =>
     route.fulfill({ json: { enabled: true, watches: [] } }),

--- a/apps/web/src/app/GoalsPanel.tsx
+++ b/apps/web/src/app/GoalsPanel.tsx
@@ -2,7 +2,7 @@ import "../goals/goals.css";
 
 import { Input, Textarea } from "@protolabsai/ui/forms";
 import { Button, Empty } from "@protolabsai/ui/primitives";
-import { useToast } from "@protolabsai/ui/overlays";
+import { Dialog, useToast } from "@protolabsai/ui/overlays";
 import {
 
   QueryErrorResetBoundary,
@@ -10,8 +10,8 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { Trash2 } from "lucide-react";
-import { Suspense, useEffect, useState, type FormEvent } from "react";
+import { Plus, Target, Trash2 } from "lucide-react";
+import { Suspense, useEffect, useState } from "react";
 
 import { api } from "../lib/api";
 import { ago, errMsg } from "../lib/format";
@@ -102,34 +102,40 @@ function GoalsList() {
   );
 }
 
-// Compact operator "set a goal" form, above the list. Collapsed by default (a <details>
-// disclosure) so it stays out of the way — the primary surface is still the goal list. POSTs
-// to the operator `/api/goals` (ADR 0066), which accepts any verifier type; the verifier is a
-// small JSON textarea (default `{"type":"llm"}`) parsed on submit — invalid JSON shows an
-// inline error and doesn't submit. Result is surfaced via the shared DS toast, and the goals
-// query is invalidated so the list picks up the new goal.
-function NewGoalForm() {
-  const queryClient = useQueryClient();
-  const toast = useToast();
+// Operator "set a goal" dialog (was an inline <details> form above the list). ONE form,
+// two hosts: the Goals panel's "New goal" header action and the Work overview's Goals-card
+// quick-add both open it — the host owns open-state + the setGoal mutation (this component
+// is fields + validation only, mirroring TaskCreateDialog/ScheduleModal). The payload is
+// unchanged: `{session_id, condition, verifier}` POSTed to the operator `/api/goals`
+// (ADR 0066), which accepts any verifier type; the verifier is a small JSON textarea
+// (default `{"type":"llm"}`) parsed on submit — invalid JSON shows an inline error and
+// doesn't submit.
+export function GoalCreateDialog({
+  open,
+  onClose,
+  onCreate,
+  busy,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (body: { session_id: string; condition: string; verifier: unknown }) => void;
+  busy: boolean;
+}) {
   const [sessionId, setSessionId] = useState("operator");
   const [condition, setCondition] = useState("");
   const [verifier, setVerifier] = useState('{"type":"llm"}');
   const [jsonError, setJsonError] = useState<string | null>(null);
-
-  const set = useMutation({
-    mutationFn: (body: { session_id: string; condition: string; verifier: unknown }) =>
-      api.setGoal(body),
-    onSuccess: (res) => {
+  // Blank slate each time the dialog opens (keep the session/verifier defaults).
+  useEffect(() => {
+    if (open) {
+      setSessionId("operator");
       setCondition("");
-      toast({ tone: "success", title: "Goal set", message: res.message || "The agent has a new goal." });
-    },
-    // A rejected verifier / disabled goal mode comes back as HTTP 400 → request() throws here.
-    onError: (e) => toast({ tone: "error", title: "Couldn't set goal", message: errMsg(e) }),
-    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.goals }),
-  });
+      setVerifier('{"type":"llm"}');
+      setJsonError(null);
+    }
+  }, [open]);
 
-  const submit = (e: FormEvent) => {
-    e.preventDefault();
+  const submit = () => {
     const cond = condition.trim();
     if (!cond) return;
     let parsed: unknown;
@@ -140,25 +146,46 @@ function NewGoalForm() {
       return;
     }
     setJsonError(null);
-    set.mutate({ session_id: sessionId.trim() || "operator", condition: cond, verifier: parsed });
+    onCreate({ session_id: sessionId.trim() || "operator", condition: cond, verifier: parsed });
   };
 
   return (
-    <details className="goal-new">
-      <summary>New goal</summary>
-      <form className="goal-new-form" onSubmit={submit}>
-        <label className="field">
-          <span>Session</span>
-          <Input value={sessionId} onChange={(e) => setSessionId(e.target.value)} placeholder="operator" />
-        </label>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={<><Target size={16} /> New goal</>}
+      width="min(520px, 94vw)"
+      footer={
+        <>
+          <Button type="button" onClick={onClose}>Cancel</Button>
+          <Button
+            type="button"
+            variant="primary"
+            loading={busy}
+            disabled={!condition.trim() || busy}
+            data-testid="goal-create-submit"
+            onClick={submit}
+          >
+            {busy ? null : <Plus size={16} />} Set goal
+          </Button>
+        </>
+      }
+    >
+      <div className="goal-create-form" data-testid="goal-create-dialog">
         <label className="field">
           <span>Condition</span>
           <Input
+            autoFocus
             value={condition}
             onChange={(e) => setCondition(e.target.value)}
             placeholder="What the agent should achieve"
+            data-testid="goal-create-condition"
             required
           />
+        </label>
+        <label className="field">
+          <span>Session</span>
+          <Input value={sessionId} onChange={(e) => setSessionId(e.target.value)} placeholder="operator" />
         </label>
         <label className="field">
           <span>Verifier (JSON)</span>
@@ -176,28 +203,44 @@ function NewGoalForm() {
         {jsonError ? (
           <p className="goal-new-error field-warn" role="alert">{jsonError}</p>
         ) : null}
-        <Button
-          type="submit"
-          variant="primary"
-          loading={set.isPending}
-          disabled={!condition.trim() || set.isPending}
-        >
-          Set goal
-        </Button>
-      </form>
-    </details>
+      </div>
+    </Dialog>
   );
 }
 
 export function GoalsPanel() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const set = useMutation({
+    mutationFn: (body: { session_id: string; condition: string; verifier: unknown }) =>
+      api.setGoal(body),
+    onSuccess: (res) => {
+      setDialogOpen(false);
+      toast({ tone: "success", title: "Goal set", message: res.message || "The agent has a new goal." });
+    },
+    // A rejected verifier / disabled goal mode comes back as HTTP 400 → request() throws here.
+    onError: (e) => toast({ tone: "error", title: "Couldn't set goal", message: errMsg(e) }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.goals }),
+  });
   return (
     <section className="panel side-panel goals-panel">
       <PanelHeader
         compact
         title="Goals"
         kicker={<>the agent's standing goals · set with <code>/goal</code> in chat</>}
+        actions={
+          <Button variant="primary" type="button" onClick={() => setDialogOpen(true)} data-testid="goal-new">
+            <Plus size={16} /> New goal
+          </Button>
+        }
       />
-      <NewGoalForm />
+      <GoalCreateDialog
+        open={dialogOpen}
+        onClose={() => { setDialogOpen(false); set.reset(); }}
+        onCreate={(body) => set.mutate(body)}
+        busy={set.isPending}
+      />
       <ScrollArea className="goals-list" role="region" aria-label="Goals" tabIndex={0}>
         <QueryErrorResetBoundary>
           {({ reset }: { reset: () => void }) => (

--- a/apps/web/src/app/TasksPanel.tsx
+++ b/apps/web/src/app/TasksPanel.tsx
@@ -58,8 +58,10 @@ type ConfirmRequest = {
 
 // Create a task from a dialog (opened by the panel's "New task" action) instead of
 // an always-visible inline form — keeps the board the focus, with the full set of
-// fields (title, type, priority, description) only when you're adding.
-function TaskCreateDialog({
+// fields (title, type, priority, description) only when you're adding. Exported so the
+// Work overview's Tasks-card quick-add reuses it (that host owns its own open-state +
+// create mutation) — one form, two hosts.
+export function TaskCreateDialog({
   open,
   onClose,
   onCreate,

--- a/apps/web/src/app/WorkPanel.tsx
+++ b/apps/web/src/app/WorkPanel.tsx
@@ -1,194 +1,416 @@
-import { useEffect, useState, type ComponentProps, type ReactNode } from "react";
-import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { Tabs } from "@protolabsai/ui/navigation";
-import { Boxes, CalendarClock, ChevronRight, Eye, LayoutDashboard, Target } from "lucide-react";
+import {
+  useEffect,
+  useState,
+  type ComponentProps,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { Badge, Button, Empty, type Status } from "@protolabsai/ui/primitives";
+import { StatusDot } from "@protolabsai/ui/data";
+import { useToast } from "@protolabsai/ui/overlays";
+import { ArrowLeft, Boxes, CalendarClock, Eye, Plus, Target } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 import { StagePanel } from "./ErrorBoundary";
-import { GoalsPanel } from "./GoalsPanel";
+import { GoalCreateDialog, GoalsPanel } from "./GoalsPanel";
 import { WatchesPanel } from "./WatchesPanel";
-import { TasksPanel } from "./TasksPanel";
-import { SchedulePanel } from "../schedule/SchedulePanel";
+import { TaskCreateDialog, TasksPanel } from "./TasksPanel";
+import { ScheduleModal, SchedulePanel } from "../schedule/SchedulePanel";
+import { api } from "../lib/api";
+import { errMsg } from "../lib/format";
 import { onServerEvent } from "../lib/events";
-import { tasksQuery, goalsQuery, schedulesQuery, queryKeys } from "../lib/queries";
-import type { Task, GoalState, ScheduledJob } from "../lib/types";
+import { tasksQuery, goalsQuery, schedulesQuery, watchesQuery, queryKeys } from "../lib/queries";
+import type { GoalState, ScheduledJob, Task, WatchState } from "../lib/types";
+import type { IssueDraft } from "./tasks";
+import {
+  activeGoals,
+  activeWatches,
+  goalsPulse,
+  schedulePulse,
+  taskBuckets,
+  tasksPulse,
+  untilLabel,
+  upcomingJobs,
+  visibleWatches,
+  watchesPulse,
+} from "./workOverview";
 
 import "./work.css";
 
-type WorkTab = "overview" | "goals" | "watches" | "tasks" | "schedule";
+type WorkView = "overview" | "goals" | "watches" | "tasks" | "schedule";
 type Confirm = ComponentProps<typeof TasksPanel>["confirm"];
 
-const TABS: { id: WorkTab; label: string; icon: LucideIcon }[] = [
-  { id: "overview", label: "Overview", icon: LayoutDashboard },
-  { id: "goals", label: "Goals", icon: Target },
-  { id: "watches", label: "Watches", icon: Eye },
-  { id: "tasks", label: "Tasks", icon: Boxes },
-  { id: "schedule", label: "Schedule", icon: CalendarClock },
-];
-
 /**
- * The agent's WORK hub (2026-06) — one right-rail surface consolidating the three "what's
- * the agent doing" panels: what it's steering toward (Goals), the concrete backlog
- * (Tasks/Tasks), and timed runs (Schedule), with a glanceable Overview roll-up on top. The
- * Goals/Tasks/Schedule tabs reuse the standalone panels verbatim; only the Overview is new.
+ * The agent's WORK hub (2026-06) — one right-rail surface consolidating the "what's the
+ * agent doing" panels: what it's steering toward (Goals), what it's passively supervising
+ * (Watches), the concrete backlog (Tasks), and timed runs (Schedule).
+ *
+ * Card-first navigation (2026-07, no tabs): the landing is ALWAYS the Overview — four live
+ * cards that each click through to the full panel, rendered verbatim under a slim
+ * "← Overview" back bar. The view is deliberately not persisted: reopening Work lands on
+ * the roll-up, drilling in is a gesture away.
  */
 export function WorkPanel({ confirm }: { confirm: Confirm }) {
-  const [tab, setTab] = useState<WorkTab>("overview");
-  return (
-    <>
-      <Tabs
-        responsive
-        active={tab}
-        onSelect={(t) => setTab(t as WorkTab)}
-        items={TABS.map((t) => ({ id: t.id, label: t.label, icon: <t.icon size={15} /> }))}
-      />
-      {tab === "overview" ? (
-        <StagePanel label="work" variant="side">
-          <WorkOverview onJump={setTab} />
-        </StagePanel>
-      ) : tab === "goals" ? (
-        <GoalsPanel />
-      ) : tab === "watches" ? (
-        <WatchesPanel />
-      ) : tab === "tasks" ? (
-        <TasksPanel confirm={confirm} />
-      ) : (
-        <SchedulePanel />
-      )}
-    </>
-  );
-}
-
-const normStatus = (s: string | undefined) => (s ?? "").toLowerCase().replace(/[ _-]/g, "");
-
-function WorkOverview({ onJump }: { onJump: (t: WorkTab) => void }) {
-  const goals = useSuspenseQuery(goalsQuery()).data.goals;
-  const issues = useSuspenseQuery(tasksQuery()).data.issues;
-  // The scheduler bus only emits `scheduler.fired` (a dispatch) — there is NO push when the
-  // AGENT adds/cancels a job mid-turn (schedule_task/cancel_schedule mutate the store directly).
-  // A gentle per-use poll (NOT on the shared schedulesQuery() factory — that would regress
-  // SchedulePanel and other `schedules`-key consumers) self-heals that one change-class (#1537).
-  const jobs = useSuspenseQuery({ ...schedulesQuery(), refetchInterval: 15_000 }).data.jobs;
+  const [view, setView] = useState<WorkView>("overview");
   const queryClient = useQueryClient();
 
-  // Live roll-up: the Overview is a different tab than the Goals/Tasks/Schedule panels, so
-  // while it's showing those panels are unmounted and their own bus subscriptions are gone.
-  // Subscribe here too so agent-driven changes mid-turn refresh the counts without a remount
-  // (#1537) — the same push pattern as the panels (invalidate the matching query key on the
-  // relevant ADR 0039 topic, no polling): `goal.changed`/`goal.iteration` (set/advance/clear/
-  // terminal), `task.changed` (filed/closed/updated), `scheduler.fired` (a job dispatched, so
-  // its next_fire moved).
+  // Surface-level live roll-up: the panels' own bus subscriptions only exist while that
+  // panel is MOUNTED, so with card navigation the overview (and every other card) would go
+  // stale while you're inside one panel. Subscribe once at the surface level — the same
+  // push pattern as the panels (invalidate the matching query key on the relevant ADR 0039
+  // topic, no polling): `goal.changed`/`goal.iteration` (set/advance/clear/terminal),
+  // `watch.changed`/`watch.met`/`watch.expired`/`watch.stalled` (create/check/terminal),
+  // `task.changed` (filed/closed/updated), `scheduler.fired` (a job dispatched, so its
+  // next_fire moved). The panels keep their own subscriptions (double-invalidate is a no-op).
   useEffect(() => {
     const refresh = (key: readonly unknown[]) => () =>
       void queryClient.invalidateQueries({ queryKey: key });
     const offs = [
       onServerEvent("goal.changed", refresh(queryKeys.goals)),
       onServerEvent("goal.iteration", refresh(queryKeys.goals)),
+      onServerEvent("watch.changed", refresh(queryKeys.watches)),
+      onServerEvent("watch.met", refresh(queryKeys.watches)),
+      onServerEvent("watch.expired", refresh(queryKeys.watches)),
+      onServerEvent("watch.stalled", refresh(queryKeys.watches)),
       onServerEvent("task.changed", refresh(queryKeys.tasks)),
       onServerEvent("scheduler.fired", refresh(queryKeys.schedules)),
     ];
     return () => offs.forEach((off) => off());
   }, [queryClient]);
 
-  const activeGoals = goals.filter(
-    (g) => g.status !== "achieved" && g.status !== "failed" && !g.finished_at,
-  );
-  const ready = issues.filter((i) => normStatus(i.status) === "ready");
-  const inProgress = issues.filter((i) => normStatus(i.status) === "inprogress");
-  const upcoming = jobs
-    .filter((j) => j.enabled !== false && j.next_fire)
-    .sort((a, b) => ((a.next_fire ?? "") < (b.next_fire ?? "") ? -1 : 1))
-    .slice(0, 3);
+  if (view === "overview") {
+    return (
+      <StagePanel label="work" variant="side">
+        <WorkOverview onOpen={setView} />
+      </StagePanel>
+    );
+  }
 
   return (
-    <div className="work-overview stage-body">
-      <OverviewCard
-        title="Goals"
-        count={activeGoals.length}
-        hint="active"
-        onOpen={() => onJump("goals")}
-        empty="No active goals — set one in chat with /goal …"
-      >
-        {activeGoals.slice(0, 4).map((g: GoalState) => (
-          <li className="work-row" key={g.session_id}>
-            <span className="work-row-title">{g.condition}</span>
-            <span className="work-row-meta">
-              {g.mode === "monitor" ? "monitor" : `${g.iteration ?? 0}/${g.max_iterations ?? "∞"}`}
-            </span>
-          </li>
-        ))}
-      </OverviewCard>
-
-      <OverviewCard
-        title="Tasks"
-        count={ready.length + inProgress.length}
-        hint={`${ready.length} ready · ${inProgress.length} in progress`}
-        onOpen={() => onJump("tasks")}
-        empty="No open tasks"
-      >
-        {[...inProgress, ...ready].slice(0, 5).map((i: Task) => (
-          <li className="work-row" key={i.id}>
-            <span className="work-row-title">{i.title}</span>
-            <span className="work-row-meta">{i.id}</span>
-          </li>
-        ))}
-      </OverviewCard>
-
-      <OverviewCard
-        title="Next runs"
-        count={upcoming.length}
-        hint="scheduled"
-        onOpen={() => onJump("schedule")}
-        empty="Nothing scheduled"
-      >
-        {upcoming.map((j: ScheduledJob) => (
-          <li className="work-row" key={j.id}>
-            <span className="work-row-title">{j.prompt}</span>
-            <span className="work-row-meta">{whenLabel(j.next_fire)}</span>
-          </li>
-        ))}
-      </OverviewCard>
+    <div
+      className="work-view"
+      onKeyDown={(e) => {
+        // Escape backs out to the Overview — but only when no overlay owns the key: DS
+        // Dialogs close on a document-level Escape handler while their .pl-overlay is
+        // still mounted during this same bubble, and radix menus float in a popper
+        // wrapper, so their dismissal never doubles as a navigation.
+        if (e.key !== "Escape") return;
+        if (document.querySelector(".pl-overlay, [data-radix-popper-content-wrapper]")) return;
+        setView("overview");
+      }}
+    >
+      <div className="work-view-bar">
+        <Button variant="ghost" size="sm" type="button" onClick={() => setView("overview")} data-testid="work-back">
+          <ArrowLeft size={15} /> Overview
+        </Button>
+      </div>
+      {view === "goals" ? (
+        <GoalsPanel />
+      ) : view === "watches" ? (
+        <WatchesPanel />
+      ) : view === "tasks" ? (
+        <TasksPanel confirm={confirm} />
+      ) : (
+        <SchedulePanel />
+      )}
     </div>
   );
 }
 
-function OverviewCard({
-  title,
-  count,
-  hint,
-  onOpen,
-  empty,
-  children,
-}: {
-  title: string;
-  count: number;
-  hint?: string;
-  onOpen: () => void;
-  empty: string;
-  children: ReactNode;
-}) {
+// Row-dot tones. Goals on the card are all in-flight (terminal ones are filtered), so the
+// dot reads "loop running"; watches carry their full status; tasks distinguish
+// in-progress from ready.
+const goalDot = (status: string): Status => {
+  if (status === "achieved") return "success";
+  if (status === "unachievable" || status === "failed") return "error";
+  return "warning";
+};
+const watchDot = (status: string): Status => {
+  if (status === "met") return "success";
+  if (status === "expired") return "error";
+  if (status === "stalled") return "warning";
+  if (status === "active") return "info";
+  return "neutral";
+};
+const taskDot = (status: string | undefined): Status =>
+  (status ?? "").toLowerCase().replace(/[ _-]/g, "") === "inprogress" ? "warning" : "neutral";
+
+function WorkOverview({ onOpen }: { onOpen: (v: WorkView) => void }) {
+  const goals = useSuspenseQuery(goalsQuery()).data.goals;
+  const watches = useSuspenseQuery(watchesQuery()).data.watches;
+  const issues = useSuspenseQuery(tasksQuery()).data.issues;
+  // The scheduler bus only emits `scheduler.fired` (a dispatch) — there is NO push when the
+  // AGENT adds/cancels a job mid-turn (schedule_task/cancel_schedule mutate the store
+  // directly). A gentle per-use poll (NOT on the shared schedulesQuery() factory — that
+  // would regress SchedulePanel and other `schedules`-key consumers) self-heals that one
+  // change-class while the overview is up (#1537); chosen over a per-card refresh button
+  // as the lighter affordance.
+  const jobs = useSuspenseQuery({ ...schedulesQuery(), refetchInterval: 60_000 }).data.jobs;
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  // Quick-add: the overview hosts the same creator dialogs the panels use (one form, two
+  // hosts) — open-state + mutation + invalidation live here, mirroring the panel hosts.
+  const [goalOpen, setGoalOpen] = useState(false);
+  const [taskOpen, setTaskOpen] = useState(false);
+  const [scheduleOpen, setScheduleOpen] = useState(false);
+
+  const setGoal = useMutation({
+    mutationFn: (body: { session_id: string; condition: string; verifier: unknown }) =>
+      api.setGoal(body),
+    onSuccess: (res) => {
+      setGoalOpen(false);
+      toast({ tone: "success", title: "Goal set", message: res.message || "The agent has a new goal." });
+    },
+    onError: (e) => toast({ tone: "error", title: "Couldn't set goal", message: errMsg(e) }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.goals }),
+  });
+  const createTask = useMutation({
+    mutationFn: (d: IssueDraft) =>
+      api.createTask({
+        title: d.title.trim(),
+        type: d.type,
+        priority: d.priority,
+        description: d.description.trim() || undefined,
+      }),
+    onSuccess: () => {
+      setTaskOpen(false);
+      toast({ tone: "success", title: "Task created", message: "Added to the board." });
+    },
+    onError: (e) => toast({ tone: "error", title: "Couldn't create task", message: errMsg(e) }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.tasks }),
+  });
+  const addSchedule = useMutation({
+    mutationFn: (body: { prompt: string; schedule: string; job_id?: string; timezone?: string }) =>
+      api.addSchedule(body),
+    onSuccess: () => {
+      setScheduleOpen(false);
+      toast({ tone: "success", title: "Scheduled", message: "The job was added." });
+    },
+    onError: (e) => toast({ tone: "error", title: "Couldn't schedule", message: errMsg(e) }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.schedules }),
+  });
+
+  const active = activeGoals(goals);
+  const watchList = visibleWatches(watches);
+  const { ready, inProgress } = taskBuckets(issues);
+  const upcoming = upcomingJobs(jobs);
+
   return (
-    <section className="work-card">
-      <button type="button" className="work-card-head" onClick={onOpen}>
-        <span className="work-card-title">{title}</span>
-        <span className="work-card-count">
-          {count}
-          {hint ? <span className="work-card-hint"> · {hint}</span> : null}
-        </span>
-        <ChevronRight size={15} className="work-card-go" />
-      </button>
-      {count > 0 ? (
-        <ul className="work-card-body">{children}</ul>
-      ) : (
-        <p className="work-card-empty">{empty}</p>
-      )}
-    </section>
+    <>
+      <div className="work-overview stage-body">
+        <OverviewCard
+          id="goals"
+          title="Goals"
+          icon={Target}
+          count={active.length}
+          pulse={goalsPulse(goals)}
+          onOpen={() => onOpen("goals")}
+          quickAdd={{ label: "Goal", testId: "work-add-goal", onAdd: () => setGoalOpen(true) }}
+          empty={
+            active.length === 0
+              ? { title: "No active goals", description: <>set one here, or in chat with <code>/goal …</code></> }
+              : null
+          }
+        >
+          {active.slice(0, 4).map((g: GoalState) => (
+            <li className="work-row" key={g.session_id}>
+              <StatusDot status={goalDot(g.status)} />
+              <span className="work-row-title">{g.condition}</span>
+              <span className="work-row-meta">
+                {g.mode === "monitor" ? "monitor" : `${g.iteration ?? 0}/${g.max_iterations ?? "∞"}`}
+              </span>
+            </li>
+          ))}
+        </OverviewCard>
+
+        <OverviewCard
+          id="watches"
+          title="Watches"
+          icon={Eye}
+          count={activeWatches(watches).length}
+          pulse={watchesPulse(watches)}
+          onOpen={() => onOpen("watches")}
+          // No quick-add: watches are agent-created (ADR 0067), not an operator form.
+          quickAdd={null}
+          empty={
+            watchList.length === 0
+              ? {
+                  title: "No watches",
+                  description: "The agent sets watches when you ask it to keep an eye on something.",
+                }
+              : null
+          }
+        >
+          {watchList.slice(0, 4).map((w: WatchState) => (
+            <li className="work-row" key={w.id}>
+              <StatusDot status={watchDot(w.status)} />
+              <span className="work-row-title">{w.condition || w.id}</span>
+              <span className="work-row-meta">
+                <Badge status={watchDot(w.status)}>{w.status}</Badge>
+              </span>
+            </li>
+          ))}
+        </OverviewCard>
+
+        <OverviewCard
+          id="tasks"
+          title="Tasks"
+          icon={Boxes}
+          count={ready.length + inProgress.length}
+          pulse={tasksPulse(issues)}
+          onOpen={() => onOpen("tasks")}
+          quickAdd={{ label: "Task", testId: "work-add-task", onAdd: () => setTaskOpen(true) }}
+          empty={
+            ready.length + inProgress.length === 0
+              ? { title: "No open tasks", description: "add one, or the agent will file its own" }
+              : null
+          }
+        >
+          {[...inProgress, ...ready].slice(0, 4).map((i: Task) => (
+            <li className="work-row" key={i.id}>
+              <StatusDot status={taskDot(i.status)} />
+              <span className="work-row-title">{i.title}</span>
+              <span className="work-row-meta">{i.id}</span>
+            </li>
+          ))}
+        </OverviewCard>
+
+        <OverviewCard
+          id="schedule"
+          title="Schedule"
+          icon={CalendarClock}
+          count={upcoming.length}
+          pulse={schedulePulse(jobs)}
+          onOpen={() => onOpen("schedule")}
+          quickAdd={{ label: "Schedule", testId: "work-add-schedule", onAdd: () => setScheduleOpen(true) }}
+          empty={upcoming.length === 0 ? { title: "Nothing scheduled", description: "give the agent a timed run" } : null}
+        >
+          {upcoming.slice(0, 3).map((j: ScheduledJob) => (
+            <li className="work-row" key={j.id}>
+              <StatusDot status="info" />
+              <span className="work-row-title">{j.prompt}</span>
+              <span className="work-row-meta">{untilLabel(j.next_fire)}</span>
+            </li>
+          ))}
+        </OverviewCard>
+      </div>
+
+      <GoalCreateDialog
+        open={goalOpen}
+        onClose={() => { setGoalOpen(false); setGoal.reset(); }}
+        onCreate={(body) => setGoal.mutate(body)}
+        busy={setGoal.isPending}
+      />
+      <TaskCreateDialog
+        open={taskOpen}
+        onClose={() => { setTaskOpen(false); createTask.reset(); }}
+        onCreate={(d) => createTask.mutate(d)}
+        busy={createTask.isPending}
+      />
+      <ScheduleModal
+        open={scheduleOpen}
+        onClose={() => { setScheduleOpen(false); addSchedule.reset(); }}
+        onAdd={(b) => addSchedule.mutate(b)}
+        busy={addSchedule.isPending}
+      />
+    </>
   );
 }
 
-function whenLabel(iso?: string | null): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  return d.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+// One overview card: the WHOLE card is the click-through to its panel (role=button,
+// Enter/Space, selection-guarded like the chat report card), with a header (icon + name +
+// count Badge), the muted one-line pulse, a short StatusDot micro-list, and a corner "+"
+// quick-add that stops propagation so adding never navigates. When the card is empty the
+// DS Empty takes over the body, with the same quick-add as its action (when the card has
+// one — Watches doesn't).
+function OverviewCard({
+  id,
+  title,
+  icon: Icon,
+  count,
+  pulse,
+  onOpen,
+  quickAdd,
+  empty,
+  children,
+}: {
+  id: string;
+  title: string;
+  icon: LucideIcon;
+  count: number;
+  pulse?: string;
+  onOpen: () => void;
+  quickAdd: { label: string; testId: string; onAdd: () => void } | null;
+  // `title` stays a string — the DS Empty spreads div HTMLAttributes, whose own
+  // `title` (the tooltip attr) intersects the slot prop down to string.
+  empty: { title?: string; description?: ReactNode } | null;
+  children?: ReactNode;
+}) {
+  const add = quickAdd
+    ? (e: MouseEvent) => {
+        e.stopPropagation(); // adding is not navigating
+        quickAdd.onAdd();
+      }
+    : undefined;
+  return (
+    <section
+      className="work-card"
+      role="button"
+      tabIndex={0}
+      aria-label={`Open ${title}`}
+      data-testid={`work-card-${id}`}
+      onClick={() => {
+        // Convenience click-anywhere — but selecting a row's text must not navigate.
+        if (window.getSelection()?.isCollapsed !== false) onOpen();
+      }}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return; // inner buttons keep their own keys
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+    >
+      <header className="work-card-head">
+        <Icon size={15} className="work-card-icon" aria-hidden />
+        <span className="work-card-title">{title}</span>
+        <Badge status={count > 0 ? "info" : "neutral"}>{count}</Badge>
+      </header>
+      {empty ? (
+        <Empty
+          className="work-card-blank"
+          title={empty.title}
+          description={empty.description}
+          action={
+            quickAdd ? (
+              <Button size="sm" type="button" data-testid={quickAdd.testId} onClick={add}>
+                <Plus size={14} /> {quickAdd.label}
+              </Button>
+            ) : undefined
+          }
+        />
+      ) : (
+        <>
+          {pulse ? <p className="work-card-pulse">{pulse}</p> : null}
+          <ul className="work-card-body">{children}</ul>
+          {quickAdd ? (
+            <div className="work-card-foot">
+              <Button
+                variant="ghost"
+                size="sm"
+                type="button"
+                title={`New ${quickAdd.label.toLowerCase()}`}
+                data-testid={quickAdd.testId}
+                onClick={add}
+              >
+                <Plus size={14} /> {quickAdd.label}
+              </Button>
+            </div>
+          ) : null}
+        </>
+      )}
+    </section>
+  );
 }

--- a/apps/web/src/app/work.css
+++ b/apps/web/src/app/work.css
@@ -1,83 +1,143 @@
-/* Work hub Overview (2026-06) — three roll-up cards (Goals · Tasks · Next runs) that each
-   click through to their tab. The Goals/Tasks/Schedule tabs reuse the standalone panels, so
-   they bring their own styles; this is only the Overview dashboard. */
+/* Work hub Overview (card-first navigation, 2026-07) — four live roll-up cards
+   (Goals · Watches · Tasks · Schedule) that ARE the navigation: the whole card clicks
+   through to its panel (no tab strip). The nested panels bring their own styles; this
+   file owns the overview grid, the raised-card language (the .chat-report-card
+   precedent: lift + popover shadow on hover), and the slim "← Overview" back bar. */
+
+/* Responsive grid — the .plugin-card-grid auto-fill pattern; collapses to a single
+   column in the narrow right rail. */
 .work-overview {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 12px;
+  align-content: start;
   padding: 12px;
   overflow-y: auto;
 }
 
+/* The nested-view wrapper only scopes the Escape-to-overview key handler; it must not
+   introduce a box between the shell panel container and the bar/panel pair. */
+.work-view {
+  display: contents;
+}
+
+.work-view-bar {
+  flex: none;
+  display: flex;
+  align-items: center;
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* One card = one destination: role=button, so it gets the full interactive treatment —
+   pointer, hover lift + shadow + border step-up, and a visible focus ring. */
 .work-card {
+  display: flex;
+  flex-direction: column;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-panel);
   overflow: hidden;
+  cursor: pointer;
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease,
+    border-color 120ms ease;
+}
+.work-card:hover {
+  transform: translateY(-1px);
+  /* Raised-element shadow — same literal fallback as .chat-report-card / .pl-convo__jump. */
+  box-shadow: var(--pl-shadow-popover, 0 2px 8px rgba(0, 0, 0, 0.22));
+  border-color: var(--border-strong);
+}
+.work-card:focus-visible {
+  outline: 1px solid var(--fg);
+  outline-offset: 2px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .work-card {
+    transition: none;
+  }
+  .work-card:hover {
+    transform: none;
+  }
 }
 
 .work-card-head {
   display: flex;
   align-items: center;
   gap: 8px;
-  width: 100%;
-  padding: 9px 12px;
-  border: 0;
-  background: none;
-  color: var(--fg);
-  cursor: pointer;
-  text-align: left;
-  font: inherit;
+  padding: 10px 12px 0;
 }
-.work-card-head:hover {
-  background: var(--bg-hover, rgba(255, 255, 255, 0.03));
+.work-card-icon {
+  flex: none;
+  color: var(--fg-muted);
 }
 .work-card-title {
   font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.work-card-count {
+.work-card-head .pl-badge {
   margin-left: auto;
-  color: var(--fg-muted);
   font-variant-numeric: tabular-nums;
-  font-size: 13px;
 }
-.work-card-hint {
+
+/* The pulse line — one muted sentence with the card's most useful live fact. */
+.work-card-pulse {
+  margin: 4px 0 0;
+  padding: 0 12px;
   color: var(--fg-muted);
-}
-.work-card-go {
-  color: var(--fg-muted);
-  flex: none;
+  font-size: 12px;
 }
 
 .work-card-body {
   list-style: none;
   margin: 0;
-  padding: 0 12px 10px;
+  padding: 8px 12px 4px;
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 .work-row {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 10px;
+  align-items: center;
+  gap: 7px;
   min-width: 0;
 }
+.work-row .pl-dot {
+  flex: none;
+}
 .work-row-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .work-row-meta {
   flex: none;
+  margin-left: auto;
   color: var(--fg-muted);
   font-size: 12px;
+  font-variant-numeric: tabular-nums;
 }
 
-.work-card-empty {
-  margin: 0;
-  padding: 0 12px 10px;
-  color: var(--fg-muted);
-  font-size: 13px;
+/* Corner "+" quick-add (stopPropagation in JSX — adding is not navigating). */
+.work-card-foot {
+  display: flex;
+  justify-content: flex-end;
+  padding: 2px 8px 8px;
+  margin-top: auto;
+}
+
+/* Empty card body — the DS Empty scaled down to card size. */
+.work-card-blank {
+  padding: 14px 12px 16px;
+}
+.work-card-blank .pl-empty__desc {
+  font-size: 12px;
 }

--- a/apps/web/src/app/workOverview.test.ts
+++ b/apps/web/src/app/workOverview.test.ts
@@ -80,14 +80,32 @@ describe("watches card", () => {
     expect(activeWatches(ws)).toHaveLength(1);
   });
 
-  it("pulse counts watching + met-today (local day)", () => {
+  it("pulse counts watching + met-today (local day) off finished_at", () => {
     const ws = [
       watch({ id: "a" }),
       watch({ id: "b" }),
-      watch({ id: "m1", status: "met", last_checked: secsAt(9) }), // this morning
-      watch({ id: "m2", status: "met", last_checked: secsAt(9) - 86_400 }), // yesterday
+      watch({ id: "m1", status: "met", finished_at: secsAt(9) }), // this morning
+      watch({ id: "m2", status: "met", finished_at: secsAt(9) - 86_400 }), // yesterday
     ];
     expect(watchesPulse(ws, now)).toBe("2 watching · 1 met today");
+  });
+
+  it("met time is finished_at, not the stale pre-met last_checked (falls back when absent)", () => {
+    // The controller's met path finishes BEFORE the `last_checked = now` write: a watch
+    // that met on its FIRST check has no last_checked at all, and one that met later
+    // still carries the previous check's time (possibly yesterday).
+    const firstCheckMet = watch({ id: "f", status: "met", finished_at: secsAt(9) });
+    const metAfterYesterdaysCheck = watch({
+      id: "y",
+      status: "met",
+      finished_at: secsAt(9),
+      last_checked: secsAt(9) - 86_400,
+    });
+    expect(watchesPulse([watch({}), firstCheckMet], now)).toBe("1 watching · 1 met today");
+    expect(watchesPulse([watch({}), metAfterYesterdaysCheck], now)).toBe("1 watching · 1 met today");
+    // Older payloads without finished_at still count via last_checked.
+    const legacy = watch({ id: "l", status: "met", last_checked: secsAt(9) });
+    expect(watchesPulse([watch({}), legacy], now)).toBe("1 watching · 1 met today");
   });
 
   it("pulse omits the met fragment when nothing was met today", () => {

--- a/apps/web/src/app/workOverview.test.ts
+++ b/apps/web/src/app/workOverview.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import type { GoalState, ScheduledJob, Task, WatchState } from "../lib/types";
+import {
+  activeGoals,
+  activeWatches,
+  goalsPulse,
+  schedulePulse,
+  taskBuckets,
+  tasksPulse,
+  untilLabel,
+  upcomingJobs,
+  visibleWatches,
+  watchesPulse,
+} from "./workOverview";
+
+const goal = (over: Partial<GoalState>): GoalState => ({
+  session_id: "s",
+  condition: "c",
+  status: "active",
+  ...over,
+});
+
+const watch = (over: Partial<WatchState>): WatchState => ({
+  id: "w",
+  condition: "c",
+  status: "active",
+  ...over,
+});
+
+const task = (over: Partial<Task>): Task => ({ id: "t", title: "t", ...over });
+
+const job = (over: Partial<ScheduledJob>): ScheduledJob => ({
+  id: "j",
+  prompt: "p",
+  schedule: "0 9 * * *",
+  ...over,
+});
+
+describe("goals card", () => {
+  it("activeGoals drops achieved/failed/finished", () => {
+    const goals = [
+      goal({ session_id: "a" }),
+      goal({ session_id: "b", status: "achieved" }),
+      goal({ session_id: "c", status: "failed" }),
+      goal({ session_id: "d", finished_at: 123 }),
+    ];
+    expect(activeGoals(goals).map((g) => g.session_id)).toEqual(["a"]);
+  });
+
+  it("pulse reports the count and the furthest-along iteration", () => {
+    const goals = [
+      goal({ session_id: "a", iteration: 1, max_iterations: 6 }),
+      goal({ session_id: "b", iteration: 3, max_iterations: 8 }),
+      goal({ session_id: "c", status: "achieved", iteration: 9, max_iterations: 9 }),
+    ];
+    expect(goalsPulse(goals)).toBe("2 driving · iteration 3/8");
+  });
+
+  it("pulse tolerates missing iteration fields and empty lists", () => {
+    expect(goalsPulse([goal({})])).toBe("1 driving · iteration 0/∞");
+    expect(goalsPulse([])).toBe("");
+    expect(goalsPulse([goal({ status: "achieved" })])).toBe("");
+  });
+});
+
+describe("watches card", () => {
+  // Fixed "now": 2026-07-01T12:00:00 local time.
+  const now = new Date(2026, 6, 1, 12, 0, 0).getTime();
+  const secsAt = (h: number) => new Date(2026, 6, 1, h, 0, 0).getTime() / 1000;
+
+  it("visibleWatches hides cleared and floats actives first", () => {
+    const ws = [
+      watch({ id: "m", status: "met" }),
+      watch({ id: "a", status: "active" }),
+      watch({ id: "x", status: "cleared" }),
+      watch({ id: "e", status: "expired" }),
+    ];
+    expect(visibleWatches(ws).map((w) => w.id)).toEqual(["a", "m", "e"]);
+    expect(activeWatches(ws)).toHaveLength(1);
+  });
+
+  it("pulse counts watching + met-today (local day)", () => {
+    const ws = [
+      watch({ id: "a" }),
+      watch({ id: "b" }),
+      watch({ id: "m1", status: "met", last_checked: secsAt(9) }), // this morning
+      watch({ id: "m2", status: "met", last_checked: secsAt(9) - 86_400 }), // yesterday
+    ];
+    expect(watchesPulse(ws, now)).toBe("2 watching · 1 met today");
+  });
+
+  it("pulse omits the met fragment when nothing was met today", () => {
+    expect(watchesPulse([watch({})], now)).toBe("1 watching");
+    expect(watchesPulse([], now)).toBe("");
+    expect(watchesPulse([watch({ status: "expired" })], now)).toBe("");
+  });
+});
+
+describe("tasks card", () => {
+  it("buckets open/ready vs in-progress and ignores the rest", () => {
+    const issues = [
+      task({ id: "1", status: "open" }),
+      task({ id: "2", status: "ready" }),
+      task({ id: "3", status: "in_progress" }),
+      task({ id: "4", status: "blocked" }),
+      task({ id: "5", status: "deferred" }),
+      task({ id: "6", status: "closed" }),
+    ];
+    const { ready, inProgress } = taskBuckets(issues);
+    expect(ready.map((i) => i.id)).toEqual(["1", "2"]);
+    expect(inProgress.map((i) => i.id)).toEqual(["3"]);
+    expect(tasksPulse(issues)).toBe("2 ready · 1 in progress");
+  });
+
+  it("pulse is empty with no open work", () => {
+    expect(tasksPulse([task({ status: "closed" })])).toBe("");
+    expect(tasksPulse([])).toBe("");
+  });
+});
+
+describe("schedule card", () => {
+  const now = Date.parse("2026-07-01T12:00:00Z");
+
+  it("upcomingJobs keeps enabled+armed jobs, soonest first", () => {
+    const jobs = [
+      job({ id: "late", next_fire: "2026-07-02T09:00:00Z" }),
+      job({ id: "soon", next_fire: "2026-07-01T12:30:00Z" }),
+      job({ id: "off", enabled: false, next_fire: "2026-07-01T12:10:00Z" }),
+      job({ id: "unarmed", next_fire: null }),
+    ];
+    expect(upcomingJobs(jobs).map((j) => j.id)).toEqual(["soon", "late"]);
+  });
+
+  it("pulse derives from the soonest next fire", () => {
+    const jobs = [
+      job({ id: "a", next_fire: "2026-07-01T12:25:00Z" }),
+      job({ id: "b", next_fire: "2026-07-03T12:00:00Z" }),
+    ];
+    expect(schedulePulse(jobs, now)).toBe("next in 25m");
+    expect(schedulePulse([], now)).toBe("");
+  });
+
+  it("untilLabel covers now/minutes/hours/days and bad input", () => {
+    expect(untilLabel("2026-07-01T12:00:30Z", now)).toBe("due now");
+    expect(untilLabel("2026-07-01T11:00:00Z", now)).toBe("due now"); // past → scheduler hasn't recomputed
+    expect(untilLabel("2026-07-01T12:25:00Z", now)).toBe("in 25m");
+    expect(untilLabel("2026-07-01T15:00:00Z", now)).toBe("in 3h");
+    expect(untilLabel("2026-07-03T12:00:00Z", now)).toBe("in 2d");
+    expect(untilLabel(null, now)).toBe("");
+    expect(untilLabel("not-a-date", now)).toBe("");
+  });
+});

--- a/apps/web/src/app/workOverview.ts
+++ b/apps/web/src/app/workOverview.ts
@@ -36,14 +36,19 @@ export function activeWatches(watches: WatchState[]): WatchState[] {
 }
 
 /** "2 watching · 1 met today" (the met fragment only when something was met today).
- *  `last_checked` is epoch seconds; "today" is the local calendar day of `now`. */
+ *  The met time is `finished_at` — the controller's met path finishes BEFORE its
+ *  `last_checked = now` write, so `last_checked` on a met watch is the PREVIOUS check
+ *  (or unset when it met on the first one). Both are epoch seconds; "today" is the
+ *  local calendar day of `now`. */
 export function watchesPulse(watches: WatchState[], now: number = Date.now()): string {
   const watching = activeWatches(watches).length;
   const dayStart = new Date(now);
   dayStart.setHours(0, 0, 0, 0);
-  const metToday = watches.filter(
-    (w) => w.status === "met" && (w.last_checked ?? 0) * 1000 >= dayStart.getTime() && (w.last_checked ?? 0) * 1000 <= now,
-  ).length;
+  const metToday = watches.filter((w) => {
+    if (w.status !== "met") return false;
+    const met = (w.finished_at ?? w.last_checked ?? 0) * 1000;
+    return met >= dayStart.getTime() && met <= now;
+  }).length;
   if (!watching && !metToday) return "";
   const head = `${watching} watching`;
   return metToday ? `${head} · ${metToday} met today` : head;

--- a/apps/web/src/app/workOverview.ts
+++ b/apps/web/src/app/workOverview.ts
@@ -1,0 +1,99 @@
+// Work Overview derivation helpers — the pure logic behind the four overview cards
+// (Goals · Watches · Tasks · Schedule): which items each card lists, the count on its
+// Badge, and the one-line muted "pulse" sentence under the header. Kept out of
+// WorkPanel.tsx so they're unit-testable without mounting the query layer.
+
+import type { GoalState, ScheduledJob, Task, WatchState } from "../lib/types";
+
+// ── goals ────────────────────────────────────────────────────────────────────
+
+/** Goals still in flight — not terminal and not finished (mirrors the old overview). */
+export function activeGoals(goals: GoalState[]): GoalState[] {
+  return goals.filter((g) => g.status !== "achieved" && g.status !== "failed" && !g.finished_at);
+}
+
+/** "2 driving · iteration 3/6" — count of active goals + the furthest-along loop.
+ *  Empty string when nothing is active (the card shows its Empty state instead). */
+export function goalsPulse(goals: GoalState[]): string {
+  const active = activeGoals(goals);
+  if (!active.length) return "";
+  const lead = active.reduce((a, b) => ((b.iteration ?? 0) > (a.iteration ?? 0) ? b : a));
+  const head = `${active.length} driving`;
+  if (lead.mode === "monitor") return head;
+  return `${head} · iteration ${lead.iteration ?? 0}/${lead.max_iterations ?? "∞"}`;
+}
+
+// ── watches ──────────────────────────────────────────────────────────────────
+
+/** Watches worth showing on the card: everything but cleared, actives first. */
+export function visibleWatches(watches: WatchState[]): WatchState[] {
+  const kept = watches.filter((w) => w.status !== "cleared");
+  return [...kept.filter((w) => w.status === "active"), ...kept.filter((w) => w.status !== "active")];
+}
+
+export function activeWatches(watches: WatchState[]): WatchState[] {
+  return watches.filter((w) => w.status === "active");
+}
+
+/** "2 watching · 1 met today" (the met fragment only when something was met today).
+ *  `last_checked` is epoch seconds; "today" is the local calendar day of `now`. */
+export function watchesPulse(watches: WatchState[], now: number = Date.now()): string {
+  const watching = activeWatches(watches).length;
+  const dayStart = new Date(now);
+  dayStart.setHours(0, 0, 0, 0);
+  const metToday = watches.filter(
+    (w) => w.status === "met" && (w.last_checked ?? 0) * 1000 >= dayStart.getTime() && (w.last_checked ?? 0) * 1000 <= now,
+  ).length;
+  if (!watching && !metToday) return "";
+  const head = `${watching} watching`;
+  return metToday ? `${head} · ${metToday} met today` : head;
+}
+
+// ── tasks ────────────────────────────────────────────────────────────────────
+
+const normStatus = (s: string | undefined) => (s ?? "").toLowerCase().replace(/[ _-]/g, "");
+
+/** The card's working set: in-progress first, then ready-to-pick-up (`open`, plus a
+ *  literal `ready` for beads-shaped feeds). Blocked/deferred/closed stay off the card. */
+export function taskBuckets(issues: Task[]): { ready: Task[]; inProgress: Task[] } {
+  const ready = issues.filter((i) => ["open", "ready"].includes(normStatus(i.status)));
+  const inProgress = issues.filter((i) => normStatus(i.status) === "inprogress");
+  return { ready, inProgress };
+}
+
+/** "3 ready · 1 in progress"; empty string when there's no open work. */
+export function tasksPulse(issues: Task[]): string {
+  const { ready, inProgress } = taskBuckets(issues);
+  if (!ready.length && !inProgress.length) return "";
+  return `${ready.length} ready · ${inProgress.length} in progress`;
+}
+
+// ── schedule ─────────────────────────────────────────────────────────────────
+
+/** Enabled jobs with a computed next fire, soonest first. */
+export function upcomingJobs(jobs: ScheduledJob[]): ScheduledJob[] {
+  return jobs
+    .filter((j) => j.enabled !== false && j.next_fire)
+    .sort((a, b) => ((a.next_fire ?? "") < (b.next_fire ?? "") ? -1 : 1));
+}
+
+/** "next in 25m" from the soonest upcoming fire; empty string when nothing is armed. */
+export function schedulePulse(jobs: ScheduledJob[], now: number = Date.now()): string {
+  const next = upcomingJobs(jobs)[0];
+  if (!next) return "";
+  const rel = untilLabel(next.next_fire, now);
+  return rel ? `next ${rel}` : "";
+}
+
+/** Future-relative time, e.g. "in 5m" / "in 3h" / "in 2d" — `ago()`'s forward twin.
+ *  A past/imminent fire (the scheduler hasn't recomputed yet) reads "due now". */
+export function untilLabel(iso: string | null | undefined, now: number = Date.now()): string {
+  if (!iso) return "";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  const s = (t - now) / 1000;
+  if (s < 60) return "due now";
+  if (s < 3600) return `in ${Math.round(s / 60)}m`;
+  if (s < 86400) return `in ${Math.round(s / 3600)}h`;
+  return `in ${Math.round(s / 86400)}d`;
+}

--- a/apps/web/src/goals/goals.css
+++ b/apps/web/src/goals/goals.css
@@ -48,28 +48,12 @@
   right: 6px;
 }
 
-/* Compact operator "New goal" form above the list — collapsed <details> by default. */
-.goal-new {
-  border-bottom: 1px solid var(--border);
-}
-
-.goal-new > summary {
-  cursor: pointer;
-  padding: 8px 12px;
-  font-size: 12px;
-  color: var(--fg-muted);
-  user-select: none;
-}
-
-.goal-new[open] > summary {
-  color: var(--fg);
-}
-
-.goal-new-form {
+/* New-goal dialog (GoalCreateDialog) — a vertical stack of .field rows, one component
+   hosted by both the Goals panel header action and the Work overview quick-add. */
+.goal-create-form {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 4px 12px 12px;
+  gap: 12px;
 }
 
 .goal-new-error {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -358,6 +358,7 @@ export type WatchState = {
   last_reason?: string;
   last_evidence?: string;
   last_checked?: number | null; // last out-of-band verifier check (epoch seconds)
+  finished_at?: number | null; // met/expired time (epoch seconds); the met path sets THIS, not last_checked
   created_at?: number;
 };
 

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -33,7 +33,9 @@ import {
 
 type Mode = "once" | "repeat" | "cron";
 
-function ScheduleModal({
+// Exported so the Work overview's Schedule-card quick-add reuses it (that host owns its
+// own open-state + add mutation) — one form, two hosts.
+export function ScheduleModal({
   open,
   onClose,
   onAdd,


### PR DESCRIPTION
## What

Reworks the console **Work** surface (right rail) from a tab strip to **card-first navigation**, per the operator-approved design.

### No tabs
- The `Tabs responsive` strip is gone. `WorkPanel` keeps local `view` state (`overview | goals | watches | tasks | schedule`), **always landing on the Overview** (deliberately not persisted).
- Nested views render the existing panels **unchanged** under a slim header row with a **"← Overview"** ghost back button (`ArrowLeft` + label, keyboard accessible). **Escape** also backs out when focus is in the Work surface and no overlay is open (guarded on `.pl-overlay` / radix popper presence, so it never fights dialog dismissal).

### Four live cards (Watches added — it was missing from the roll-up)
Responsive grid (the `.plugin-card-grid` auto-fill/minmax pattern; single column in the narrow rail). Each card:
- **whole-card click-through** — `role=button`, Enter/Space, selection-guarded like `.chat-report-card`;
- **header**: icon + name + count `Badge` (info tone when non-zero);
- **pulse line**: one muted live sentence — Goals `"2 driving · iteration 3/6"`, Watches `"1 watching · 1 met today"`, Tasks `"0 ready · 1 in progress"`, Schedule `"next in 25m"`;
- **micro-list**: up to 4 rows (3 for Schedule) with `StatusDot` + primary text + right-aligned meta (goal iteration, watch status badge, task id, relative next-fire);
- **corner "+" quick-add** (stopPropagation — adding never navigates). **Watches has none**: watches are agent-created, and its `Empty` copy says so ("The agent sets watches when you ask it to keep an eye on something", no CTA). Other cards' empty states use the DS `Empty` with the quick-add as the action.

Pulse/count derivations are pure helpers in `apps/web/src/app/workOverview.ts` (unit-tested), including `untilLabel` — `ago()`'s forward twin.

### Quick-add wiring (one form, two hosts)
- `TaskCreateDialog` (TasksPanel) and `ScheduleModal` (SchedulePanel) are now **exported** and reused by the overview, which owns its own open-state + mutation + invalidation, mirroring the panel hosts.
- The Goals inline `<details>` form is extracted into an exported **`GoalCreateDialog`** (DS Dialog) used by BOTH the overview quick-add and the Goals panel (new "New goal" `PanelHeader` action — same pattern as Tasks). Payload/endpoint identical (`POST /api/goals`, `{session_id, condition, verifier}`, JSON-validated verifier).

### Liveness
- **One surface-level SSE subscription set in `WorkPanel`** (`goal.changed`/`goal.iteration`, `watch.changed`/`met`/`expired`/`stalled`, `task.changed`, `scheduler.fired`) so cards stay fresh whichever view is mounted; the panels keep their own subscriptions (double-invalidate is harmless).
- Schedule has no push for agent-side add/cancel: kept the **per-use 60s `refetchInterval`** on the overview's read (the lighter option vs. a card refresh affordance; NOT on the shared `schedulesQuery()` factory, so `SchedulePanel` and other consumers are unaffected).

### Presence
`--bg-panel` + 1px `--border` + `--radius`; hover = `translateY(-1px)` + `var(--pl-shadow-popover, 0 2px 8px rgba(0,0,0,0.22))` + `--border-strong` — the chat-report-card raised language. `:focus-visible` ring per the app convention; `prefers-reduced-motion` drops the transform.

### Tests
- `tasks.spec.ts` / `schedule.spec.ts` / `navigation.spec.ts` navigate via overview cards (the `.pl-tabs__select` path is gone; the bottom-dock assertion now checks the card grid).
- New `work-overview.spec.ts`: all four cards render with counts + pulses (mock server gains a seeded `GET /api/watches`); click-through + "← Overview" + Escape; Tasks quick-add opens `TaskCreateDialog` and creating **updates the card** (stateful `page.route`); Watches has no quick-add; empty-state CTA path (Goals) and the Watches no-CTA empty state.
- New `workOverview.test.ts` unit tests for the pulse/count helpers.

## Gates
- `npm run test:unit` — 279 passed (28 files)
- `npm run build` — clean (incl. check-css-comments prebuild)
- `npm run test:e2e` — 179 passed, 1 fail: `nesting.spec.ts` (known parallel flake — passes in isolation; untouched by this diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)