### PR TITLE
fix(tools): tools.disabled covers the full toolset + per-agent run_command settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   same way.
 
 ### Security
+- **`tools.disabled` now actually removes any tool — including `run_command` — and
+  the filesystem knobs are per-agent Settings toggles.** The operator denylist used
+  to be applied only inside `get_all_tools()`, while the filesystem tools (incl. the
+  dual-use `run_command`), plugin/MCP extras, delegation and late-seam tools were
+  appended after it — so `tools.disabled: [run_command]` silently did nothing. The
+  filter now runs over the **fully assembled** toolset in `create_agent_graph` (and
+  the out-of-graph manual-subagent runner), before the deferred `search_tools`
+  index is built, and the graph build syncs the denylist from its own config (eval
+  sweeps / scripts no longer inherit a stale process global). New **Settings ▸
+  Capabilities ▸ Filesystem** exposes `filesystem.enabled` / `allow_run` (the
+  per-agent `run_command` kill switch — the tool is never built when off) /
+  `run_requires_approval` / `bypass_allowed`, and **Settings ▸ Capabilities ▸
+  Tools** exposes the `tools.disabled` list; all hot-reload on save. `filesystem.
+  projects` now round-trips through `config_to_dict` like the other registries.
+
 - **Fleet: the hub no longer lends a remote member's token over an unauthenticated
   WebSocket, and live events now work through a token-gated hub.** Two proxy-auth
   gaps in remote fleet members (ADR 0042 §I), both only reachable on a non-loopback

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -235,6 +235,25 @@ export const SETTINGS_SCHEMA = [
       { key: "runtime.autostart_on_boot", label: "Autostart on boot", type: "bool", section: "Runtime", restart: true, description: "Install/remove the boot LaunchAgent.", options: [], value: false, default: false, scope: "agent", source: "agent" },
     ],
   },
+  // The per-agent run_command controls + the operator tool denylist — edited via the
+  // Tools panel's QuickSetting chips (no generic Capabilities panel renders these).
+  {
+    section: "Filesystem",
+    category: "Capabilities",
+    fields: [
+      { key: "filesystem.enabled", label: "Filesystem tools", type: "bool", section: "Filesystem", restart: false, description: "", options: [], value: true, default: true, scope: "agent", source: "agent" },
+      { key: "filesystem.allow_run", label: "Allow run_command", type: "bool", section: "Filesystem", restart: false, description: "", options: [], value: true, default: true, scope: "agent", source: "agent", depends_on: { key: "filesystem.enabled" } },
+      { key: "filesystem.run_requires_approval", label: "Require approval per command", type: "bool", section: "Filesystem", restart: false, description: "", options: [], value: true, default: true, scope: "agent", source: "agent", depends_on: { key: "filesystem.allow_run" } },
+      { key: "filesystem.bypass_allowed", label: "Allow /bypass", type: "bool", section: "Filesystem", restart: false, description: "", options: [], value: true, default: true, scope: "agent", source: "agent", depends_on: { key: "filesystem.run_requires_approval" } },
+    ],
+  },
+  {
+    section: "Tools",
+    category: "Capabilities",
+    fields: [
+      { key: "tools.disabled", label: "Disabled tools", type: "string_list", section: "Tools", restart: false, description: "", options: [], value: [], default: [], scope: "agent", source: "agent" },
+    ],
+  },
   // A plugin-contributed group (ADR 0019/0059) — tagged with plugin_id so the
   // Plugins surface folds it into the "Demo Plugin" Installed row (Configure).
   {

--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -60,3 +60,56 @@ test("the chat composer model picker overrides the model per-tab (no global save
   await page.waitForTimeout(300);
   expect(settingsWrite).toBe(false);
 });
+
+test("Tools panel: the Shell & filesystem chip disables run_command via /api/settings", async ({ page }) => {
+  // The per-agent run_command kill switch lives on the Tools capability panel as a
+  // QuickSetting chip (ADR 0048 §2.2) — same /api/settings write path as the central home.
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("header-menu").click();
+  await page.getByTestId("app-drawer").getByRole("button", { name: "Settings", exact: true }).click();
+  await page
+    .locator(".settings-overlay .pl-sidenav")
+    .getByRole("tab", { name: "Tools", exact: true })
+    .click();
+
+  await page.getByRole("button", { name: "Shell & filesystem tools" }).click();
+  const dialog = page.getByRole("dialog", { name: "Shell & filesystem tools" });
+  await expect(dialog).toBeVisible();
+  // All four gates render, allow_run being the full kill switch.
+  await expect(dialog.getByText("Allow run_command")).toBeVisible();
+  await expect(dialog.getByText("Require approval per command")).toBeVisible();
+
+  const saved = page.waitForRequest(
+    (r) => r.url().endsWith("/api/settings") && ["POST", "PUT"].includes(r.method()),
+  );
+  await dialog.locator('[data-key="filesystem.allow_run"] .pl-switch').click();
+  await dialog.getByRole("button", { name: "Save" }).click();
+  const req = await saved;
+  const body = req.postDataJSON();
+  expect(body.updates["filesystem.allow_run"]).toBe(false);
+  expect(body.layer ?? "agent").toBe("agent"); // per-agent leaf, not box-wide
+  await expect(page.locator(".pl-toast").getByText("Saved")).toBeVisible();
+});
+
+test("Tools panel: the Disabled tools chip edits the tools.disabled denylist", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("header-menu").click();
+  await page.getByTestId("app-drawer").getByRole("button", { name: "Settings", exact: true }).click();
+  await page
+    .locator(".settings-overlay .pl-sidenav")
+    .getByRole("tab", { name: "Tools", exact: true })
+    .click();
+
+  await page.getByRole("button", { name: "Disabled tools" }).click();
+  const dialog = page.getByRole("dialog", { name: "Disabled tools" });
+  await expect(dialog).toBeVisible();
+
+  const saved = page.waitForRequest(
+    (r) => r.url().endsWith("/api/settings") && ["POST", "PUT"].includes(r.method()),
+  );
+  // string_list renders as the one-per-line editor.
+  await dialog.locator('[data-key="tools.disabled"] textarea').fill("run_command");
+  await dialog.getByRole("button", { name: "Save" }).click();
+  const req = await saved;
+  expect(req.postDataJSON().updates["tools.disabled"]).toEqual(["run_command"]);
+});

--- a/apps/web/src/app/ToolsPanel.tsx
+++ b/apps/web/src/app/ToolsPanel.tsx
@@ -4,9 +4,12 @@ import { Input } from "@protolabsai/ui/forms";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
+import { Ban, TerminalSquare } from "lucide-react";
+
 import { Accordion, AccordionItem, PanelHeader } from "@protolabsai/ui/navigation";
 import { Badge } from "@protolabsai/ui/primitives";
 import { toolsQuery } from "../lib/queries";
+import { QuickSetting } from "../settings/QuickSetting";
 import { StagePanel } from "./ErrorBoundary";
 
 // Runtime → Tools: the live tool inventory the lead agent + subagents can call.
@@ -58,6 +61,29 @@ function ToolsBody() {
     <>
       <PanelHeader title="Tools" kicker={`${data.count} wired tool${data.count === 1 ? "" : "s"} · ${groups.size} group${groups.size === 1 ? "" : "s"}`} />
       <div className="stage-body">
+        <div className="tools-config-row">
+          {/* Contextual settings chips (ADR 0048 §2.2) — same /api/settings save path as
+              the central home. Shell & filesystem = the per-agent run_command controls
+              (incl. the full kill switch, filesystem.allow_run); Disabled tools = the
+              tools.disabled denylist over the whole assembled set. Saves hot-rebuild. */}
+          <QuickSetting
+            keys={[
+              "filesystem.enabled",
+              "filesystem.allow_run",
+              "filesystem.run_requires_approval",
+              "filesystem.bypass_allowed",
+            ]}
+            title="Shell & filesystem tools"
+            label="Shell & filesystem tools"
+            icon={<TerminalSquare size={16} />}
+          />
+          <QuickSetting
+            keys={["tools.disabled"]}
+            title="Disabled tools"
+            label="Disabled tools"
+            icon={<Ban size={16} />}
+          />
+        </div>
         <Input
           className="playbook-search"
           type="search"

--- a/apps/web/src/app/tools.css
+++ b/apps/web/src/app/tools.css
@@ -41,3 +41,11 @@
   color: var(--fg-muted);
   min-width: 0;
 }
+
+/* Contextual settings chips above the search (mirrors .mcp-browse-row). */
+.tools-config-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 6px;
+}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -207,7 +207,7 @@ execute_code:
 
 ```yaml
 tools:
-  disabled: []              # core tool names to DROP (a fork's denylist)
+  disabled: []              # tool names to DROP (the operator's denylist)
   deferred:
     enabled: false          # OFF by default — the full tool set is shown
     keep: []                # always-on tool names; empty = built-in base
@@ -215,7 +215,7 @@ tools:
 
 | Key | Default | What |
 |---|---|---|
-| `disabled` | `[]` | Core tool names to **drop** from the agent without editing `get_all_tools` — a fork keeps what it wants by listing the rest. Live-reloadable. Plugins still ADD tools on top (see [Plugins](/guides/plugins)). ([ADR 0005](../adr/0005-tool-pollution-and-progressive-disclosure.md)) |
+| `disabled` | `[]` | Tool names to **drop** from the agent at graph build — covers the **fully assembled** set: core, plugin, MCP, the delegation tools, and the filesystem tools (so `disabled: [run_command]` removes shell access for this agent). Live-reloadable, editable at **Settings ▸ Capabilities ▸ Tools**. Plugins still ADD tools on top (see [Plugins](/guides/plugins)). ([ADR 0005](../adr/0005-tool-pollution-and-progressive-disclosure.md)) |
 | `deferred.enabled` | `false` | Withhold most tool schemas; expose them via `search_tools`. |
 | `deferred.keep` | `[]` | Tool names always shown. Empty → built-in base (keyless core + `task`/`task_batch`/`run_workflow`/`save_workflow` + `search_tools`). `search_tools` is always kept regardless. |
 
@@ -243,8 +243,9 @@ Fenced multi-project filesystem toolset ([ADR 0007](../adr/0007-directory-aware-
 ```yaml
 filesystem:
   enabled: true                  # ON by default
-  allow_run: true                # run_command available (ON); HITL-gated below
+  allow_run: true                # run_command available (ON); HITL-gated below — false = never built
   run_requires_approval: true    # each run_command pauses for operator approval
+  bypass_allowed: true           # false = /bypass can't skip the approval gate
   projects:
     - { name: orbis, path: /Users/kj/dev/ORBIS, write: false }   # read-only monitor
     - { name: pixelgen, path: /Users/kj/dev/pixelgen, write: true }
@@ -253,9 +254,12 @@ filesystem:
 | Key | Default | What |
 |---|---|---|
 | `enabled` | `true` | Expose the fs tools (`list_projects`/`read_file`/`list_dir`/`find_files`/`search_files`/`write_file`/`edit_file`). Off → no fs tools. |
-| `allow_run` | `true` | Also expose `run_command` (fenced `cwd`, but arbitrary argv — dual-use, like `execute_code`). |
+| `allow_run` | `true` | Also expose `run_command` (fenced `cwd`, but arbitrary argv — dual-use, like `execute_code`). **`false` is the per-agent kill switch**: the tool is never built, so the model can't see or call it. |
 | `run_requires_approval` | `true` | Each `run_command` call pauses for HITL operator approval (A2A `input-required`). Drop to `false` to let commands run unattended. |
+| `bypass_allowed` | `true` | Permit the per-tab `/bypass` chat toggle to skip the approval gate. `false` = approvals enforced regardless of caller-supplied metadata. |
 | `projects` | `[]` | Managed workspaces: `{name, path, write}`. **Empty falls back to a default `workspace` dir** (so the tools are usable out of the box). **Every path is fenced under a project root** (`..`/symlink escapes refused); `write:false` makes a project read-only; invalid paths are skipped. |
+
+The four toggles are editable per agent in the console at **Settings ▸ Capabilities ▸ Filesystem** (hot-reload — a save rebuilds the graph). `tools.disabled: [run_command]` (above) is an equivalent per-tool route.
 
 **Security:** the project roots are the **hard fence** — every tool resolves paths under a root and refuses escapes; `write_file`/`edit_file` need `write:true`; the agent's own repo is not a project unless you add it. All mutations are audited. See ADR 0007 §4.
 

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -20,7 +20,7 @@ from graph.middleware.memory import SessionSummaryMiddleware
 from graph.middleware.message_capture import MessageCaptureMiddleware
 from graph.state import ProtoAgentState
 from graph.subagents.config import SUBAGENT_REGISTRY
-from tools.lg_tools import HITL_TOOL_NAMES, _session_id_from, get_all_tools
+from tools.lg_tools import HITL_TOOL_NAMES, _session_id_from, drop_disabled_tools, get_all_tools
 
 
 def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_index=None, extra_middleware=None):
@@ -376,6 +376,10 @@ async def run_manual_subagent(
     )
     if extra_tools:
         all_tools = all_tools + list(extra_tools)
+    # Operator denylist over the extras (get_all_tools filtered the core set) — the
+    # out-of-graph runner must not see tools the lead graph dropped (parity, see
+    # create_agent_graph).
+    all_tools = drop_disabled_tools(all_tools)
     tool_map = {t.name: t for t in all_tools}
     available_subagents = ", ".join(SUBAGENT_REGISTRY.keys()) or "(none configured)"
 
@@ -812,6 +816,13 @@ def create_agent_graph(
     """
     llm = create_llm(config)
 
+    # Sync the operator denylist from THIS config — the server boot/reload path already
+    # set it, but out-of-server builders (eval sweeps, scripts) pass a config directly
+    # and would otherwise silently keep whatever the process global last held.
+    from tools.lg_tools import set_disabled_tools
+
+    set_disabled_tools(getattr(config, "tools_disabled", []))
+
     all_tools = get_all_tools(
         knowledge_store,
         scheduler=scheduler,
@@ -832,6 +843,11 @@ def create_agent_graph(
 
     if extra_tools:
         all_tools.extend(extra_tools)
+    # Operator denylist (config ``tools.disabled``) over the plugin/MCP extras too —
+    # get_all_tools already filtered the core set, but extra_tools bypassed it. Applied
+    # BEFORE the subagent tool_map snapshot below so a disabled tool can't ride into a
+    # subagent via an allowlist either.
+    all_tools = drop_disabled_tools(all_tools)
 
     if include_subagents:
         all_tools.extend(
@@ -865,6 +881,13 @@ def create_agent_graph(
             continue
         if _produced:
             all_tools.extend(_produced if isinstance(_produced, list) else [_produced])
+
+    # Operator denylist, final pass — covers the tools appended since the extra_tools
+    # filter above (task/task_batch, the filesystem tools incl. ``run_command``, late-seam
+    # tools). Sits before the deferred build so search_tools never advertises a dropped
+    # name. This is what makes ``tools.disabled: [run_command]`` actually work (#1527-era
+    # gap: the filter used to live only inside get_all_tools, which fs tools bypass).
+    all_tools = drop_disabled_tools(all_tools)
 
     # Deferred tools (ADR 0005 #3) — opt-in progressive disclosure. The
     # search_tools meta-tool is built over the full set (so it can surface any

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -453,6 +453,12 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
                 # contextual_enrichment is a settings field; its doc cap is config-only.
                 "context_max_doc_chars": config.knowledge_context_max_doc_chars,
             },
+            # The filesystem toggles are settings-schema fields (§A); the projects
+            # REGISTRY (list of {name,path,write} dicts) is config-only, so emit it
+            # here or a consumer treating this dict as the complete config loses it.
+            "filesystem": {
+                "projects": list(config.filesystem_projects),
+            },
             "mcp": {
                 "enabled": config.mcp_enabled,
                 "servers": list(config.mcp_servers),

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -536,6 +536,63 @@ FIELDS: list[Field] = [
         "secrets on every agent, so share only servers you trust box-wide.",
         options=["scoped", "layered"],
     ),
+    # ── Filesystem (ADR 0007 operator primitives) — the fenced project fs toolset,
+    # incl. the dual-use ``run_command``. Per-agent (leaf scope): an operator can
+    # fully remove run_command for one agent while siblings keep it. Hot-reloads:
+    # a save rebuilds the graph, so binding changes apply without a restart. ──────
+    Field(
+        "filesystem.enabled",
+        "filesystem_enabled",
+        "Filesystem tools",
+        "bool",
+        "Filesystem",
+        "The fenced multi-project filesystem toolset (list/read/search/write/edit + "
+        "run_command). Off = none of them are bound. With no explicit projects "
+        "configured, a default read-write `workspace` project is provided.",
+    ),
+    Field(
+        "filesystem.allow_run",
+        "filesystem_allow_run",
+        "Allow run_command",
+        "bool",
+        "Filesystem",
+        "Bind the run_command shell tool (runs arbitrary commands in a project dir as "
+        "the server user). Off = the tool is never built — the model can't see or call "
+        "it; the read/write file tools stay. The full kill switch for shell access.",
+        depends_on={"key": "filesystem.enabled"},
+    ),
+    Field(
+        "filesystem.run_requires_approval",
+        "filesystem_run_requires_approval",
+        "Require approval per command",
+        "bool",
+        "Filesystem",
+        "Pause every run_command invocation for operator approval (HITL) before it "
+        "executes. Turn off only inside a hardened container or for a trusted "
+        "autonomous deploy.",
+        depends_on={"key": "filesystem.allow_run"},
+    ),
+    Field(
+        "filesystem.bypass_allowed",
+        "filesystem_bypass_allowed",
+        "Allow /bypass",
+        "bool",
+        "Filesystem",
+        "Permit the per-tab /bypass chat toggle to skip the approval gate. Off = "
+        "approvals are enforced regardless of any caller-supplied bypass flag.",
+        depends_on={"key": "filesystem.run_requires_approval"},
+    ),
+    # ── Tools — the operator denylist over the assembled toolset ────────────────
+    Field(
+        "tools.disabled",
+        "tools_disabled",
+        "Disabled tools",
+        "string_list",
+        "Tools",
+        "Tool names removed from this agent's toolset at graph build — one per line. "
+        "Covers every contributor: core, plugin, MCP, filesystem (e.g. run_command), "
+        "and delegation tools. Applies on save (the graph rebuilds).",
+    ),
     # ── Middleware toggles ───────────────────────────────────────────────────
     Field("middleware.knowledge", "knowledge_middleware", "Knowledge middleware", "bool", "Middleware"),
     Field("middleware.memory", "memory_middleware", "Memory middleware", "bool", "Middleware"),
@@ -860,6 +917,8 @@ _SECTION_CATEGORY = {
     # Tools/MCP/Skills/Subagents/Delegates managers are bespoke console panels).
     "Skills": "Capabilities",
     "MCP": "Capabilities",
+    "Filesystem": "Capabilities",
+    "Tools": "Capabilities",
     # Knowledge — recall / RAG config, split into sub-sections (see _KNOWLEDGE_SUBSECTION).
     "Recall": "Knowledge",
     "Ingestion": "Knowledge",

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -272,6 +272,7 @@ def test_config_to_dict_shape_and_redaction():
 # identity_org, knowledge_scope and skills_scope were all missing from round-trip coverage.)
 _LEGACY_EMITTED_ATTRS = {
     "researcher",  # subagents.researcher (a SubagentDef)
+    "filesystem_projects",  # filesystem.projects (registry of {name,path,write} dicts)
     "checkpoint_background_keep",
     "knowledge_db_path",
     "knowledge_embed_breaker_threshold",

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -237,3 +237,36 @@ def test_core_field_depends_on_passed_through(monkeypatch):
     groups = build_schema(LangGraphConfig())
     entry = next(e for g in groups for e in g["fields"] if e["key"] == "demo.child")
     assert entry["depends_on"] == {"key": "compaction.enabled", "equals": True}
+
+
+def test_filesystem_and_tools_sections_surfaced_under_capabilities():
+    """run_command is fully disableable from Settings (per agent): the filesystem
+    knobs (ADR 0007) + the tools.disabled denylist render under Capabilities, all
+    hot-reload (a save rebuilds the graph), all agent-scoped (leaf overridable)."""
+    groups = build_schema(LangGraphConfig())
+    by_key = {f["key"]: f for g in groups for f in g["fields"]}
+    section_cat = {g["section"]: g["category"] for g in groups}
+    assert section_cat["Filesystem"] == "Capabilities"
+    assert section_cat["Tools"] == "Capabilities"
+
+    for key in (
+        "filesystem.enabled",
+        "filesystem.allow_run",
+        "filesystem.run_requires_approval",
+        "filesystem.bypass_allowed",
+    ):
+        f = by_key[key]
+        assert f["type"] == "bool" and f["section"] == "Filesystem"
+        assert f["restart"] is False  # a settings save rebuilds the graph
+        assert f["scope"] == "agent"  # per-agent kill switch, not box-wide
+        assert f["default"] is True  # matches the shipped LangGraphConfig defaults
+
+    # The gates cascade in the UI: allow_run hides under enabled, approval under
+    # allow_run, bypass under approval (truthy depends_on, #963).
+    assert by_key["filesystem.allow_run"]["depends_on"] == {"key": "filesystem.enabled"}
+    assert by_key["filesystem.run_requires_approval"]["depends_on"] == {"key": "filesystem.allow_run"}
+    assert by_key["filesystem.bypass_allowed"]["depends_on"] == {"key": "filesystem.run_requires_approval"}
+
+    dis = by_key["tools.disabled"]
+    assert dis["type"] == "string_list" and dis["section"] == "Tools"
+    assert dis["default"] == [] and dis["restart"] is False

--- a/tests/test_tools_disabled.py
+++ b/tests/test_tools_disabled.py
@@ -1,0 +1,105 @@
+"""``tools.disabled`` must cover the FULLY assembled toolset, not just ``get_all_tools``.
+
+The denylist used to be applied only inside ``get_all_tools``, while the filesystem
+tools (incl. the dual-use ``run_command``), plugin/MCP ``extra_tools``, delegation and
+late-seam tools were appended AFTER it in ``graph.agent.create_agent_graph`` — so
+``tools.disabled: [run_command]`` silently did nothing. These tests pin the fixed
+contract: a disabled name is gone from the bound set no matter which seam contributed
+it, and ``create_agent_graph`` derives the denylist from the config it's given.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.tools import tool
+
+from graph.agent import create_agent_graph
+from graph.config import LangGraphConfig
+from tools.lg_tools import drop_disabled_tools, get_all_tools, set_disabled_tools
+
+
+@pytest.fixture(autouse=True)
+def _reset_denylist():
+    """The denylist is a module global (set from config at boot/reload/graph-build);
+    reset it so a test's denylist never leaks into the rest of the suite."""
+    yield
+    set_disabled_tools([])
+
+
+def _cfg(tmp_path, **over) -> LangGraphConfig:
+    proj = tmp_path / "proj"
+    proj.mkdir(exist_ok=True)
+    return LangGraphConfig(
+        filesystem_enabled=True,
+        filesystem_allow_run=True,
+        filesystem_projects=[{"name": "proj", "path": str(proj), "write": True}],
+        **over,
+    )
+
+
+def _bound_names(graph) -> set[str]:
+    return {t.name for t in graph.bound_tools}
+
+
+# ── the fs seam (the original gap) ────────────────────────────────────────────
+
+
+def test_run_command_bound_by_default(tmp_path):
+    names = _bound_names(create_agent_graph(_cfg(tmp_path)))
+    assert "run_command" in names
+
+
+def test_tools_disabled_drops_run_command(tmp_path):
+    names = _bound_names(create_agent_graph(_cfg(tmp_path, tools_disabled=["run_command"])))
+    assert "run_command" not in names
+    # Only the named tool is dropped — the rest of the fs toolset stays bound.
+    assert "read_file" in names and "list_projects" in names
+
+
+# ── the extra_tools (plugin/MCP) seam ─────────────────────────────────────────
+
+
+def test_tools_disabled_drops_extra_tool(tmp_path):
+    @tool
+    def sample_plugin_tool() -> str:
+        """A plugin-contributed tool."""
+        return "ok"
+
+    g = create_agent_graph(
+        _cfg(tmp_path, tools_disabled=["sample_plugin_tool"]),
+        extra_tools=[sample_plugin_tool],
+    )
+    assert "sample_plugin_tool" not in _bound_names(g)
+
+
+# ── the delegation seam ───────────────────────────────────────────────────────
+
+
+def test_tools_disabled_drops_task_tools(tmp_path):
+    names = _bound_names(create_agent_graph(_cfg(tmp_path, tools_disabled=["task", "task_batch"])))
+    assert "task" not in names and "task_batch" not in names
+
+
+# ── config-driven sync (no reliance on the server boot side effect) ──────────
+
+
+def test_graph_build_syncs_denylist_from_config(tmp_path):
+    # Simulate a stale process global from a PREVIOUS config: building with a config
+    # whose denylist is empty must clear it, not inherit it.
+    set_disabled_tools(["run_command"])
+    names = _bound_names(create_agent_graph(_cfg(tmp_path)))
+    assert "run_command" in names
+
+
+# ── the primitives ────────────────────────────────────────────────────────────
+
+
+def test_get_all_tools_still_filters_core():
+    set_disabled_tools(["calculator"])
+    assert "calculator" not in {t.name for t in get_all_tools(None)}
+
+
+def test_drop_disabled_tools_noop_when_empty():
+    set_disabled_tools([])
+    tools = get_all_tools(None)
+    assert drop_disabled_tools(tools) is tools  # same list — no copy on the hot path

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -439,17 +439,29 @@ _MEMORY_RECALL_MAX_K = 20
 _MEMORY_LIST_MAX_LIMIT = 200
 _RECALL_SESSION_MAX_CHARS = 6000
 
-# Fork tool denylist — names dropped from ``get_all_tools``. Set once from config
-# (``tools.disabled``) by ``set_disabled_tools`` at config load/reload, so a fork
-# removes core tools via YAML instead of editing ``get_all_tools`` (a core edit
-# that would conflict on every upstream re-sync). Plugins still ADD tools.
+# Operator/fork tool denylist — names dropped from the agent's toolset. Set once from
+# config (``tools.disabled``) by ``set_disabled_tools`` at config load/reload, so an
+# operator removes tools via YAML/Settings instead of editing core (an edit that would
+# conflict on every upstream re-sync). Applied inside ``get_all_tools`` AND — via
+# ``drop_disabled_tools`` — over the fully assembled set in ``graph.agent`` (so it also
+# covers plugin/MCP ``extra_tools``, the delegation tools, the filesystem tools incl.
+# ``run_command``, and late-seam tools). Plugins still ADD tools.
 _disabled_tools: set[str] = set()
 
 
 def set_disabled_tools(names) -> None:
-    """Set the fork tool denylist (config ``tools.disabled``)."""
+    """Set the operator tool denylist (config ``tools.disabled``)."""
     global _disabled_tools
     _disabled_tools = {str(n).strip() for n in (names or []) if str(n).strip()}
+
+
+def drop_disabled_tools(tools: list) -> list:
+    """Filter the denylist (``tools.disabled``) out of ``tools`` — the single filter
+    every assembly point uses, so a disabled name is gone no matter which seam
+    contributed it. Returns ``tools`` unchanged (same list) when the denylist is empty."""
+    if not _disabled_tools:
+        return tools
+    return [t for t in tools if getattr(t, "name", None) not in _disabled_tools]
 
 
 # Stable list of scheduler tool names. Exposed as a module-level
@@ -1622,11 +1634,10 @@ def get_all_tools(
     # + skill inventory + additive-only skill creation). Self-gate on STATE at call
     # time; present in the full set so the subagent allowlists can pick them up.
     tools.extend(_build_curation_tools())
-    # Fork denylist (config ``tools.disabled``): drop named core tools without
-    # editing this function. Applied last so it covers every branch above.
-    if _disabled_tools:
-        tools = [t for t in tools if getattr(t, "name", None) not in _disabled_tools]
-    return tools
+    # Operator denylist (config ``tools.disabled``): drop named core tools without
+    # editing this function. Applied last so it covers every branch above. (graph.agent
+    # re-applies it over the FULL assembled set — extra/fs/late tools — post-assembly.)
+    return drop_disabled_tools(tools)
 
 
 # ── deferred tools (ADR 0005 #3) ──────────────────────────────────────────────


### PR DESCRIPTION
## The ask

> as a user I would like to be able to completely disable that tool [`run_command`] for a given agent

Two gaps stood in the way; this PR closes both.

## 1. `tools.disabled` now actually removes any tool (security-relevant)

The operator denylist was applied only inside `get_all_tools()`, but the filesystem tools (incl. the dual-use `run_command`), plugin/MCP `extra_tools`, delegation and late-seam tools are appended **after** that call in `create_agent_graph` — so `tools.disabled: [run_command]` silently did nothing while looking like a security control.

- New `drop_disabled_tools()` in `tools/lg_tools.py` is the single filter, applied over the **fully assembled** set: after the `extra_tools` merge (before the subagent `tool_map` snapshot, so a disabled tool can't ride into a subagent via an allowlist), and again after the fs/late-tools appends — **before** the deferred `search_tools` index is built, so a dropped name is never advertised.
- `run_manual_subagent` (the out-of-graph console fan-out) applies the same filter — parity with the lead graph.
- `create_agent_graph` syncs the denylist from **its own config**, so eval sweeps / scripts that build graphs directly no longer inherit a stale process global.

## 2. The filesystem knobs are per-agent Settings toggles

New schema sections under **Capabilities**: **Filesystem** (`filesystem.enabled`, `allow_run` — the kill switch: `run_command` is never built when off, the model can't see or call it — `run_requires_approval`, `bypass_allowed`, with cascading `depends_on` visibility) and **Tools** (`tools.disabled`, one-per-line). Since Capabilities renders bespoke panels (not the generic schema panel), the fields surface as **QuickSetting chips on the Tools panel** — the same ADR 0048 §2.2 pattern Skills/MCP use. All hot-reload: a settings save rebuilds the graph. Config is per-instance, so this is genuinely per-agent.

Also: `filesystem.projects` now round-trips through `config_to_dict` §B (it was silently unserialized), and `docs/reference/configuration.md` documents `bypass_allowed` + the corrected `tools.disabled` semantics.

## Tests

- **New `tests/test_tools_disabled.py`** — pins each seam (`run_command`, an extra/plugin tool, `task`/`task_batch`), the config-driven sync (a stale global is cleared by a clean config), and the no-copy fast path.
- Settings-schema test pins the new fields, their `depends_on` cascade, agent scope, and Capabilities routing; the FIELDS-driven roundtrip goldens extend automatically (`filesystem_projects` added to the legacy emitted set).
- Two new e2e specs drive both Tools-panel chips end-to-end and assert the exact `/api/settings` payloads (`filesystem.allow_run: false`, `tools.disabled: ["run_command"]`).

## Gates

- `ruff` ✅ · `lint-imports` ✅ (3 kept, 0 broken) · full `pytest` ✅ 2769 passed / 5 skipped (incl. the new file)
- `vitest` ✅ 268 passed · `tsc` ×2 + `vite build` ✅ · full Playwright ✅ 175/176 passed (the one `nesting.spec.ts` failure is a parallelism flake in an area this diff doesn't touch — passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)