### PR TITLE
chore: release v0.80.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.80.0] - 2026-07-02
+
 ### Added
 - **Remote fleet members are fully manageable from the console** (ADR 0042 §I).
   You can now **add a remote by URL** (name + URL + optional token) — the only way

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.79.0"
+version = "0.80.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "v0.80.0",
+    "date": "2026-07-02",
+    "changes": [
+      "Remote fleet members are fully manageable from the console",
+      "A down or mis-tokened fleet agent gives you a way out instead of a boot hang.",
+      "Background results are pushed, indexed, and worker-disposable",
+      "The Work surface is card-first — no tabs",
+      "The background report card is a real card",
+      "/compact is now behind the chat.compact developer flag",
+      "tools.disabled now actually removes any tool — including run_command — and the filesystem knobs are per-agent Settings toggles.",
+      "Fleet: the hub no longer lends a remote member's token over an unauthenticated WebSocket, and live events now work through a token-gated hub."
+    ]
+  },
+  {
     "version": "v0.79.0",
     "date": "2026-07-01",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.80.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.80.0 -m 'Release v0.80.0' && git push origin v0.80.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).