### PR TITLE
fix(console): memory tabs take an auto grid row + drop work-card title icons

### DIFF
--- a/apps/web/src/app/WorkPanel.tsx
+++ b/apps/web/src/app/WorkPanel.tsx
@@ -9,8 +9,7 @@ import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-q
 import { Badge, Button, Empty, type Status } from "@protolabsai/ui/primitives";
 import { StatusDot } from "@protolabsai/ui/data";
 import { useToast } from "@protolabsai/ui/overlays";
-import { ArrowLeft, Boxes, CalendarClock, Eye, Plus, Target } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import { ArrowLeft, Plus } from "lucide-react";
 
 import { StagePanel } from "./ErrorBoundary";
 import { GoalCreateDialog, GoalsPanel } from "./GoalsPanel";
@@ -203,7 +202,6 @@ function WorkOverview({ onOpen }: { onOpen: (v: WorkView) => void }) {
         <OverviewCard
           id="goals"
           title="Goals"
-          icon={Target}
           count={active.length}
           pulse={goalsPulse(goals)}
           onOpen={() => onOpen("goals")}
@@ -228,7 +226,6 @@ function WorkOverview({ onOpen }: { onOpen: (v: WorkView) => void }) {
         <OverviewCard
           id="watches"
           title="Watches"
-          icon={Eye}
           count={activeWatches(watches).length}
           pulse={watchesPulse(watches)}
           onOpen={() => onOpen("watches")}
@@ -257,7 +254,6 @@ function WorkOverview({ onOpen }: { onOpen: (v: WorkView) => void }) {
         <OverviewCard
           id="tasks"
           title="Tasks"
-          icon={Boxes}
           count={ready.length + inProgress.length}
           pulse={tasksPulse(issues)}
           onOpen={() => onOpen("tasks")}
@@ -280,7 +276,6 @@ function WorkOverview({ onOpen }: { onOpen: (v: WorkView) => void }) {
         <OverviewCard
           id="schedule"
           title="Schedule"
-          icon={CalendarClock}
           count={upcoming.length}
           pulse={schedulePulse(jobs)}
           onOpen={() => onOpen("schedule")}
@@ -320,7 +315,7 @@ function WorkOverview({ onOpen }: { onOpen: (v: WorkView) => void }) {
 }
 
 // One overview card: the WHOLE card is the click-through to its panel (role=button,
-// Enter/Space, selection-guarded like the chat report card), with a header (icon + name +
+// Enter/Space, selection-guarded like the chat report card), with a header (name +
 // count Badge), the muted one-line pulse, a short StatusDot micro-list, and a corner "+"
 // quick-add that stops propagation so adding never navigates. When the card is empty the
 // DS Empty takes over the body, with the same quick-add as its action (when the card has
@@ -328,7 +323,6 @@ function WorkOverview({ onOpen }: { onOpen: (v: WorkView) => void }) {
 function OverviewCard({
   id,
   title,
-  icon: Icon,
   count,
   pulse,
   onOpen,
@@ -338,7 +332,6 @@ function OverviewCard({
 }: {
   id: string;
   title: string;
-  icon: LucideIcon;
   count: number;
   pulse?: string;
   onOpen: () => void;
@@ -374,7 +367,6 @@ function OverviewCard({
       }}
     >
       <header className="work-card-head">
-        <Icon size={15} className="work-card-icon" aria-hidden />
         <span className="work-card-title">{title}</span>
         <Badge status={count > 0 ? "info" : "neutral"}>{count}</Badge>
       </header>

--- a/apps/web/src/app/work.css
+++ b/apps/web/src/app/work.css
@@ -69,10 +69,6 @@
   gap: 8px;
   padding: 10px 12px 0;
 }
-.work-card-icon {
-  flex: none;
-  color: var(--fg-muted);
-}
 .work-card-title {
   font-weight: 600;
   min-width: 0;

--- a/apps/web/src/memory/MemorySurface.tsx
+++ b/apps/web/src/memory/MemorySurface.tsx
@@ -38,7 +38,7 @@ export function MemorySurface() {
   const [injectionFilter, setInjectionFilter] = useState("");
 
   return (
-    <section className="panel stage-panel" data-testid="memory-surface">
+    <section className="panel stage-panel memory-panel" data-testid="memory-surface">
       <PanelHeader
         title="Memory"
         kicker="what auto-injects into the agent's turns — inspect, audit, prune"

--- a/apps/web/src/memory/memory.css
+++ b/apps/web/src/memory/memory.css
@@ -118,3 +118,10 @@
 .memory-none {
   color: var(--pl-color-text-muted, #8a8f98);
 }
+
+/* Header · tab strip · scrolling body. The tab strip is a direct child of the
+   .stage-panel grid, so without this it lands in the default template's 1fr row
+   and stretches to fill the panel (same shape as .settings-panel's sub-nav). */
+.stage-panel.memory-panel {
+  grid-template-rows: auto auto minmax(0, 1fr);
+}


### PR DESCRIPTION
Two console polish items from local testing of the v0.80.0 surfaces.

## Memory view: giant tab strip

The Memory surface (`#1596`) renders its DS `Tabs` as a **direct child of the `.stage-panel` grid** (`auto minmax(0,1fr) auto`), so the tab strip landed in the `1fr` row and stretched to fill the whole panel — tabs floating mid-panel, hint + body squeezed to the bottom. Every other `Tabs` usage sits inside a wrapper div, so only this surface hit it.

Fix: a `.memory-panel` row template — `auto` header · `auto` tab strip · `minmax(0,1fr)` scrolling body — the same shape `.settings-panel` already uses for its sub-nav row.

## Work overview cards: drop the title icons

The overview cards (`#1610`) each carried a lucide icon next to the title. Removed — the card header is now just the name + count badge. Deletes the `icon` prop from `OverviewCard`, the four lucide imports, and the `.work-card-icon` rule.

## Verification

- `npm run test:unit --workspace @protoagent/web` — 291 passed
- `npm run build --workspace @protoagent/web` — green (both tsconfig typechecks)
- `playwright test memory-inspector / navigation / schedule` — 27 passed
- Visual check against the e2e mock server: tabs render as a normal strip under the header; cards show title + badge only

Draft per the console-UX local-test gate — flip when it looks right in your build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified the Work hub overview cards by showing cleaner headers with just the title and count.
  * Updated the Memory panel layout so its header, tabs, and content area align more consistently.

* **Bug Fixes**
  * Improved panel spacing and sizing behavior to better fill available space in the Memory view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->