### PR TITLE
feat(release): in-app update notes reuse the LLM changelog posted to Discord (#1516)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -405,12 +405,19 @@ jobs:
             exit 0
           fi
           # Updater notes, best → worst source:
-          #   1. The curated CHANGELOG.md section for this version (the human-written
-          #      "### Added/Changed/Fixed" markdown) — what the in-app UpdateNotice renders.
-          #   2. The GitHub Release body (auto-generated commit subjects) — used when the
-          #      CHANGELOG section is empty (e.g. a patch with no [Unreleased] bullets).
-          #   3. A generic placeholder, if both are empty.
-          NOTES="$(python3 scripts/changelog.py notes "$VERSION" 2>/dev/null || true)"
+          #   1. The LLM-themed notes posted to Discord — release.yml uploads them as the
+          #      `release-notes.md` asset, so the in-app UpdateNotice renders the SAME text as
+          #      the Discord embed (one changelog, one voice — #1516).
+          #   2. The curated CHANGELOG.md section for this version (the human-written
+          #      "### Added/Changed/Fixed" markdown) — used when the LLM step didn't run
+          #      (e.g. a fork with no gateway key, or the Discord step failed).
+          #   3. The GitHub Release body (auto-generated commit subjects) — if both are empty.
+          #   4. A generic placeholder, if all are empty.
+          NOTES=""
+          if gh release download "$TAG" --repo "${{ github.repository }}" -p release-notes.md -D "$RUNNER_TEMP" --clobber 2>/dev/null; then
+            NOTES="$(cat "$RUNNER_TEMP/release-notes.md" 2>/dev/null || true)"
+          fi
+          [ -z "$NOTES" ] && NOTES="$(python3 scripts/changelog.py notes "$VERSION" 2>/dev/null || true)"
           [ -z "$NOTES" ] && NOTES="$(gh release view "$TAG" --repo "${{ github.repository }}" --json body -q .body 2>/dev/null || true)"
           [ -z "$NOTES" ] && NOTES="protoAgent ${TAG} — see the GitHub Release for details."
           npx --yes -p '@protolabsai/release-tools@latest' build-updater-manifest \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,11 +167,28 @@ jobs:
       # scripts/post-release-notes.mjs.
 
       - name: Generate + post release notes
+        id: relnotes
         continue-on-error: true
         uses: protoLabsAI/release-tools@b7c3531dd67accb57ca09242f47d8c0eb1ace8eb # v1.1.0
         with:
           version: ${{ steps.version.outputs.tag }}
           previous-version: ${{ steps.version.outputs.prev_tag }}
+          # Persist the SAME themed notes it posts to Discord (one generation writes the file
+          # AND posts the embed), so the in-app updater can render the identical text — one
+          # changelog, one voice (#1516). Uploaded as a release asset below; the (later,
+          # manual) desktop build prefers it for latest.json.
+          out-file: release-notes.md
         env:
           GATEWAY_API_KEY: ${{ secrets.GATEWAY_API_KEY }}
           DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+
+      # Attach the LLM notes to the release so desktop-build.yml's latest.json fan-in can read
+      # them (it runs on a later manual dispatch, so the asset must live on the release, not a
+      # step output). Best-effort + guarded: a fork with no GATEWAY_API_KEY writes no file, the
+      # upload is skipped, and the updater falls back to the curated CHANGELOG.md section.
+      - name: Persist LLM release notes as an asset
+        if: hashFiles('release-notes.md') != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ steps.version.outputs.tag }}" release-notes.md --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The in-app update notes now match the Discord release announcement** ([#1516]).
+  The desktop updater's "what's new" card renders the same LLM-themed release notes
+  that are posted to Discord — one changelog, one voice — instead of the raw
+  `CHANGELOG.md` section. The release pipeline persists the generated notes as a
+  `release-notes.md` release asset (the *same* generation that posts the Discord
+  embed), and the desktop build's `latest.json` fan-in prefers it, falling back to
+  the curated `CHANGELOG.md` section when the notes step didn't run (e.g. a fork
+  with no gateway key). Takes effect from the next release.
+
+[#1516]: https://github.com/protoLabsAI/protoAgent/issues/1516
+
 ## [0.80.0] - 2026-07-02
 
 ### Added


### PR DESCRIPTION
Closes #1516.

## Why

The in-app updater card ("what's new") and the Discord release embed diverged in tone and format because they had **two different writers**:
- **Discord** = LLM-themed notes generated from the commit range by the external `protoLabsAI/release-tools` action (via the protoLabs gateway), posted to the webhook — **fire-and-forget, never persisted**.
- **In-app** = the raw human-curated `CHANGELOG.md` `## [x.y.z]` section (my verbose `### Added/Fixed` bullets), baked into `latest.json.notes` by the desktop build and rendered as markdown in `UpdateNotice.tsx`.

#1516 asks for a single source of truth — one changelog, one voice.

## What (workflow-only)

The key discovery: **release-tools already writes its generated notes to a file** (`out-file` → `bin/rewrite-release-notes.mjs`) in the *same* invocation that posts the Discord embed. So no external-repo change is needed — just wiring:

- **`release.yml`** — the *Generate + post release notes* step now sets `out-file: release-notes.md` and a follow-up step uploads it as a release asset. Same generation → the asset and the Discord embed are identical. Guarded (`if: hashFiles(...)`) + `continue-on-error`, so a fork with no `GATEWAY_API_KEY` writes no file and nothing breaks.
- **`desktop-build.yml`** — the `latest.json` fan-in now prefers that `release-notes.md` asset for the updater notes, falling back to `changelog.py notes` (curated CHANGELOG) → the release body → a placeholder. The in-app `UpdateNotice` then renders the **same themed prose as Discord**, unchanged.

Net: `latest.json.notes` (what the desktop updater shows) = the LLM notes = what Discord shows. Takes effect from the next release.

## Verification

Both workflows YAML-validated. `desktop-build.yml`'s fan-in job checks out the tag (line 382), so the `changelog.py notes` fallback still works. This is CI-workflow-only — there's no in-repo unit surface (release-tools already tests `out-file`); it proves out on the next release cut.

## Follow-up (not this PR)

`UpdateNotice.tsx` has **no front-end test** today (flagged during investigation). The component is unchanged here (it still renders `latest.json.notes` as markdown, and the LLM `**Section**`/`•` format renders cleanly), so I didn't add a flaky Tauri-mock RTL test to a file I didn't touch — but closing that coverage gap is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)