### PR TITLE
feat(chat): container-responsive markdown tables (mobile-first)

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -845,6 +845,54 @@ select:disabled {
    `.markdown` rules + the streamdown Tailwind scan are gone (protoContent#297/#298). The
    `.markdown` class still rides the same element as an e2e/selector alias. */
 
+/* ── Container-responsive markdown tables ─────────────────────────────────────
+   The DS (@protolabsai/ui 0.52 `.pl-markdown`) styles GFM tables with a FIXED 0.85em /
+   5px·10px and horizontal-scroll-on-overflow. That reads fine in the wide doc viewer but
+   is cramped in a narrow chat column, where a multi-column table just scrolls. Make the
+   table MOBILE-FIRST and respond to its CONTAINER (the markdown column width) instead of
+   the viewport — so the SAME table is compact in a narrow chat panel and roomy in the doc
+   viewer, automatically, wherever markdown renders (chat, reports, memory, doc viewer).
+
+   Console-side override (the DS still owns the base rules; the `.markdown` alias rides the
+   same element as `.pl-markdown`, and this file loads after the DS styles so it wins by
+   cascade). Fold back into @protolabsai/ui markdown.css when the DS repo is next synced —
+   see the [[ds-contribute-back-loop]]. */
+
+/* Establish an inline-size query context on the table wrapper so the cells query the
+   COLUMN width, not the viewport. The DS wrapper is already full-column-width. */
+.pl-markdown.markdown [data-streamdown="table-wrapper"] {
+  container-type: inline-size;
+  container-name: pl-mdtable;
+}
+
+/* Base = narrow column (mobile-first): compact type + padding. The DS keeps overflow-x:auto
+   on the inner wrapper, so a genuinely wide table still scrolls instead of clipping. */
+.pl-markdown.markdown [data-streamdown="table"] {
+  font-size: 0.8em;
+}
+.pl-markdown.markdown [data-streamdown="table-header-cell"],
+.pl-markdown.markdown [data-streamdown="table-cell"] {
+  padding: 4px 8px;
+  line-height: 1.35;
+}
+
+/* Roomier as the column widens (a wider chat panel, or the doc viewer). */
+@container pl-mdtable (min-width: 30rem) {
+  .pl-markdown.markdown [data-streamdown="table"] {
+    font-size: 0.85em;
+  }
+  .pl-markdown.markdown [data-streamdown="table-header-cell"],
+  .pl-markdown.markdown [data-streamdown="table-cell"] {
+    padding: 5px 10px;
+  }
+}
+@container pl-mdtable (min-width: 48rem) {
+  .pl-markdown.markdown [data-streamdown="table-header-cell"],
+  .pl-markdown.markdown [data-streamdown="table-cell"] {
+    padding: 7px 12px;
+  }
+}
+
 /* Chat composer + slash-command autocomplete — moved to src/chat/chat.css (#832). */
 /* HITL request card — moved to src/chat/hitl.css (#832). */
 


### PR DESCRIPTION
> **Draft — console UX, please eyeball locally.** CSS-only; CI can't judge how tables look at various column widths. Resize a chat panel / open a wide table in the doc viewer to check.

## Why

The DS (`@protolabsai/ui` `.pl-markdown`) styles GFM tables with a **fixed** `0.85em` / `5px·10px` and horizontal-scroll-on-overflow. That's comfortable in the wide doc viewer, but in a narrow chat column a multi-column table just scrolls sideways and reads cramped.

## What

Make markdown tables **mobile-first** and respond to their **container** (the markdown column width) rather than the viewport — a container query on streamdown's `table-wrapper`:

- Establish `container-type: inline-size` (`container-name: pl-mdtable`) on the wrapper.
- **Base (narrow / mobile):** `0.8em`, `4px·8px` padding, `line-height: 1.35` — the DS's `overflow-x: auto` on the inner wrapper is kept, so a genuinely wide table still scrolls instead of clipping.
- **`@container (min-width: 30rem)`:** back to `0.85em`, `5px·10px`.
- **`@container (min-width: 48rem)`:** roomier `7px·12px`.

The **same** table is now compact in a narrow chat panel and comfortable in the doc viewer, automatically, wherever markdown renders (chat, reports, memory, doc viewer) — because it queries its own column, not the screen.

## Where it lives (and why not the DS)

Markdown/table styling is DS-owned, so the *right* long-term home is `@protolabsai/ui` `markdown.css`. But the local DS checkout is **stale** — `packages/ui` is at 0.47.0 on a feature branch and doesn't even have `markdown.css` yet (it landed between 0.47 and the 0.52 the console runs). So this ships as a **console-side override**: the `.markdown` alias rides the same element as `.pl-markdown`, and `theme.css` loads after the DS styles, so it wins by cascade (no `!important`, no specificity hacks). **Follow-up:** fold this into `@protolabsai/ui` `markdown.css` on the next DS sync (contribute-back).

## Verification

Console production build clean (CSS minifies fine — no `*/`-in-comment trap). No behavior/logic change; pure CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)