### PR TITLE
fix(chat): code blocks AND tables stack + stay responsive (streamdown flex-col fallback)

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -873,6 +873,11 @@ select:disabled {
   max-width: 100%;
   container-type: inline-size;
   container-name: pl-mdtable;
+  /* The DS clips the wrapper (overflow:hidden) for rounded corners, but the inner table
+     scroller is inset by the p-2 padding + has its own radius, so the clip isn't needed for
+     that — and it was eating the copy dropdown (which opens below the top-right button). Let
+     it escape. The table's own horizontal scroll lives on the inner overflow-x:auto child. */
+  overflow: visible;
 }
 /* The table's own scroll container (streamdown's overflow-x:auto child) must be able to shrink
    below the table's intrinsic width for that scroll to engage. */
@@ -960,6 +965,13 @@ select:disabled {
   border: var(--pl-border-width) solid var(--pl-color-border);
   border-radius: var(--pl-radius);
   box-shadow: 0 6px 20px rgb(0 0 0 / 28%);
+  /* streamdown positions the menu with an inline left offset (its right-0/top-full Tailwind is
+     inert), which shoved the 150px menu off the wrapper's right edge and out of view. Anchor it
+     explicitly under the button, right-aligned, so it stays on-screen. !important beats the
+     inline style. */
+  top: 100% !important;
+  right: 0 !important;
+  left: auto !important;
 }
 .pl-markdown [data-streamdown="table-wrapper"] .relative > div button {
   display: block;

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -859,10 +859,26 @@ select:disabled {
    see the [[ds-contribute-back-loop]]. */
 
 /* Establish an inline-size query context on the table wrapper so the cells query the
-   COLUMN width, not the viewport. The DS wrapper is already full-column-width. */
+   COLUMN width, not the viewport. Also force the vertical stack: streamdown emits the
+   wrapper as `flex flex-col` (a copy-action row above the table), but the console build only
+   generates `flex`, not `flex-col` — so it falls back to flex-ROW, putting the copy cluster
+   BESIDE a crushed table (cell text wraps one char per line in a narrow panel). flex-direction:
+   column restores the stack; min-width:0 lets the table scroller shrink so a wide table scrolls
+   inside its own overflow-x:auto instead of pinning the panel. (Same streamdown flex-col
+   fallback as code blocks.) */
 .pl-markdown.markdown [data-streamdown="table-wrapper"] {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  max-width: 100%;
   container-type: inline-size;
   container-name: pl-mdtable;
+}
+/* The table's own scroll container (streamdown's overflow-x:auto child) must be able to shrink
+   below the table's intrinsic width for that scroll to engage. */
+.pl-markdown.markdown [data-streamdown="table-wrapper"] > * {
+  min-width: 0;
+  max-width: 100%;
 }
 
 /* Base = narrow column (mobile-first): compact type + padding. The DS keeps overflow-x:auto

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -893,6 +893,26 @@ select:disabled {
   }
 }
 
+/* ── Code block layout (streamdown flex-col fallback fix) ──────────────────────
+   streamdown lays the code block out as `flex flex-col` (a language HEADER stacked on top
+   of the code body). But the console build only generates the `flex` utility, NOT `flex-col`
+   — so the block falls back to flex-ROW: the language label renders as a cramped LEFT column
+   beside the code, and the row grows past the message width. Force the intended vertical
+   stack and let the body own its horizontal scroll, so the header sits on TOP and a long line
+   scrolls INSIDE the block instead of stretching the panel. Applies wherever markdown renders
+   (chat, reports, memory, doc viewer). DS-owned — the `[data-streamdown]` selectors should set
+   this; fold back into @protolabsai/ui markdown.css on the next DS sync (see the DS issue). */
+.pl-markdown [data-streamdown="code-block"] {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  max-width: 100%;
+}
+.pl-markdown [data-streamdown="code-block-body"] {
+  min-width: 0; /* shrink so overflow-x:auto scrolls the code instead of widening the block */
+  max-width: 100%;
+}
+
 /* Chat composer + slash-command autocomplete — moved to src/chat/chat.css (#832). */
 /* HITL request card — moved to src/chat/hitl.css (#832). */
 

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -929,6 +929,50 @@ select:disabled {
   max-width: 100%;
 }
 
+/* ── GFM task-list items ───────────────────────────────────────────────────────
+   Two bugs: the disc marker shows alongside the checkbox, and — the real one — the console's
+   global `input,textarea,select { width: 100% }` blew the checkbox to the full row width,
+   shoving the label onto the next line. Drop the marker and pin the checkbox back to its
+   intrinsic size so the checkbox + label sit inline. Scoped to .task-list-item, so plain/
+   ordered items (which render fine) are untouched. */
+.pl-markdown [data-streamdown="list-item"].task-list-item {
+  list-style: none;
+}
+.pl-markdown [data-streamdown="list-item"].task-list-item input[type="checkbox"] {
+  width: auto;
+  margin: 0 0.4em 0 0;
+  vertical-align: middle;
+}
+.pl-markdown [data-streamdown="list-item"].task-list-item > p {
+  display: inline; /* if a label happens to be wrapped in a <p> (multi-node items) */
+  margin: 0;
+}
+
+/* ── Table "copy as" dropdown ──────────────────────────────────────────────────
+   streamdown's table copy button opens a Markdown/CSV/TSV menu styled with inert Tailwind
+   (min-w-[120px], px-3, py-2, w-full), so the menu collapses to ~22px and the labels wrap
+   one character per line (unreadable). Give it a readable surface + real menu items. */
+.pl-markdown [data-streamdown="table-wrapper"] .relative > div {
+  min-width: 150px;
+  white-space: nowrap;
+  padding: 4px;
+  background: var(--pl-color-bg-raised);
+  border: var(--pl-border-width) solid var(--pl-color-border);
+  border-radius: var(--pl-radius);
+  box-shadow: 0 6px 20px rgb(0 0 0 / 28%);
+}
+.pl-markdown [data-streamdown="table-wrapper"] .relative > div button {
+  display: block;
+  width: 100%;
+  padding: 6px 10px;
+  text-align: left;
+  white-space: nowrap;
+  border-radius: var(--pl-radius);
+}
+.pl-markdown [data-streamdown="table-wrapper"] .relative > div button:hover {
+  background: var(--pl-color-bg-inset);
+}
+
 /* Chat composer + slash-command autocomplete — moved to src/chat/chat.css (#832). */
 /* HITL request card — moved to src/chat/hitl.css (#832). */
 

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -43,6 +43,16 @@
    max-width:80%) + the markdown root, so a code block can't push either wide. */
 .chat-session-slot .pl-message:not(.pl-message--user) .pl-message__content { min-width: 0; max-width: 100%; }
 .chat-session-slot .pl-markdown { min-width: 0; max-width: 100%; }
+/* The message-column ANCESTORS above .pl-message__content are flex/grid items that default to
+   min-width:auto — so a wide code line's min-content propagates all the way up and pins the
+   whole convo (and the resizable chat panel) to the code's width, killing the panel's ability
+   to slide narrow. The DS sets min-width:0 on .pl-convo and .pl-message__body but MISSES these
+   three, so the floor leaks through. Zero them so the constraint chain reaches .chat-session-slot
+   (the grid that's correctly sized to the panel) and the overflow lands in the code body's
+   overflow-x:auto instead. */
+.chat-session-slot .pl-convo-wrap,
+.chat-session-slot .pl-convo-scroll,
+.chat-session-slot .pl-message { min-width: 0; }
 .chat-session-slot .pl-markdown [data-streamdown="code-block"] {
   max-width: 100%;
   background: var(--pl-color-bg-raised);


### PR DESCRIPTION
> **Draft — console UX. The dev env is live at http://localhost:5173/app/ serving this build, so test it there.** CSS-only.

## Root cause (both complaints are one bug)

Diagnosed by rendering a real code block in a headless browser and dumping the DOM. streamdown emits the code block as `flex flex-col` — a language **header** stacked on top of the code body. But the console's build only generates the `flex` Tailwind utility, **not `flex-col`**, so the block fell back to `flex-direction: row`:

- the language label ("python") rendered as a cramped **vertical column on the LEFT** of the code (your "language should be on top, not the left"), and
- the flex **row** grew with the code, pushing past the message width (the overflow #1593 only partly tamed with `.chat-session-slot` min-width guards).

Before (headless capture): language stacked vertically at left, code beside it. After: language is a top header, code below.

## Fix

Force the intended vertical stack on the streamdown code block, wherever markdown renders (not just `.chat-session-slot`):

```css
.pl-markdown [data-streamdown="code-block"] { display: flex; flex-direction: column; min-width: 0; max-width: 100%; }
.pl-markdown [data-streamdown="code-block-body"] { min-width: 0; max-width: 100%; }
```

`flex-direction: column` puts the language header on top; `min-width: 0` on the body lets its `overflow-x: auto` scroll a long line **inside** the block instead of stretching the panel.

## Verification (headless playwright vs the preview build)

- code-block `flex-direction` flips **row → column**; language moves to a **top header**.
- **No page-level horizontal overflow** at a narrow (560px) width; the code-block reports `scrollWidth <= clientWidth` (contained, scrolls internally).
- Console production build clean.

## DS follow-up

The real cause is DS-owned: `@protolabsai/ui`'s `[data-streamdown="code-block"]` relies on streamdown's `flex-col` class being present, which it isn't in the consumer build. This ships as a console override (interim); the DS should set `flex-direction: column` itself. Same contribute-back bucket as the responsive-tables issue (protoContent#382).

🤖 Generated with [Claude Code](https://claude.com/claude-code)