### PR TITLE
fix(tests): local-path plugin clones use file:// — kill the git local-transport race

### DIFF
--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -191,11 +191,20 @@ def _summary(m: PluginManifest, *, source: str, ref: str, sha: str) -> dict:
 def _clone(url: str, ref: str | None, dest: Path) -> str:
     """Clone ``url`` at ``ref`` into ``dest``; return the resolved commit SHA.
 
-    ``--no-hardlinks``: when ``url`` is a LOCAL path, ``git clone`` hardlinks the
-    source's object files by default, which intermittently fails with
-    ``fatal: hardlink different from source`` (a known local-clone race — it also
-    silently ignores ``--depth``). It's a no-op for the normal remote/network case,
-    so this only makes local-path installs (and the test fixtures) robust."""
+    A plain LOCAL path is rewritten to a ``file://`` URL first. Without it git
+    uses its "local transport" — a readdir+copy of the source's ``.git/objects``
+    — which silently ignores ``--depth`` and races anything concurrently writing
+    the source repo: ``git commit`` spawns a DETACHED ``git maintenance run
+    --auto``, and on CI that background maintenance renamed a ``tmp_rev_*`` pack
+    file mid-copy → ``fatal: failed to copy file … No such file or directory``
+    (#1600). ``file://`` forces the regular pack transport (upload-pack streams a
+    fresh pack; nothing enumerates the source's raw object files), which is
+    immune to that race — exactly what git's own warning recommends.
+    ``--no-hardlinks`` stays as the belt for any local-transport clone that
+    slips through (it avoids the older ``hardlink different from source`` race);
+    it's a no-op for the file:// and remote cases."""
+    if url.startswith("/"):
+        url = Path(url).resolve().as_uri()
     if ref and _SHA_RE.match(ref):
         # A specific commit: full clone (shallow can't reliably check out an
         # arbitrary SHA), then check it out.

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -11,7 +11,15 @@ from graph.plugins import installer
 
 
 def _git(cwd: Path, *args: str) -> None:
-    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True)
+    # maintenance.auto=false / gc.auto=0: `git commit` spawns a DETACHED
+    # `git maintenance run --auto` in the fixture repo, whose pack-file churn can
+    # race a subsequent clone of that repo (#1600). Fixture repos stay inert.
+    subprocess.run(
+        ["git", "-c", "maintenance.auto=false", "-c", "gc.auto=0", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+    )
 
 
 def _make_plugin_repo(root: Path, pid: str = "demo_ext", manifest_extra: str = "", tag: str | None = None) -> Path:

--- a/tests/test_plugin_lifecycle_smoke.py
+++ b/tests/test_plugin_lifecycle_smoke.py
@@ -18,7 +18,15 @@ from graph.plugins import installer
 
 
 def _git(cwd: Path, *args: str) -> None:
-    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True)
+    # maintenance.auto=false / gc.auto=0: `git commit` spawns a DETACHED
+    # `git maintenance run --auto` in the fixture repo, whose pack-file churn can
+    # race a subsequent clone of that repo (#1600). Fixture repos stay inert.
+    subprocess.run(
+        ["git", "-c", "maintenance.auto=false", "-c", "gc.auto=0", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+    )
 
 
 def _make_rich_plugin_repo(root: Path, pid: str = "demo_kit") -> Path:


### PR DESCRIPTION
## Root cause (diagnosed from the attempt-1 CI log of run 28547950813)

The full stderr **was** in the log (it is not truncated by `InstallError` — issue note 1 is moot):

```
warning: --depth is ignored in local clones; use file:// instead.
fatal: failed to copy file to '/tmp/pa-plugin-g7d8825m/repo/.git/objects/pack/tmp_rev_HN0Wws': No such file or directory
```

Mechanism:

1. `git clone <plain local path>` uses git's **"local transport"** — a readdir+copy of the source's `.git/objects` (which also silently ignores `--depth`).
2. The fixture's `git commit` spawns a **detached** `git maintenance run --auto --quiet --detach` in the just-created repo (verified via `GIT_TRACE2_EVENT`; it detaches and outlives the commit).
3. On the runner (git 2.54.0), that background maintenance writes and renames `tmp_rev_*` pack temp files in the source's `objects/pack/`. If the rename lands between the clone's readdir and its per-file copy, the copy dies with ENOENT — before the assertion under test (PEP 508 rejection) is ever reached. Passes on re-run because the window is milliseconds wide.

**Reproduced locally**: churning `tmp_rev_*` files in the source's `objects/pack/` while cloning produced the byte-for-byte CI fatal in **2/60** plain-path clones — and **0/60** `file://` clones under identical churn.

## Fix (no retries anywhere)

- **`graph/plugins/installer.py` — `_clone()`**: a plain local path is rewritten to a `file://` URL, forcing the regular pack transport (upload-pack streams a fresh pack; nothing enumerates the source's raw object files) — exactly what git's own warning recommends. This makes production local-path installs deterministic against *any* concurrent writer in the source repo, and `--depth 1` is now honored instead of ignored. `--no-hardlinks` stays as the belt for any local-transport clone that slips through.
- **Test fixtures** (`test_plugin_installer.py`, `test_plugin_lifecycle_smoke.py`): the `_git()` helper passes `-c maintenance.auto=false -c gc.auto=0`, so fixture repos never spawn the detached background writer in the first place.

No production retry logic added; stderr capture needed no change (already full).

## Verification

- Affected parametrized test: **20/20** repeat runs green
- `tests/test_plugin_installer.py` + `tests/test_plugin_lifecycle_smoke.py`: **20/20** repeat runs green
- Full suite: **2795 passed, 5 skipped**
- `ruff check .` clean; `lint-imports` skipped locally (not in the venv) — the diff adds zero imports, so the layering contract is untouched; CI runs it.

Closes #1600

🤖 Generated with [Claude Code](https://claude.com/claude-code)