### PR TITLE
fix(chat): Stop cancels re-attached turns — durable task-id fallback + settle bubbles

### DIFF
--- a/apps/web/e2e/chat-stop.spec.ts
+++ b/apps/web/e2e/chat-stop.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+
+// Composer Stop (#1617). While a turn streams, the Stop control must actually
+// halt it: a server-side A2A CancelTask on the wire — the only thing that stops
+// the turn when the local stream can't be aborted (the desktop relay ignores the
+// abort signal; a re-attached slot has no controller at all) — plus the thread
+// settled locally so no bubble is left `streaming`. Before the fix, Stop was a
+// silent no-op whenever the slot's live taskId state was empty.
+
+test("Stop during a streaming turn sends CancelTask for the turn's task and settles the thread", async ({
+  page,
+}) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await expect(composer).toBeVisible();
+
+  // Start a turn the mock HOLDS OPEN — the surface stays "streaming", the state
+  // where the kit renders the dedicated Stop control beside Send.
+  await composer.fill("hold the turn open");
+  await composer.press("Enter");
+  const stop = page.getByRole("button", { name: "Stop" });
+  await expect(stop).toBeVisible();
+
+  // Stop must put a CancelTask for THIS turn's task id on the wire — prove the
+  // RPC, not just the local settle (the server cancel is what halts generation).
+  const cancelled = page.waitForRequest(
+    (r) =>
+      r.method() === "POST" &&
+      r.url().endsWith("/a2a") &&
+      (r.postData() || "").includes('"CancelTask"'),
+  );
+  await stop.click();
+  const req = await cancelled;
+  expect(req.postData()).toContain("task-e2e-1");
+
+  // Locally settled: composer back to idle (Stop gone, send placeholder back),
+  // and no assistant bubble left spinning.
+  await expect(stop).toBeHidden();
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+  await expect(page.locator(".pl-message--assistant .spin")).toHaveCount(0);
+});

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -30,6 +30,7 @@ import { ChatMessageView } from "./ChatMessageView";
 import { ComposerModelSelect } from "./ComposerModelSelect";
 import { filesFromTransfer, isLargePaste, pastedTextFile } from "./paste";
 import { inputHistory, pushInputHistory } from "./inputHistory";
+import { finalizeStoppedMessages, resolveStopTarget } from "./stopTurn";
 import { addComponent, addToolRef, appendReasoning, appendText } from "./parts";
 
 function messageId() {
@@ -1296,18 +1297,33 @@ function ChatSessionSlot({
   }
 
   async function stop() {
-    if (taskId) {
-      try {
-        await api.cancelTask(taskId);
-      } catch {
-        // The local abort below still releases the UI even if the task already finished.
-      }
-    }
+    // Release any locally-owned stream first — the server cancel is an RPC and
+    // must never gate the UI stopping (#1617: Stop appeared dead while a long
+    // reasoning chain streamed).
     abortRef.current?.abort();
+    // The task to cancel: this slot's live turn, or — when the slot re-attached
+    // to a turn it didn't start (reload / remount / the desktop relay, all of
+    // which leave taskId state empty and abortRef null) — the streaming
+    // message's durable taskId. Resolve BEFORE settling bubbles below, which
+    // erases the `streaming` marker the fallback keys off. On desktop the relay
+    // ignores the abort signal entirely, so this server-side cancel is the only
+    // thing that actually halts the turn there.
+    const before = chatStore.getSnapshot().sessions.find((s) => s.id === sessionId);
+    const cancelId = resolveStopTarget(before?.messages || [], taskId);
+    // Settle the thread immediately: no bubble may stay `streaming` after Stop.
+    // The send-loop only finalizes turns it owns; a re-attached turn has none.
+    if (before) chatStore.updateMessages(sessionId, finalizeStoppedMessages(before.messages));
     chatStore.setSessionStatus(sessionId, "idle");
     setStatusMessage("stopped");
     // Drop any optimistic queued-steer bubbles; the user chose to stop.
     setSteerQueue([]);
+    if (cancelId) {
+      try {
+        await api.cancelTask(cancelId);
+      } catch {
+        // Best-effort — the UI is already released; the task may have finished.
+      }
+    }
   }
 
   if (!session) return null;

--- a/apps/web/src/chat/stopTurn.test.ts
+++ b/apps/web/src/chat/stopTurn.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatMessage } from "../lib/types";
+import { finalizeStoppedMessages, resolveStopTarget } from "./stopTurn";
+
+const msg = (over: Partial<ChatMessage>): ChatMessage => ({
+  role: "assistant",
+  content: "",
+  ...over,
+});
+
+describe("resolveStopTarget", () => {
+  it("prefers the slot's live taskId when it owns the turn", () => {
+    const messages = [msg({ id: "a1", status: "streaming", taskId: "task-old" })];
+    expect(resolveStopTarget(messages, "task-live")).toBe("task-live");
+  });
+
+  it("falls back to the streaming message's durable taskId when the slot re-attached (#1617)", () => {
+    const messages = [
+      msg({ id: "a1", status: "done", taskId: "task-done" }),
+      msg({ id: "a2", status: "streaming", taskId: "task-live" }),
+    ];
+    expect(resolveStopTarget(messages, "")).toBe("task-live");
+  });
+
+  it("picks the MOST RECENT streaming assistant message", () => {
+    const messages = [
+      msg({ id: "a1", status: "streaming", taskId: "task-stale" }),
+      msg({ id: "a2", status: "streaming", taskId: "task-current" }),
+    ];
+    expect(resolveStopTarget(messages, "")).toBe("task-current");
+  });
+
+  it("ignores user/system messages and returns empty when nothing streams", () => {
+    const messages = [
+      { role: "user" as const, content: "hi", status: "streaming" as const, taskId: "not-a-turn" },
+      msg({ id: "a1", status: "done", taskId: "task-done" }),
+    ];
+    expect(resolveStopTarget(messages, "")).toBe("");
+  });
+
+  it("returns empty for a streaming message that never got a task id", () => {
+    expect(resolveStopTarget([msg({ id: "a1", status: "streaming" })], "")).toBe("");
+  });
+});
+
+describe("finalizeStoppedMessages", () => {
+  it("flips every streaming assistant bubble to done, keeping partial content", () => {
+    const out = finalizeStoppedMessages([
+      msg({ id: "a1", status: "streaming", content: "partial answer" }),
+      msg({ id: "a2", status: "done", content: "finished" }),
+    ]);
+    expect(out[0]).toMatchObject({ status: "done", content: "partial answer" });
+    expect(out[1]).toMatchObject({ status: "done", content: "finished" });
+  });
+
+  it("settles running tool cards on the stopped bubble", () => {
+    const out = finalizeStoppedMessages([
+      msg({
+        id: "a1",
+        status: "streaming",
+        toolCalls: [
+          { id: "t1", name: "search", status: "running" },
+          { id: "t2", name: "read", status: "error" },
+        ],
+      }),
+    ]);
+    expect(out[0].toolCalls).toEqual([
+      { id: "t1", name: "search", status: "done" },
+      { id: "t2", name: "read", status: "error" },
+    ]);
+  });
+
+  it("leaves user messages and non-streaming bubbles untouched (same reference)", () => {
+    const user = { role: "user" as const, content: "hi" };
+    const done = msg({ id: "a1", status: "error", content: "failed" });
+    const out = finalizeStoppedMessages([user, done]);
+    expect(out[0]).toBe(user);
+    expect(out[1]).toBe(done);
+  });
+});

--- a/apps/web/src/chat/stopTurn.ts
+++ b/apps/web/src/chat/stopTurn.ts
@@ -1,0 +1,34 @@
+import type { ChatMessage } from "../lib/types";
+
+/** Which A2A task a Stop press should cancel (#1617).
+ *
+ *  The composer's Stop historically used only the slot's live `taskId` state —
+ *  set when THIS ChatSurface instance started the turn. But a slot can render a
+ *  turn it did not start: after a reload, a navigation remount, or on desktop
+ *  where the Tauri relay pumps frames into the shared chat store regardless of
+ *  which instance is mounted. In every one of those states the live taskId is
+ *  empty and Stop was a silent no-op — no CancelTask on the wire, nothing to
+ *  abort locally. The durable `taskId` persisted on the streaming message (the
+ *  same one the self-heal reconciler uses) is the fallback that makes Stop work
+ *  from any slot that can see the turn. */
+export function resolveStopTarget(messages: ChatMessage[], liveTaskId: string): string {
+  if (liveTaskId) return liveTaskId;
+  const streaming = [...messages]
+    .reverse()
+    .find((m) => m.role === "assistant" && m.status === "streaming");
+  return streaming?.taskId || "";
+}
+
+/** Settle every bubble a stop leaves behind: no message may stay `streaming`
+ *  after the user pressed Stop. The send-loop only finalizes turns it owns —
+ *  a re-attached turn has no owner in this slot, so its bubble (and any
+ *  `running` tool cards) would spin forever. Partial content is kept. */
+export function finalizeStoppedMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map((m) => {
+    if (m.role !== "assistant" || m.status !== "streaming") return m;
+    const toolCalls = m.toolCalls?.map((c) =>
+      c.status === "running" ? { ...c, status: "done" as const } : c,
+    );
+    return { ...m, status: "done" as const, toolCalls };
+  });
+}


### PR DESCRIPTION
Closes #1617

## Root cause

`stop()` only worked when the ChatSurface slot had **started the turn itself**: it cancelled the slot's live `taskId` state and aborted its own fetch controller. A slot rendering a turn it did not start had neither, making Stop a **silent no-op** — no CancelTask on the wire, nothing aborted locally, tokens keep streaming into the shared chat store. That state is easy to reach:

- a **reload / webview reload** (the self-heal reconciler re-attaches the turn, but `taskId` state stays empty),
- a turn launched **outside the slot** — ⌘K palette chat, or the new Work-surface quick-add (#1610, merged the day before this was reported — likely why it surfaced now),
- **desktop**, where the Tauri `chat_stream` relay pumps frames into the store and **ignores `handlers.signal` entirely** (`api.ts` — the relay has no abort wiring), so even the local-abort half of stop() has no effect there.

The escalation in the issue ("stop now does nothing at all, even on plain output") is consistent: once the slot is in this state, *every* turn is unstoppable, reasoning or not.

**Server-side cancel is healthy** — verified live against an isolated instance (`PROTOAGENT_BOX_ROOT=/tmp/... :7899`): `CancelTask` mid-reasoning returned in **10ms**, the SSE closed immediately, task went `TASK_STATE_CANCELED`. So the fix is entirely client-side.

## Fix (`stop()` in ChatSurface + `stopTurn.ts`)

1. **Abort any locally-owned stream first** — the cancel RPC must never gate UI release (the original "delayed until the reasoning block finishes" symptom was the old code `await`ing the RPC before aborting).
2. **Resolve the task to cancel with a durable fallback**: the slot's live `taskId`, else the streaming message's persisted `taskId` — the same field the self-heal reconciler keys off, and every send path (ChatSurface + PaletteChat) stamps it. On desktop this server-side cancel is the *only* thing that actually halts the turn.
3. **Settle the thread**: flip every bubble left `streaming` (and its `running` tool cards) to done — the send loop only finalizes turns it owns; a re-attached turn has no owner.

`resolveStopTarget` / `finalizeStoppedMessages` are extracted pure into `stopTurn.ts`.

## Tests

- **Unit (8 new)**: live-id preference, durable fallback, most-recent-streaming selection, role filtering, no-task-id turn; settle keeps partial content, settles running tool cards, leaves non-streaming messages by reference. `299/299` pass.
- **e2e (new `chat-stop.spec.ts`)**: holds a turn open via the mock, clicks Stop, **asserts the CancelTask RPC hits the wire with the turn's task id**, and the thread settles. `184/184` pass. (No prior spec clicked the composer Stop at all.)

## Known gaps (called out, not fixed here)

- Stop pressed in the ~100ms before the task frame arrives has no task id to cancel yet (pre-existing; browser still aborts locally).
- The desktop relay still has no client-side abort seam — a follow-up in the Tauri `chat_stream` command would let stop() kill the relay without waiting for the server's canceled frame. With this fix the server cancel closes the stream from the other end, so it's cosmetic.
- `nesting.spec.ts` is flaky on clean origin/main (2/10 local failures, pre-existing — reproduced with this branch's changes stashed); filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopping an in-progress response now settles the chat UI more reliably.
  * The Stop action correctly cancels the active turn even after reloading or reattaching to a conversation.
  * Streaming assistant bubbles and running tool indicators now clear promptly after stopping.
* **Tests**
  * Added end-to-end and unit coverage for Stop behavior, cancel requests, and post-stop UI state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->