### PR TITLE
fix(hitl): hold queued operator messages until form resolves

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -293,7 +293,14 @@ function ChatSessionSlot({
   // a spinner/"working…" strip above the composer — the inline indicators cover it now.
   const [, setStatusMessage] = useState("");
   const [taskId, setTaskId] = useState("");
-  const [hitl, setHitl] = useState<HitlPayload | null>(null);
+  const [hitl, setHitlState] = useState<HitlPayload | null>(null);
+  // Ref mirror for async closures (reconcileSteer runs after an await — the render
+  // closure's `hitl` is stale by then). Always set both via updateHitl.
+  const hitlRef = useRef<HitlPayload | null>(null);
+  const updateHitl = (payload: HitlPayload | null) => {
+    hitlRef.current = payload;
+    setHitlState(payload);
+  };
   const abortRef = useRef<AbortController | null>(null);
   // Transient "copied ✓" feedback on a message's copy action.
   const [copiedId, setCopiedId] = useState<string | null>(null);
@@ -719,6 +726,15 @@ function ChatSessionSlot({
 
   async function send() {
     if (!session || !canSend) return;
+    // A HITL form/question/approval is open (#1560): a fresh send would race the
+    // pending form — the server holds unmarked messages anyway — so queue it as a
+    // steer instead. It folds into the agent's context right AFTER the form
+    // response (submit or dismiss), with the same queued-bubble + ✕ affordances
+    // as mid-turn steering. Attachments stay in the tray for the next real send.
+    if (hitl) {
+      void queueSteer();
+      return;
+    }
     const text = draft.trim();
     pushInputHistory(text); // record for ↑/↓ recall, then reset nav to the newest
     histIndexRef.current = null;
@@ -843,6 +859,14 @@ function ChatSessionSlot({
     const consumed = queued.filter((q) => !remainingIds.has(q.id));
     const unconsumed = queued.filter((q) => remainingIds.has(q.id));
     if (consumed.length) settleConsumed(consumed);
+    // The turn parked on a HITL form (#1560): steers the agent hasn't folded yet stay
+    // QUEUED — the server keeps holding them and folds them in right after the form
+    // response. Re-sending them as a fresh turn here would deliver them BEFORE the
+    // form answer (and abandon the pending interrupt).
+    if (unconsumed.length && hitlRef.current) {
+      setSteerQueue(unconsumed);
+      return;
+    }
     setSteerQueue([]);
     if (unconsumed.length) {
       void runTurn(unconsumed.map((u) => u.text).join("\n\n"));
@@ -965,14 +989,17 @@ function ChatSessionSlot({
     // the tool card itself (running → done on approve, error on deny), so the bubble is
     // just noise. A form/question answer IS meaningful content, so those stay visible.
     const silent = hitl?.kind === "approval";
-    setHitl(null);
+    updateHitl(null);
     // For an approval resume, CONTINUE the original assistant message (the one that paused) so the
     // pre- and post-approval tool cards live in ONE bubble / one WorkBlock — otherwise they split
     // across two message bubbles with a gap between them. Forms/questions keep the new-bubble path
     // (their answer is meaningful conversation).
+    // `hitlResume` marks this as THE answer to the pending interrupt (#1560): the server
+    // resumes the parked graph with it, while any other message sent meanwhile is held
+    // and folds in right after.
     void runTurn(
       typeof response === "string" ? response : JSON.stringify(response),
-      silent ? { hidden: true, resumeMessageId: lastAssistantId } : {},
+      silent ? { hidden: true, resumeMessageId: lastAssistantId, hitlResume: true } : { hitlResume: true },
     );
   }
 
@@ -984,11 +1011,11 @@ function ChatSessionSlot({
   // the paused assistant message (matching the approval-resume path) rather than minting a
   // new bubble.
   async function dismissHitl() {
-    setHitl(null);
+    updateHitl(null);
     void runTurn(
       "[dismissed] The operator dismissed this request without providing input. Continue " +
         "without it — proceed using your best judgment, or stop and explain what you need.",
-      { hidden: true, resumeMessageId: lastAssistantId },
+      { hidden: true, resumeMessageId: lastAssistantId, hitlResume: true },
     );
   }
 
@@ -999,6 +1026,8 @@ function ChatSessionSlot({
       sendAs?: string;
       images?: { b64: string; mime: string; name: string }[];
       resumeMessageId?: string;
+      // This message answers the pending HITL interrupt (#1560) — see resumeHitl.
+      hitlResume?: boolean;
     } = {},
   ) {
     if (!session || !content) return;
@@ -1085,7 +1114,7 @@ function ChatSessionSlot({
           }
         },
         onInputRequired: (payload) => {
-          setHitl(payload);
+          updateHitl(payload);
           // Alert natively if the window is hidden/unfocused (menu-bar-only
           // desktop, or a backgrounded tab) so the form isn't missed.
           notifyIfHidden(
@@ -1265,6 +1294,8 @@ function ChatSessionSlot({
         // EVERY send while the tab's toggle is on (a mixed thread would leak earlier
         // incognito content into a later non-incognito turn's summary).
         incognito: chatStore.getSnapshot().sessions.find((s) => s.id === session.id)?.incognito,
+        // Marks this message as the answer to the pending HITL interrupt (#1560).
+        hitlResume: opts.hitlResume,
       });
       chatStore.setSessionStatus(session.id, "idle");
       setStatusMessage("idle");

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1334,6 +1334,11 @@ export const api = {
       // console stamps it on EVERY send while the thread's toggle is on — a mixed
       // thread would leak earlier incognito content into a later turn's summary.
       incognito?: boolean;
+      // This message ANSWERS a pending HITL form/question/approval (#1560): the server
+      // resumes the parked interrupt with it (Command(resume=…)) instead of running a
+      // fresh turn. Unmarked messages sent while a form is pending are held server-side
+      // until the form resolves.
+      hitlResume?: boolean;
     } = {},
   ) {
     // One A2A SendStreamingMessage body + one frame dispatcher, shared by the desktop
@@ -1355,13 +1360,14 @@ export const api = {
           // Per-turn overrides ride the A2A message metadata (server/chat.py reads them):
           // the tab's chosen model + the /effort reasoning level + incognito (ADR 0069 D3b —
           // per-message server-side, stamped on every send while the thread toggle is on).
-          ...((opts.model || opts.reasoningEffort || opts.bypassPermissions || opts.incognito)
+          ...((opts.model || opts.reasoningEffort || opts.bypassPermissions || opts.incognito || opts.hitlResume)
             ? {
                 metadata: {
                   ...(opts.model ? { model: opts.model } : {}),
                   ...(opts.reasoningEffort ? { reasoning_effort: opts.reasoningEffort } : {}),
                   ...(opts.bypassPermissions ? { bypass_permissions: true } : {}),
                   ...(opts.incognito ? { incognito: true } : {}),
+                  ...(opts.hitlResume ? { hitl_resume: true } : {}),
                 },
               }
             : {}),
@@ -1455,6 +1461,9 @@ export const api = {
             // The non-streaming fallback must carry incognito too — dropping it here
             // would silently persist a thread the operator marked private.
             ...(opts.incognito ? { incognito: true } : {}),
+            // …and hitl_resume (#1560) — dropping it would make the server HOLD the
+            // operator's own form answer behind the form it answers (deadlock).
+            ...(opts.hitlResume ? { hitl_resume: true } : {}),
           }),
         });
         if (!res.ok) {

--- a/docs/explanation/steering.md
+++ b/docs/explanation/steering.md
@@ -35,6 +35,29 @@ next step regardless of how deep the tool loop is.
   the turn's last model call (so it wasn't folded in) is **re-sent as a fresh turn**, so a
   late steer is never silently lost.
 
+## While a HITL form is open: messages are held
+
+When the agent pauses on a **HITL interrupt** — a `request_user_input` form, an
+`ask_human` question, or a `run_command` approval card — the graph is parked at the
+interrupt and makes no model calls. A fresh message invoked on that parked thread would
+make LangGraph *abandon* the interrupt (the form could never resolve) and the agent would
+see your message **before** the form answer.
+
+So while a form is pending, operator messages are **held**, not delivered (#1560):
+
+- The console queues them as steers (same pending bubble + ✕ as mid-turn steering), and
+  the server holds any unmarked message that arrives for the parked thread in the same
+  queue — re-parking the caller on the same form payload.
+- The form **submission or dismissal** (marked `hitl_resume`, or an A2A `message/send` on
+  the parked task id) resumes the interrupt properly — the tool returns the answer — and
+  the held messages fold in at the very next model call: **after** the form response, in
+  arrival order. Dismissing the form releases them too, so nothing can deadlock or be
+  silently dropped.
+- The pending-form state is read from the durable LangGraph checkpoint each time, so a
+  restart can't leave messages held behind a form that no longer exists.
+
+With no pending form, none of this runs — sends behave exactly as before.
+
 ## Steering vs. cancelling a delegation
 
 Two different controls:

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -42,6 +42,11 @@ class ChatRequest(BaseModel):
     # memory injection for this turn. Additive, default False — existing
     # callers are unaffected.
     incognito: bool = False
+    # This message answers a pending HITL form/question/approval (#1560): resume
+    # the parked interrupt instead of running a fresh turn. Set by the console's
+    # desktop /api/chat fallback — the streaming path carries the same flag as
+    # A2A message metadata (`hitl_resume`). Additive, default False.
+    hitl_resume: bool = False
 
 
 _B36 = "0123456789abcdefghijklmnopqrstuvwxyz"
@@ -67,7 +72,9 @@ def register_chat_routes(app, ui: str) -> None:
         # Echo the (possibly minted) session_id so callers can continue the
         # session — additive key, existing consumers unaffected.
         session_id = req.session_id.strip() or _mint_session_id()
-        result = await chat(req.message, session_id, model=req.model, incognito=req.incognito)
+        result = await chat(
+            req.message, session_id, model=req.model, incognito=req.incognito, hitl_resume=req.hitl_resume
+        )
         parts = [m["content"] for m in result if m.get("role") == "assistant" and m.get("content")]
         return {"response": "\n\n".join(parts), "messages": result, "session_id": session_id}
 

--- a/server/chat.py
+++ b/server/chat.py
@@ -301,7 +301,12 @@ def _setup_required_message() -> list[dict[str, Any]]:
 
 
 async def chat(
-    message: str, session_id: str, *, model: str | None = None, incognito: bool = False
+    message: str,
+    session_id: str,
+    *,
+    model: str | None = None,
+    incognito: bool = False,
+    hitl_resume: bool = False,
 ) -> list[dict[str, Any]]:
     """Route a user message through LangGraph and return the final assistant
     response as a list of ``{"role": "assistant", "content": ...}`` dicts.
@@ -312,11 +317,13 @@ async def chat(
     artifact. ``model`` overrides the lead model for this turn (per-tab / per
     OpenAI request); unset → the configured default. ``incognito`` (ADR 0069
     D3b) marks the turn as leaving no memory trail: no session-summary
-    persistence, no memory injection.
+    persistence, no memory injection. ``hitl_resume`` marks the message as the
+    operator's answer to a pending HITL interrupt (#1560 — the desktop /api/chat
+    fallback's analogue of the streaming path's ``hitl_resume`` metadata).
     """
     if STATE.graph is None:
         return _setup_required_message()
-    return await _chat_langgraph(message, session_id, model=model, incognito=incognito)
+    return await _chat_langgraph(message, session_id, model=model, incognito=incognito, hitl_resume=hitl_resume)
 
 
 # Cap tool input/output previews so a single frame stays small on the wire.
@@ -863,6 +870,65 @@ _AUTONOMOUS_HITL_SENTINEL = (
 _MAX_AUTONOMOUS_AUTOANSWERS = 3
 
 
+def _is_autonomous(request_metadata: dict | None) -> bool:
+    """Whether this turn runs with no operator watching (see _AUTONOMOUS_ORIGINS)."""
+    return ((request_metadata or {}).get("origin") or "").strip().lower() in _AUTONOMOUS_ORIGINS
+
+
+def _is_hitl_resume(request_metadata: dict | None) -> bool:
+    """Whether this message IS the operator's answer to the pending HITL pause.
+
+    The console stamps ``hitl_resume`` on the message metadata when it submits or
+    dismisses a form / question / approval card — that message must resume the parked
+    interrupt (``Command(resume=…)``), not run a fresh graph turn. A2A callers that
+    resume properly (message/send on the parked taskId) never need this marker — the
+    executor already flips ``resume`` for them."""
+    return bool((request_metadata or {}).get("hitl_resume"))
+
+
+# _hold_if_hitl_pending's "this message answers the pending interrupt" signal — a
+# sentinel (not a string) so it can never collide with an interrupt VALUE.
+_HITL_RESUME = object()
+
+
+async def _hold_if_hitl_pending(message: str, session_id: str, config: dict, *, request_metadata: dict | None):
+    """The HITL hold (#1560): decide what a FRESH message may do while this thread is
+    parked at a ``request_user_input`` / ``ask_human`` / approval ``interrupt()``.
+
+    LangGraph treats fresh input on an interrupted thread as "abandon the interrupt and
+    continue" — the un-answered tool_call is left dangling (later stripped by
+    ToolCallRepairMiddleware) and the model sees the new message BEFORE (and instead of)
+    the form answer, while the parked task can never resolve. So while a HITL interrupt
+    is pending:
+
+    - the operator's actual answer (``hitl_resume`` metadata) → resume the graph
+      properly (returns the ``_HITL_RESUME`` sentinel);
+    - any other operator message → HOLD it: park it in the per-session steering queue
+      (returns the interrupt payload). It stays queued while the form is open — the
+      queue only drains at a model call, and the parked graph makes none — and folds in
+      via ``SteeringMiddleware`` at the FIRST model call after the form resolves
+      (submitted OR dismissed), i.e. immediately after the form response, in arrival
+      order. A dismissal is also a resume, so held messages can never deadlock; the
+      pending-form state itself lives in the durable LangGraph checkpoint (re-read
+      here every time), so a restart can't strand the hold.
+
+    Autonomous turns are exempt (they must never park — unchanged clobber semantics),
+    and with no pending interrupt this returns ``None`` and the turn is untouched.
+    Callers must hold the per-thread lock (the check must not race a parking turn)."""
+    if _is_autonomous(request_metadata):
+        return None
+    pending_val = await _pending_interrupt_value(config)
+    if pending_val is None:
+        return None
+    if _is_hitl_resume(request_metadata):
+        return _HITL_RESUME
+    from graph import steering
+
+    steering.enqueue(session_id, message)
+    log.info("[hitl] holding operator message for session %s — form pending", session_id)
+    return pending_val
+
+
 async def _run_native_turn(message, session_id, config, *, request_metadata=None, resume=False, images=None):
     """One native LangGraph turn (the non-ACP path): run the graph, the dropped-turn
     kicker retry, and goal-mode continuations, then yield the terminal confidence + done
@@ -890,7 +956,7 @@ async def _run_native_turn(message, session_id, config, *, request_metadata=None
     # An autonomous turn (no operator watching) must never deadlock on a HITL pause: when one
     # of these turns hits input_required we resume the graph with a "no operator" sentinel and
     # run another pass, up to a cap, instead of parking the task forever (see _AUTONOMOUS_*).
-    _autonomous = ((request_metadata or {}).get("origin") or "").strip().lower() in _AUTONOMOUS_ORIGINS
+    _autonomous = _is_autonomous(request_metadata)
     _resume_value = (message if resume else None)
     _auto_answers = 0
     with goal_turn(goal_active):
@@ -1180,6 +1246,20 @@ async def _chat_langgraph_stream(
             # queue; different contexts never block each other). The turn body lives in
             # _run_native_turn so the lock wraps it without a deep in-line reindent.
             async with _thread_lock(_tid):
+                # HITL hold (#1560): while this thread is parked at a form/question/
+                # approval interrupt, a fresh operator message is HELD in the steering
+                # queue (it folds in right after the form response) and the turn re-parks
+                # on the same payload; the marked form answer converts to a real resume.
+                # No pending interrupt ⇒ hold is None and nothing changes.
+                if not resume:
+                    hold = await _hold_if_hitl_pending(
+                        message, session_id, config, request_metadata=request_metadata
+                    )
+                    if hold is _HITL_RESUME:
+                        resume = True
+                    elif hold is not None:
+                        yield ("input_required", _interrupt_payload(hold))
+                        return
                 async for frame in _run_native_turn(
                     message, session_id, config, request_metadata=request_metadata, resume=resume, images=images
                 ):
@@ -1315,7 +1395,12 @@ async def rewind_session(
 
 
 async def _chat_langgraph(
-    message: str, session_id: str, *, model: str | None = None, incognito: bool = False
+    message: str,
+    session_id: str,
+    *,
+    model: str | None = None,
+    incognito: bool = False,
+    hitl_resume: bool = False,
 ) -> list[dict[str, Any]]:
     """Non-streaming LangGraph entry — used by the console + OpenAI-compat."""
     from observability import tracing
@@ -1386,11 +1471,37 @@ async def _chat_langgraph(
             # unlocked graph turn here could lost-update a concurrent one (e.g. the
             # desktop /api/chat fallback racing a console /compact on the same tab).
             async with _thread_lock(config["configurable"]["thread_id"]):
+                # HITL hold (#1560) — same contract as the streaming path: while the
+                # thread is parked at a form/question/approval interrupt, hold a fresh
+                # operator message (it folds in right after the form response) and echo
+                # the pending ask; the marked answer resumes the graph properly.
+                hold = await _hold_if_hitl_pending(
+                    message, session_id, config, request_metadata=({"hitl_resume": True} if hitl_resume else None)
+                )
+                if hold is not None and hold is not _HITL_RESUME:
+                    payload = _interrupt_payload(hold)
+                    question = payload.get("question") or payload.get("title") or "The agent needs input to continue."
+                    return [
+                        {
+                            "role": "assistant",
+                            "content": (
+                                f"🙋 **Input needed first:** {question}\n\n"
+                                "_(Your message is queued — the agent gets it right after you answer.)_"
+                            ),
+                        }
+                    ]
+                if hold is _HITL_RESUME:
+                    from langgraph.types import Command
+
+                    graph_input = Command(resume=message)
+                else:
+                    graph_input = {
+                        "messages": [HumanMessage(content=message)],
+                        "session_id": session_id,
+                        **_state_extra,
+                    }
                 with goal_turn(goal_active):
-                    result = await STATE.graph.ainvoke(
-                        {"messages": [HumanMessage(content=message)], "session_id": session_id, **_state_extra},
-                        config=config,
-                    )
+                    result = await STATE.graph.ainvoke(graph_input, config=config)
             raw = _last_ai(result)
             response = extract_output(raw)
 

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -11,7 +11,7 @@ def _client(monkeypatch, *, graph=object(), goal=None, chat_reply=None):
     import operator_api.chat_routes as cr
     import runtime.state as rs
 
-    async def _fake_chat(message, session_id, *, model=None, incognito=False):
+    async def _fake_chat(message, session_id, *, model=None, incognito=False, hitl_resume=False):
         suffix = f"@{model}" if model else ""
         return chat_reply or [{"role": "assistant", "content": f"echo:{message}{suffix}"}]
 
@@ -39,7 +39,7 @@ def test_api_chat_mints_unique_session_id_when_omitted(monkeypatch):
 
     seen: list[str] = []
 
-    async def _fake_chat(message, session_id, *, model=None, incognito=False):
+    async def _fake_chat(message, session_id, *, model=None, incognito=False, hitl_resume=False):
         seen.append(session_id)
         return [{"role": "assistant", "content": "ok"}]
 
@@ -74,7 +74,7 @@ def test_api_chat_passes_incognito_flag(monkeypatch):
 
     seen: list[bool] = []
 
-    async def _fake_chat(message, session_id, *, model=None, incognito=False):
+    async def _fake_chat(message, session_id, *, model=None, incognito=False, hitl_resume=False):
         seen.append(incognito)
         return [{"role": "assistant", "content": "ok"}]
 

--- a/tests/test_hitl_hold.py
+++ b/tests/test_hitl_hold.py
@@ -1,0 +1,284 @@
+"""HITL hold (#1560) — while a form/question/approval interrupt is pending, fresh
+operator messages are HELD (queued, not delivered) until the form resolves.
+
+Why the hold lives at TURN ENTRY (server.chat) and not in SteeringMiddleware: while
+the graph is parked at an ``interrupt()`` it makes no model calls, so the fold seam
+never runs — the interleaving actually happened when a fresh message invoked the
+parked thread, which LangGraph treats as "abandon the interrupt and continue"
+(dangling tool_call, form unresolvable, message seen BEFORE the form answer).
+``_hold_if_hitl_pending`` intercepts that: unmarked messages are parked in the
+steering queue and the turn re-parks on the same payload; the marked answer
+(``hitl_resume``) becomes a real ``Command(resume=…)``. Held messages then fold in
+via ``SteeringMiddleware`` at the first model call after the resume — i.e.
+immediately AFTER the form response, in arrival order.
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import patch
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from graph import steering
+from runtime.state import STATE
+
+# `server.chat` the attribute is shadowed by the re-exported `chat` function in
+# server/__init__.py, so resolve the actual submodule from sys.modules.
+chat_mod = importlib.import_module("server.chat")
+
+
+class _ToolFake(GenericFakeChatModel):
+    """Fake chat model that supports bind_tools (returns itself) so it drops into
+    create_agent and replays preset AIMessages, including tool calls.
+
+    The streaming turn driver consumes the model via ``astream_events``, but the
+    stock ``GenericFakeChatModel._stream`` drops ``tool_calls`` (it only chunks
+    content / additional_kwargs) and yields NOTHING for an empty-content tool-call
+    message ("No generations found in stream"). Override ``_astream`` to emit one
+    chunk carrying the full message, tool calls included."""
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+    async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+        import json
+
+        from langchain_core.messages import AIMessageChunk
+        from langchain_core.outputs import ChatGenerationChunk
+
+        message = next(self.messages)
+        tool_call_chunks = [
+            {
+                "name": tc["name"],
+                "args": json.dumps(tc["args"]),
+                "id": tc["id"],
+                "index": i,
+                "type": "tool_call_chunk",
+            }
+            for i, tc in enumerate(getattr(message, "tool_calls", []) or [])
+        ]
+        yield ChatGenerationChunk(
+            message=AIMessageChunk(content=message.content or "", tool_call_chunks=tool_call_chunks)
+        )
+
+
+_FORM_STEPS = [{"schema": {"type": "object", "properties": {"env": {"type": "string"}}, "required": ["env"]}}]
+
+
+def _form_call(call_id: str = "c1") -> AIMessage:
+    """An assistant turn that opens the real ``request_user_input`` form (which
+    parks the graph at a LangGraph interrupt)."""
+    return AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "request_user_input",
+                "args": {"title": "Pick env", "steps": _FORM_STEPS},
+                "id": call_id,
+                "type": "tool_call",
+            }
+        ],
+    )
+
+
+def _install_graph(monkeypatch, messages):
+    import runtime.state as rs
+    from graph.config import LangGraphConfig
+    from langgraph.checkpoint.memory import MemorySaver
+
+    fake = _ToolFake(messages=iter(messages))
+    with patch("graph.agent.create_llm", lambda *a, **k: fake):
+        from graph.agent import create_agent_graph
+
+        g = create_agent_graph(LangGraphConfig(), include_subagents=False, checkpointer=MemorySaver())
+    monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
+    monkeypatch.setattr(rs.STATE, "goal_controller", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", LangGraphConfig(), raising=False)
+    return g
+
+
+def _cfg(session_id: str) -> dict:
+    return {"configurable": {"thread_id": f"a2a:{session_id}"}}
+
+
+async def _frames(message: str, session_id: str, *, request_metadata=None):
+    return [
+        frame
+        async for frame in chat_mod._chat_langgraph_stream(message, session_id, request_metadata=request_metadata)
+    ]
+
+
+async def _history(session_id: str) -> list:
+    snap = await STATE.graph.aget_state(_cfg(session_id))
+    return list(snap.values.get("messages", []))
+
+
+@pytest.fixture(autouse=True)
+def _clear_queue():
+    steering._QUEUES.clear()
+    yield
+    steering._QUEUES.clear()
+
+
+# ── held while the form is pending ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_message_held_while_form_pending(monkeypatch):
+    sid = "hold-1"
+    _install_graph(monkeypatch, [_form_call(), AIMessage(content="unused")])
+
+    frames = await _frames("deploy the service", sid)
+    assert frames[-1][0] == "input_required"
+    form = frames[-1][1]
+    assert form.get("kind") == "form" and form.get("title") == "Pick env"
+
+    # A message typed while the form is open: NOT delivered — held in the steering
+    # queue, and the turn re-parks on the SAME form payload (no model call, no text
+    # frames, nothing folded into the thread).
+    held = await _frames("also make it blue", sid)
+    assert held == [("input_required", form)]
+    assert steering.pending(sid) == 1
+
+    history = await _history(sid)
+    assert not any(isinstance(m, HumanMessage) and "also make it blue" in str(m.content) for m in history)
+    # The interrupt is still pending — the form can still be answered.
+    assert await chat_mod._pending_interrupt_value(_cfg(sid)) is not None
+
+
+# ── released in order, AFTER the form response, on submit ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_held_messages_fold_in_order_after_submit(monkeypatch):
+    sid = "hold-2"
+    _install_graph(monkeypatch, [_form_call(), AIMessage(content="Deployed to staging.")])
+
+    await _frames("deploy the service", sid)
+    await _frames("first note while form open", sid)
+    await _frames("second note while form open", sid)
+    assert steering.pending(sid) == 2
+
+    # The operator submits the form: the console marks the answer with hitl_resume,
+    # which resumes the parked interrupt (a real Command resume — the tool RETURNS).
+    frames = await _frames('{"env": "staging"}', sid, request_metadata={"hitl_resume": True})
+    assert any(kind == "done" for kind, _ in frames)
+    assert steering.pending(sid) == 0  # released — nothing left queued
+
+    history = await _history(sid)
+    tool_idx = next(
+        i for i, m in enumerate(history) if isinstance(m, ToolMessage) and "staging" in str(m.content)
+    )
+    fold = next(
+        (i, m)
+        for i, m in enumerate(history)
+        if isinstance(m, HumanMessage) and "first note while form open" in str(m.content)
+    )
+    fold_idx, fold_msg = fold
+    final_idx = max(i for i, m in enumerate(history) if isinstance(m, AIMessage) and m.content)
+
+    # The form response (the tool result) comes FIRST; the held messages fold in
+    # right after it, before the final answer — and keep their arrival order.
+    assert tool_idx < fold_idx < final_idx
+    content = str(fold_msg.content)
+    assert "second note while form open" in content
+    assert content.index("first note while form open") < content.index("second note while form open")
+
+
+# ── released on cancel/dismiss (no deadlock, nothing dropped) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_held_messages_released_on_dismiss(monkeypatch):
+    sid = "hold-3"
+    _install_graph(monkeypatch, [_form_call(), AIMessage(content="Proceeding without the form.")])
+
+    await _frames("deploy the service", sid)
+    await _frames("note sent while form open", sid)
+    assert steering.pending(sid) == 1
+
+    # The operator DISMISSES the form (the console's ✕): also a marked resume — the
+    # tool returns the dismissal sentinel and the turn completes; held messages are
+    # released right after it. Nothing is dropped, nothing deadlocks.
+    dismissal = "[dismissed] The operator dismissed this request without providing input."
+    frames = await _frames(dismissal, sid, request_metadata={"hitl_resume": True})
+    assert any(kind == "done" for kind, _ in frames)
+    assert steering.pending(sid) == 0
+
+    history = await _history(sid)
+    tool_idx = next(i for i, m in enumerate(history) if isinstance(m, ToolMessage) and "[dismissed]" in str(m.content))
+    fold_idx = next(
+        i for i, m in enumerate(history) if isinstance(m, HumanMessage) and "note sent while form open" in str(m.content)
+    )
+    assert tool_idx < fold_idx
+    assert await chat_mod._pending_interrupt_value(_cfg(sid)) is None  # the pause is resolved
+
+
+# ── no pending form ⇒ behavior unchanged ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_pending_form_leaves_turns_untouched(monkeypatch):
+    sid = "hold-4"
+    _install_graph(monkeypatch, [AIMessage(content="plain answer"), AIMessage(content="second answer")])
+
+    frames = await _frames("hello", sid)
+    assert not any(kind == "input_required" for kind, _ in frames)
+    assert any(kind == "done" for kind, _ in frames)
+    assert steering.pending(sid) == 0  # nothing was queued
+
+    # A stray hitl_resume marker with NO pending interrupt degrades to a normal
+    # fresh turn (never an error, never held).
+    frames = await _frames("hello again", sid, request_metadata={"hitl_resume": True})
+    assert any(kind == "done" for kind, _ in frames)
+    assert any(isinstance(m, HumanMessage) and "hello again" in str(m.content) for m in await _history(sid))
+
+
+# ── restart with a pending form can't strand the flow ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_restart_with_pending_form_still_resumes(monkeypatch):
+    sid = "hold-5"
+    _install_graph(monkeypatch, [_form_call(), AIMessage(content="Deployed.")])
+
+    await _frames("deploy the service", sid)
+    await _frames("note before the restart", sid)
+
+    # Simulated restart: the in-memory steering queue is gone; the pending-form
+    # state lives in the DURABLE checkpoint (re-read on every turn), so the hold
+    # cannot latch shut — the form still resumes and the thread completes.
+    steering._QUEUES.clear()
+    frames = await _frames('{"env": "prod"}', sid, request_metadata={"hitl_resume": True})
+    assert any(kind == "done" for kind, _ in frames)
+    assert await chat_mod._pending_interrupt_value(_cfg(sid)) is None
+
+
+# ── the non-streaming path (/api/chat desktop fallback) mirrors the contract ──
+
+
+@pytest.mark.asyncio
+async def test_nonstreaming_chat_holds_and_resumes(monkeypatch):
+    sid = "hold-6"
+    _install_graph(monkeypatch, [_form_call(), AIMessage(content="Deployed to prod.")])
+
+    out = await chat_mod.chat("deploy the service", sid)
+    assert "Input needed" in out[0]["content"]  # parked on the form
+
+    out = await chat_mod.chat("typed while form open", sid)
+    assert "queued" in out[0]["content"]  # held, with an honest ack
+    assert steering.pending(sid) == 1
+    assert await chat_mod._pending_interrupt_value(_cfg(sid)) is not None  # form untouched
+
+    out = await chat_mod.chat('{"env": "prod"}', sid, hitl_resume=True)
+    assert out[0]["content"] == "Deployed to prod."
+    assert steering.pending(sid) == 0
+    history = await _history(sid)
+    tool_idx = next(i for i, m in enumerate(history) if isinstance(m, ToolMessage) and "prod" in str(m.content))
+    fold_idx = next(
+        i for i, m in enumerate(history) if isinstance(m, HumanMessage) and "typed while form open" in str(m.content)
+    )
+    assert tool_idx < fold_idx


### PR DESCRIPTION
## Problem (#1560)

While a HITL form (`request_user_input` / `ask_human` / `run_command` approval) is pending, operator messages typed in the meantime were delivered to the agent **before** the form response — a confusing interleaved state.

## Where the interleaving actually happens (and why the hold is NOT at the fold seam)

The task pointed at the steering **fold seam** (`SteeringMiddleware.before_model`). Code reading + an empirical probe on our exact stack (langgraph 1.2.4 / langchain 1.3.6 `create_agent`) show the fold seam is the wrong place, for a structural reason:

- While the graph is parked at an `interrupt()`, it makes **no model calls** — so `before_model` never runs and nothing can fold while a form is pending. The queue was never the leak.
- The interleave happens at **turn entry**: the console never sends `taskId`, so a message sent while a form is open arrives as a *fresh* A2A message, and LangGraph treats fresh input on an interrupted thread as **"abandon the interrupt and continue"** — the un-answered `request_user_input` tool_call is left dangling (later stripped by `ToolCallRepairMiddleware`), the model sees the new message before (and instead of) the form answer, and the parked task can never resolve. Two console paths triggered it: (1) the composer is idle while a form is open, so Enter ran a fresh turn; (2) `reconcileSteer` re-sent unconsumed mid-turn steers as a fresh turn the moment the stream parked on `input_required`.
- Bonus finding: the console's form **submission** took the same fresh-input path — the "resume" comment in `resumeHitl` described intent, not reality. The tool never actually returned its answer; the model only saw the form values as a raw human message next to an "[abandoned tool call]" repair.

## Design: the hold lives at turn entry; release rides the existing fold seam

**Server (`server/chat.py::_hold_if_hitl_pending`, called under the per-thread lock by both the streaming and non-streaming drivers):** for a fresh, non-autonomous message while a HITL interrupt is pending on the thread —

- **Unmarked message → HELD**: parked in the existing per-session steering queue; the caller re-parks on the *same* form payload (`input_required` re-emission on the streaming path; an honest "queued — the agent gets it right after you answer" ack on `/api/chat`). Nothing is delivered to the model; the graph is untouched.
- **The operator's answer → real resume**: the console now stamps `hitl_resume` on form submit, approval, and dismiss (A2A message metadata + the desktop `/api/chat` fallback body), which converts the turn to `Command(resume=…)`. This also fixes the broken resume contract — `request_user_input` / the approval gate actually *return* now, matching remote A2A callers that resume by `taskId` (that path is unchanged).
- **Release**: held messages fold in via the untouched `SteeringMiddleware` at the *first model call after the resume* — i.e. immediately **after** the form response (ToolMessage), in arrival order. No new fold logic was needed; the ordering falls out of the existing seam once entry stops clobbering the interrupt.

**Console (`ChatSurface.tsx` / `api.ts`):** sends while a form is open queue as steers (same pending-bubble + ✕ affordances as mid-turn steering; attachments stay in the tray); turn-end reconcile keeps unconsumed steers queued while a form is pending instead of re-sending them as a fresh turn.

## Edge cases

- **(a) Cancellation releases held messages** — dismissing the form is also a marked resume (the tool returns the dismissal sentinel), so held messages fold right after it; nothing is dropped, nothing deadlocks. Tested.
- **(b) Restart with a pending form** — the pending-form state is re-read from the **durable checkpoint** on every turn (no in-memory "held" flag to desync), so the hold can't latch shut; the form still resumes after a restart. Held messages share the in-memory steering queue's existing restart semantics (console reconcile re-sends). Tested.
- **(c) No pending form ⇒ unchanged** — the guard returns `None` and every path is byte-identical to before (the whole existing suite + a dedicated test). A stray `hitl_resume` with no pending interrupt degrades to a normal fresh turn.
- **Autonomous turns** (scheduler/inbox/webhook/background) stay exempt — they must never park, so their pre-existing clobber semantics on a parked operator thread are unchanged (a held autonomous turn would strand its own task forever).
- **Guard runs inside the per-thread lock**, so it can't race a turn that's about to park or a concurrent submit — both interleavings resolve correctly.
- Known minor: image parts on a *server-held* message don't ride the steering queue (text does); the console path defers attachments in the tray instead, matching mid-turn steering today.

## Tests (`tests/test_hitl_hold.py`, real `create_agent` graph + real `request_user_input` tool)

- `test_message_held_while_form_pending` — no model call, nothing in history, interrupt still answerable, queue holds the message.
- `test_held_messages_fold_in_order_after_submit` — ToolMessage(form answer) < folded messages (arrival order) < final answer.
- `test_held_messages_released_on_dismiss` — dismissal releases held messages after the dismissal ToolMessage; pause fully resolved.
- `test_no_pending_form_leaves_turns_untouched`, `test_restart_with_pending_form_still_resumes`, `test_nonstreaming_chat_holds_and_resumes` (the `/api/chat` fallback mirror).

Gates: `ruff` ✓ · `lint-imports` (3 kept / 0 broken) ✓ · `pytest` 2801 passed ✓ · vitest 291 passed ✓ · playwright 183 passed ✓ (one pre-existing `nesting.spec.ts` flake reproduces on pristine origin/main under `--repeat-each`; unrelated).

Closes #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)