### PR TITLE
chore(deps): bump @protolabsai/ui 0.53.1 + retire the redundant markdown overrides

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.53.0",
+    "@protolabsai/ui": "^0.53.1",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -845,118 +845,31 @@ select:disabled {
    `.markdown` rules + the streamdown Tailwind scan are gone (protoContent#297/#298). The
    `.markdown` class still rides the same element as an e2e/selector alias. */
 
-/* ── Container-responsive markdown tables ─────────────────────────────────────
-   The DS (@protolabsai/ui 0.52 `.pl-markdown`) styles GFM tables with a FIXED 0.85em /
-   5px·10px and horizontal-scroll-on-overflow. That reads fine in the wide doc viewer but
-   is cramped in a narrow chat column, where a multi-column table just scrolls. Make the
-   table MOBILE-FIRST and respond to its CONTAINER (the markdown column width) instead of
-   the viewport — so the SAME table is compact in a narrow chat panel and roomy in the doc
-   viewer, automatically, wherever markdown renders (chat, reports, memory, doc viewer).
+/* ── Markdown chrome: console-side gaps the DS can't cover ─────────────────────
+   @protolabsai/ui 0.53.1 folded in the responsive tables + the code-block/table vertical
+   stack (protoContent#382), so those overrides are gone. What remains here patches
+   CONSOLE-specific behaviour the DS package can't see. */
 
-   Console-side override (the DS still owns the base rules; the `.markdown` alias rides the
-   same element as `.pl-markdown`, and this file loads after the DS styles so it wins by
-   cascade). Fold back into @protolabsai/ui markdown.css when the DS repo is next synced —
-   see the [[ds-contribute-back-loop]]. */
-
-/* Establish an inline-size query context on the table wrapper so the cells query the
-   COLUMN width, not the viewport. Also force the vertical stack: streamdown emits the
-   wrapper as `flex flex-col` (a copy-action row above the table), but the console build only
-   generates `flex`, not `flex-col` — so it falls back to flex-ROW, putting the copy cluster
-   BESIDE a crushed table (cell text wraps one char per line in a narrow panel). flex-direction:
-   column restores the stack; min-width:0 lets the table scroller shrink so a wide table scrolls
-   inside its own overflow-x:auto instead of pinning the panel. (Same streamdown flex-col
-   fallback as code blocks.) */
-.pl-markdown.markdown [data-streamdown="table-wrapper"] {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  max-width: 100%;
-  container-type: inline-size;
-  container-name: pl-mdtable;
-  /* The DS clips the wrapper (overflow:hidden) for rounded corners, but the inner table
-     scroller is inset by the p-2 padding + has its own radius, so the clip isn't needed for
-     that — and it was eating the copy dropdown (which opens below the top-right button). Let
-     it escape. The table's own horizontal scroll lives on the inner overflow-x:auto child. */
-  overflow: visible;
-}
-/* The table's own scroll container (streamdown's overflow-x:auto child) must be able to shrink
-   below the table's intrinsic width for that scroll to engage. */
-.pl-markdown.markdown [data-streamdown="table-wrapper"] > * {
-  min-width: 0;
-  max-width: 100%;
-}
-
-/* Base = narrow column (mobile-first): compact type + padding. The DS keeps overflow-x:auto
-   on the inner wrapper, so a genuinely wide table still scrolls instead of clipping. */
-.pl-markdown.markdown [data-streamdown="table"] {
-  font-size: 0.8em;
-}
-.pl-markdown.markdown [data-streamdown="table-header-cell"],
-.pl-markdown.markdown [data-streamdown="table-cell"] {
-  padding: 4px 8px;
-  line-height: 1.35;
-}
-
-/* Roomier as the column widens (a wider chat panel, or the doc viewer). */
-@container pl-mdtable (min-width: 30rem) {
-  .pl-markdown.markdown [data-streamdown="table"] {
-    font-size: 0.85em;
-  }
-  .pl-markdown.markdown [data-streamdown="table-header-cell"],
-  .pl-markdown.markdown [data-streamdown="table-cell"] {
-    padding: 5px 10px;
-  }
-}
-@container pl-mdtable (min-width: 48rem) {
-  .pl-markdown.markdown [data-streamdown="table-header-cell"],
-  .pl-markdown.markdown [data-streamdown="table-cell"] {
-    padding: 7px 12px;
-  }
-}
-
-/* ── Code block layout (streamdown flex-col fallback fix) ──────────────────────
-   streamdown lays the code block out as `flex flex-col` (a language HEADER stacked on top
-   of the code body). But the console build only generates the `flex` utility, NOT `flex-col`
-   — so the block falls back to flex-ROW: the language label renders as a cramped LEFT column
-   beside the code, and the row grows past the message width. Force the intended vertical
-   stack and let the body own its horizontal scroll, so the header sits on TOP and a long line
-   scrolls INSIDE the block instead of stretching the panel. Applies wherever markdown renders
-   (chat, reports, memory, doc viewer). DS-owned — the `[data-streamdown]` selectors should set
-   this; fold back into @protolabsai/ui markdown.css on the next DS sync (see the DS issue). */
-.pl-markdown [data-streamdown="code-block"] {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  max-width: 100%;
-}
-.pl-markdown [data-streamdown="code-block-body"] {
-  min-width: 0; /* shrink so overflow-x:auto scrolls the code instead of widening the block */
-  max-width: 100%;
-}
-
-/* ── GFM task-list items ───────────────────────────────────────────────────────
-   Two bugs: the disc marker shows alongside the checkbox, and — the real one — the console's
-   global `input,textarea,select { width: 100% }` blew the checkbox to the full row width,
-   shoving the label onto the next line. Drop the marker and pin the checkbox back to its
-   intrinsic size so the checkbox + label sit inline. Scoped to .task-list-item, so plain/
-   ordered items (which render fine) are untouched. */
+/* GFM task-list checkbox: the console's global `input,textarea,select { width: 100% }` (below)
+   blows the markdown checkbox to the full row width, shoving the label onto the next line. The
+   DS can't fix that (it has no such global rule). Pin it back to intrinsic size, and drop the
+   disc marker the DS still leaves on the item (it has a checkbox, not a bullet). */
 .pl-markdown [data-streamdown="list-item"].task-list-item {
   list-style: none;
 }
 .pl-markdown [data-streamdown="list-item"].task-list-item input[type="checkbox"] {
   width: auto;
-  margin: 0 0.4em 0 0;
-  vertical-align: middle;
-}
-.pl-markdown [data-streamdown="list-item"].task-list-item > p {
-  display: inline; /* if a label happens to be wrapped in a <p> (multi-node items) */
-  margin: 0;
 }
 
-/* ── Table "copy as" dropdown ──────────────────────────────────────────────────
-   streamdown's table copy button opens a Markdown/CSV/TSV menu styled with inert Tailwind
-   (min-w-[120px], px-3, py-2, w-full), so the menu collapses to ~22px and the labels wrap
-   one character per line (unreadable). Give it a readable surface + real menu items. */
+/* Table "copy as" dropdown (Markdown/CSV/TSV): streamdown styles the menu with inert Tailwind
+   (min-w-[120px], px-3, w-full) and an inline left offset (its right-0/top-full are inert), so
+   it collapses to ~22px and drifts off the wrapper's right edge. Give it a readable surface,
+   anchor it under the button, and let it escape the DS's overflow:hidden (which clips it below a
+   short table). The table's own horizontal scroll lives on the inner overflow-x:auto child, so
+   opening the wrapper up doesn't leak a wide table. */
+.pl-markdown [data-streamdown="table-wrapper"] {
+  overflow: visible;
+}
 .pl-markdown [data-streamdown="table-wrapper"] .relative > div {
   min-width: 150px;
   white-space: nowrap;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.53.0",
+        "@protolabsai/ui": "^0.53.1",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -70,9 +70,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.53.0.tgz",
-      "integrity": "sha512-ZxzXaITxvGCX3UHgQBwz6X4y4a3u0Vzwi/uv258v8afLVus1l9dAH2V7zYWf13IwjkILF0SxJHRnZbosyFks9w==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.53.1.tgz",
+      "integrity": "sha512-umGTBXinXFZGanESQS8WZKBBA1JBCSaD7a3/YS6YANK2q4f4P3i3jh1cZ1Bn6axlv0ZwZLv5iMwtO4+0WIo9FQ==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Follows up the markdown-chrome fixes (#1618) now that the DS shipped them.

## What

`@protolabsai/ui` **0.53.1** folded the markdown-chrome fixes into the DS (protoContent#382, closed): the code-block + table **vertical stack** (`flex-direction: column`, owned in the DS so it no longer depends on the consumer generating streamdown's `flex-col`) and the **container-responsive tables**. So the console overrides for those retire — **−87 lines** in `theme.css`.

Bump done via a surgical `package-lock.json` edit + `npm ci` (a plain `npm install` won't upgrade an already-resolved DS — the recurring gotcha).

## What stays (three console-specific gaps the DS package can't see)

- **Task-list checkbox** `width: auto` + `list-style: none` — the console's global `input,textarea,select { width: 100% }` blows the markdown checkbox to full width (the DS has no such rule), and the DS still leaves the disc marker on a task item.
- **Table copy-format dropdown** (Markdown/CSV/TSV) — streamdown's inert Tailwind collapses the menu and an inline offset drifts it off-screen; needs the readable surface, an explicit anchor, and wrapper `overflow: visible` to escape the DS's `overflow: hidden` clip.
- **`.pl-convo-wrap` / `.pl-convo-scroll` / `.pl-message` `min-width: 0` chain** (chat.css, unchanged) — the DS `ai.css` still only zeroes `.pl-message__body`, so a wide code line would re-floor the resizable panel.

## Verified (headless, against the running 0.53.1 build)

- Code blocks: language header on top, long line scrolls **inside** the body (470px: block 434px contained, body scroll 1297), panel narrows to mobile with no page overflow — all from the DS + the kept min-width chain.
- Tables: full-width via the DS's absolute-cluster model + container-query responsive; copy menu 150px, on-screen, all three formats.
- Task lists: checkbox intrinsic size, no disc bullet.

`tsc --noEmit` clean · 299 unit tests pass · production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console Markdown rendering for task lists and tables.
  * Task-list items now display more cleanly, and table action menus can open without being clipped.
  * Streamlined Markdown styling to better match console behavior across content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->