### PR TITLE
fix(release): bump release-tools pin to v2.4.0 (out-file input)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
       - name: Generate + post release notes
         id: relnotes
         continue-on-error: true
-        uses: protoLabsAI/release-tools@b7c3531dd67accb57ca09242f47d8c0eb1ace8eb # v1.1.0
+        uses: protoLabsAI/release-tools@d6bfc09ce7d17da3f196f3b54afde5830b8a6398 # v2.4.0 — first version with the out-file input (#1516/#1615)
         with:
           version: ${{ steps.version.outputs.tag }}
           previous-version: ${{ steps.version.outputs.prev_tag }}


### PR DESCRIPTION
v0.81.0's release run warned `Unexpected input(s) 'out-file'` — release.yml passes `out-file` (#1615) but the action pin was still v1.1.0, which predates the input, so `release-notes.md` silently never materialized and the guarded asset-upload step skipped. This bumps the pin to v2.4.0 (`d6bfc09`), the input schema that matches what we pass. The CLI itself is fetched `@latest` inside the composite, so the stale input allow-list was the only broken layer.

v0.81.0's asset was backfilled manually with the same CLI (identical generation path, no Discord re-post).

🤖 Generated with [Claude Code](https://claude.com/claude-code)