### PR TITLE
fix(settings): QuickSetting dialogs — full-width helper text + capped height

### DIFF
--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -9,6 +9,15 @@
 }
 /* QuickSetting dialog (ADR 0048) — contextual settings shortcut. Reuses the
    .setting-row chrome; the dialog just stacks the rows with breathing room. */
+
+/* Cap the dialog well short of the viewport (the DS default max-height is ~full height, so a
+   handful of fields make it tower over the surface it popped from). The DS body already scrolls
+   (overflow-y:auto), so overflow just scrolls inside the cap. Two-class selector so it beats the
+   DS `.pl-dialog` max-height regardless of stylesheet load order (both classes ride the same
+   element). */
+.pl-dialog.quick-setting-dialog {
+  max-height: min(72vh, 620px);
+}
 .quick-setting-body {
   display: flex;
   flex-direction: column;
@@ -23,9 +32,18 @@
   white-space: nowrap;
 }
 .quick-setting-body .setting-row {
+  /* The base .setting-row is `display: grid` with a 220–320px control column — right for a text
+     input on the wide settings page, but in the narrow dialog it starves the meta column, so a
+     long field description wraps into a tall one-word-per-line sliver. This override always MEANT
+     to stack the row (per the comment above), but `flex-direction: column` is inert on a grid, so
+     the grid + its wide control column stayed in effect. Switch to a real flex column: label +
+     FULL-WIDTH description, then the control below — shorter overall, and works for every control
+     type (toggle / input / select). */
+  display: flex;
   flex-direction: column;
   align-items: stretch;
   gap: 6px;
+  padding: 16px 4px;
 }
 
 /* ── Settings shell: DS SideNav rail + content ───────────────────────────────


### PR DESCRIPTION
> Draft — console UX. Verified headless (screenshots below), but worth a click-through.

Fixes the two things reported in the "Shell & filesystem tools" QuickSetting (Settings ▸ Tools):

## 1. Helper text was crammed into a narrow sliver
The base `.setting-row` is a grid reserving **220–320px for the control column** — right for a text input on the wide settings page, but in the **460px dialog** it starves the meta column, so a long field description wrapped one-word-per-line and towered. The dialog override *meant* to stack (its comment says so), but `flex-direction: column` is **inert on a `display: grid`** element, so the grid stayed. Made it a real flex column → **label + full-width description, then the control**. Descriptions go from ~15 lines to ~3.

## 2. The dialog stretched to nearly full viewport height
The DS `.pl-dialog` max-height is ~`100vh`, so a handful of fields made the dialog tower over the settings surface it popped from. **Capped at `min(72vh, 620px)`** — the DS body already scrolls (`overflow-y: auto`), so overflow scrolls *inside* the cap with the footer pinned. Used a two-class selector (`.pl-dialog.quick-setting-dialog`) to beat the DS rule regardless of stylesheet load order, scoped to QuickSetting so the main settings overlay is untouched.

## Verified (headless, Settings ▸ Tools ▸ fs dialog)
- Description width **210px → 450px**; each description now ~3 lines.
- Dialog height **913px → 618px**, body scrolls, footer stays fixed.
- Console build clean.

CSS-only, scoped to `.quick-setting-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)