### PR TITLE
feat(tools): per-row on/off toggles in the Tools panel (denylist editor chip removed)

### DIFF
--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -135,13 +135,18 @@ function handleApiGet(pathname, fleet = FLEET) {
     case "/api/subagents":
       return { subagents: SUBAGENTS };
     case "/api/tools":
+      // run_command ships toggled OFF (still listed — disabled tools stay in the
+      // catalog); `disabled` is the RAW denylist and carries a stale name with no
+      // live tool (ghost_tool) so specs can assert a row toggle preserves it.
       return {
         tools: [
-          { name: "web_search", description: "Search the web.", source: "core", category: "General" },
-          { name: "memory_recall", description: "Search long-term memory.", source: "core", category: "Memory" },
-          { name: "echo__ping", description: "Echo ping.", source: "mcp", category: "echo" },
+          { name: "web_search", description: "Search the web.", source: "core", category: "General", enabled: true },
+          { name: "memory_recall", description: "Search long-term memory.", source: "core", category: "Memory", enabled: true },
+          { name: "run_command", description: "Run a shell command.", source: "core", category: "Filesystem", enabled: false },
+          { name: "echo__ping", description: "Echo ping.", source: "mcp", category: "echo", enabled: true },
         ],
         count: 3,
+        disabled: ["run_command", "ghost_tool"],
       };
     case "/api/chat/commands":
       return { commands: SLASH_COMMANDS };

--- a/apps/web/e2e/nesting.spec.ts
+++ b/apps/web/e2e/nesting.spec.ts
@@ -19,6 +19,12 @@ test("subagent child tools collapse inside the task card with a count", async ({
   // The child is NOT rendered until you expand — no always-on rail (that's the bounce fix).
   await expect(page.locator(".pl-toolcard__children")).toHaveCount(0);
 
+  // Settle the turn BEFORE expanding: on settle the live-parts view regroups into the
+  // history card (#1272-76), which REMOUNTS the toolcard — an expansion clicked
+  // mid-stream is silently dropped (this was a load-sensitive flake under a parallel
+  // suite, where the click landed inside the live window).
+  await expect(page.getByText("Delegated research to a subagent and summarized.")).toBeVisible();
+
   // Expand → the subagent's web_search appears nested in the body.
   await card.locator(".pl-toolcard__head").click();
   await expect(card.locator(".pl-toolcard__children .pl-toolcard__name")).toHaveText("web_search");

--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 // Contextual quick-settings + the topbar Settings overlay (ADR 0048): a gear icon
 // opens a dialog editing fields via the same /api/settings path, and the central
@@ -91,7 +92,11 @@ test("Tools panel: the Shell & filesystem chip disables run_command via /api/set
   await expect(page.locator(".pl-toast").getByText("Saved")).toBeVisible();
 });
 
-test("Tools panel: the Disabled tools chip edits the tools.disabled denylist", async ({ page }) => {
+// The old "Disabled tools" chip (a raw tools.disabled textarea) is gone — every row
+// in the list carries an on/off switch writing the same denylist. These specs pin the
+// row-toggle contract: the POST edits the RAW denylist (preserving entries it didn't
+// touch, incl. stale names with no live tool) and off rows stay listed.
+async function openToolsTab(page: Page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByTestId("header-menu").click();
   await page.getByTestId("app-drawer").getByRole("button", { name: "Settings", exact: true }).click();
@@ -99,17 +104,47 @@ test("Tools panel: the Disabled tools chip edits the tools.disabled denylist", a
     .locator(".settings-overlay .pl-sidenav")
     .getByRole("tab", { name: "Tools", exact: true })
     .click();
+}
 
-  await page.getByRole("button", { name: "Disabled tools" }).click();
-  const dialog = page.getByRole("dialog", { name: "Disabled tools" });
-  await expect(dialog).toBeVisible();
+test("Tools panel: the Disabled tools chip is gone (row switches replaced it)", async ({ page }) => {
+  await openToolsTab(page);
+  await expect(page.getByRole("button", { name: "Shell & filesystem tools" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Disabled tools" })).toHaveCount(0);
+});
+
+test("Tools panel: toggling a tool row off appends it to tools.disabled", async ({ page }) => {
+  await openToolsTab(page);
+
+  // web_search sits in General — the first group, expanded by default.
+  const row = page.locator(".tools-row", { has: page.getByText("web_search", { exact: true }) });
+  await expect(row).toBeVisible();
 
   const saved = page.waitForRequest(
     (r) => r.url().endsWith("/api/settings") && ["POST", "PUT"].includes(r.method()),
   );
-  // string_list renders as the one-per-line editor.
-  await dialog.locator('[data-key="tools.disabled"] textarea').fill("run_command");
-  await dialog.getByRole("button", { name: "Save" }).click();
+  await row.locator(".pl-switch").click();
   const req = await saved;
-  expect(req.postDataJSON().updates["tools.disabled"]).toEqual(["run_command"]);
+  const body = req.postDataJSON();
+  // Appends the toggled name and PRESERVES the rest of the raw denylist — including
+  // ghost_tool, a stale entry with no live tool row to recompute it from.
+  expect(body.updates["tools.disabled"]).toEqual(["run_command", "ghost_tool", "web_search"]);
+  expect(body.layer ?? "agent").toBe("agent"); // per-agent leaf, not box-wide
+});
+
+test("Tools panel: an off tool stays listed and toggles back on", async ({ page }) => {
+  await openToolsTab(page);
+
+  // run_command ships disabled in the fixture — still listed (dimmed) under Filesystem.
+  await page.locator(".pl-accordion__trigger", { hasText: "Filesystem" }).click();
+  const row = page.locator(".tools-row", { has: page.getByText("run_command", { exact: true }) });
+  await expect(row).toBeVisible();
+  await expect(row).toHaveClass(/tools-row--off/);
+
+  const saved = page.waitForRequest(
+    (r) => r.url().endsWith("/api/settings") && ["POST", "PUT"].includes(r.method()),
+  );
+  await row.locator(".pl-switch").click();
+  const req = await saved;
+  // Re-enabling removes ONLY run_command; the stale ghost_tool entry survives.
+  expect(req.postDataJSON().updates["tools.disabled"]).toEqual(["ghost_tool"]);
 });

--- a/apps/web/src/app/ToolsPanel.tsx
+++ b/apps/web/src/app/ToolsPanel.tsx
@@ -1,14 +1,17 @@
 import "./tools.css";
 
-import { Input } from "@protolabsai/ui/forms";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { Input, Switch } from "@protolabsai/ui/forms";
+import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
-import { Ban, TerminalSquare } from "lucide-react";
+import { TerminalSquare } from "lucide-react";
 
 import { Accordion, AccordionItem, PanelHeader } from "@protolabsai/ui/navigation";
+import { useToast } from "@protolabsai/ui/overlays";
 import { Badge } from "@protolabsai/ui/primitives";
-import { toolsQuery } from "../lib/queries";
+import { api } from "../lib/api";
+import { errMsg } from "../lib/format";
+import { queryKeys, toolsQuery } from "../lib/queries";
 import { QuickSetting } from "../settings/QuickSetting";
 import { StagePanel } from "./ErrorBoundary";
 
@@ -17,6 +20,8 @@ import { StagePanel } from "./ErrorBoundary";
 // (backend stamps the category); MCP tools by server. Order: core subsystems first
 // (CORE_ORDER), then plugin groups (alpha), then MCP — so the baseline reads top-down
 // and everything an extension adds sits below it. Searchable; a search expands matches.
+// Every row carries an on/off switch editing the tools.disabled denylist — a toggled-off
+// tool stays listed (the backend catalogs dropped tools too) so it can be re-enabled.
 
 // Core subsystem order. Plugin/MCP group names are dynamic, so they're NOT listed here —
 // they sort after core by source rank (below).
@@ -30,6 +35,51 @@ const SOURCE_RANK: Record<string, number> = { core: 0, plugin: 1, mcp: 2 };
 function ToolsBody() {
   const { data } = useSuspenseQuery(toolsQuery());
   const [q, setQ] = useState("");
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  // Per-row on/off = editing the tools.disabled denylist — the same config the YAML /
+  // central-settings route writes, enforced over the FULL assembled set (#1612), so a
+  // switch here and `tools.disabled: [run_command]` are literally the same thing.
+  const toggle = useMutation({
+    mutationFn: ({ next }: { name: string; enabled: boolean; next: string[] }) =>
+      api.saveSettings({ "tools.disabled": next }, "agent"),
+    // Optimistic flip so the switch tracks the click; the settled refetch below is
+    // authoritative (the save hot-rebuilds the graph and its bound/disabled catalog).
+    onMutate: async ({ name, enabled, next }) => {
+      const key = toolsQuery().queryKey;
+      await queryClient.cancelQueries({ queryKey: key });
+      const prev = queryClient.getQueryData(key);
+      queryClient.setQueryData(key, (old: typeof data | undefined) =>
+        old && {
+          ...old,
+          tools: old.tools.map((t) => (t.name === name ? { ...t, enabled } : t)),
+          count: old.count + (enabled ? 1 : -1),
+          disabled: next,
+        });
+      return { key, prev };
+    },
+    onSuccess: (r) => {
+      if (!r.ok) toast({ tone: "error", title: "Toggle failed", message: r.messages.join(" · ") });
+    },
+    onError: (e) => toast({ tone: "error", title: "Toggle failed", message: errMsg(e) }),
+    onSettled: (_r, _e, _vars, ctx) => {
+      void queryClient.invalidateQueries({ queryKey: ctx?.key ?? queryKeys.tools });
+      // tools.disabled's current value also renders in the settings schema (central home).
+      void queryClient.invalidateQueries({ queryKey: queryKeys.settings });
+    },
+  });
+
+  const onToggle = (name: string, enabled: boolean) => {
+    // Edit the RAW denylist the backend echoes (freshest cache copy, so rapid toggles
+    // compound instead of clobbering) — never recompute it from the visible rows, or a
+    // stale entry (a disabled tool from a since-removed plugin) would be silently lost.
+    const cur = queryClient.getQueryData(toolsQuery().queryKey)?.disabled ?? data.disabled;
+    const next = cur.filter((n) => n !== name);
+    if (!enabled) next.push(name);
+    toggle.mutate({ name, enabled, next });
+  };
+
   const query = q.trim().toLowerCase();
   const tools = query
     ? data.tools.filter((t) =>
@@ -57,15 +107,20 @@ function ToolsBody() {
     return a.localeCompare(b);
   });
 
+  const off = data.tools.length - data.count;
   return (
     <>
-      <PanelHeader title="Tools" kicker={`${data.count} wired tool${data.count === 1 ? "" : "s"} · ${groups.size} group${groups.size === 1 ? "" : "s"}`} />
+      <PanelHeader
+        title="Tools"
+        kicker={`${data.count} wired tool${data.count === 1 ? "" : "s"}${off ? ` · ${off} off` : ""} · ${groups.size} group${groups.size === 1 ? "" : "s"}`}
+      />
       <div className="stage-body">
         <div className="tools-config-row">
-          {/* Contextual settings chips (ADR 0048 §2.2) — same /api/settings save path as
-              the central home. Shell & filesystem = the per-agent run_command controls
-              (incl. the full kill switch, filesystem.allow_run); Disabled tools = the
-              tools.disabled denylist over the whole assembled set. Saves hot-rebuild. */}
+          {/* Contextual settings chip (ADR 0048 §2.2) — same /api/settings save path as
+              the central home. This is the run_command EXECUTION policy (approval,
+              /bypass) plus the coarse kill switches; per-tool wiring is the row
+              switches below (the old "Disabled tools" denylist editor is gone — a row
+              toggle writes the same tools.disabled). Saves hot-rebuild. */}
           <QuickSetting
             keys={[
               "filesystem.enabled",
@@ -76,12 +131,6 @@ function ToolsBody() {
             title="Shell & filesystem tools"
             label="Shell & filesystem tools"
             icon={<TerminalSquare size={16} />}
-          />
-          <QuickSetting
-            keys={["tools.disabled"]}
-            title="Disabled tools"
-            label="Disabled tools"
-            icon={<Ban size={16} />}
           />
         </div>
         <Input
@@ -95,6 +144,7 @@ function ToolsBody() {
           <Accordion className="tools-groups">
             {ordered.map((cat, i) => {
               const items = groups.get(cat)!;
+              const offCount = items.filter((t) => !t.enabled).length;
               return (
                 <AccordionItem
                   // Re-key on the query so a search remounts the sections with the
@@ -111,16 +161,22 @@ function ToolsBody() {
                       {groupSource(cat) !== "core" ? (
                         <Badge status="neutral">{groupSource(cat)}</Badge>
                       ) : null}
+                      {offCount ? <Badge status="warning">{offCount} off</Badge> : null}
                     </span>
                   }
                 >
                   <div className="tools-list">
                     {items.map((t) => (
-                      <div className="tools-row" key={t.name}>
+                      <div className={`tools-row${t.enabled ? "" : " tools-row--off"}`} key={t.name}>
                         <div className="tools-row-main">
                           <code className="tools-name">{t.name}</code>
                           {t.description ? <span className="tools-desc">{t.description}</span> : null}
                         </div>
+                        <Switch
+                          checked={t.enabled}
+                          onCheckedChange={(v) => onToggle(t.name, v)}
+                          aria-label={`Toggle ${t.name}`}
+                        />
                       </div>
                     ))}
                   </div>

--- a/apps/web/src/app/ToolsPanel.tsx
+++ b/apps/web/src/app/ToolsPanel.tsx
@@ -59,10 +59,19 @@ function ToolsBody() {
         });
       return { key, prev };
     },
-    onSuccess: (r) => {
-      if (!r.ok) toast({ tone: "error", title: "Toggle failed", message: r.messages.join(" · ") });
+    // On failure, roll the optimistic flip back to the snapshot NOW — the settled
+    // refetch is authoritative but can itself fail (often for the same reason the
+    // save did), which would strand the never-persisted state in the cache; onToggle
+    // computes the next payload from that cache, so a stale flip would compound.
+    onSuccess: (r, _vars, ctx) => {
+      if (r.ok) return;
+      if (ctx?.prev !== undefined) queryClient.setQueryData(ctx.key, ctx.prev);
+      toast({ tone: "error", title: "Toggle failed", message: r.messages.join(" · ") });
     },
-    onError: (e) => toast({ tone: "error", title: "Toggle failed", message: errMsg(e) }),
+    onError: (e, _vars, ctx) => {
+      if (ctx?.prev !== undefined) queryClient.setQueryData(ctx.key, ctx.prev);
+      toast({ tone: "error", title: "Toggle failed", message: errMsg(e) });
+    },
     onSettled: (_r, _e, _vars, ctx) => {
       void queryClient.invalidateQueries({ queryKey: ctx?.key ?? queryKeys.tools });
       // tools.disabled's current value also renders in the settings schema (central home).

--- a/apps/web/src/app/tools.css
+++ b/apps/web/src/app/tools.css
@@ -41,6 +41,16 @@
   color: var(--fg-muted);
   min-width: 0;
 }
+/* The per-row on/off switch must not shrink against a long description. */
+.tools-row .pl-switch {
+  flex-shrink: 0;
+}
+/* Toggled-off rows stay listed (so they can be re-enabled) but read as inert. */
+.tools-row--off .tools-name,
+.tools-row--off .tools-desc {
+  color: var(--fg-muted);
+  opacity: 0.65;
+}
 
 /* Contextual settings chips above the search (mirrors .mcp-browse-row). */
 .tools-config-row {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -993,7 +993,9 @@ export const api = {
   },
 
   tools() {
-    return request<{ tools: ToolInfo[]; count: number }>("/api/tools");
+    // `count` = wired (enabled) tools; `disabled` = the RAW tools.disabled denylist —
+    // the base a row toggle edits, so stale names (no live tool) survive a save.
+    return request<{ tools: ToolInfo[]; count: number; disabled: string[] }>("/api/tools");
   },
 
   runSubagent(body: {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -386,12 +386,15 @@ export type Subagent = {
 };
 
 // A live wired tool (Agent → Tools): its source (core/plugin/mcp) + the subsystem
-// category it's grouped under in the console.
+// category it's grouped under in the console. `enabled: false` = present in the
+// assembled catalog but dropped by the tools.disabled denylist (still listed so the
+// operator can toggle it back on).
 export type ToolInfo = {
   name: string;
   description: string;
   source: "core" | "plugin" | "mcp";
   category?: string;
+  enabled: boolean;
 };
 
 export type ToolCall = {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -215,7 +215,7 @@ tools:
 
 | Key | Default | What |
 |---|---|---|
-| `disabled` | `[]` | Tool names to **drop** from the agent at graph build — covers the **fully assembled** set: core, plugin, MCP, the delegation tools, and the filesystem tools (so `disabled: [run_command]` removes shell access for this agent). Live-reloadable, editable at **Settings ▸ Capabilities ▸ Tools**. Plugins still ADD tools on top (see [Plugins](/guides/plugins)). ([ADR 0005](../adr/0005-tool-pollution-and-progressive-disclosure.md)) |
+| `disabled` | `[]` | Tool names to **drop** from the agent at graph build — covers the **fully assembled** set: core, plugin, MCP, the delegation tools, and the filesystem tools (so `disabled: [run_command]` removes shell access for this agent). Live-reloadable — in the console, **every row at Settings ▸ Capabilities ▸ Tools carries an on/off switch** that edits this list (a toggled-off tool stays listed, dimmed, so it can be re-enabled). Plugins still ADD tools on top (see [Plugins](/guides/plugins)). ([ADR 0005](../adr/0005-tool-pollution-and-progressive-disclosure.md)) |
 | `deferred.enabled` | `false` | Withhold most tool schemas; expose them via `search_tools`. |
 | `deferred.keep` | `[]` | Tool names always shown. Empty → built-in base (keyless core + `task`/`task_batch`/`run_workflow`/`save_workflow` + `search_tools`). `search_tools` is always kept regardless. |
 
@@ -259,7 +259,7 @@ filesystem:
 | `bypass_allowed` | `true` | Permit the per-tab `/bypass` chat toggle to skip the approval gate. `false` = approvals enforced regardless of caller-supplied metadata. |
 | `projects` | `[]` | Managed workspaces: `{name, path, write}`. **Empty falls back to a default `workspace` dir** (so the tools are usable out of the box). **Every path is fenced under a project root** (`..`/symlink escapes refused); `write:false` makes a project read-only; invalid paths are skipped. |
 
-The four toggles are editable per agent in the console at **Settings ▸ Capabilities ▸ Filesystem** (hot-reload — a save rebuilds the graph). `tools.disabled: [run_command]` (above) is an equivalent per-tool route.
+The four toggles are editable per agent in the console via the **Shell & filesystem** chip on **Settings ▸ Capabilities ▸ Tools** (hot-reload — a save rebuilds the graph). `tools.disabled: [run_command]` (above) is an equivalent per-tool route — in the console, that's the `run_command` row switch in the same panel's Filesystem group.
 
 **Security:** the project roots are the **hard fence** — every tool resolves paths under a root and refuses escapes; `write_file`/`edit_file` need `write:true`; the agent's own repo is not a project unless you add it. All mutations are audited. See ADR 0007 §4.
 

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -823,6 +823,12 @@ def create_agent_graph(
 
     set_disabled_tools(getattr(config, "tools_disabled", []))
 
+    # Everything the denylist drops, across every assembly seam below. Stamped on the
+    # graph (like bound_tools) so the operator Tools tab can render disabled tools as
+    # toggled-off rows — without this a disabled tool vanishes from the catalog and
+    # can never be re-enabled from the console.
+    disabled_tools: list = []
+
     all_tools = get_all_tools(
         knowledge_store,
         scheduler=scheduler,
@@ -839,6 +845,7 @@ def create_agent_graph(
         graph_config=config,
         # Lets knowledge_ingest detach a slow URL/media ingest as a background job (ADR 0050).
         background_mgr=background_mgr,
+        dropped=disabled_tools,
     )
 
     if extra_tools:
@@ -847,7 +854,7 @@ def create_agent_graph(
     # get_all_tools already filtered the core set, but extra_tools bypassed it. Applied
     # BEFORE the subagent tool_map snapshot below so a disabled tool can't ride into a
     # subagent via an allowlist either.
-    all_tools = drop_disabled_tools(all_tools)
+    all_tools = drop_disabled_tools(all_tools, disabled_tools)
 
     if include_subagents:
         all_tools.extend(
@@ -887,7 +894,7 @@ def create_agent_graph(
     # tools). Sits before the deferred build so search_tools never advertises a dropped
     # name. This is what makes ``tools.disabled: [run_command]`` actually work (#1527-era
     # gap: the filter used to live only inside get_all_tools, which fs tools bypass).
-    all_tools = drop_disabled_tools(all_tools)
+    all_tools = drop_disabled_tools(all_tools, disabled_tools)
 
     # Deferred tools (ADR 0005 #3) — opt-in progressive disclosure. The
     # search_tools meta-tool is built over the full set (so it can surface any
@@ -898,6 +905,12 @@ def create_agent_graph(
 
         keep = resolve_deferred_keep(config.tools_deferred_keep)
         all_tools.append(build_search_tools_tool(all_tools, keep))
+        # The meta-tool is denylistable like everything else — without this pass,
+        # ``tools.disabled: [search_tools]`` silently re-binds it (it's appended after
+        # the final filter above), which a Tools-tab row toggle would surface as a
+        # switch that snaps back on. Everything else was already filtered, so only
+        # search_tools can drop here.
+        all_tools = drop_disabled_tools(all_tools, disabled_tools)
 
     middleware = _build_middleware(
         config, knowledge_store, skills_index=skills_index, extra_middleware=extra_middleware
@@ -929,6 +942,9 @@ def create_agent_graph(
     # and drifting from it (set_goal advertised-but-unbound bd-2aa; task /
     # filesystem / execute_code under-reported bd-67j).
     agent.bound_tools = list(all_tools)
+    # The denylist's complement — what ``tools.disabled`` dropped, kept as tool objects
+    # so /api/tools can list them (name/description/category) as toggle-off rows.
+    agent.disabled_tools = list(disabled_tools)
     return agent
 
 

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -182,16 +182,24 @@ def _tool_category(
 
 def _operator_tools_list():
     """Live tool inventory for the Tools tab — name, one-line description, source
-    (core/plugin/mcp), and a subsystem category for grouping.
+    (core/plugin/mcp), a subsystem category for grouping, and ``enabled`` (whether
+    the tool is bound vs dropped by the ``tools.disabled`` denylist).
 
     Reads the tools ACTUALLY BOUND to the compiled graph (``graph.bound_tools``,
     stamped by ``create_agent_graph``) so the Tools tab can't drift from what the
     model can really call — it covers task/task_batch, filesystem, execute_code,
     and the deferred search tool, not just the shared ``get_all_tools`` base
-    (bd-2aa / bd-67j). Falls back to re-deriving the base pre-setup, before the
-    graph exists."""
+    (bd-2aa / bd-67j). Denylisted tools (``graph.disabled_tools``) are listed too,
+    ``enabled: false`` — a toggled-off tool must stay visible or the console could
+    never toggle it back on. ``disabled`` echoes the RAW config denylist (it may
+    hold names with no live tool, e.g. from an uninstalled plugin) so the console
+    can add/remove one name without clobbering the rest. Falls back to re-deriving
+    the base pre-setup, before the graph exists."""
     out: list[dict] = []
     seen: set[str] = set()
+    # The raw denylist, verbatim from config — NOT recomputed from the catalog.
+    cfg = STATE.graph_config
+    denylist = [str(n) for n in (getattr(cfg, "tools_disabled", None) or [])]
     # Source is derived by cross-referencing the plugin/mcp tool name sets;
     # everything else bound to the graph is core.
     plugin_names = {getattr(t, "name", None) for t in (getattr(STATE, "plugin_tools", None) or [])}
@@ -202,7 +210,7 @@ def _operator_tools_list():
     # tools by the server that serves them, mirroring the plugin grouping.
     mcp_servers = [m.get("name") for m in (getattr(STATE, "mcp_meta", None) or []) if m.get("name")]
 
-    def add(tool, source=None):
+    def add(tool, source=None, enabled=True):
         name = getattr(tool, "name", None)
         if not name or name in seen:
             return
@@ -215,36 +223,48 @@ def _operator_tools_list():
                 "description": desc,
                 "source": src,
                 "category": _tool_category(name, src, plugin_owner.get(name), mcp_servers),
+                "enabled": enabled,
             }
         )
+
+    def result():
+        # ``count`` stays the WIRED count (what the model can call) — the kicker's
+        # "N wired tools" contract predates the disabled rows.
+        return {"tools": out, "count": sum(1 for t in out if t["enabled"]), "disabled": denylist}
 
     bound = getattr(STATE.graph, "bound_tools", None)
     if bound is not None:
         for t in bound:
             add(t)
-        return {"tools": out, "count": len(out)}
+        for t in getattr(STATE.graph, "disabled_tools", None) or []:
+            add(t, enabled=False)
+        return result()
 
     # Pre-setup fallback (no compiled graph yet): re-derive the shared base.
-    cfg = STATE.graph_config
+    denied = set(denylist)
     try:
         from tools.lg_tools import get_all_tools
 
+        dropped: list = []
         core = get_all_tools(
             STATE.knowledge_store,
             scheduler=STATE.scheduler,
             inbox_store=STATE.inbox_store,
             tasks_store=STATE.tasks_store,
             goal_enabled=bool(getattr(cfg, "goal_enabled", False)) if cfg else False,
+            dropped=dropped,
         )
         for t in core:
             add(t, "core")
+        for t in dropped:
+            add(t, "core", enabled=False)
     except Exception:  # noqa: BLE001
         log.exception("[tools] core enumeration failed")
     for t in getattr(STATE, "plugin_tools", None) or []:
-        add(t, "plugin")
+        add(t, "plugin", enabled=getattr(t, "name", None) not in denied)
     for t in getattr(STATE, "mcp_tools", None) or []:
-        add(t, "mcp")
-    return {"tools": out, "count": len(out)}
+        add(t, "mcp", enabled=getattr(t, "name", None) not in denied)
+    return result()
 
 
 async def _operator_subagent_run(req: dict):

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -1302,6 +1302,11 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
                 late_tool_factories=new_late_tool_factories,
                 checkpointer=STATE.checkpointer,
                 inbox_store=new_inbox_store,
+                # The tasks store survives reloads like the checkpointer (its path isn't
+                # reloadable config). It was missing here, so ANY settings hot-reload
+                # silently dropped task_create/task_list/task_update/task_close from the
+                # rebuilt graph until the next full restart.
+                tasks_store=STATE.tasks_store,
                 # The background manager (ADR 0050) survives reloads unchanged — its
                 # store path + self-invoke URL/auth don't depend on reloadable config.
                 background_mgr=STATE.background_mgr,

--- a/tests/test_reload_rebuild_deps.py
+++ b/tests/test_reload_rebuild_deps.py
@@ -1,0 +1,90 @@
+"""The hot-reload graph rebuild must thread the SAME runtime deps as boot.
+
+`_reload_langgraph_agent` (drawer saves, /api/settings, /api/config/reload)
+rebuilds the compiled graph from fresh config. Stores that survive reloads
+(checkpointer, tasks store, background manager) must be re-threaded into
+`create_agent_graph` — the tasks store was silently omitted, so ANY settings
+hot-reload dropped task_create/task_list/task_update/task_close from the
+rebuilt graph until the next full restart (found via the Tools-tab row
+toggles, which hot-reload on every flip and made the 4 rows vanish).
+
+The test intercepts `create_agent_graph` inside a real `_reload_langgraph_agent`
+run (heavy builders stubbed), captures its kwargs, and RAISES — the reload's
+own failure path then returns without committing anything to STATE, so the
+process-global state is untouched.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_denylist():
+    """The reload syncs the module-global denylist from the temp config; clear it."""
+    from tools.lg_tools import set_disabled_tools
+
+    yield
+    set_disabled_tools([])
+
+
+def test_reload_threads_surviving_stores_into_the_rebuilt_graph(tmp_path, monkeypatch):
+    import graph.config_io as cio
+    import server.agent_init as ai
+    from runtime.state import STATE
+
+    # A minimal live leaf (scheduler off so the reload doesn't construct one).
+    leaf = tmp_path / "langgraph-config.yaml"
+    leaf.write_text("scheduler:\n  enabled: false\n")
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: leaf)
+    monkeypatch.setattr(cio, "ensure_live_config", lambda: None)
+    monkeypatch.setattr(cio, "is_setup_complete", lambda: True)
+
+    # Stub the heavy builders — this test is about the create_agent_graph WIRING.
+    monkeypatch.setattr(ai, "_build_knowledge_store", lambda cfg: None)
+    monkeypatch.setattr(ai, "_build_mcp", lambda *a, **k: ([], [], []))
+    monkeypatch.setattr(ai, "_apply_plugin_knowledge_backend", lambda cfg, store, plugins: store)
+    monkeypatch.setattr(ai, "_register_plugin_subagents", lambda subagents: None)
+    monkeypatch.setattr(ai, "_apply_config_subagents", lambda cfg: None)
+    monkeypatch.setattr(ai, "_resolve_plugin_middleware", lambda cfg, mw: [])
+    monkeypatch.setattr(ai, "_build_skills_index", lambda cfg, extra_skill_dirs=None: None)
+    monkeypatch.setattr(ai, "_build_inbox_store", lambda cfg: None)
+    monkeypatch.setattr(
+        ai,
+        "_build_plugins",
+        lambda *a, **k: SimpleNamespace(
+            mcp_servers=[], tools=[], tool_plugins={}, skill_dirs=[], meta=[],
+            chat_commands={}, subagents=[], middleware=[], late_tool_factories=[], routers=[],
+        ),
+    )
+
+    # The reload-surviving stores (monkeypatch snapshots + restores the real values).
+    checkpointer, tasks_store, background_mgr = object(), object(), object()
+    monkeypatch.setattr(STATE, "checkpointer", checkpointer, raising=False)
+    monkeypatch.setattr(STATE, "tasks_store", tasks_store, raising=False)
+    monkeypatch.setattr(STATE, "background_mgr", background_mgr, raising=False)
+    monkeypatch.setattr(STATE, "scheduler", None, raising=False)
+    monkeypatch.setattr(STATE, "workflow_registry", None, raising=False)
+    monkeypatch.setattr(STATE, "workflow_run", None, raising=False)
+
+    # Capture the rebuild call, then abort so nothing commits to STATE.
+    import graph.agent as ga
+
+    captured: dict = {}
+
+    def _capture(config, **kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("stop before commit")
+
+    monkeypatch.setattr(ga, "create_agent_graph", _capture)
+
+    ok, msg = ai._reload_langgraph_agent()
+
+    assert ok is False and "rebuild failed" in msg  # our abort — nothing committed
+    assert captured, "create_agent_graph was never reached"
+    assert captured["checkpointer"] is checkpointer
+    assert captured["background_mgr"] is background_mgr
+    # THE regression: the tasks store must ride the rebuild like its siblings.
+    assert captured["tasks_store"] is tasks_store

--- a/tests/test_tools_disabled.py
+++ b/tests/test_tools_disabled.py
@@ -80,6 +80,41 @@ def test_tools_disabled_drops_task_tools(tmp_path):
     assert "task" not in names and "task_batch" not in names
 
 
+# ── the deferred meta-tool seam (appended after the final assembly pass) ─────
+
+
+def test_tools_disabled_drops_search_tools(tmp_path):
+    # search_tools is appended AFTER the final denylist pass (it's built over the
+    # filtered set), so it needs its own pass — otherwise a disabled search_tools
+    # silently re-binds, which the Tools-tab row toggle would surface as a switch
+    # that snaps back on.
+    g = create_agent_graph(
+        _cfg(tmp_path, tools_deferred_enabled=True, tools_disabled=["search_tools"])
+    )
+    assert "search_tools" not in _bound_names(g)
+    assert "search_tools" in {t.name for t in g.disabled_tools}
+
+
+# ── the disabled catalog (Tools-tab rows stay toggleable) ─────────────────────
+
+
+def test_disabled_tools_are_stamped_for_the_catalog(tmp_path):
+    g = create_agent_graph(
+        _cfg(tmp_path, tools_disabled=["run_command", "calculator", "ghost_tool"])
+    )
+    dropped = {t.name for t in g.disabled_tools}
+    # The dropped tool OBJECTS are kept (name/description feed the console row) …
+    assert {"run_command", "calculator"} <= dropped
+    # … a denylisted name with no live tool has nothing to catalog …
+    assert "ghost_tool" not in dropped
+    # … and nothing cataloged as dropped leaks into the bound set.
+    assert not (dropped & _bound_names(g))
+
+
+def test_empty_denylist_stamps_an_empty_catalog(tmp_path):
+    assert create_agent_graph(_cfg(tmp_path)).disabled_tools == []
+
+
 # ── config-driven sync (no reliance on the server boot side effect) ──────────
 
 
@@ -103,3 +138,21 @@ def test_drop_disabled_tools_noop_when_empty():
     set_disabled_tools([])
     tools = get_all_tools(None)
     assert drop_disabled_tools(tools) is tools  # same list — no copy on the hot path
+
+
+def test_drop_disabled_tools_collects_dropped():
+    @tool
+    def alpha() -> str:
+        """A."""
+        return "a"
+
+    @tool
+    def beta() -> str:
+        """B."""
+        return "b"
+
+    set_disabled_tools(["alpha"])
+    dropped: list = []
+    kept = drop_disabled_tools([alpha, beta], dropped)
+    assert [t.name for t in kept] == ["beta"]
+    assert [t.name for t in dropped] == ["alpha"]

--- a/tests/test_tools_inventory_single_source.py
+++ b/tests/test_tools_inventory_single_source.py
@@ -30,14 +30,14 @@ class _ToolFake(GenericFakeChatModel):
         return self
 
 
-def _graph(goal_enabled=True, **over):
+def _graph(goal_enabled=True, extra_tools=None, **over):
     from graph.agent import create_agent_graph
     from graph.config import LangGraphConfig
 
     fake = _ToolFake(messages=iter([AIMessage(content="x")]))
     cfg = LangGraphConfig(goal_enabled=goal_enabled, **over)
     with patch("graph.agent.create_llm", lambda *a, **k: fake):
-        return create_agent_graph(cfg), cfg
+        return create_agent_graph(cfg, extra_tools=extra_tools), cfg
 
 
 def test_tools_tab_exactly_matches_the_bound_graph(monkeypatch):
@@ -91,6 +91,49 @@ def test_denylisted_tools_stay_listed_toggled_off(monkeypatch):
     # The raw denylist survives verbatim; a stale name has no row to render.
     assert res["disabled"] == ["calculator", "ghost_tool"]
     assert "ghost_tool" not in by_name
+
+
+def test_denylisted_plugin_and_mcp_tools_stay_listed(monkeypatch):
+    """The row toggles cover EVERY seam, not just core: a denylisted plugin/MCP tool
+    (they enter as extra_tools) is dropped from the bound set but stays cataloged —
+    enabled: false, still grouped under its owning plugin / MCP server."""
+    from langchain_core.tools import tool
+
+    import operator_api.console_handlers as ch
+    import runtime.state as rs
+
+    @tool
+    def show_artifact() -> str:
+        """Render an artifact."""
+        return "ok"
+
+    @tool
+    def echo__ping() -> str:
+        """Echo ping."""
+        return "pong"
+
+    g, cfg = _graph(
+        goal_enabled=False,
+        extra_tools=[show_artifact, echo__ping],
+        tools_disabled=["show_artifact", "echo__ping"],
+    )
+    monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", cfg, raising=False)
+    monkeypatch.setattr(rs.STATE, "plugin_tools", [show_artifact], raising=False)
+    monkeypatch.setattr(rs.STATE, "mcp_tools", [echo__ping], raising=False)
+    monkeypatch.setattr(rs.STATE, "plugin_tool_owner", {"show_artifact": "Artifact"}, raising=False)
+    monkeypatch.setattr(rs.STATE, "mcp_meta", [{"name": "echo"}], raising=False)
+
+    bound = {getattr(t, "name", None) for t in g.bound_tools}
+    assert "show_artifact" not in bound and "echo__ping" not in bound
+
+    by_name = {t["name"]: t for t in ch._operator_tools_list()["tools"]}
+    assert by_name["show_artifact"]["enabled"] is False
+    assert by_name["show_artifact"]["source"] == "plugin"
+    assert by_name["show_artifact"]["category"] == "Artifact"  # still groups by owner
+    assert by_name["echo__ping"]["enabled"] is False
+    assert by_name["echo__ping"]["source"] == "mcp"
+    assert by_name["echo__ping"]["category"] == "echo"  # still groups by server
 
 
 def test_tools_tab_omits_set_goal_when_goal_disabled(monkeypatch):

--- a/tests/test_tools_inventory_single_source.py
+++ b/tests/test_tools_inventory_single_source.py
@@ -10,8 +10,19 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage
+
+
+@pytest.fixture(autouse=True)
+def _reset_denylist():
+    """The denylist is a module global (graph builds sync it from their config);
+    reset it so a test's denylist never leaks into the rest of the suite."""
+    from tools.lg_tools import set_disabled_tools
+
+    yield
+    set_disabled_tools([])
 
 
 class _ToolFake(GenericFakeChatModel):
@@ -19,39 +30,76 @@ class _ToolFake(GenericFakeChatModel):
         return self
 
 
-def _graph(goal_enabled=True):
+def _graph(goal_enabled=True, **over):
     from graph.agent import create_agent_graph
     from graph.config import LangGraphConfig
 
     fake = _ToolFake(messages=iter([AIMessage(content="x")]))
+    cfg = LangGraphConfig(goal_enabled=goal_enabled, **over)
     with patch("graph.agent.create_llm", lambda *a, **k: fake):
-        return create_agent_graph(LangGraphConfig(goal_enabled=goal_enabled))
+        return create_agent_graph(cfg), cfg
 
 
 def test_tools_tab_exactly_matches_the_bound_graph(monkeypatch):
     import operator_api.console_handlers as ch
     import runtime.state as rs
 
-    g = _graph(goal_enabled=True)
+    g, cfg = _graph(goal_enabled=True)
     monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", cfg, raising=False)
     monkeypatch.setattr(rs.STATE, "plugin_tools", [], raising=False)
     monkeypatch.setattr(rs.STATE, "mcp_tools", [], raising=False)
 
-    listed = {t["name"] for t in ch._operator_tools_list()["tools"]}
+    res = ch._operator_tools_list()
+    listed = {t["name"] for t in res["tools"]}
     bound = {getattr(t, "name", None) for t in g.bound_tools}
 
     assert listed == bound  # no drift, either direction
     assert "task" in listed  # subagent delegation now visible
     assert "read_file" in listed  # filesystem now visible (was omitted)
     assert "set_goal" in listed  # bound when goal_enabled (bd-2aa)
+    # Empty denylist → every row is wired, count is the full set, raw denylist empty.
+    assert all(t["enabled"] for t in res["tools"])
+    assert res["count"] == len(res["tools"])
+    assert res["disabled"] == []
+
+
+def test_denylisted_tools_stay_listed_toggled_off(monkeypatch):
+    """A tools.disabled tool is NOT bound but STAYS in the inventory (enabled: false) —
+    drop it from the catalog and the console row toggle could never re-enable it. The
+    response also echoes the RAW denylist (stale names included) so a row toggle edits
+    one name without clobbering the rest."""
+    import operator_api.console_handlers as ch
+    import runtime.state as rs
+
+    g, cfg = _graph(goal_enabled=False, tools_disabled=["calculator", "ghost_tool"])
+    monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", cfg, raising=False)
+    monkeypatch.setattr(rs.STATE, "plugin_tools", [], raising=False)
+    monkeypatch.setattr(rs.STATE, "mcp_tools", [], raising=False)
+
+    res = ch._operator_tools_list()
+    by_name = {t["name"]: t for t in res["tools"]}
+
+    assert "calculator" not in {getattr(t, "name", None) for t in g.bound_tools}
+    assert by_name["calculator"]["enabled"] is False
+    assert by_name["calculator"]["category"] == "General"  # still grouped like a live row
+    assert by_name["current_time"]["enabled"] is True
+    # ``count`` stays the WIRED count (the "N wired tools" kicker), not rows.
+    assert res["count"] == sum(1 for t in res["tools"] if t["enabled"])
+    assert res["count"] == len(res["tools"]) - 1
+    # The raw denylist survives verbatim; a stale name has no row to render.
+    assert res["disabled"] == ["calculator", "ghost_tool"]
+    assert "ghost_tool" not in by_name
 
 
 def test_tools_tab_omits_set_goal_when_goal_disabled(monkeypatch):
     import operator_api.console_handlers as ch
     import runtime.state as rs
 
-    g = _graph(goal_enabled=False)
+    g, cfg = _graph(goal_enabled=False)
     monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", cfg, raising=False)
     monkeypatch.setattr(rs.STATE, "plugin_tools", [], raising=False)
     monkeypatch.setattr(rs.STATE, "mcp_tools", [], raising=False)
 
@@ -108,7 +156,7 @@ def test_inventory_uses_plugin_owner_map(monkeypatch):
             self.name = name
             self.description = "x"
 
-    g = _graph(goal_enabled=True)
+    g, _cfg = _graph(goal_enabled=True)
     monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
     monkeypatch.setattr(rs.STATE, "plugin_tools", [_Tool("show_artifact")], raising=False)
     monkeypatch.setattr(rs.STATE, "mcp_tools", [], raising=False)

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -455,13 +455,24 @@ def set_disabled_tools(names) -> None:
     _disabled_tools = {str(n).strip() for n in (names or []) if str(n).strip()}
 
 
-def drop_disabled_tools(tools: list) -> list:
+def drop_disabled_tools(tools: list, dropped: list | None = None) -> list:
     """Filter the denylist (``tools.disabled``) out of ``tools`` — the single filter
     every assembly point uses, so a disabled name is gone no matter which seam
-    contributed it. Returns ``tools`` unchanged (same list) when the denylist is empty."""
+    contributed it. Returns ``tools`` unchanged (same list) when the denylist is empty.
+
+    ``dropped`` (optional) collects the tool objects that were filtered out, so the
+    graph builder can stamp a full catalog (bound + disabled) for the operator Tools
+    tab — a toggled-off tool must stay visible there or it could never be re-enabled."""
     if not _disabled_tools:
         return tools
-    return [t for t in tools if getattr(t, "name", None) not in _disabled_tools]
+    kept = []
+    for t in tools:
+        if getattr(t, "name", None) in _disabled_tools:
+            if dropped is not None:
+                dropped.append(t)
+        else:
+            kept.append(t)
+    return kept
 
 
 # Stable list of scheduler tool names. Exposed as a module-level
@@ -1576,6 +1587,7 @@ def get_all_tools(
     goal_enabled=False,
     graph_config=None,
     background_mgr=None,
+    dropped=None,
 ):
     """Return every LangChain tool the lead agent + subagents can use.
 
@@ -1636,8 +1648,9 @@ def get_all_tools(
     tools.extend(_build_curation_tools())
     # Operator denylist (config ``tools.disabled``): drop named core tools without
     # editing this function. Applied last so it covers every branch above. (graph.agent
-    # re-applies it over the FULL assembled set — extra/fs/late tools — post-assembly.)
-    return drop_disabled_tools(tools)
+    # re-applies it over the FULL assembled set — extra/fs/late tools — post-assembly.
+    # ``dropped`` collects the filtered-out tools for the operator catalog.)
+    return drop_disabled_tools(tools, dropped)
 
 
 # ── deferred tools (ADR 0005 #3) ──────────────────────────────────────────────


### PR DESCRIPTION
## What

Settings ▸ Capabilities ▸ Tools redesign: **every tool row now carries an on/off switch** backed by `tools.disabled` — turning a tool off IS disabling it, so the separate **"Disabled tools" chip (raw denylist textarea) is removed**. Shell & filesystem tools were already rows in the list (Filesystem group); with switches they're now directly toggleable like everything else, including `run_command`.

The **Shell & filesystem chip stays**: it's the only UI home for the `run_command` execution policy (`run_requires_approval`, `bypass_allowed`) and the coarse kill switches (`filesystem.enabled`, `allow_run`) — those govern *how* the shell runs / whether the tools are built at all, not per-tool wiring.


## How

- **A toggled-off tool must stay listed or it can never be re-enabled.** `/api/tools` used to read only post-denylist `bound_tools`. `create_agent_graph` now also stamps `graph.disabled_tools` — everything the denylist dropped, collected via a new optional `dropped` collector on `drop_disabled_tools()` at every assembly seam (core via `get_all_tools`, extra_tools, fs/task/late tools, deferred). `/api/tools` rows gain `enabled`, and the response echoes the **raw** config denylist so the console edits one name without clobbering stale entries (e.g. a disabled tool from an uninstalled plugin). `count` stays the wired count.
- Console: DS `Switch` per row (optimistic flip, error toast, invalidates tools+settings queries), dimmed off-rows, amber `N off` badge per group, kicker shows `· N off`.
- Enforcement semantics unchanged — same `drop_disabled_tools` filter at the same seams (#1612 contract intact, `tests/test_tools_disabled.py` still green).

## Bugs found & fixed along the way

1. **`tools.disabled: [search_tools]` silently didn't work** — the deferred meta-tool is appended *after* the final denylist pass, so it re-bound itself (a row toggle would have snapped back on). Now filtered like everything else.
2. **Hot-reload dropped the 4 tasks tools** — `_reload_langgraph_agent` omitted `tasks_store` from its `create_agent_graph` call, so ANY settings save (not just toggles) lost `task_create/task_list/task_update/task_close` until restart. Found live: 57 tools at boot → 53 after one settings save. Fixed + kwargs-capture regression test (`tests/test_reload_rebuild_deps.py`, red without the fix).
3. **Deflaked `nesting.spec.ts`** (~40% failure under a parallel suite): it expanded the task card mid-stream and the live→history regroup on settle (#1272-76) remounts the toolcard, dropping the expansion. The spec now settles the turn before expanding.

## Verification

- Live on an isolated instance (`PROTOAGENT_BOX_ROOT=/tmp/... python -m server`): toggle `run_command` off via the UI → POST `/api/settings` → hot rebuild → row stays (dimmed, switch off), `task_create` still present, toggle back on restores; raw denylist round-trips a stale `ghost_tool` name untouched.
- e2e pins: chip gone; toggle-off **appends** to the denylist preserving existing entries; an off tool stays listed and toggles back on. Mock `/api/tools` fixture carries an off `run_command` + stale `ghost_tool`.

## Gates

| Gate | Result |
|---|---|
| `ruff check .` | ✅ |
| `lint-imports` | ✅ 3 kept / 0 broken |
| `pytest tests/ -q` | ✅ 2807 passed, 5 skipped |
| `scripts/live_smoke.py` | ✅ |
| web unit | ✅ 299 passed |
| web e2e | ✅ 186 passed (×2) |

Draft per the console-UX local-test gate — needs a human eyeball on the panel before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tools now show individual on/off switches in Settings, with disabled tools kept visible for easier re-enabling.
  * The tools view now shows enabled/disabled status and a clearer count of available tools.

* **Bug Fixes**
  * Fixed tools that were turned off from reappearing after updates.
  * Improved settings reload behavior so tool-related functionality persists correctly after refreshes.

* **Documentation**
  * Updated configuration guidance for the new tools toggle experience and settings navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->