### PR TITLE
fix(plugins): re-install from a plugin's own origin converges (no --force)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Re-installing a plugin from its own origin converges instead of erroring.**
+  `plugin install` of an already-installed plugin from the SAME recorded source is
+  now a no-op at the same commit (`up_to_date` in the summary) and an in-place
+  update when the ref moved — so re-running a bundle install (e.g. after a pin
+  bump) no longer aborts on its first already-installed member with
+  `already installed — use --force`. `--force` remains required for the real
+  conflicts: a same-id install from a different source, or a plugins-dir entry
+  `plugins.lock` doesn't know about (a working-tree plugin).
+
 ## [0.81.0] - 2026-07-02
 
 ### Changed

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -45,6 +45,7 @@ def lock_path() -> Path:
     (honors ``PROTOAGENT_PLUGINS_LOCK``)."""
     return instance_paths().plugins_lock
 
+
 _SHA_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
 # A git ref we'll accept from a caller — branch/tag/sha shapes only. Keeps a ref
 # from being interpolated into the GitHub API URL (path/query injection) or passed
@@ -420,8 +421,22 @@ def install(
 
         target = target_root / pid
         if target.exists():
-            if not force:
-                raise InstallError(f"plugin {pid!r} already installed — use --force to replace.")
+            # Re-install from the plugin's OWN recorded origin is a CONVERGE, not a
+            # conflict: same commit → no-op, moved pin/ref → update — so re-running a
+            # bundle install never dies on its own already-installed members. --force
+            # stays the lever for the real conflicts: an id-colliding install from a
+            # DIFFERENT source, or a dir the lock doesn't know (a working-tree /
+            # hand-copied plugin that a git install must not silently clobber).
+            prior = next((e for e in _read_lock().get("plugins") or [] if e.get("id") == pid), None)
+            same_source = prior is not None and prior.get("source_url") == url
+            if not force and not same_source:
+                origin = f"from {prior.get('source_url')!r}" if prior else "untracked (no plugins.lock entry)"
+                raise InstallError(f"plugin {pid!r} already installed — {origin}; use --force to replace.")
+            if not force and same_source and prior.get("resolved_sha") == sha:
+                log.info("[plugins] %s already at %s from %s — up to date", pid, sha[:10], url)
+                summary = _summary(manifest, source=url, ref=ref or "", sha=sha)
+                summary["up_to_date"] = True
+                return summary
             shutil.rmtree(target)
 
         shutil.rmtree(staging / ".git", ignore_errors=True)  # drop git metadata; lock holds provenance

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -74,12 +74,52 @@ def test_install_pins_a_tag(env):
     assert summary["requested_ref"] == "v1" and len(summary["resolved_sha"]) == 40
 
 
-def test_duplicate_requires_force(env):
+def test_reinstall_same_source_same_commit_is_up_to_date(env):
+    """Re-install from the plugin's own origin at the same commit = converge, not
+    conflict — a bundle re-install must not die on already-installed members."""
+    repo = _make_plugin_repo(env)
+    first = installer.install(str(repo))
+    again = installer.install(str(repo))  # no force needed
+    assert again["up_to_date"] is True
+    assert again["resolved_sha"] == first["resolved_sha"]
+    # lock unchanged — one entry, original provenance kept
+    lock = installer._read_lock()
+    assert [e["id"] for e in lock["plugins"]] == ["demo_ext"]
+
+
+def test_reinstall_same_source_new_commit_updates_without_force(env):
+    repo = _make_plugin_repo(env)
+    first = installer.install(str(repo))
+    (repo / "extra.py").write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "update")
+    updated = installer.install(str(repo))  # a moved ref from the same origin: update
+    assert updated["resolved_sha"] != first["resolved_sha"]
+    assert not updated.get("up_to_date")
+    assert (installer.live_plugins_dir() / "demo_ext" / "extra.py").exists()
+    lock = installer._read_lock()
+    assert [e["resolved_sha"] for e in lock["plugins"] if e["id"] == "demo_ext"] == [updated["resolved_sha"]]
+
+
+def test_same_id_from_different_source_requires_force(env):
     repo = _make_plugin_repo(env)
     installer.install(str(repo))
-    with pytest.raises(installer.InstallError, match="already installed"):
+    other = _make_plugin_repo(env / "elsewhere", pid="demo_ext")  # same id, different origin
+    with pytest.raises(installer.InstallError, match="different source|already installed"):
+        installer.install(str(other))
+    installer.install(str(other), force=True)  # explicit clobber still works
+
+
+def test_untracked_dir_requires_force(env):
+    """A dir the lock doesn't know (working-tree / hand-copied plugin) must not be
+    silently clobbered by a git install of the same id."""
+    repo = _make_plugin_repo(env)
+    tree = installer.live_plugins_dir() / "demo_ext"
+    tree.mkdir(parents=True)
+    (tree / "protoagent.plugin.yaml").write_text("id: demo_ext\nname: local\nversion: 0.0.1\ndescription: wip\n")
+    with pytest.raises(installer.InstallError, match="untracked"):
         installer.install(str(repo))
-    installer.install(str(repo), force=True)  # ok with force
+    installer.install(str(repo), force=True)
 
 
 def test_refuses_to_shadow_a_builtin(env):
@@ -304,6 +344,27 @@ def test_install_bundle_fans_out_and_records_provenance(env):
     assert bundles[0]["enabled"] == ["delegates", "demo_a", "demo_b"]
     # ...and the recommended config defaults too (#1350), for the same consumer.
     assert bundles[0]["config"] == {"demo_a": {"k": "v"}}
+
+
+def test_bundle_reinstall_converges_instead_of_erroring(env):
+    """Re-running a bundle install over an already-provisioned host must converge:
+    unchanged members report up-to-date, a member whose repo moved gets updated —
+    never an 'already installed' abort mid-fan-out."""
+    a = _make_plugin_repo(env, pid="demo_a")
+    b = _make_plugin_repo(env, pid="demo_b")
+    bundle = _make_bundle_repo(env, [a, b])
+    installer.install(str(bundle))
+
+    # advance one member's repo (a moved pin)
+    (a / "extra.py").write_text("x = 1\n")
+    _git(a, "add", "-A")
+    _git(a, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "update")
+
+    summary = installer.install(str(bundle))  # no force
+    by_id = {p["id"]: p for p in summary["installed"]}
+    assert not by_id["demo_a"].get("up_to_date")  # updated to the new commit
+    assert by_id["demo_b"].get("up_to_date") is True  # unchanged — converged
+    assert (installer.live_plugins_dir() / "demo_a" / "extra.py").exists()
 
 
 def test_bundle_config_overlay_fills_only_unset_keys():


### PR DESCRIPTION
## The bug

Re-running `plugin install <bundle>` on an already-provisioned host aborted on the **first already-installed member**:

```
plugin 'portfolio' already installed — use --force to replace.
```

The bundle fan-out reuses single-plugin `install()` with `force=False`, and its guard hard-errored on `target.exists()` regardless of provenance — so a bundle could never converge a host to a moved pin set without `--force`, and a partially-uninstalled host got stuck mid-fan-out. Hit installing pm-stack on a 0.81.0 desktop workspace after the portfolio pin moved to v0.14.2.

## The fix

`install()` distinguishes provenance via the plugin's `plugins.lock` entry:

| existing install | behavior |
|---|---|
| same source, same resolved sha | **no-op** — summary carries `up_to_date: true`, lock untouched |
| same source, moved ref | **in-place update**, no `--force` needed |
| different source, or a dir `plugins.lock` doesn't know | `InstallError` naming the origin — `--force` to replace |

Bundle re-installs converge member-by-member instead of aborting; hand-installed / working-tree plugins keep the same-id clobber protection.

## Tests

- `test_reinstall_same_source_same_commit_is_up_to_date` / `test_reinstall_same_source_new_commit_updates_without_force`
- `test_same_id_from_different_source_requires_force` / `test_untracked_dir_requires_force` (replace `test_duplicate_requires_force` — the contract deliberately changed)
- `test_bundle_reinstall_converges_instead_of_erroring` — end-to-end: one member's pin moved, the other unchanged; no force, no abort

69 plugin tests pass locally; `ruff check` clean; CHANGELOG entry under [Unreleased].

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-running plugin installation now behaves more predictably: unchanged plugins are recognized as already up to date instead of being replaced.
  * If a plugin comes from a different origin, the installer now shows a clearer error and only proceeds when forced.
  * Bundle installs now continue cleanly when some items are already current, while still updating items that have changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->