### PR TITLE
fix(config): relocate inline secrets to secrets.yaml on strip — never drop them

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -73,7 +73,7 @@ auth:
   federation_token: fed-...   # optional (ADR 0066) — semi-trusted peers get THIS, not `token`
 ```
 
-`LangGraphConfig.from_yaml` overlays this file on top of the main config at load time. Precedence for each secret: **`secrets.yaml` → main YAML value → env var** (`OPENAI_API_KEY` / `A2A_AUTH_TOKEN`). So env-injected deployments (e.g. `infisical run`) work unchanged — just leave `secrets.yaml` absent. Every config save also strips any secret keys the main YAML might still carry, so a checkout converges to secret-free. The `/api/config` endpoint redacts both fields to `""`; runtime status reports only whether a key is set (`model.api_key_configured`), never the value.
+`LangGraphConfig.from_yaml` overlays this file on top of the main config at load time. Precedence for each secret: **`secrets.yaml` → main YAML value → env var** (`OPENAI_API_KEY` / `A2A_AUTH_TOKEN`). So env-injected deployments (e.g. `infisical run`) work unchanged — just leave `secrets.yaml` absent. Every config save also strips any secret keys the main YAML might still carry, so a checkout converges to secret-free — and the strip **relocates, never drops**: an inline value `secrets.yaml` doesn't already hold (e.g. a hand-seeded `model.api_key` on a fresh instance with no secrets file yet) is written to the overlay in the same save, an existing overlay value is never overwritten by a stale inline copy, and if the overlay write fails the key stays inline rather than being lost (#1645). The `/api/config` endpoint redacts both fields to `""`; runtime status reports only whether a key is set (`model.api_key_configured`), never the value.
 
 ### Federation token — operator vs peer (ADR 0066)
 

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -617,14 +617,58 @@ def split_secret_updates(config: dict[str, Any]) -> tuple[dict[str, Any], dict[s
 
 
 def strip_secrets_from_doc(doc: Any) -> Any:
-    """Remove any secret keys already present in the main YAML document.
+    """Relocate any secret keys still present in the main YAML document to the
+    ``secrets.yaml`` overlay, then remove them from the doc.
 
     Belt-and-suspenders alongside ``split_secret_updates``: even if an older
     YAML still carries an ``api_key`` (or a hand-edit reintroduces one), every
-    save scrubs it so the tracked file converges to secret-free.
+    save scrubs it so the tracked file converges to secret-free. Stripping is
+    only safe once the value is preserved, though — a hand-seeded key on a
+    fresh instance (no ``secrets.yaml`` yet) used to be scrubbed with no
+    overlay write, losing the credential outright (#1645). So: a non-blank
+    inline value the overlay doesn't already hold is written to ``secrets.yaml``
+    first (an existing overlay value is never clobbered by a stale inline copy —
+    the overlay wins at load time, so the inline copy was shadowed anyway), and
+    if that write fails the key is left inline rather than dropped.
     """
+
+    def _blank(v: Any) -> bool:
+        return v is None or (isinstance(v, str) and not v.strip())
+
+    # Pass 1: find every inline secret; queue the ones whose value would be
+    # LOST by stripping (non-blank, and not already stored in the overlay).
+    stored = load_secrets()
+    present: list[tuple[str, str]] = []
+    pending: dict[str, dict[str, Any]] = {}
     for section, key in secret_paths():
         sect = doc.get(section) if hasattr(doc, "get") else None
+        if not isinstance(sect, dict) or key not in sect:
+            continue
+        present.append((section, key))
+        value = sect.get(key)
+        overlay = stored.get(section)
+        held = overlay.get(key) if isinstance(overlay, dict) else None
+        if not _blank(value) and _blank(held):
+            pending.setdefault(section, {})[key] = value.strip() if isinstance(value, str) else value
+
+    relocated = True
+    if pending:
+        try:
+            save_secrets(pending)
+        except Exception:
+            relocated = False
+            log.warning(
+                "[config] secrets overlay write failed — leaving %s inline in the main "
+                "YAML rather than dropping the value(s) (#1645)",
+                ", ".join(f"{s}.{k}" for s, vals in pending.items() for k in vals),
+                exc_info=True,
+            )
+
+    # Pass 2: strip. A key whose relocation failed stays inline (recoverable).
+    for section, key in present:
+        if not relocated and key in pending.get(section, {}):
+            continue
+        sect = doc.get(section)
         if isinstance(sect, dict) and key in sect:
             del sect[key]
         if isinstance(sect, dict) and not sect:

--- a/tests/test_config_secrets.py
+++ b/tests/test_config_secrets.py
@@ -45,9 +45,20 @@ def test_split_does_not_mutate_input() -> None:
     assert original["model"]["api_key"] == "sk-x"  # deep-copied, untouched
 
 
-def test_strip_secrets_from_doc_scrubs_existing_key() -> None:
+def _isolate_secrets_file(monkeypatch, tmp_path: Path) -> Path:
+    """Point the secrets overlay at a temp file so strip/save never touch the
+    developer's real ``secrets.yaml`` (strip RELOCATES inline secrets, #1645)."""
+    from graph import config_io
+
+    secrets_path = tmp_path / "secrets.yaml"
+    monkeypatch.setattr(config_io, "secrets_yaml_path", lambda: secrets_path)
+    return secrets_path
+
+
+def test_strip_secrets_from_doc_scrubs_existing_key(monkeypatch, tmp_path: Path) -> None:
     from graph.config_io import strip_secrets_from_doc
 
+    _isolate_secrets_file(monkeypatch, tmp_path)
     doc = {"model": {"name": "m", "api_key": "sk-leftover"}, "auth": {"token": "t"}}
     strip_secrets_from_doc(doc)
     assert doc["model"] == {"name": "m"}
@@ -166,10 +177,12 @@ def test_secret_paths_falls_back_to_cache_on_discovery_failure(monkeypatch, capl
     assert any("secret-path discovery failed" in r.message for r in caplog.records)
 
 
-def test_a_plugin_secret_is_stripped_from_the_doc_even_if_rediscovery_fails(monkeypatch):
+def test_a_plugin_secret_is_stripped_from_the_doc_even_if_rediscovery_fails(monkeypatch, tmp_path):
     """End-to-end of the #877 guarantee: once a plugin secret is known, a later
     discovery failure doesn't let strip_secrets_from_doc leave it in the main YAML."""
     from graph import config_io
+
+    _isolate_secrets_file(monkeypatch, tmp_path)
 
     class _Schema:
         section = "myplugin"
@@ -215,3 +228,86 @@ def test_config_to_dict_blanks_plugin_section_on_discovery_failure(monkeypatch):
     )
     d2 = config_io.config_to_dict(cfg)
     assert d2["discord"] == {"bot_token": "", "guild": ""}
+
+
+# ── #1645: stripping an inline secret must RELOCATE it to secrets.yaml, never drop it ──
+
+
+def test_strip_relocates_inline_secret_to_secrets_yaml(monkeypatch, tmp_path: Path) -> None:
+    """Fresh instance with a hand-seeded ``model.api_key`` and NO secrets.yaml:
+    stripping the key from the main YAML must land it in the overlay in the same
+    operation — stripping without the overlay write loses the credential (#1645)."""
+    from graph import config_io
+
+    secrets_path = _isolate_secrets_file(monkeypatch, tmp_path)
+    doc = {"model": {"name": "m", "api_key": "sk-seeded"}}
+    config_io.strip_secrets_from_doc(doc)
+
+    assert "api_key" not in doc["model"]  # stripped from the tracked YAML…
+    assert secrets_path.exists()  # …because it landed in the overlay
+    assert config_io.load_secrets() == {"model": {"api_key": "sk-seeded"}}
+    assert stat.S_IMODE(os.stat(secrets_path).st_mode) == 0o600  # still owner-only
+
+
+def test_strip_keeps_secret_inline_when_overlay_write_fails(monkeypatch, tmp_path: Path) -> None:
+    """Failure injection (#1645): if the secrets-file write raises, the key must
+    STAY in the main YAML (recoverable) rather than being stripped (gone)."""
+    from graph import config_io
+
+    secrets_path = _isolate_secrets_file(monkeypatch, tmp_path)
+
+    def _boom(updates):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(config_io, "save_secrets", _boom)
+    doc = {"model": {"name": "m", "api_key": "sk-keep-me"}, "auth": {"token": ""}}
+    config_io.strip_secrets_from_doc(doc)
+
+    assert doc["model"]["api_key"] == "sk-keep-me"  # left inline, not dropped
+    assert not secrets_path.exists()
+    assert "auth" not in doc  # a blank secret has nothing to preserve → still scrubbed
+
+
+def test_strip_does_not_clobber_existing_overlay_value(monkeypatch, tmp_path: Path) -> None:
+    """A stale inline copy must not overwrite a stored overlay value: the overlay
+    wins at load time (the inline copy was shadowed), so relocation only fills a
+    MISSING overlay entry — it never replaces one."""
+    from graph import config_io
+
+    secrets_path = _isolate_secrets_file(monkeypatch, tmp_path)
+    secrets_path.write_text("model:\n  api_key: sk-current\n")
+
+    doc = {"model": {"name": "m", "api_key": "sk-stale-inline"}}
+    config_io.strip_secrets_from_doc(doc)
+
+    assert "api_key" not in doc["model"]
+    assert config_io.load_secrets() == {"model": {"api_key": "sk-current"}}
+
+
+def test_unrelated_save_relocates_seeded_secret(monkeypatch, tmp_path: Path) -> None:
+    """#1645 end-to-end at the server save path: a fresh instance whose main YAML
+    was hand-seeded with ``model.api_key`` (no secrets.yaml yet) gets ANY config
+    save (the live repro was a plugin enable/disable toggle) — the key must move
+    to secrets.yaml, and the follow-up graph rebuild must still see it."""
+    import yaml as _yaml
+
+    import graph.config_io as cio
+    import server.agent_init as ai
+    from graph.config import LangGraphConfig
+
+    leaf = tmp_path / "langgraph-config.yaml"
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: leaf)
+    _isolate_secrets_file(monkeypatch, tmp_path)
+    monkeypatch.setattr(ai, "_reload_langgraph_agent", lambda: (True, "reloaded"))
+
+    leaf.write_text("model:\n  name: m\n  api_key: sk-seeded\n")
+
+    ok, _ = ai._apply_settings_changes(config={"plugins": {"enabled": []}})
+    assert ok
+
+    doc = _yaml.safe_load(leaf.read_text())
+    assert "api_key" not in (doc.get("model") or {})  # stripped from the tracked YAML
+    assert _yaml.safe_load((tmp_path / "secrets.yaml").read_text()) == {"model": {"api_key": "sk-seeded"}}
+    # The rebuild that follows the save still has credentials (this is what
+    # failed live: "config saved; graph rebuild failed: Missing credentials").
+    assert LangGraphConfig.from_yaml(str(leaf)).api_key == "sk-seeded"


### PR DESCRIPTION
## Problem

On a fresh instance whose main YAML was hand-seeded with `model.api_key` (no `secrets.yaml` yet), **any** config save — the live repro was `POST /api/plugins/<id>/enabled` — stripped the key from the tracked YAML (`SECRET_PATHS` scrub) without ever writing the secrets overlay. The credential was simply gone; every subsequent graph rebuild failed with `Missing credentials` until the operator re-entered the key.

Root cause: `graph/config_io.strip_secrets_from_doc` deleted inline secrets from the loaded doc, while the only overlay write in the save path (`save_secrets(secret_updates)`) covers secrets in the **incoming update payload** — never the ones already sitting in the doc.

## Fix

`strip_secrets_from_doc` now upholds the invariant **strip iff the value is preserved**:

- a non-blank inline secret the overlay doesn't already hold is written to `secrets.yaml` (0600, merge semantics) in the same operation, then stripped;
- an existing overlay value is never clobbered by a stale inline copy — the overlay wins at load time (`from_yaml` precedence `secrets.yaml → main YAML → env`), so the inline copy was shadowed anyway;
- if the overlay write fails, the key is left **inline** (recoverable) instead of dropped, with a logged warning.

All three call sites (agent-layer save, wizard `finish_setup`, host-layer save) get the behavior for free. On the host layer this means a hand-edited host-config secret is preserved into the instance overlay instead of silently discarded — the host file still converges to secret-free (D5 unchanged).

The #877 fail-safe (cached plugin secret-path discovery so a transient discovery failure can't downgrade a plugin secret to plaintext) is untouched; its tests still pass.

## Tests

Written first, confirmed failing on `origin/main`:

- `test_strip_relocates_inline_secret_to_secrets_yaml` — fresh-instance repro at the unit level (no secrets.yaml → key lands in overlay, stripped from doc, 0600).
- `test_strip_keeps_secret_inline_when_overlay_write_fails` — failure injection: `save_secrets` raises → key stays inline, blank secrets still scrubbed.
- `test_strip_does_not_clobber_existing_overlay_value` — stale inline copy never overwrites a stored overlay value.
- `test_unrelated_save_relocates_seeded_secret` — end-to-end through `server.agent_init._apply_settings_changes` (the plugin-toggle save path from the issue): key moves to secrets.yaml and `LangGraphConfig.from_yaml` still resolves it.

Also isolated the two pre-existing bare `strip_secrets_from_doc` tests onto a temp secrets path (strip now touches the overlay, and the suite must never write a developer's real `secrets.yaml`).

## Docs

`docs/reference/configuration.md` § Secrets — documents the relocate-never-drop semantics (existing page; no nav change).

## Gates

- `ruff check .` — clean
- `lint-imports` — 3 contracts kept
- `python -m pytest tests/ -q` — 2812 passed, 5 skipped
- No config dataclass fields added — config-roundtrip golden untouched.

Fixes #1645

🤖 Generated with [Claude Code](https://claude.com/claude-code)