### PR TITLE
fix(testkit): FakeRegistry mirrors the full PluginRegistry surface — chat commands, late tools, live_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `already installed — use --force`. `--force` remains required for the real
   conflicts: a same-id install from a different source, or a plugins-dir entry
   `plugins.lock` doesn't know about (a working-tree plugin).
+- **Testkit `FakeRegistry` now mirrors the full `PluginRegistry` surface** (#1637).
+  `register_chat_command` (with the live slugify/reserved-`goal` validation — the fake
+  *raises* where the host warns-and-skips, so a typo'd registration fails the test),
+  `register_late_tool_factory`, and `live_config()` were missing, which made those seams
+  silently untestable in host-free plugin smoke tests (plugins `hasattr`-guard the
+  calls). A parity test now introspects both classes so the next registry seam can't
+  drift out of the testkit. Refresh a standalone plugin's vendored copy by recopying
+  `graph/plugins/testkit.py` to `tests/_plugin_testkit.py`.
 
 ## [0.81.0] - 2026-07-02
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -80,6 +80,8 @@ a fork adds any of them as a plugin, never editing the core `server/` package:
 | `register_middleware(factory)` | A LangGraph **`AgentMiddleware`** (per-turn before/after-model + tool hooks) — `factory(config) → middleware \| None` | graph build; appended before message-capture (ADR 0032) |
 | `register_mcp_server(factory)` | A **managed MCP server** the agent connects to | `factory(config)` called at each graph build → entry dict or `None` |
 | `register_thread_id_resolver(fn)` | A `(request_metadata, session_id) → str` checkpointer-scope resolver (e.g. per-project memory) | each turn; one wins (last plugin) |
+| `register_chat_command(name, handler)` | A **user-only** `/<name>` chat control command that short-circuits the turn (the generalized `/goal`) — token slugified+lowercased; `goal` reserved; see [publish guide](/guides/plugin-registry) | chat dispatch; first plugin to claim a token wins |
+| `register_late_tool_factory(factory)` | A tool factory that runs **after** the full toolset is assembled — `factory(all_tools, config) → tool \| list \| None`, for meta-tools that must see every other tool | graph build, appended last |
 
 ```python
 def register(registry):
@@ -315,6 +317,34 @@ Bundled skills load as `disk`-source [skills](./skills.md), re-seeded each boot.
 - `GET /api/runtime/status` lists `plugins` with `{id, name, enabled, loaded,
   tools, skills}`.
 - Plugins are (re)loaded at startup and on config reload.
+
+## Test it host-free (the testkit)
+
+`graph/plugins/testkit.py` is a host-free test harness: it loads a plugin the way the
+runtime does (as a package, so relative imports and deep engine modules work), stubs the
+host-only `graph.*` / `knowledge.*` imports, and hands `register()` a **`FakeRegistry`**
+that captures every contribution — so a plugin's real modules run under plain `pytest`
+with no protoAgent server. It's stdlib-only by design: `scaffold_plugin(with_tests=True)`
+vendors it verbatim into a standalone plugin repo as `tests/_plugin_testkit.py`; bundled
+plugins import it directly (`from graph.plugins.testkit import load_plugin,
+install_host_stubs, FakeRegistry`).
+
+```python
+install_host_stubs()                       # graph.* / knowledge.* resolve with no host
+pkg = load_plugin("path/to/my-plugin")     # loaded as a package, like the runtime
+reg = FakeRegistry()
+pkg.register(reg)
+assert reg.tools and "issue" in reg.chat_commands   # assert the captured contributions
+```
+
+**The parity contract:** `FakeRegistry` mirrors every public `PluginRegistry` method
+(`register_*`, `emit`, `on`, `navigate`, `live_config`) with the same parameters — a
+missing method would make that seam silently untestable (plugins `hasattr`-guard these
+calls, so a typo'd registration would ship green). A drift guard in
+`tests/test_plugin_testkit.py` introspects both classes and fails when a new registry
+seam isn't mirrored. One intentional divergence: where the real registry *warns and
+skips* an invalid registration (degrade-safe live — e.g. a chat command named `goal`,
+which is reserved), the fake **raises `ValueError`** so the mistake fails your test.
 
 ## Try it
 

--- a/graph/plugins/testkit.py
+++ b/graph/plugins/testkit.py
@@ -158,16 +158,43 @@ def install_host_stubs(extra: dict | None = None) -> list[str]:
 
 
 # ── fake registry ────────────────────────────────────────────────────────────────────
+def _slugify_slash(raw: str) -> str:
+    """Lowercase + non-alphanumerics→hyphens slug for a slash token — mirrors
+    ``graph.slash_commands.slugify_slash`` (this file is host-free by contract, so it
+    can't import it; a parity test in ``tests/test_plugin_testkit.py`` keeps them in sync)."""
+    return re.sub(r"[^a-z0-9]+", "-", (raw or "").strip().lower()).strip("-")
+
+
 class FakeRegistry:
     """Records what ``register(registry)`` contributes, with no host — mirrors the real
     ``graph.plugins.registry.PluginRegistry`` surface so a plugin's ``register()`` runs
     unchanged. Assert against the captured lists/dicts.
 
     e.g. ``reg = FakeRegistry(); plugin.register(reg); assert reg.tools and reg.verifiers``.
+
+    **Parity contract: every public method on ``PluginRegistry`` (``register_*``, ``emit``,
+    ``on``, ``navigate``, ``live_config``) must exist here with the same parameters** — a
+    missing method makes that seam silently untestable (a plugin's ``hasattr`` guard skips
+    it and a typo'd registration ships green). Enforced by
+    ``tests/test_plugin_testkit.py::test_fake_registry_mirrors_the_full_plugin_registry_surface``
+    — adding a seam to the registry without mirroring it here fails that test.
+
+    Capture shapes are assert-friendly, not the registry's internal shapes. One behavioral
+    divergence, on purpose: where the real registry *warns and skips* a bad registration
+    (degrade-safe live), the fake **raises ``ValueError``** — a test harness must fail loud,
+    not ship a silently-dropped registration green.
     """
 
-    def __init__(self, config: dict | None = None):
+    def __init__(
+        self, config: dict | None = None, *, plugin_id: str = "test-plugin", plugin_dir=None, config_section=None
+    ):
+        # The registry attributes a plugin reads in register() (host is None — like the
+        # real registry docstring says, "guard for None (e.g. in tests)").
+        self.plugin_id = plugin_id
+        self.plugin_dir = Path(plugin_dir) if plugin_dir is not None else Path(".")
         self.config = config or {}
+        self.config_section = config_section or plugin_id
+        self.host = None
         self.tools: list = []
         self.routers: list = []
         self.surfaces: list = []
@@ -182,10 +209,17 @@ class FakeRegistry:
         self.watch_hooks: list = []
         self.knowledge_stores: dict = {}
         self.embedders: dict = {}
+        self.chat_commands: dict = {}  # slugified token -> handler
+        self.late_tool_factories: list = []
         self.handlers: dict = {}  # topic -> [handlers]
         self.emitted: list = []  # (topic, data)
         self.navigations: list = []
         self.thread_id_resolver = None
+
+    def live_config(self) -> dict:
+        """The real registry re-reads host state here; with no host that falls back to
+        the register-time snapshot — which is all the fake has."""
+        return self.config
 
     # contributions
     def register_tool(self, tool) -> None:
@@ -193,6 +227,21 @@ class FakeRegistry:
 
     def register_tools(self, tools) -> None:
         self.tools.extend(tools)
+
+    def register_chat_command(self, name: str, handler) -> None:
+        """Capture a user-only ``/<name>`` control command — with the real registry's
+        slugify + validation, so a registration the host would refuse (empty/unslugifiable
+        name, non-callable handler, the reserved core token ``goal``, a duplicate token)
+        fails the test instead of shipping green. Live those are warn-and-skip; here they
+        raise (see the class docstring)."""
+        token = _slugify_slash(name)
+        if not token or not callable(handler):
+            raise ValueError(f"register_chat_command needs a name + callable: {name!r} / {handler!r}")
+        if token == "goal":  # reserved core token — mirrors PluginRegistry
+            raise ValueError(f"chat command /{token} is reserved")
+        if token in self.chat_commands:
+            raise ValueError(f"chat command /{token} registered twice")
+        self.chat_commands[token] = handler
 
     def register_router(self, router, prefix: str | None = None) -> None:
         self.routers.append((prefix, router))
@@ -205,6 +254,9 @@ class FakeRegistry:
 
     def register_middleware(self, factory) -> None:
         self.middlewares.append(factory)
+
+    def register_late_tool_factory(self, factory) -> None:
+        self.late_tool_factories.append(factory)
 
     def register_mcp_server(self, factory) -> None:
         self.mcp_servers.append(factory)

--- a/plugins/plugin-devkit/skills/building-plugins/SKILL.md
+++ b/plugins/plugin-devkit/skills/building-plugins/SKILL.md
@@ -184,6 +184,13 @@ test it; keeping host-only imports lazy is still good practice but no longer a h
 requirement. In-repo (bundled) plugins import the same testkit directly:
 `from graph.plugins.testkit import load_plugin, install_host_stubs, FakeRegistry`.
 
+`FakeRegistry` mirrors **every** public `PluginRegistry` method (a parity test in core
+enforces it), so run `register()` against it bare — no `hasattr` guards — and assert every
+contribution: `reg.tools`, `reg.chat_commands["issue"]`, `reg.subagents`, … . Where the live
+registry warns-and-skips an invalid registration (a chat command named `goal` — reserved,
+an unslugifiable name, a duplicate token), the fake **raises `ValueError`**, so a typo'd
+registration fails your suite instead of shipping green.
+
 From the shell (no agent): `python -m server plugin new "My Plugin" --view --skill --tests`
 scaffolds the skeleton; `plugin new-bundle "My Stack" --member id=url@ref --builtin delegates`
 scaffolds an ADR-0040 bundle.

--- a/tests/fixtures/sample_plugin/__init__.py
+++ b/tests/fixtures/sample_plugin/__init__.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 
 def register(registry):
-    """Contribute a tool + a goal verifier + a skill dir (host imports lazy)."""
+    """Contribute a tool + a goal verifier + a skill dir + a chat command (host imports lazy)."""
     from graph.goals.types import VerifyResult  # lazy host import — resolved by host_stubs
 
     from . import tools
@@ -19,3 +19,9 @@ def register(registry):
 
     registry.register_goal_verifier("sample:done", _verify)
     registry.register_skill_dir("skills")
+
+    async def _cmd(rest, session_id):
+        return f"sample:{rest}"
+
+    registry.register_chat_command("Sample Cmd", _cmd)  # mixed case — slugified to /sample-cmd
+    registry.register_late_tool_factory(lambda all_tools, config: None)

--- a/tests/test_plugin_testkit.py
+++ b/tests/test_plugin_testkit.py
@@ -14,6 +14,7 @@ so the test never clobbers the real host.
 from __future__ import annotations
 
 import importlib
+import inspect
 import sys
 from pathlib import Path
 
@@ -21,6 +22,7 @@ import pytest
 
 from graph.plugins import testkit
 from graph.plugins.loader import _plugin_module_name  # the harness must match the runtime
+from graph.plugins.registry import PluginRegistry  # the surface FakeRegistry must mirror
 
 FIXTURE = Path(__file__).parent / "fixtures" / "sample_plugin"
 PID = "sample-plugin"
@@ -75,6 +77,78 @@ def test_register_runs_host_free_and_fake_registry_captures():
     assert len(reg.tools) == 1
     assert "sample:done" in reg.verifiers
     assert reg.skill_dirs == ["skills"]
+    assert "sample-cmd" in reg.chat_commands  # "Sample Cmd" slugified — the #1637 hole, now captured
+    assert len(reg.late_tool_factories) == 1
+
+
+# ── registry parity — the drift guard (#1637) ────────────────────────────────────────
+# FakeRegistry drifted from PluginRegistry (register_chat_command was missing), which made
+# that seam silently untestable: plugins hasattr-guard the call, so the smoke test passed
+# while asserting nothing. These tests make the NEXT new seam fail here instead of drifting.
+
+
+def _public_methods(cls) -> dict:
+    return {n: fn for n, fn in inspect.getmembers(cls, inspect.isfunction) if not n.startswith("_")}
+
+
+def test_fake_registry_mirrors_the_full_plugin_registry_surface():
+    real = _public_methods(PluginRegistry)
+    fake = _public_methods(testkit.FakeRegistry)
+    assert "register_chat_command" in real  # sanity: introspection sees the surface
+    for name, fn in real.items():
+        fake_fn = fake.get(name)
+        assert fake_fn is not None, (
+            f"FakeRegistry is missing PluginRegistry.{name} — every public registry method "
+            f"must be mirrored in graph/plugins/testkit.py, or the seam is silently "
+            f"untestable in plugin smoke tests (plugins hasattr-guard these calls)."
+        )
+        real_params = [(p.name, p.kind) for p in inspect.signature(fn).parameters.values()]
+        fake_params = [(p.name, p.kind) for p in inspect.signature(fake_fn).parameters.values()]
+        assert fake_params == real_params, (
+            f"FakeRegistry.{name} signature drifted from PluginRegistry.{name}: "
+            f"{fake_params} != {real_params}"
+        )
+
+
+def test_testkit_slugify_matches_the_host_slugifier():
+    # testkit is host-free by contract (vendored verbatim into standalone plugin CI), so it
+    # duplicates slugify_slash instead of importing it — this keeps the copies in sync.
+    from graph.slash_commands import slugify_slash
+
+    for raw in ("Issue", "My Cmd", "foo_bar", "  /Weird--Token!!  ", "GOAL", "", "---", "héllo", "a1-b2"):
+        assert testkit._slugify_slash(raw) == slugify_slash(raw), f"slug drift for {raw!r}"
+
+
+def test_fake_registry_captures_chat_commands_slugified():
+    reg = testkit.FakeRegistry()
+
+    async def h(rest, session_id):
+        return "ok"
+
+    reg.register_chat_command("Issue", h)  # mixed case — stored under the live token
+    assert reg.chat_commands == {"issue": h}
+
+
+def test_fake_registry_chat_command_rejects_what_the_host_rejects():
+    # The real registry warns-and-skips these (degrade-safe live); the fake raises so a
+    # broken registration fails the test instead of shipping green.
+    reg = testkit.FakeRegistry()
+
+    async def h(rest, session_id):
+        return "ok"
+
+    with pytest.raises(ValueError):  # reserved core token
+        reg.register_chat_command("goal", h)
+    with pytest.raises(ValueError):  # slugifies to the reserved token too
+        reg.register_chat_command("/GOAL", h)
+    with pytest.raises(ValueError):  # empty after slugify
+        reg.register_chat_command("!!!", h)
+    with pytest.raises(ValueError):  # non-callable handler
+        reg.register_chat_command("fine-name", "not-callable")
+    reg.register_chat_command("Issue", h)
+    with pytest.raises(ValueError):  # duplicate token (live: first wins + warning)
+        reg.register_chat_command("issue", h)
+    assert reg.chat_commands == {"issue": h}  # nothing rejected leaked into the capture
 
 
 def test_install_host_stubs_creates_patchable_seam_for_absent_host():


### PR DESCRIPTION
## Problem

`graph/plugins/testkit.py::FakeRegistry` mirrors `PluginRegistry` so a plugin's `register()` runs unchanged in host-free tests — but it drifted. `register_chat_command` was missing (#1637), and a sweep found two more holes: `register_late_tool_factory` and `live_config()`. Plugins `hasattr`-guard these calls, so the seams were **silently untestable**: the smoke test passed while asserting nothing, and a typo'd registration shipped green (found adding `test_register_smoke.py` to spacetraders-plugin v1.8.0).

## What changed

**`register_chat_command` on FakeRegistry, with the live validation.** Same slugify + reserved-name rules as `PluginRegistry.register_chat_command` (`/goal` reserved, empty/unslugifiable token, non-callable handler, duplicate token). One deliberate divergence, documented on the class: live is *warn-and-skip* (degrade-safe at boot); the fake **raises `ValueError`** — a test harness must fail loud, not ship a silently-dropped registration green.

**Why the slugify is duplicated, not imported.** The testkit is stdlib-only by contract — `scaffold_plugin(with_tests=True)` vendors it *verbatim* into standalone plugin repos as `tests/_plugin_testkit.py` (see the module docstring + `scaffold.py`), so it cannot import `graph.slash_commands`. The copy is one line, and `test_testkit_slugify_matches_the_host_slugifier` pins it to the host's `slugify_slash` so it can't drift.

**Sweep results — two more drifted seams fixed the same way:**
- `register_late_tool_factory` (late-tools seam, #1240) → captured into `reg.late_tool_factories`
- `live_config()` → returns the config snapshot (all the fake has, matching the real method's no-host fallback)
- plus the registry attributes a `register()` body reads: `plugin_id`, `plugin_dir`, `config_section`, `host` (`None` — "guard for None (e.g. in tests)", per the real registry's own docstring)

**Durable drift guard.** `test_fake_registry_mirrors_the_full_plugin_registry_surface` introspects `PluginRegistry`'s public methods and asserts `FakeRegistry` exposes each one **with the same parameter names/kinds** — the next new registry seam fails this test instead of drifting out of the testkit. The contract is also spelled out on the `FakeRegistry` docstring.

## Tests

- Parity guard (verified it fails on both a removed method and a drifted signature)
- Slugify parity vs `graph.slash_commands.slugify_slash`
- Captured chat command asserts (`"Issue"` → stored under the live `issue` token)
- Every rejected shape raises: reserved `/goal` (incl. via slugify), empty token, non-callable, duplicate
- Fixture plugin now registers a chat command + late tool factory, asserted end-to-end through `load_plugin` + `register()`

## Docs

- `docs/guides/plugins.md`: new **"Test it host-free (the testkit)"** section (the testkit had no docs-site home) + the two missing contribution-table rows (`register_chat_command`, `register_late_tool_factory`)
- `plugins/plugin-devkit/skills/building-plugins/SKILL.md`: parity contract + fail-loud note
- CHANGELOG under `[Unreleased]` (standalone plugins refresh by recopying `graph/plugins/testkit.py`)

## Gates

- `ruff check .` ✅ · `lint-imports` ✅ (3 contracts kept) · `python -m pytest tests/ -q` ✅ 2812 passed, 5 skipped · `npm run docs:build` ✅ (docs `build` is a required check)
- Runtime-inert: the testkit is never imported at runtime (scaffold vendors it as text), so no live-smoke surface changed.

Fixes #1637

🤖 Generated with [Claude Code](https://claude.com/claude-code)