### PR TITLE
feat(goals): verifier ctx carries the invoking goal/watch identity (ctx.invoker)

### DIFF
--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -117,6 +117,7 @@ Set via `verifier.type` in the JSON spec:
 | `test` | same as `command` | exits `0` (the runner's summary line is surfaced in the reason) |
 | `ci` | `pr` **or** `branch` | `gh pr checks <pr>` is all-green, or the latest run on `branch` concluded `success` |
 | `data` | `path` + (`contains` **or** `expr`) | the file contains the substring, or `expr` (evaluated over parsed JSON as `data`) is truthy |
+| `plugin` | `check` (`<plugin-id>:<name>`) + `args?` | the plugin-registered verifier returns met — see [Plugins ▸ Goal & watch verifiers](/guides/plugins#goal-and-watch-verifiers) for `register_goal_verifier` and the `(spec, ctx)` contract (incl. `ctx.invoker`, the polling goal/watch's identity) |
 | `llm` | — (uses `condition`) | a strict evaluator judges the transcript shows the goal demonstrably done (fuzzy fallback) |
 
 `data` `expr` runs in a restricted namespace — the parsed document is `data`, with only read-only builtins (`len`, `any`, `all`, `sum`, …). `__import__`, `open`, `eval`, etc. are unavailable.

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -78,6 +78,7 @@ a fork adds any of them as a plugin, never editing the core `server/` package:
 | `register_surface(start, stop=None, name=None, reload=None)` | A background surface (a Discord-style gateway) | `start` in startup, `stop` in shutdown, `reload(cfg)` on config save |
 | `register_subagent(config)` | A `SubagentConfig` (a delegate) | added to `SUBAGENT_REGISTRY` |
 | `register_middleware(factory)` | A LangGraph **`AgentMiddleware`** (per-turn before/after-model + tool hooks) — `factory(config) → middleware \| None` | graph build; appended before message-capture (ADR 0032) |
+| `register_goal_verifier(name, fn)` | An in-process **goal/watch verifier** (ADR 0028) — dispatched by a `{"type": "plugin", "check": "<plugin-id>:<name>"}` goal or watch spec | graph build (re-set on reload) |
 | `register_mcp_server(factory)` | A **managed MCP server** the agent connects to | `factory(config)` called at each graph build → entry dict or `None` |
 | `register_thread_id_resolver(fn)` | A `(request_metadata, session_id) → str` checkpointer-scope resolver (e.g. per-project memory) | each turn; one wins (last plugin) |
 
@@ -136,6 +137,70 @@ class ScopeBannerMiddleware(AgentMiddleware):
 def register(registry):
     registry.register_middleware(lambda config: ScopeBannerMiddleware())
 ```
+
+### Goal & watch verifiers — `register_goal_verifier` (ADR 0028) {#goal-and-watch-verifiers}
+
+A plugin can **ground-truth its own domain state** as a verifier — an async
+`(spec, ctx) -> VerifyResult` that a `{"type": "plugin", "check": "<plugin-id>:<name>"}`
+[goal](/guides/goal-mode) or [watch](/guides/watches) dispatches to. `args` in the
+spec are declarative data your verifier validates (no shell, no eval — which is why
+`plugin` is the only verifier type an agent/plugin may set programmatically):
+
+```python
+from graph.goals import VerifyContext, VerifyResult
+
+async def verify_credits(spec: dict, ctx: VerifyContext) -> VerifyResult:
+    want = int(spec.get("args", {}).get("min", 0))
+    have = await current_credits()             # in-process; state the plugin owns
+    return VerifyResult(have >= want, f"credits {have:,}/{want:,}", evidence=str(have))
+
+def register(registry):
+    registry.register_goal_verifier("credits", verify_credits)   # → <plugin-id>:credits
+```
+
+**The `ctx` contract** (`graph.goals.VerifyContext`) is stable and grows only
+additively — a verifier that ignores it keeps working:
+
+| Field | Meaning |
+|---|---|
+| `config` | the live `LangGraphConfig` |
+| `condition` | the goal/watch condition text |
+| `last_text` | last assistant message of the turn (goals; `""` for a watch tick) |
+| `tool_summary` | short summary of the turn's tool calls (goals; `""` for a watch tick) |
+| `cwd` | working directory (used by the command/test verifiers) |
+| `invoker` | **who is polling** — a `VerifierInvoker`, or `None` outside the goal/watch loops |
+
+`ctx.invoker` (#1641) identifies the invoking controller, so one verifier can serve
+many goals/watches without resorting to global state:
+
+- `kind` — `"goal"` or `"watch"`.
+- `id` — the invoker's id: a **goal** is keyed by its session (so `id == session_id`);
+  a **watch** by its own watch id.
+- `session_id` — the owning session: the goal's session, or the watch's
+  `run_session` (`""` when the watch targets no session).
+- `interval_s` — the watch's effective polling cadence (its `interval_s` override,
+  else the config `watch_interval`); `None` for goals (they evaluate post-turn).
+
+`VerifierInvoker` is a **frozen, hashable** dataclass — key per-invoker state by it.
+E.g. a drawdown verifier keeping one high-water mark *per watch* instead of one
+global mark:
+
+```python
+from graph.goals import VerifierInvoker, VerifyContext, VerifyResult
+
+_marks: dict[VerifierInvoker | None, float] = {}
+
+async def verify_drawdown(spec: dict, ctx: VerifyContext) -> VerifyResult:
+    equity = await current_equity()
+    mark = _marks[ctx.invoker] = max(_marks.get(ctx.invoker, equity), equity)
+    frac = float(spec.get("args", {}).get("frac", 0.1))
+    tripped = equity <= mark * (1 - frac)
+    return VerifyResult(tripped, f"equity {equity:,.0f} vs mark {mark:,.0f}", evidence=str(equity))
+```
+
+To *react* when a goal/watch finishes, pair with `register_goal_hook` /
+`register_watch_hook` — see [Goal mode ▸ Reacting to a goal](/guides/goal-mode#reacting-to-a-goal)
+and [Watches](/guides/watches).
 
 ## Host services — `registry.host`
 

--- a/docs/guides/watches.md
+++ b/docs/guides/watches.md
@@ -16,7 +16,10 @@ metric stops moving.
 `{ condition, verifier, interval_s?, deadline?, stall_after?, run_prompt?, run_session? }` — the
 `verifier` is the same spec [goals use](/guides/goal-mode#verifier-types) (`plugin` / `command`
 / `test` / `ci` / `data` / `llm`). It's polled **out-of-band** on a cadence (default 30s),
-verifier-only — no agent turn, no model call.
+verifier-only — no agent turn, no model call. A `plugin` verifier is handed the invoking
+watch's identity on `ctx.invoker` (`kind="watch"`, the watch `id`, its `run_session`, and the
+effective `interval_s`) so one verifier can keep **per-watch** state — see
+[Plugins ▸ Goal & watch verifiers](/guides/plugins#goal-and-watch-verifiers).
 
 ## Creating a watch
 

--- a/graph/goals/__init__.py
+++ b/graph/goals/__init__.py
@@ -8,5 +8,6 @@ pluggable completion checks. Wired into the server invocation paths in
 from graph.goals.controller import Decision, GoalController
 from graph.goals.store import GoalStore
 from graph.goals.types import GoalState, VerifyResult
+from graph.goals.verifiers import VerifierInvoker, VerifyContext
 
-__all__ = ["GoalController", "GoalStore", "GoalState", "VerifyResult", "Decision"]
+__all__ = ["GoalController", "GoalStore", "GoalState", "VerifyResult", "Decision", "VerifierInvoker", "VerifyContext"]

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 
 from graph.goals.store import GoalStore
 from graph.goals.types import GoalState
-from graph.goals.verifiers import VerifyContext, run_verifier
+from graph.goals.verifiers import VerifierInvoker, VerifyContext, run_verifier
 
 log = logging.getLogger(__name__)
 
@@ -258,6 +258,8 @@ class GoalController:
             last_text=last_text or "",
             tool_summary=tool_summary or "",
             cwd=os.getcwd(),
+            # A goal is keyed by its session (one per session), so id == session_id (#1641).
+            invoker=VerifierInvoker(kind="goal", id=state.session_id, session_id=state.session_id),
         )
         result = await run_verifier(state.verifier, ctx)
 

--- a/graph/goals/verifiers.py
+++ b/graph/goals/verifiers.py
@@ -25,6 +25,7 @@ import ast
 import json
 import logging
 from dataclasses import dataclass
+from typing import Literal
 
 from graph.goals.types import VerifyResult
 
@@ -104,7 +105,7 @@ class VerifierInvoker:
                  goals (they evaluate post-turn, not on a cadence).
     """
 
-    kind: str
+    kind: Literal["goal", "watch"]
     id: str
     session_id: str = ""
     interval_s: float | None = None

--- a/graph/goals/verifiers.py
+++ b/graph/goals/verifiers.py
@@ -1,8 +1,9 @@
 """Goal verifiers — the testable-outcome backing for goal mode.
 
 Each verifier is ``async verify(spec, ctx) -> VerifyResult``. ``spec`` is the
-goal's ``verifier`` dict (``type`` + params); ``ctx`` carries the runtime
-(config + last-turn transcript) the verifier may need. Look up by
+goal's ``verifier`` dict (``type`` + params); ``ctx`` is a ``VerifyContext``
+carrying the runtime (config + last-turn transcript) the verifier may need,
+plus ``ctx.invoker`` — which goal/watch is polling (#1641). Look up by
 ``spec["type"]`` in ``VERIFIERS``.
 
 Types:
@@ -84,13 +85,44 @@ def _eval_data_expr(expr: str, data):
     return eval(code, {"__builtins__": _SAFE_BUILTINS}, {"data": data})  # noqa: S307 — AST-validated above
 
 
+@dataclass(frozen=True)
+class VerifierInvoker:
+    """Identity of the goal/watch whose controller is running the verifier (#1641).
+
+    Lets a plugin verifier tell WHO is polling it — so it can key per-invoker
+    state (e.g. one drawdown high-water mark PER watch instead of one global
+    mark), tailor evidence, or log trips against the right context. Frozen and
+    hashable, so the invoker itself (or ``(kind, id)``) works as a dict key.
+
+    kind       — ``"goal"`` or ``"watch"``.
+    id         — the invoker's id: a goal is keyed by its session (== ``session_id``);
+                 a watch by its own watch id.
+    session_id — the session that owns the invoker: the goal's session, or the
+                 watch's ``run_session`` (``""`` when the watch targets no session).
+    interval_s — the watch's effective polling cadence (its ``interval_s``
+                 override, else the config ``watch_interval``); ``None`` for
+                 goals (they evaluate post-turn, not on a cadence).
+    """
+
+    kind: str
+    id: str
+    session_id: str = ""
+    interval_s: float | None = None
+
+
 @dataclass
 class VerifyContext:
+    # These five fields are the frozen (pre-#1641) ctx contract external plugin
+    # verifiers may already read — enrich this dataclass additively, never
+    # rename/remove them.
     config: object = None
     condition: str = ""  # the goal condition (used by the llm verifier)
     last_text: str = ""  # last assistant message of the turn
     tool_summary: str = ""  # short summary of recent tool calls
     cwd: str | None = None  # working dir for command/test verifiers
+    # Who is polling — set by the goal/watch controllers (#1641); None when the
+    # verifier runs outside either loop (e.g. a direct run_verifier call).
+    invoker: VerifierInvoker | None = None
 
 
 def _tail(text: str, cap: int = _EVIDENCE_CAP) -> str:

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -205,12 +205,14 @@ class PluginRegistry:
         self.workflow_dirs.append(p)
 
     def register_goal_verifier(self, name: str, fn) -> None:
-        """Contribute an in-process goal verifier (ADR 0028) — an async
+        """Contribute an in-process goal/watch verifier (ADR 0028) — an async
         ``(spec, ctx) -> VerifyResult`` referenced by a ``{"type":"plugin",
-        "check":"<name>"}`` goal. Name it ``<plugin-id>:<verifier>`` to avoid
-        collisions; ``args`` in the spec are declarative data your verifier
+        "check":"<name>"}`` goal or watch. Name it ``<plugin-id>:<verifier>`` to
+        avoid collisions; ``args`` in the spec are declarative data your verifier
         validates (no shell, no eval). This is the only verifier type safe to set
-        programmatically (D3)."""
+        programmatically (D3). ``ctx`` is a ``graph.goals.VerifyContext``;
+        ``ctx.invoker`` identifies the polling goal/watch (kind/id/session_id/
+        interval_s, #1641) so a verifier can keep per-invoker state."""
         if not name or not callable(fn):
             log.warning(
                 "[plugins] %s: register_goal_verifier needs a name + callable: %r / %r", self.plugin_id, name, fn

--- a/graph/watches/controller.py
+++ b/graph/watches/controller.py
@@ -14,7 +14,7 @@ import hashlib
 import logging
 import os
 
-from graph.goals.verifiers import VERIFIERS, VerifyContext, run_verifier
+from graph.goals.verifiers import VERIFIERS, VerifierInvoker, VerifyContext, run_verifier
 from graph.watches.store import WatchStore
 from graph.watches.types import Watch
 
@@ -156,8 +156,20 @@ class WatchController:
         watch = self._store.get(watch_id)
         if watch is None or not watch.active:
             return None
+        # Effective cadence: the per-watch override, else the config default the
+        # server's _watch_loop ticks at (mirrors its getattr fallback).
+        interval_s = watch.interval_s
+        if interval_s is None:
+            interval_s = float(getattr(self._config, "watch_interval", 30) or 30)
         ctx = VerifyContext(
-            config=self._config, condition=watch.condition, last_text="", tool_summary="", cwd=os.getcwd()
+            config=self._config,
+            condition=watch.condition,
+            last_text="",
+            tool_summary="",
+            cwd=os.getcwd(),
+            invoker=VerifierInvoker(
+                kind="watch", id=watch.id, session_id=watch.run_session or "", interval_s=interval_s
+            ),
         )
         result = await run_verifier(watch.verifier, ctx)
         from time import time

--- a/tests/test_goal_controller.py
+++ b/tests/test_goal_controller.py
@@ -231,3 +231,42 @@ def test_set_goal_operator_requires_condition(tmp_path):
     c = _ctrl(tmp_path)
     ok, msg = c.set_goal_operator("s", "", {"type": "command", "command": "true"})
     assert not ok and "condition is required" in msg
+
+
+# --- verifier invoker identity (#1641) --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_passes_goal_invoker_to_plugin_verifier(tmp_path):
+    # A plugin verifier registered via the normal path (PluginRegistry →
+    # set_plugin_verifiers) can tell WHICH goal is polling it: kind="goal",
+    # id == the owning session (goals are keyed per session), no cadence.
+    from pathlib import Path
+
+    from graph.goals.types import VerifyResult
+    from graph.goals.verifiers import set_plugin_verifiers
+    from graph.plugins.registry import PluginRegistry
+
+    seen = []
+
+    async def probe(spec, ctx):
+        seen.append(ctx)
+        return VerifyResult(True, "met")
+
+    reg = PluginRegistry("demo", Path("."))
+    reg.register_goal_verifier("probe", probe)  # → demo:probe
+    set_plugin_verifiers(reg.goal_verifiers)
+    try:
+        c = _ctrl(tmp_path)
+        ok, _msg = c.set_goal_safe("sess-9", "reach it", {"type": "plugin", "check": "demo:probe"})
+        assert ok
+        decision = await c.evaluate("sess-9", last_text="done")
+        assert decision.state.status == "achieved"
+    finally:
+        set_plugin_verifiers({})
+    (ctx,) = seen
+    assert ctx.invoker.kind == "goal"
+    assert ctx.invoker.id == "sess-9"
+    assert ctx.invoker.session_id == "sess-9"
+    assert ctx.invoker.interval_s is None  # goals evaluate post-turn, not on a cadence
+    assert ctx.condition == "reach it"  # the pre-#1641 ctx fields still flow

--- a/tests/test_goal_verifiers.py
+++ b/tests/test_goal_verifiers.py
@@ -197,3 +197,28 @@ def test_registry_auto_namespaces_and_guards():
     reg.register_goal_verifier("", _ok_verifier)  # invalid — ignored
     reg.register_goal_verifier("bad", None)  # invalid — ignored
     assert set(reg.goal_verifiers) == {"myplugin:credits", "other:explicit"}
+
+
+# ── verifier invoker identity (#1641) ────────────────────────────────────────
+
+from graph.goals.verifiers import VerifierInvoker  # noqa: E402
+
+
+def test_bare_ctx_carries_no_invoker():
+    # The pre-#1641 ctx shape is frozen contract: a bare context still builds,
+    # the legacy fields keep their defaults, and there is no invoker — so
+    # verifiers that ignore ctx (or run outside the loops) are unaffected.
+    ctx = VerifyContext()
+    assert ctx.invoker is None
+    assert (ctx.config, ctx.condition, ctx.last_text, ctx.tool_summary, ctx.cwd) == (None, "", "", "", None)
+
+
+def test_invoker_is_frozen_and_hashable():
+    from dataclasses import FrozenInstanceError
+
+    inv = VerifierInvoker(kind="watch", id="w-1", session_id="ops", interval_s=30.0)
+    with pytest.raises(FrozenInstanceError):
+        inv.kind = "goal"
+    # hashable + value-equal → usable directly as a per-invoker state key
+    same = VerifierInvoker(kind="watch", id="w-1", session_id="ops", interval_s=30.0)
+    assert {inv: "high-water"}[same] == "high-water"

--- a/tests/test_watch_controller.py
+++ b/tests/test_watch_controller.py
@@ -226,3 +226,49 @@ async def test_concurrent_evaluate_finishes_once(tmp_path, monkeypatch):
     )
     await asyncio.gather(c.evaluate(w.id), c.evaluate(w.id))
     assert calls.count(f"watch-{w.id}") == 1  # not 2 — the lock prevented a double-finish
+
+
+# --- verifier invoker identity (#1641) --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_evaluate_passes_watch_invoker_to_plugin_verifier(tmp_path):
+    # A plugin verifier registered via the normal path (PluginRegistry →
+    # set_plugin_verifiers) can tell WHICH watch is polling it — the key that
+    # lets one verifier hold per-watch state (e.g. a per-watch high-water mark)
+    # instead of one global mark.
+    from pathlib import Path
+
+    from graph.goals.types import VerifyResult
+    from graph.goals.verifiers import set_plugin_verifiers
+    from graph.plugins.registry import PluginRegistry
+
+    seen = []
+
+    async def probe(spec, ctx):
+        seen.append(ctx.invoker)
+        return VerifyResult(False, "still waiting")
+
+    reg = PluginRegistry("demo", Path("."))
+    reg.register_goal_verifier("probe", probe)  # → demo:probe
+    set_plugin_verifiers(reg.goal_verifiers)
+    try:
+        c = _ctrl(tmp_path)
+        _ok, _m, w1 = c.create(
+            condition="reach 1M",
+            verifier={"type": "plugin", "check": "demo:probe"},
+            interval_s=12.5,
+            run_session="ops",
+        )
+        assert await c.evaluate(w1.id) is None
+        _ok, _m, w2 = c.create(condition="other thing", verifier={"type": "plugin", "check": "demo:probe"})
+        assert await c.evaluate(w2.id) is None
+    finally:
+        set_plugin_verifiers({})
+    first, second = seen
+    assert first.kind == "watch" and first.id == w1.id
+    assert first.session_id == "ops"  # the watch's run_session is the owning session
+    assert first.interval_s == 12.5  # per-watch cadence override
+    assert second.kind == "watch" and second.id == w2.id and second.id != w1.id
+    assert second.session_id == ""  # no target session
+    assert second.interval_s == 30.0  # config-default cadence (the server tick fallback)


### PR DESCRIPTION
## Problem

Plugin verifiers get `(spec, ctx)` but `ctx`'s contract was undocumented and carried no invoker identity — a verifier couldn't tell whether a **goal** or a **watch** was polling it, which one, or which session owns it. That forces global state where per-invoker state is wanted: spacetraders' `drawdown` verifier keeps ONE high-water mark in a plugin state file because there's no invoking-watch id to key a per-watch mark by.

Fixes #1641

## What changed (purely additive)

**The contract** — `graph/goals/verifiers.py`:

- New frozen, hashable dataclass **`VerifierInvoker`**: `{kind: "goal"|"watch", id, session_id, interval_s?}`. Frozen+hashable so a verifier can key per-invoker state directly by it.
- `VerifyContext` gains **`invoker: VerifierInvoker | None = None`**. The five pre-existing fields (`config`, `condition`, `last_text`, `tool_summary`, `cwd`) are now explicitly documented as **frozen contract** — external plugins may already read them, so they are never renamed/removed, only added to.
- Both exported from `graph.goals` (`from graph.goals import VerifierInvoker, VerifyContext`).

**Threading** — both controllers, additively:

- `GoalController.evaluate` → `kind="goal"`, `id == session_id` (goals are keyed per session, so the goal's id *is* its session), `interval_s=None` (goals evaluate post-turn, not on a cadence).
- `WatchController._evaluate_unlocked` → `kind="watch"`, the watch `id`, `session_id = run_session or ""`, and the **effective** cadence (`watch.interval_s` override, else the config `watch_interval` fallback the server's `_watch_loop` ticks at — same `getattr(..., 30)`).
- Existing verifiers that ignore `ctx` keep working unchanged; a bare `VerifyContext()` still builds with `invoker=None` (all pre-existing tests untouched and green).

## Tests

- `tests/test_goal_controller.py::test_evaluate_passes_goal_invoker_to_plugin_verifier` — a fake plugin verifier registered via the **normal path** (`PluginRegistry.register_goal_verifier` → `set_plugin_verifiers`), set as a goal via `set_goal_safe`, asserts `kind="goal"` + goal/session id + `interval_s is None` + legacy `condition` still flows.
- `tests/test_watch_controller.py::test_evaluate_passes_watch_invoker_to_plugin_verifier` — same verifier invoked by the watch controller asserts `kind="watch"` + the watch id + `run_session` + `interval_s` (both the per-watch `12.5` override and the config-default `30.0` fallback).
- `tests/test_goal_verifiers.py` — bare-ctx backward-compat (`invoker is None`, legacy defaults intact) and `VerifierInvoker` frozen/hashable (usable as a state key).

## Docs

- `docs/guides/plugins.md` — new **Goal & watch verifiers — `register_goal_verifier`** section (the plugin-authoring home): the full `ctx` contract table, the `ctx.invoker` fields, and a per-watch drawdown high-water-mark example; plus a `register_goal_verifier` row in the contribution-types table (it was missing entirely).
- `docs/guides/goal-mode.md` — the verifier-types table gains the missing `plugin` row, linking to the contract.
- `docs/guides/watches.md` — notes that a `plugin` verifier receives the invoking watch's identity on `ctx.invoker`.

> Note: the plugin-devkit `building-plugins` skill the issue mentions lives in the separate projectBoard-plugin repo — it needs a follow-up sync there to pick up the `ctx.invoker` contract; this PR documents in-tree only.

## Gates

- `ruff check .` — clean
- `lint-imports` — 3 contracts kept, 0 broken
- `python -m pytest tests/ -q` — 2812 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)