### PR TITLE
fix(version): repo pyproject beats stale editable-install dist-info — one shared resolver for the plugin gate and the A2A card

### DIFF
--- a/docs/adr/0027-install-plugins-from-git-url.md
+++ b/docs/adr/0027-install-plugins-from-git-url.md
@@ -89,7 +89,11 @@ fast-follow; untrusted code → MCP (D1).
 ### D7 — Manifest additions (all data, all optional)
 
 `requires_pip: [..]` (D4); `repository:` / `homepage:` (provenance, shown in review);
-`min_protoagent_version:` (compat — warn/refuse if the host is older).
+`min_protoagent_version:` (compat — warn/refuse if the host is older; the host
+version is the shared `infra.paths.package_version()` resolver the A2A card also
+advertises — repo `pyproject.toml` first, installed metadata on wheel/frozen
+installs — so a dev checkout's stale editable-install dist-info can't refuse a
+valid plugin, #1644).
 
 ### D8 — Integrity rails
 

--- a/docs/dev/version-coherence.md
+++ b/docs/dev/version-coherence.md
@@ -144,17 +144,32 @@ leaving a bare 404 with no surfaced reason.
 > `build_panel_router` builds `/panel` cleanly, its WASM/WAD assets are intact — yet
 > `/plugins/doom/panel` 404s on the live host. A restart mounts it.
 
-## Cross-cutting B — Version truth is broken off-source
+## Cross-cutting B — Version truth off-source *(fixed: #894, #1644)*
 
-`paths.package_version()` (`paths.py:55-89`) tries `importlib.metadata.version` then
-falls back to reading `pyproject.toml` next to the module / at `_MEIPASS`, else
-`"0.0.0"`. In the **frozen desktop binary** `pyproject.toml` is *not* bundled
-(`apps/desktop/sidecar/build_sidecar.py` `BUNDLED_DATA`) and there's no dist-info →
-**`0.0.0`**. In **Docker** the package is never pip-installed (only `PYTHONPATH`), and
-the `VERSION` build-arg is dead (the Dockerfile never declares `ARG VERSION`). So on
-those artifacts the A2A card, the fleet handshake, the runtime-status version, and
-the plugin compat gate **all read `0.0.0`** — no version-based detection can fire,
-and the `min_protoagent_version` gate wrongly refuses every plugin that sets one.
+`infra.paths.package_version()` is the **one shared resolver** — the A2A card
+(`server/a2a.py`), the plugin `min_protoagent_version` gate
+(`graph/plugins/loader.py`), the runtime status, and the fleet version handshake
+all delegate to it, so those surfaces can never disagree. It resolves
+**pyproject-first, anchored to the package's own location** (never the cwd, never
+an upward search — so a wheel install under someone else's project can't pick up
+*their* `pyproject.toml`): the repo-root `pyproject.toml` on a source checkout /
+`COPY .` image, the `_MEIPASS`-bundled copy in the frozen desktop binary, then
+installed dist-info metadata (wheel installs), else `"0.0.0"`.
+
+Two failure modes shaped that order, both closed:
+
+- **Frozen/Docker read `0.0.0`.** The frozen binary didn't bundle
+  `pyproject.toml` and Docker never pip-installs the package (only `PYTHONPATH`),
+  so every off-source artifact reported `0.0.0` — no version-based detection could
+  fire, and the `min_protoagent_version` gate wrongly refused every plugin that
+  sets one. Fixed by bundling `pyproject.toml` at `_MEIPASS`
+  (`apps/desktop/sidecar/build_sidecar.py` `BUNDLED_DATA`, #894).
+- **Stale editable-install dist-info beat the pyproject.** Editable installs don't
+  rewrite dist-info on a version bump (only the next `uv sync` does), so with the
+  old metadata-first order a dev checkout advertised the stale version and the
+  gate refused valid plugins (`requires protoAgent >= 0.78.0 but this host is
+  0.72.0` — on a 0.80.0 checkout). Fixed by preferring the anchored pyproject
+  (#1644).
 
 ## Desktop ("Tori") projection — every axis gets worse
 

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -162,6 +162,13 @@ requires_pip: ["httpx>=0.27"]
 min_protoagent_version: "0.20.0"
 ```
 
+`min_protoagent_version` is enforced at load: the plugin is refused when it needs a
+newer host. The host version it's compared against is the same shared resolver the
+A2A agent card advertises (`infra.paths.package_version()` — the repo
+`pyproject.toml` on a source checkout, installed package metadata on wheel/frozen
+installs), so the gate and the card always agree — a dev checkout's stale
+editable-install metadata can no longer refuse a valid plugin (#1644).
+
 ## Get listed in the directory
 
 Anyone can install your plugin from its git URL once it's a public repo. To make it

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -195,30 +195,17 @@ def run_plugin_mcp_main(plugin_id: str) -> None:
 def _host_version() -> str:
     """The running protoAgent version, for the manifest compat gate.
 
-    Same resolution order as the A2A card (``server.a2a._package_version`` —
-    not imported here, ``graph`` must not depend on ``server``): installed
-    package metadata first, then the repo ``pyproject.toml`` ``[project].version``.
+    Delegates to the shared resolver ``infra.paths.package_version()`` — the same
+    source the A2A card advertises (``server.a2a._package_version``; ``graph``
+    must not import ``server``, so both delegate to the ``infra`` leaf) — so the
+    gate and the card can never disagree. The resolver prefers the repo
+    ``pyproject.toml`` over installed metadata: on a dev checkout the editable
+    install's dist-info goes stale on version bumps, and this gate used to refuse
+    valid plugins because of it (#1644).
     """
-    try:
-        from importlib.metadata import PackageNotFoundError, version
+    from infra.paths import package_version
 
-        try:
-            return version("protoagent")
-        except PackageNotFoundError:
-            pass
-    except ImportError:  # pragma: no cover - importlib.metadata always present on 3.11+
-        pass
-
-    from infra.paths import instance_paths
-
-    pyproject = instance_paths().app_root / "pyproject.toml"
-    try:
-        m = re.search(r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.MULTILINE)
-        if m:
-            return m.group(1)
-    except OSError:
-        pass
-    return "0.0.0"
+    return package_version()
 
 
 def _min_version_gate(manifest: PluginManifest) -> str | None:

--- a/infra/paths.py
+++ b/infra/paths.py
@@ -54,17 +54,57 @@ def atomic_write(path: Path | str, text: str, *, mode: int | None = None) -> Non
         raise
 
 
+def _anchored_pyproject_version() -> str | None:
+    """``[project].version`` from the ``pyproject.toml`` that governs *this* package,
+    or ``None`` when this package didn't ship one (wheel install).
+
+    Anchored to the package's **own location** — never the cwd, never an unbounded
+    upward search (either could swallow an unrelated project's ``pyproject.toml``,
+    e.g. when protoAgent is wheel-installed under ``<their-project>/.venv``):
+
+    - **Frozen (PyInstaller onefile):** the bundle root ``_MEIPASS``, where
+      ``build_sidecar.py`` bundles ``pyproject.toml`` (#894).
+    - **Source checkout / ``COPY .`` image:** the repo root, exactly two levels up
+      (this module is ``<root>/infra/paths.py``).
+    - **Wheel install:** the anchor is ``site-packages`` — no pyproject there, so
+      this returns ``None`` and installed metadata answers instead.
+    """
+    import sys
+
+    here = Path(__file__).resolve()
+    if getattr(sys, "frozen", False):
+        root = Path(getattr(sys, "_MEIPASS", here.parent))
+    else:
+        root = here.parents[1]
+    try:
+        m = re.search(r'^version\s*=\s*"([^"]+)"', (root / "pyproject.toml").read_text(), re.MULTILINE)
+    except OSError:
+        return None
+    return m.group(1) if m else None
+
+
 def package_version() -> str:
     """This instance's app version — ``pyproject.toml`` ``[project].version`` is the
     one source of truth (the release pipeline bumps it).
 
-    Prefer installed-package metadata; fall back to reading pyproject.toml next to
-    this module (source checkout / ``COPY .`` image) or the PyInstaller bundle root;
-    final fallback keeps callers valid if neither is available. Lives here (a leaf
-    module) so the A2A card (``server/a2a.py``), the runtime status, and the fleet
-    supervisor all report it without import cycles — the hub↔remote version
-    handshake compares it.
+    Prefer the pyproject this package ships with (source checkout / ``COPY .``
+    image / PyInstaller bundle — see ``_anchored_pyproject_version``); fall back to
+    installed-package metadata (wheel installs, where no pyproject ships); final
+    ``"0.0.0"`` fallback keeps callers valid if neither is available. The pyproject
+    must win when both exist: editable installs don't rewrite dist-info on a
+    version bump (only the next ``uv sync`` does), so on a dev checkout the
+    metadata goes stale — and when metadata was consulted first, the plugin
+    ``min_protoagent_version`` gate refused valid plugins and the A2A card
+    advertised the old version (#1644).
+
+    Lives here (a leaf module) so the A2A card (``server/a2a.py``), the plugin
+    compat gate (``graph/plugins/loader.py``), the runtime status, and the fleet
+    supervisor all report it without import cycles — one shared resolver, so those
+    surfaces can never disagree.
     """
+    pinned = _anchored_pyproject_version()
+    if pinned:
+        return pinned
     try:
         from importlib.metadata import PackageNotFoundError, version
 
@@ -74,25 +114,6 @@ def package_version() -> str:
             pass
     except ImportError:  # pragma: no cover - importlib.metadata always present on 3.11+
         pass
-
-    import sys
-
-    here = Path(__file__).resolve()
-    if getattr(sys, "frozen", False):  # PyInstaller onefile — pyproject bundled at _MEIPASS (#894)
-        candidates = [Path(getattr(sys, "_MEIPASS", here.parent))]
-    else:
-        # Search UPWARD for pyproject.toml: it's at the repo root (or the `COPY .`
-        # image root), NOT next to this module — paths.py lives in infra/, so a
-        # plain `__file__.parent` would look in infra/ and miss it (the regression
-        # the root-module reorg introduced). The nearest one going up is the repo's.
-        candidates = list(here.parents)
-    for base in candidates:
-        try:
-            m = re.search(r'^version\s*=\s*"([^"]+)"', (base / "pyproject.toml").read_text(), re.MULTILINE)
-            if m:
-                return m.group(1)
-        except OSError:
-            continue
     return "0.0.0"
 
 

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -289,11 +289,12 @@ def structured_skill_schema(skill_id: str) -> dict | None:
 
 
 def _package_version() -> str:
-    """Single-source the agent-card version from the package metadata.
+    """Single-source the agent-card version.
 
     Delegates to ``paths.package_version()`` (one source of truth — the
     pyproject ``[project].version`` the release pipeline bumps) so the card,
-    the runtime status, and the fleet version handshake can never disagree.
+    the plugin ``min_protoagent_version`` gate (``graph/plugins/loader.py``),
+    the runtime status, and the fleet version handshake can never disagree (#1644).
     Kept as a name here for its existing importers (``server.__init__`` re-exports it).
     """
     from infra.paths import package_version

--- a/tests/test_package_version.py
+++ b/tests/test_package_version.py
@@ -1,8 +1,14 @@
-"""`paths.package_version()` resolution — especially the frozen-binary `_MEIPASS`
-fallback that keeps the desktop app from reporting `0.0.0` (version-coherence
-Cross-cutting B). A `0.0.0` blinds the A2A card, the fleet version handshake, runtime
-status, and the plugin `min_protoagent_version` compat gate, so this must resolve a
-real version on every artifact.
+"""`paths.package_version()` resolution — the anchored pyproject-first order (#1644)
+plus the frozen-binary `_MEIPASS` fallback that keeps the desktop app from reporting
+`0.0.0` (version-coherence Cross-cutting B). A wrong version here blinds the A2A card,
+the fleet version handshake, runtime status, and the plugin `min_protoagent_version`
+compat gate, so this must resolve the *fresh* version on every artifact:
+
+- source checkout: the repo `pyproject.toml` must beat stale editable-install
+  dist-info (editable installs only rewrite metadata on the next `uv sync`, so on a
+  dev checkout the metadata lags every version bump — #1644);
+- wheel/frozen installs: no pyproject ships at the anchor, so installed metadata
+  answers — and the anchor must never wander into an unrelated project's pyproject.
 """
 
 from __future__ import annotations
@@ -15,13 +21,65 @@ from infra import paths
 
 def _force_no_installed_metadata(monkeypatch):
     """Make ``importlib.metadata.version("protoagent")`` raise, so resolution falls
-    through to the pyproject read — the frozen-binary + Docker reality (the package
-    is never pip-installed there)."""
+    through past the metadata fallback — the frozen-binary + Docker reality (the
+    package is never pip-installed there)."""
 
     def _raise(name):
         raise importlib.metadata.PackageNotFoundError(name)
 
     monkeypatch.setattr(importlib.metadata, "version", _raise)
+
+
+def _force_installed_metadata(monkeypatch, value: str):
+    """Pretend the venv's dist-info says *value* for ``protoagent``."""
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: value)
+
+
+def _anchor_module_at(monkeypatch, module_file):
+    """Relocate the resolver's self-anchor: pretend ``infra/paths.py`` lives at
+    *module_file* (the resolver reads its own ``__file__``, never the cwd)."""
+    monkeypatch.setattr(paths, "__file__", str(module_file))
+
+
+def test_repo_pyproject_beats_stale_editable_metadata(monkeypatch, tmp_path):
+    # THE #1644 regression: on a source checkout the editable install's dist-info
+    # says 0.72.0 while pyproject.toml says 0.80.0 — pyproject must win, or the
+    # plugin gate refuses valid plugins and the A2A card advertises the old version.
+    repo = tmp_path / "repo"
+    (repo / "infra").mkdir(parents=True)
+    (repo / "pyproject.toml").write_text('[project]\nname = "protoagent"\nversion = "0.80.0"\n', encoding="utf-8")
+    _anchor_module_at(monkeypatch, repo / "infra" / "paths.py")
+    _force_installed_metadata(monkeypatch, "0.72.0")
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+
+    assert paths.package_version() == "0.80.0"
+
+
+def test_wheel_install_falls_back_to_metadata(monkeypatch, tmp_path):
+    # Wheel install: the anchor is site-packages, which ships no pyproject.toml —
+    # installed metadata is the truth there.
+    site = tmp_path / ".venv" / "lib" / "python3.11" / "site-packages"
+    (site / "infra").mkdir(parents=True)
+    _anchor_module_at(monkeypatch, site / "infra" / "paths.py")
+    _force_installed_metadata(monkeypatch, "0.75.0")
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+
+    assert paths.package_version() == "0.75.0"
+
+
+def test_never_reads_an_unrelated_projects_pyproject(monkeypatch, tmp_path):
+    # protoAgent wheel-installed under someone else's project: `<their-project>/
+    # pyproject.toml` exists up the directory tree, but the anchor is exact (the
+    # package's own root), not an upward search — their version must not leak in.
+    theirs = tmp_path / "their-project"
+    site = theirs / ".venv" / "lib" / "python3.11" / "site-packages"
+    (site / "infra").mkdir(parents=True)
+    (theirs / "pyproject.toml").write_text('[project]\nname = "their-app"\nversion = "9.9.9"\n', encoding="utf-8")
+    _anchor_module_at(monkeypatch, site / "infra" / "paths.py")
+    _force_installed_metadata(monkeypatch, "0.75.0")
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+
+    assert paths.package_version() == "0.75.0"
 
 
 def test_reads_meipass_pyproject_when_frozen(monkeypatch, tmp_path):
@@ -33,9 +91,20 @@ def test_reads_meipass_pyproject_when_frozen(monkeypatch, tmp_path):
     assert paths.package_version() == "9.9.9"
 
 
+def test_frozen_without_bundled_pyproject_uses_metadata(monkeypatch, tmp_path):
+    # A frozen build whose bundle step dropped pyproject.toml must still answer
+    # from whatever metadata PyInstaller collected — not read some on-disk repo.
+    _force_installed_metadata(monkeypatch, "0.77.0")
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)  # empty dir
+
+    assert paths.package_version() == "0.77.0"
+
+
 def test_source_checkout_reads_repo_pyproject(monkeypatch):
-    # Not frozen, no installed metadata → reads pyproject.toml next to paths.py (the
-    # repo root / `COPY .` image). Must be a real version, not the 0.0.0 fallback.
+    # Not frozen, no installed metadata → reads the repo-root pyproject.toml two
+    # levels up from infra/paths.py (source checkout / `COPY .` image). Must be a
+    # real version, not the 0.0.0 fallback.
     _force_no_installed_metadata(monkeypatch)
     monkeypatch.setattr(sys, "frozen", False, raising=False)
 
@@ -52,3 +121,38 @@ def test_zero_fallback_only_when_nothing_resolves(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
 
     assert paths.package_version() == "0.0.0"
+
+
+def test_loader_gate_and_a2a_card_share_the_resolver(monkeypatch):
+    # The #1644 contract: the plugin min_protoagent_version gate and the A2A agent
+    # card must consume the SAME resolver so they can never disagree. Both import
+    # it lazily from infra.paths, so patching the shared function moves both.
+    import server.a2a as a2a
+    from graph.plugins import loader
+
+    monkeypatch.setattr(paths, "package_version", lambda: "7.7.7-shared")
+
+    assert loader._host_version() == "7.7.7-shared"
+    assert a2a._package_version() == "7.7.7-shared"
+
+
+def test_min_version_gate_uses_fresh_pyproject_version(monkeypatch, tmp_path):
+    # End-to-end through the gate: stale metadata (0.72.0) + fresh pyproject
+    # (0.80.0) must ADMIT a plugin requiring 0.78.0 — the live #1644 failure mode.
+    from graph.plugins import loader
+    from graph.plugins.manifest import PluginManifest
+
+    repo = tmp_path / "repo"
+    (repo / "infra").mkdir(parents=True)
+    (repo / "pyproject.toml").write_text('[project]\nname = "protoagent"\nversion = "0.80.0"\n', encoding="utf-8")
+    _anchor_module_at(monkeypatch, repo / "infra" / "paths.py")
+    _force_installed_metadata(monkeypatch, "0.72.0")
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+
+    manifest = PluginManifest(
+        id="spacetraders",
+        name="SpaceTraders",
+        path=tmp_path,
+        min_protoagent_version="0.78.0",
+    )
+    assert loader._min_version_gate(manifest) is None


### PR DESCRIPTION
Fixes #1644

## The bug (confirmed live)

On a dev checkout, `pyproject.toml` said 0.80.0 while the venv's `importlib.metadata.version("protoagent")` said 0.72.0 — editable installs don't rewrite dist-info on a version bump (only the next `uv sync` does). `graph/plugins/loader.py::_host_version` preferred metadata first, so the `min_protoagent_version` gate refused valid plugins (`spacetraders enabled but requires protoAgent >= 0.78.0 but this host is 0.72.0 — refusing to load`), and the A2A card documented/advertised the same stale order.

## The fix

**One shared resolver, pyproject-first, anchored to the package's own location.**

- `infra/paths.py::package_version()` — already the resolver the A2A card, runtime status, and fleet handshake delegate to — now prefers the `pyproject.toml` this package *ships with* (new `_anchored_pyproject_version()`), falling back to installed metadata (wheel installs), then `"0.0.0"`.
- The anchor is exact, never the cwd and never an upward search: the repo root exactly two levels up from `infra/paths.py` (source checkout / `COPY .` image), or `_MEIPASS` when frozen (PyInstaller bundles `pyproject.toml` there since #894 — and if a bundle ever drops it, metadata still wins there). A wheel install's anchor is `site-packages` (no pyproject ships there), so a protoAgent wheel installed under `<someone-else's-project>/.venv` can never swallow *their* `pyproject.toml` — the failure mode an upward search would reintroduce.
- `graph/plugins/loader.py::_host_version` now **delegates** to that resolver instead of duplicating the (wrong-order) logic — the gate and the card literally consume the same function, so they can never disagree. Import layering holds: `graph → infra` is already an allowed edge (`lint-imports` green, nothing added to `ignore_imports`).
- `server/a2a.py::_package_version` was already delegating; its docstring now names the gate as a co-consumer.

## Tests (`tests/test_package_version.py`)

- `test_repo_pyproject_beats_stale_editable_metadata` — the live repro: metadata 0.72.0 + pyproject 0.80.0 → 0.80.0.
- `test_wheel_install_falls_back_to_metadata` — site-packages anchor, no pyproject → metadata.
- `test_never_reads_an_unrelated_projects_pyproject` — wheel under `<their-project>/.venv` with `<their-project>/pyproject.toml` present → still metadata (anchor guard).
- `test_frozen_without_bundled_pyproject_uses_metadata` — frozen + empty `_MEIPASS` → metadata.
- `test_loader_gate_and_a2a_card_share_the_resolver` — patch `infra.paths.package_version`; both `loader._host_version()` and `a2a._package_version()` move together (the #1644 contract).
- `test_min_version_gate_uses_fresh_pyproject_version` — end-to-end through `_min_version_gate`: stale 0.72.0 metadata + fresh 0.80.0 pyproject **admits** a plugin requiring 0.78.0.
- Existing `_MEIPASS` / source-checkout / `0.0.0`-fallback tests kept (still green).

Live-verified from this branch against the real venv: resolver, loader gate, and pyproject all agree (0.81.0).

## Docs

- `docs/dev/version-coherence.md` Cross-cutting B rewritten to the fixed state (it also still claimed pyproject wasn't bundled in the frozen binary — stale since #894).
- `docs/guides/plugin-registry.md` — note under the manifest example on how the host version is resolved for the gate.
- `docs/adr/0027-install-plugins-from-git-url.md` D7 — one-line clarification of the host-version source.

No new docs pages (no nav regen needed).

## Gates

- `ruff check .` (0.15.10) ✅
- `lint-imports` (2.11) ✅ — 3 contracts kept, nothing added to `ignore_imports`
- `python -m pytest tests/ -q` ✅ — 2814 passed, 5 skipped
- `python scripts/live_smoke.py` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)