### PR TITLE
fix(plugins): Configure dialog hydrates right after install — no page refresh (#1643)

### DIFF
--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -123,6 +123,14 @@ function fleetFor(req) {
   return fleetScopes.get(scope);
 }
 
+// Drop a plugin's Settings group from the (mutable, in-place) schema fixture — used by
+// install (replace-don't-duplicate) and uninstall so cross-test state stays clean (#1643).
+function removePluginSchemaGroup(id) {
+  for (let i = SETTINGS_SCHEMA.length - 1; i >= 0; i--) {
+    if (SETTINGS_SCHEMA[i].plugin_id === id) SETTINGS_SCHEMA.splice(i, 1);
+  }
+}
+
 function handleApiGet(pathname, fleet = FLEET) {
   switch (pathname) {
     case "/api/runtime/status":
@@ -720,6 +728,17 @@ const server = createServer(async (req, res) => {
       RUNTIME_STATUS.plugins = RUNTIME_STATUS.plugins.filter((p) => p.id !== id).concat({
         id, name: id, version: "0.1.0", enabled: true, loaded: true, tools: [], skills: 0,
       });
+      // ... and its declared Settings group joins the schema (ADR 0019 — install
+      // auto-enables), so the e2e can prove a fresh install's Configure dialog
+      // hydrates WITHOUT a page refresh (#1643): the console must refetch the
+      // (5-min-stale) schema after install for this group to appear.
+      removePluginSchemaGroup(id);
+      SETTINGS_SCHEMA.push({
+        section: id, category: "Plugins", plugin_id: id,
+        fields: [
+          { key: `${id}.greeting`, label: "Greeting", type: "string", section: id, restart: false, description: "Shown by the plugin.", options: [], value: "hi", default: "hi", scope: "agent", source: "agent" },
+        ],
+      });
       return sendJson(res, {
         installed: {
           id, name: id, version: "0.1.0", description: "installed via console",
@@ -752,6 +771,7 @@ const server = createServer(async (req, res) => {
       const id = decodeURIComponent(pathname.split("/").pop());
       INSTALLED_PLUGINS = INSTALLED_PLUGINS.filter((p) => p.id !== id);
       RUNTIME_STATUS.plugins = RUNTIME_STATUS.plugins.filter((p) => p.id !== id);
+      removePluginSchemaGroup(id);  // uninstall drops its Settings group too (#1643)
       return sendJson(res, { ok: true });
     }
     return sendJson(res, { ok: true });

--- a/apps/web/e2e/plugin-install.spec.ts
+++ b/apps/web/e2e/plugin-install.spec.ts
@@ -26,6 +26,14 @@ test("install a plugin from a git URL, then uninstall it from its row", async ({
   const row = page.locator(".plugin-row-wrap", { hasText: "protoagent-plugin-widgets" });
   await expect(row).toBeVisible();
 
+  // #1643 — the fresh install is configurable IMMEDIATELY (no page refresh): install
+  // invalidates the settings schema, so the row grows a Configure button and the
+  // dialog opens with the plugin's fields, not empty.
+  await row.getByRole("button", { name: "Configure protoagent-plugin-widgets" }).click();
+  const config = page.getByRole("dialog", { name: "protoagent-plugin-widgets" });
+  await expect(config.locator('.setting-row[data-key="protoagent-plugin-widgets.greeting"]')).toBeVisible();
+  await config.locator(".pl-dialog__close").click();
+
   // Uninstall from the row — a DS ConfirmDialog guards it; confirm and the row disappears.
   await row.getByRole("button", { name: /uninstall/i }).click();
   const confirm = page.getByRole("dialog", { name: "Uninstall plugin?" });
@@ -38,4 +46,36 @@ test("the install dialog's form guards an empty URL", async ({ page }) => {
   await openInstallDialog(page);
   await expect(page.getByLabel("plugin git URL")).toBeVisible();
   await expect(page.getByRole("button", { name: "Install", exact: true })).toBeDisabled();
+});
+
+test("Discover install → Configure dialog hydrates without a page refresh (#1643)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("settings-widget").click();
+  await page.locator(".pl-sidenav").getByRole("tab", { name: "Integrations", exact: true }).click();
+  // Land on Installed first so the settings schema is fetched + cached WITHOUT the new
+  // plugin's group — the bug's precondition (the schema query has a 5-min staleTime, so
+  // without the install-side invalidation the stale cache serves the Configure dialog).
+  await expect(page.locator(".plugin-row-wrap", { hasText: "Demo Plugin" })).toBeVisible();
+
+  // Install from the Discover directory (this path used to skip the schema refetch).
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Discover", exact: true }).click();
+  const card = page.locator(".plugin-card", { hasText: "Artifact" });
+  await card.getByRole("button", { name: "Install", exact: true }).click();
+  await expect(page.locator(".pl-toast", { hasText: "Plugin installed" })).toBeVisible();
+
+  // Back on Installed: the new row offers Configure NOW — no page refresh — and the
+  // dialog carries the plugin's fields (the schema was refetched after install).
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Installed", exact: true }).click();
+  const row = page.locator(".plugin-row-wrap", { hasText: "artifact-plugin" });
+  await expect(row).toBeVisible();
+  await row.getByRole("button", { name: "Configure artifact-plugin" }).click();
+  const config = page.getByRole("dialog", { name: "artifact-plugin" });
+  await expect(config.locator('.setting-row[data-key="artifact-plugin.greeting"]')).toBeVisible();
+  await config.locator(".pl-dialog__close").click();
+
+  // Clean up the shared mock state: uninstall the plugin again.
+  await row.getByRole("button", { name: /uninstall/i }).click();
+  const confirm = page.getByRole("dialog", { name: "Uninstall plugin?" });
+  await confirm.getByRole("button", { name: "Uninstall", exact: true }).click();
+  await expect(page.locator(".plugin-row-wrap", { hasText: "artifact-plugin" })).toHaveCount(0);
 });

--- a/apps/web/src/plugins/InstallPluginDialog.tsx
+++ b/apps/web/src/plugins/InstallPluginDialog.tsx
@@ -1,12 +1,12 @@
 import { Button } from "@protolabsai/ui/primitives";
 import { Input } from "@protolabsai/ui/forms";
 import { Dialog } from "@protolabsai/ui/overlays";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import { useState } from "react";
 
 import { api } from "../lib/api";
-import { queryKeys, runtimeStatusQuery } from "../lib/queries";
+import { usePluginRefresh } from "./usePluginManage";
 
 const REGISTRY_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/plugin-registry";
 
@@ -15,23 +15,20 @@ const REGISTRY_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/plug
 // tab toolbar. Installing AUTO-ENABLES + runs it (trust-by-default): its tools, console
 // views and background surfaces come up live, no separate enable step and no restart.
 export function InstallPluginDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const qc = useQueryClient();
   const [url, setUrl] = useState("");
   const [ref, setRef] = useState("");
   const [status, setStatus] = useState("");
+  const refreshAll = usePluginRefresh();
 
   const install = useMutation({
     mutationFn: () => api.installPlugin(url.trim(), ref.trim() || undefined),
     onSuccess: (res) => {
       const s = res.installed;
-      // Refresh the Installed list (runtime roster) AND the lock-backed inventory that
-      // gates Uninstall.
-      qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
-      qc.invalidateQueries({ queryKey: queryKeys.installedPlugins });
-      // Install auto-enables the plugin, so its declared Settings fields (ADR 0019) are
-      // now in the schema — refetch it or the plugin's config section won't appear until
-      // a restart clears the 5-min-stale cache (#1423).
-      qc.invalidateQueries({ queryKey: queryKeys.settings });
+      // Shared installed-set refresh: the runtime roster, the lock-backed inventory that
+      // gates Uninstall, the freshness poll, and the settings schema — install auto-enables
+      // the plugin, so its declared Settings fields (ADR 0019) must land in the schema or
+      // its Configure dialog renders empty until a page refresh (#1423 / #1643).
+      refreshAll();
       setUrl("");
       setRef("");
       // Clean install (auto-enabled, nothing to flag) → close; the new row shows in the

--- a/apps/web/src/plugins/PluginSettingsDialog.tsx
+++ b/apps/web/src/plugins/PluginSettingsDialog.tsx
@@ -1,7 +1,11 @@
 import { Dialog } from "@protolabsai/ui/overlays";
-import { Suspense } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Suspense, useEffect } from "react";
 
+import { queryKeys } from "../lib/queries";
+import type { SettingsGroup } from "../lib/types";
 import { SettingsCategory } from "../settings/SettingsCategory";
+import { pluginSchemaNeedsRefetch } from "./settingsHydration";
 
 // Per-plugin settings dialog (ADR 0059, supersedes the inline row expander). Configure
 // on a plugin row opens this instead of growing the row — the form gets real breathing
@@ -19,6 +23,20 @@ export function PluginSettingsDialog({
   open: boolean;
   onClose: () => void;
 }) {
+  const qc = useQueryClient();
+  // Fresh-install hydration (#1643): if the cached settings schema predates this
+  // plugin's install it has no group for it and the form renders empty until a page
+  // refresh. On open, when the group is missing from the cache, invalidate the schema
+  // so the mounted query refetches and the fields hydrate in place. (Install paths
+  // invalidate it too — usePluginRefresh — this covers every other way in.)
+  useEffect(() => {
+    if (!open) return;
+    const cached = qc.getQueryData<{ groups: SettingsGroup[] }>(queryKeys.settings);
+    if (pluginSchemaNeedsRefetch(cached, pluginId)) {
+      void qc.invalidateQueries({ queryKey: queryKeys.settings });
+    }
+  }, [open, pluginId, qc]);
+
   if (!open) return null;
   return (
     <Dialog open onClose={onClose} title={pluginName} width="min(640px, 95vw)" className="plugin-settings-dialog">

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -17,7 +17,7 @@ import { StatusPill } from "../app/StatusPill";
 import { InstallPluginDialog } from "./InstallPluginDialog";
 import { PluginSettingsDialog } from "./PluginSettingsDialog";
 import { PluginFreshness } from "./PluginFreshness";
-import { usePluginManage } from "./usePluginManage";
+import { usePluginManage, usePluginRefresh } from "./usePluginManage";
 import { catalogCategories, filterCatalog } from "./catalog";
 import { api } from "../lib/api";
 import type { CatalogPlugin, PluginUpdate, RuntimeStatus } from "../lib/types";
@@ -168,17 +168,11 @@ function LocalTab() {
   const [uninstallPending, setUninstallPending] = useState<Plugin | null>(null);
   const [restartPending, setRestartPending] = useState(false);
   // Update + uninstall mutations (toast + query-refresh) shared with the rail context
-  // menu (#1521 / #1522), so both entry points behave identically.
+  // menu (#1521 / #1522), so both entry points behave identically. `refreshAll` is the
+  // shared installed-set invalidation (runtime + inventory + freshness + the settings
+  // schema, which carries each enabled plugin's declared config fields — #1423/#1643).
   const { update, remove } = usePluginManage();
-
-  const refreshAll = () => {
-    qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
-    qc.invalidateQueries({ queryKey: queryKeys.installedPlugins });
-    qc.invalidateQueries({ queryKey: queryKeys.pluginUpdates });
-    // The active plugin set changed, so the settings schema (which carries each enabled
-    // plugin's declared config fields, ADR 0019) is stale — refetch it (#1423).
-    qc.invalidateQueries({ queryKey: queryKeys.settings });
-  };
+  const refreshAll = usePluginRefresh();
 
   const toggle = useMutation({
     mutationFn: (p: Plugin) => api.setPluginEnabled(p.id, !p.enabled),
@@ -367,12 +361,17 @@ function DiscoverTab() {
   const [q, setQ] = useState("");
   const [cat, setCat] = useState("All");
   const toast = useToast();
+  const refreshAll = usePluginRefresh();
 
   const install = useMutation({
     mutationFn: (p: CatalogPlugin) => api.installPlugin(p.repo),
     onSuccess: (res, p) => {
       qc.invalidateQueries({ queryKey: ["plugin-catalog"] });
-      qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+      // Full installed-set refresh — this path used to invalidate only the catalog +
+      // runtime, so the (5-min-stale) settings schema kept no group for the new plugin
+      // and its Configure dialog opened EMPTY until a page refresh (#1643). It also
+      // hid the row's Configure/Uninstall buttons (inventory + schema drive both).
+      refreshAll();
       toast({ tone: "success", title: "Plugin installed", message: `${p.name}${res.reloaded ? " — enabled and live" : ""}.` });
     },
     onError: (err: unknown, p) => toast({ tone: "error", title: "Couldn't install plugin", message: `${p.name}: ${errMsg(err)}` }),

--- a/apps/web/src/plugins/settingsHydration.test.ts
+++ b/apps/web/src/plugins/settingsHydration.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { pluginSchemaNeedsRefetch } from "./settingsHydration";
+import type { SettingsGroup } from "../lib/types";
+
+// #1643 — the Configure dialog's open-time hydration guard: refetch the settings
+// schema exactly when a CACHED schema lacks the plugin's group (a fresh install the
+// cache predates); never when there's no cache (the suspense query fetches anyway)
+// or when the group is already present (the schema GET is a gateway round-trip).
+
+const group = (over: Partial<SettingsGroup>): SettingsGroup => ({
+  section: "Section",
+  fields: [],
+  ...over,
+});
+
+describe("pluginSchemaNeedsRefetch", () => {
+  it("no cached schema → no forced refetch (the mounting query fetches fresh)", () => {
+    expect(pluginSchemaNeedsRefetch(undefined, "widgets")).toBe(false);
+  });
+
+  it("cached schema already carries the plugin's group → cache is good", () => {
+    const cached = { groups: [group({ section: "Widgets", category: "Plugins", plugin_id: "widgets" })] };
+    expect(pluginSchemaNeedsRefetch(cached, "widgets")).toBe(false);
+  });
+
+  it("cached schema lacks the plugin's group (stale, pre-install) → refetch", () => {
+    const cached = {
+      groups: [
+        group({ section: "Model", category: "Model" }), // core group, no plugin_id
+        group({ section: "Other Plugin", category: "Plugins", plugin_id: "other" }),
+      ],
+    };
+    expect(pluginSchemaNeedsRefetch(cached, "widgets")).toBe(true);
+  });
+
+  it("cached schema with no plugin groups at all → refetch", () => {
+    const cached = { groups: [group({ section: "Model", category: "Model" })] };
+    expect(pluginSchemaNeedsRefetch(cached, "widgets")).toBe(true);
+  });
+
+  it("empty cached schema → refetch", () => {
+    expect(pluginSchemaNeedsRefetch({ groups: [] }, "widgets")).toBe(true);
+  });
+});

--- a/apps/web/src/plugins/settingsHydration.ts
+++ b/apps/web/src/plugins/settingsHydration.ts
@@ -1,0 +1,24 @@
+import type { SettingsGroup } from "../lib/types";
+
+// Open-time hydration guard for the per-plugin Configure dialog (#1643). Pure —
+// unit-tested; the dialog wires it to the React Query cache.
+//
+// The settings schema query is cached with a 5-minute staleTime (the GET does a
+// gateway round-trip server-side), and the dialog opens from several entry points
+// (the plugin manager row, the rail context menu, the util-bar widget) — so a
+// cached schema can predate the plugin's install and carry no group for it, which
+// rendered the dialog EMPTY until a full page refresh. Every install path also
+// invalidates the schema (usePluginRefresh), but the dialog is the last line of
+// defense for any path that doesn't.
+//
+// Refetch exactly when a cached schema exists AND lacks this plugin's group:
+//  - no cache yet     → the mounting suspense query fetches fresh anyway;
+//  - group present    → the cache is good — don't burn the gateway round-trip;
+//  - group missing    → the cache likely predates the install (or the plugin truly
+//    has no settings — one refetch makes "Nothing to configure here" authoritative).
+export function pluginSchemaNeedsRefetch(
+  cached: { groups: SettingsGroup[] } | undefined,
+  pluginId: string,
+): boolean {
+  return cached !== undefined && !cached.groups.some((g) => g.plugin_id === pluginId);
+}

--- a/apps/web/src/plugins/usePluginManage.ts
+++ b/apps/web/src/plugins/usePluginManage.ts
@@ -8,22 +8,30 @@ import { queryKeys, runtimeStatusQuery } from "../lib/queries";
 // A plugin the actions target — just its id (for the API) + name (for the toast).
 export type PluginRef = { id: string; name: string };
 
-// Shared update + uninstall mutations for a single plugin (#1521 / #1522, ADR 0027).
-// Used by BOTH the Plugins manager rows (PluginsSurface) and the rail context-menu
-// actions (PluginRailManage), so the toast copy + query-refresh are identical wherever
-// a plugin is updated/removed. On success we refresh: runtime (the rail icons + the
+// The ONE post-mutation refresh for anything that changes the installed-plugin set
+// (install / update / uninstall / sync). Invalidates: runtime (the rail icons + the
 // loaded set), the installed inventory (removable list), the freshness poll, and the
-// settings schema (a new/removed plugin changes which config fields exist, #1423).
-export function usePluginManage() {
+// settings schema — a new/removed plugin changes which config fields exist (#1423),
+// and a stale schema renders a freshly installed plugin's Configure dialog empty
+// until a page refresh (#1643). Every install path must call this (or invalidate
+// the same keys); keeping it in one place is the fix for that class of bug.
+export function usePluginRefresh() {
   const qc = useQueryClient();
-  const toast = useToast();
-
-  const refreshAll = () => {
+  return () => {
     qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
     qc.invalidateQueries({ queryKey: queryKeys.installedPlugins });
     qc.invalidateQueries({ queryKey: queryKeys.pluginUpdates });
     qc.invalidateQueries({ queryKey: queryKeys.settings });
   };
+}
+
+// Shared update + uninstall mutations for a single plugin (#1521 / #1522, ADR 0027).
+// Used by BOTH the Plugins manager rows (PluginsSurface) and the rail context-menu
+// actions (PluginRailManage), so the toast copy + query-refresh are identical wherever
+// a plugin is updated/removed.
+export function usePluginManage() {
+  const toast = useToast();
+  const refreshAll = usePluginRefresh();
 
   // Pull the latest code at the plugin's recorded ref + hot-reload (same path as enable).
   const update = useMutation({

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -56,7 +56,7 @@ export function SettingsCategory({
   pluginId?: string;
 }) {
   const queryClient = useQueryClient();
-  const { data } = useSuspenseQuery(settingsSchemaQuery());
+  const { data, isFetching } = useSuspenseQuery(settingsSchemaQuery());
   const groups = useMemo(() => {
     // One category, or several aggregated into one panel (the `categories` prop).
     const inScope = (g: SettingsGroup) =>
@@ -289,7 +289,12 @@ export function SettingsCategory({
             Needs a restart to take effect: {pendingRestart.join(", ")}
           </Alert>
         ) : null}
-        {!groups.length && !footer ? <p className="muted">{emptyHint || "Nothing to configure here."}</p> : null}
+        {/* While a background refetch is in flight (the #1643 fresh-install hydration
+            re-pulls the schema), an empty group set is "still loading", not "nothing
+            here" — don't flash the misleading empty hint. */}
+        {!groups.length && !footer ? (
+          <p className="muted">{isFetching ? "Loading settings…" : emptyHint || "Nothing to configure here."}</p>
+        ) : null}
 
         {/* Each field group is a collapsible accordion (DS 0.29) so a dense category
             (the Workspace home's panels run long) can be tidied to the few sections

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -29,7 +29,10 @@ manifest + capabilities, install, uninstall.
 
 **Installing from the console AUTO-ENABLES + runs the plugin** (trust-by-default):
 it's added to `plugins.enabled` and hot-reloaded, so its tools, console views and
-background surfaces come up live — no separate enable step and no restart. The
+background surfaces come up live — no separate enable step and no restart. Its
+declared settings are live too: the row's **Configure** dialog carries the plugin's
+config fields immediately after install (both the Discover directory and
+install-from-URL — no page refresh needed, #1643). The
 console flashes a one-time "this runs code on your machine" confirm for unofficial
 sources first (official `protoLabsAI/*` installs skip it; "don't show again" flips to
 full trust). Only install code you trust — for untrusted code, use an MCP server.


### PR DESCRIPTION
## Problem

Right after installing a plugin, opening its configuration dialog showed **empty** — no fields, labels, or controls — until a full page refresh (#1643).

## Root cause

The per-plugin Configure form (`SettingsCategory` scoped by `plugin_id`) is driven by the **settings schema query**, which is cached with a 5-minute `staleTime` (the GET does a gateway round-trip server-side). The **Discover-tab install** invalidated only the catalog + runtime roster — never the schema — so the cache kept serving a pre-install schema with no group for the new plugin. Downstream, the stale schema/inventory also hid the new row's Configure gear and Uninstall button. (Install-from-URL already invalidated the schema — #1423 — the Discover path just never got the same treatment.)

## Fix (three layers)

1. **`usePluginRefresh()`** — one shared installed-set invalidation (runtime roster, lock inventory, freshness poll, settings schema) now used by *every* path that changes the plugin set: Discover install, install-from-URL, update, uninstall, sync. The Discover install was the broken one.
2. **`PluginSettingsDialog` open-time hydration guard** — if the cached schema has no group for this plugin when the dialog opens, invalidate the schema so the mounted query refetches and the fields hydrate in place. Covers every other entry point (rail context-menu "Configure…", util-bar widget) as a last line of defense. Pure decision extracted to `settingsHydration.ts` (no forced refetch when there's no cache, or when the group is already present — don't burn the gateway round-trip).
3. **`SettingsCategory` empty state** — while that refetch is in flight, an empty group set renders "Loading settings…" instead of the misleading "Nothing to configure here."

## Tests

- **Unit (vitest):** `settingsHydration.test.ts` — the refetch decision (no cache / group present / group missing / no plugin groups / empty schema).
- **E2E (Playwright):** new regression `Discover install → Configure dialog hydrates without a page refresh (#1643)` — stages the exact bug precondition (schema cached pre-install), installs from Discover, and asserts the row's Configure dialog carries the plugin's fields with no reload. The mock server now registers/drops a plugin's settings group on install/uninstall like the real backend. The existing URL-install spec also gained a Configure assertion.

## Gates

| Gate | Result |
|------|--------|
| Web unit (`npm run test:unit --workspace @protoagent/web`) | 304 passed |
| Web build (`npm run build --workspace @protoagent/web`, tsc + vite) | pass |
| Web e2e (`npx playwright test`, full suite on fresh dist) | 187 passed |
| Docs build (`npm run docs:build`) | pass |
| Python gates | not touched (console-only change) |

## Docs

`docs/guides/plugin-registry.md` — noted that a fresh install's Configure dialog carries its config fields immediately (both install paths, no refresh).

## Test plan (local UX check)

1. Open Settings ▸ Integrations ▸ **Discover**, install a plugin with configurable settings (e.g. Discord).
2. Switch to **Installed** — the new row should show the Configure gear immediately.
3. Open the gear — the dialog should show the plugin's config fields (labels + controls), **without any page refresh**.
4. Repeat via **Install from URL**, and via a right-click **Configure…** on the plugin's rail icon (if it ships a view) — same result.
5. Sanity: a plugin with genuinely no settings should read "Nothing to configure here." (after a brief "Loading settings…" at most).

Fixes #1643

🤖 Generated with [Claude Code](https://claude.com/claude-code)