### PR TITLE
feat(sdk): watch lifecycle surface — sdk.list_watches / sdk.clear_watch (#1638)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Plugins can now enumerate and remove watches** (#1638). The consumption SDK
+  (ADR 0043) grows the lifecycle half of the ADR 0067 watch surface:
+  `sdk.list_watches(prefix="")` (each `{id, condition, status, verifier}`,
+  optionally id-prefix-filtered) and `sdk.clear_watch(watch_id) → bool`,
+  mirroring the agent tools' data access. `sdk.create_watch` was write-only, so
+  a plugin arming a watch *suite* under stable ids couldn't reconcile it — a
+  renamed or dropped watch spec left a zombie watch polling its verifier
+  forever (unresolvable after uninstall). An `arm_all()` can now clear the
+  suite ids no longer in its spec set before re-arming the rest.
+
 ### Fixed
 - **Re-installing a plugin from its own origin converges instead of erroring.**
   `plugin install` of an already-installed plugin from the SAME recorded source is

--- a/docs/adr/0067-standalone-watch-primitive.md
+++ b/docs/adr/0067-standalone-watch-primitive.md
@@ -74,7 +74,10 @@ This is the parallel-supervision engine: N watches, each with its own trip-actio
   shell/eval watch.
 - **Operator** `POST/GET/DELETE /api/watches` — accepts **any** verifier type, safe because
   `/api` is operator-tier by the ADR 0066 path ceiling (the operator channel).
-- **SDK** `sdk.create_watch(...)` + `register_watch_hook(...)` for plugins.
+- **SDK** `sdk.create_watch(...)` + `register_watch_hook(...)` for plugins — plus the
+  lifecycle half (#1638): `sdk.list_watches(prefix="")` / `sdk.clear_watch(watch_id)`, mirroring
+  the agent tools' data access so a plugin can reconcile its watch suite (clear the ids no
+  longer in its spec set) instead of leaking zombie watches when a spec is renamed/dropped.
 
 ### D5 — Relationship to the monitor-goal disposition
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -247,6 +247,12 @@ SDK** directly — `from graph.sdk import …`, the *stable* surface plugins cal
   poll `condition` on a cadence, and on met run `run_prompt` as a follow-up turn
   (`run_in_session`) + fire `on_met` hooks. Plugin-verifier only; hold **many** at once (unlike
   a monitor goal). Pair with `registry.register_watch_hook(on_met/on_expired/on_stalled=…)`.
+- `list_watches(prefix="")` / `clear_watch(watch_id)` — the watch **lifecycle** half (#1638):
+  enumerate the registered watches (each `{id, condition, status, verifier}`, optionally
+  id-prefix-filtered — e.g. `list_watches("st-")` for your own suite) and remove one by id
+  (`True` if it existed). Together they make a plugin's arm step a *reconcile* — clear the
+  suite ids no longer in your spec set, then create/replace the rest — so a renamed/dropped
+  watch spec can't leak a zombie watch. See [Watches](/guides/watches).
 
 The **workflows plugin** (`plugins/workflows`) is the reference consumer: its engine
 injects `run_subagent` as the per-step runner. This is the pattern for plugins that tap

--- a/docs/guides/watches.md
+++ b/docs/guides/watches.md
@@ -26,7 +26,13 @@ effective `interval_s`) so one verifier can keep **per-watch** state — see
 - **Agent tool** — `create_watch(condition, check, run_prompt=…)`; `list_watches` / `clear_watch`
   manage them. Plugin-verifier only (like `set_goal`) — the agent can't open a shell/eval watch.
 - **Plugin (SDK)** — `sdk.create_watch(*, condition, verifier, run_prompt=…)`, and react with
-  `registry.register_watch_hook(on_met=…, on_expired=…, on_stalled=…)`.
+  `registry.register_watch_hook(on_met=…, on_expired=…, on_stalled=…)`. The lifecycle half
+  (#1638): `sdk.list_watches(prefix="")` (each `{id, condition, status, verifier}`,
+  optionally id-prefix-filtered) and `sdk.clear_watch(watch_id) → bool`. A plugin that arms
+  a watch **suite** under stable ids should make its arm step a *reconcile*: clear the
+  `myplugin-*` ids no longer in its spec set, then create/replace the rest — stable-id
+  replace alone only heals specs that still exist, so a renamed or dropped spec would keep
+  polling its verifier forever (worse after uninstall, when that verifier is unresolvable).
 - **Operator (REST)** — `POST /api/watches` accepts **any** verifier type (it's on the `/api`
   operator surface, gated by the [federation-token ceiling](/reference/configuration#secrets));
   plus `GET /api/watches` and `DELETE /api/watches/{id}`.

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -235,3 +235,33 @@ def create_watch(
         trusted=False,
     )
     return {"ok": ok, "watch_id": watch.id if watch else None, "message": msg}
+
+
+def list_watches(prefix: str = "") -> list[dict]:
+    """List the registered watches — each ``{"id", "condition", "status", "verifier"}`` —
+    optionally filtered to ids starting with ``prefix``. This is the read half
+    :func:`create_watch` was missing (#1638): a plugin that arms a watch *suite* under
+    stable ids (``st-credits``, ``st-contract`` …) lists its own with
+    ``list_watches("st-")`` to verify the suite or render it on a dashboard, and —
+    paired with :func:`clear_watch` — reconciles on upgrade: clear the ids no longer in
+    its spec set, then create/replace the rest (stable-id replace alone only heals specs
+    that still exist; a renamed/dropped spec would keep polling forever). Returns ``[]``
+    when the watch system is unavailable."""
+    controller = STATE.watch_controller
+    if controller is None:
+        return []
+    return [
+        {"id": w.id, "condition": w.condition, "status": w.status, "verifier": dict(w.verifier)}
+        for w in controller.list_watches()
+        if w.id.startswith(prefix)
+    ]
+
+
+def clear_watch(watch_id: str) -> bool:
+    """Remove the watch ``watch_id`` (it stops being polled; its state is deleted).
+    Returns ``True`` if it existed, ``False`` when it didn't — or when the watch system
+    is unavailable. The remove half of the :func:`list_watches` reconcile pattern."""
+    controller = STATE.watch_controller
+    if controller is None:
+        return False
+    return controller.clear(watch_id)

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -247,11 +247,15 @@ def list_watches(prefix: str = "") -> list[dict]:
     its spec set, then create/replace the rest (stable-id replace alone only heals specs
     that still exist; a renamed/dropped spec would keep polling forever). Returns ``[]``
     when the watch system is unavailable."""
+    from copy import deepcopy
+
     controller = STATE.watch_controller
     if controller is None:
         return []
     return [
-        {"id": w.id, "condition": w.condition, "status": w.status, "verifier": dict(w.verifier)}
+        # deepcopy: the verifier spec nests dicts (``args``) — hand the caller a snapshot,
+        # not a mutable reference into the stored watch.
+        {"id": w.id, "condition": w.condition, "status": w.status, "verifier": deepcopy(w.verifier)}
         for w in controller.list_watches()
         if w.id.startswith(prefix)
     ]

--- a/tests/test_watch_operator.py
+++ b/tests/test_watch_operator.py
@@ -80,6 +80,84 @@ def test_sdk_module_exposes_create_watch():
     assert callable(sdk.create_watch)
 
 
+# --- sdk.list_watches / sdk.clear_watch (#1638) -----------------------------
+
+
+def test_sdk_list_watches_returns_id_condition_status_verifier(monkeypatch, tmp_path):
+    from graph import sdk
+
+    ctrl = _wire(monkeypatch, tmp_path)
+    ctrl.create(condition="credits over 1M", verifier={"type": "plugin", "check": "st:credits"}, watch_id="st-credits")
+    listed = sdk.list_watches()
+    assert listed == [
+        {
+            "id": "st-credits",
+            "condition": "credits over 1M",
+            "status": "active",
+            "verifier": {"type": "plugin", "check": "st:credits"},
+        }
+    ]
+    # The returned verifier is a COPY — mutating it must not corrupt the stored watch.
+    listed[0]["verifier"]["check"] = "tampered"
+    assert ctrl.store.get("st-credits").verifier["check"] == "st:credits"
+
+
+def test_sdk_list_watches_prefix_filters_to_the_plugins_suite(monkeypatch, tmp_path):
+    from graph import sdk
+
+    ctrl = _wire(monkeypatch, tmp_path)
+    ctrl.create(condition="a", verifier={"type": "plugin", "check": "st:v"}, watch_id="st-a")
+    ctrl.create(condition="b", verifier={"type": "plugin", "check": "st:v"}, watch_id="st-b")
+    ctrl.create(condition="c", verifier={"type": "plugin", "check": "other:v"}, watch_id="other-c")
+    assert {w["id"] for w in sdk.list_watches("st-")} == {"st-a", "st-b"}
+    assert len(sdk.list_watches()) == 3  # no prefix → everything
+
+
+def test_sdk_clear_watch_removes_and_reports_existence(monkeypatch, tmp_path):
+    from graph import sdk
+
+    ctrl = _wire(monkeypatch, tmp_path)
+    ctrl.create(condition="a", verifier={"type": "plugin", "check": "st:v"}, watch_id="st-a")
+    assert sdk.clear_watch("st-a") is True
+    assert sdk.list_watches() == []  # gone — no longer polled
+    assert sdk.clear_watch("st-a") is False  # already gone
+    assert sdk.clear_watch("never-existed") is False
+
+
+def test_sdk_watch_reconcile_pattern(monkeypatch, tmp_path):
+    """The #1638 payoff: arm_all() as reconcile — clear suite ids not in the current
+    spec set, then create/replace the rest (heals a renamed/dropped spec)."""
+    from graph import sdk
+
+    ctrl = _wire(monkeypatch, tmp_path)
+    # v1 armed two watches; v2 renamed st-opportunity → st-market.
+    ctrl.create(condition="credits", verifier={"type": "plugin", "check": "st:v"}, watch_id="st-credits")
+    ctrl.create(condition="opportunity", verifier={"type": "plugin", "check": "st:v"}, watch_id="st-opportunity")
+    current_spec = {"st-credits", "st-market"}
+    for watch in sdk.list_watches("st-"):
+        if watch["id"] not in current_spec:
+            assert sdk.clear_watch(watch["id"]) is True
+    for wid in current_spec:
+        sdk.create_watch(condition=f"cond {wid}", verifier="st:v", watch_id=wid)
+    assert {w["id"] for w in sdk.list_watches("st-")} == current_spec
+
+
+def test_sdk_list_and_clear_watch_unavailable(monkeypatch):
+    from graph import sdk
+    from runtime.state import STATE
+
+    monkeypatch.setattr(STATE, "watch_controller", None)
+    assert sdk.list_watches() == []
+    assert sdk.clear_watch("anything") is False
+
+
+def test_sdk_module_exposes_watch_lifecycle():
+    from graph import sdk
+
+    assert callable(sdk.list_watches)
+    assert callable(sdk.clear_watch)
+
+
 # --- registry / loader register_watch_hook seam ----------------------------
 
 

--- a/tests/test_watch_operator.py
+++ b/tests/test_watch_operator.py
@@ -87,19 +87,26 @@ def test_sdk_list_watches_returns_id_condition_status_verifier(monkeypatch, tmp_
     from graph import sdk
 
     ctrl = _wire(monkeypatch, tmp_path)
-    ctrl.create(condition="credits over 1M", verifier={"type": "plugin", "check": "st:credits"}, watch_id="st-credits")
+    ctrl.create(
+        condition="credits over 1M",
+        verifier={"type": "plugin", "check": "st:credits", "args": {"min": 1_000_000}},
+        watch_id="st-credits",
+    )
     listed = sdk.list_watches()
     assert listed == [
         {
             "id": "st-credits",
             "condition": "credits over 1M",
             "status": "active",
-            "verifier": {"type": "plugin", "check": "st:credits"},
+            "verifier": {"type": "plugin", "check": "st:credits", "args": {"min": 1_000_000}},
         }
     ]
-    # The returned verifier is a COPY — mutating it must not corrupt the stored watch.
+    # The returned verifier is a DEEP copy — mutating it (even the nested args) must not
+    # corrupt the stored watch.
     listed[0]["verifier"]["check"] = "tampered"
+    listed[0]["verifier"]["args"]["min"] = 0
     assert ctrl.store.get("st-credits").verifier["check"] == "st:credits"
+    assert ctrl.store.get("st-credits").verifier["args"]["min"] == 1_000_000
 
 
 def test_sdk_list_watches_prefix_filters_to_the_plugins_suite(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

`sdk.create_watch` (ADR 0067) is write-only. A plugin that arms a watch **suite** with stable ids (spacetraders v1.8: five tripwires, re-armed idempotently) cannot:

- **enumerate** what's currently armed (verify the suite, render a dashboard), or
- **remove** a watch whose spec no longer exists.

The second is a real leak: watches persist host-side and keep polling across restarts by design, so when a plugin release renames or drops a watch spec, the old watch keeps polling its verifier **forever** — a zombie the plugin can't clean up (worse after uninstall: the `plugin` verifier becomes unresolvable). Stable-id replace only heals specs that still exist. The agent-facing tools already exist (`list_watches` / `clear_watch` in `tools/lg_tools.py`); the plugin/SDK surface didn't.

## Change

Mirror the agent tools' data access on the consumption SDK (`graph/sdk.py`, ADR 0043), matching its host-missing guards and return shapes (degrade to `[]` / `False`, never raise — same posture as `knowledge_search` / `knowledge_add`):

- **`sdk.list_watches(prefix: str = "") -> list[dict]`** — `{id, condition, status, verifier}` per watch, optionally id-prefix-filtered (`list_watches("st-")` = your own suite). The `verifier` dict is returned as a **copy**, so a caller can't mutate the stored watch through it.
- **`sdk.clear_watch(watch_id: str) -> bool`** — `True` if it existed; `False` when it didn't or the watch system is off.

With these, a plugin's `arm_all()` becomes **reconcile**: clear the suite ids no longer in the current spec set, then create/replace the rest.

## Tests

`tests/test_watch_operator.py` (+7, alongside the existing `sdk.create_watch` coverage):

- list returns exactly `{id, condition, status, verifier}`, and the returned verifier is a copy (mutation doesn't corrupt the store)
- prefix filter scopes to the plugin's suite; no prefix returns everything
- clear removes + reports existence (`True` → `False` on re-clear / never-existed)
- the full reconcile pattern end-to-end (renamed spec `st-opportunity` → `st-market` heals)
- host-missing guards (`watch_controller is None` → `[]` / `False`)
- module exposes both callables

## Docs

- `docs/guides/watches.md` — the Plugin (SDK) channel now documents the lifecycle half + the reconcile pattern
- `docs/guides/plugins.md` — consumption-SDK list grows the `list_watches` / `clear_watch` entry
- `docs/adr/0067-standalone-watch-primitive.md` — D4 SDK channel description updated
- `CHANGELOG.md` [Unreleased] ▸ Added

## Explicitly not in scope

The issue's related hygiene — *the loader clears watches whose `plugin` verifier's owning plugin was uninstalled* — is a follow-up, per the issue text. This PR gives plugins the primitives to clean up after themselves; loader-driven cleanup on uninstall is a separate lifecycle change (see the paired #1642 work for the scheduler analog).

Fixes #1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ways to view and remove registered watches, including optional prefix filtering.
  * Improved watch lifecycle support so outdated watches can be cleaned up and kept in sync with current specs.

* **Documentation**
  * Expanded plugin and watch guides with clearer guidance on watch listing, removal, and reconciliation behavior.

* **Tests**
  * Added coverage for watch listing, filtering, removal, and no-controller behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->