### PR TITLE
feat(sdk): spawn_background + background_status — the plugin↔background channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   renamed or dropped watch spec left a zombie watch polling its verifier
   forever (unresolvable after uninstall). An `arm_all()` can now clear the
   suite ids no longer in its spec set before re-arming the rest.
+- **`graph.sdk.spawn_background` + `graph.sdk.background_status`** (#1635). The
+  consumption SDK (ADR 0043) now covers detached background subagent jobs: a plugin
+  spawns campaign-scale work with `spawn_background(prompt, *, subagent_type,
+  origin_session, label=None)` — the job rides the full ADR 0070 results pipeline
+  (push-resume nudge into the origin session, KB-indexed report, console report card) —
+  and polls progress with `background_status(task_id)` (`{status, description, report?}`,
+  `report` once terminal) instead of reaching into `STATE.background_mgr` directly.
 
 ### Fixed
 - **Re-installing a plugin from its own origin converges instead of erroring.**

--- a/docs/adr/0043-plugin-consumption-sdk-workflows-extraction.md
+++ b/docs/adr/0043-plugin-consumption-sdk-workflows-extraction.md
@@ -39,6 +39,13 @@ deliberately as more plugins tap core; this is the seam we lean on going forward
 > to answer a prompt — first consumer: the artifact plugin's interactive
 > `window.protoArtifact.ask()` bridge (artifacts call back to the agent, the
 > `window.claude.complete` analog).
+>
+> `spawn_background(prompt, *, subagent_type, origin_session, label=None)` +
+> `background_status(task_id)` (#1635) — the background channel: spawn a **detached**
+> subagent job (ADR 0050) that rides the full ADR 0070 results pipeline (push-resume
+> nudge, KB-indexed report, report card), and poll its jobs-store row in between. Closes
+> the hole where a plugin with campaign-scale work had to reach into
+> `STATE.background_mgr` directly. First consumer: spacetraders exploration campaigns.
 
 **2. Workflows becomes an opt-in plugin (`plugins/workflows`, `enabled: false`).**
 

--- a/docs/adr/0070-background-results-push-resume.md
+++ b/docs/adr/0070-background-results-push-resume.md
@@ -94,6 +94,10 @@ Cursor:
   the feature; `background.auto_resume: false` restores pull-only.
 - Amends ADR 0050's "surfaced on the next turn" contract to "surfaced by a
   triggered turn"; the drain mechanism and exactly-once guarantee are unchanged.
+- The pipeline is plugin-reachable (#1635): `graph.sdk.spawn_background(…)` spawns a
+  job that rides D1–D4 for free, and `graph.sdk.background_status(task_id)` reads the
+  jobs-store row (`report` once terminal) — no more reaching into
+  `STATE.background_mgr` (ADR 0043 consumption SDK).
 
 ## 5. Alternatives considered
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -253,6 +253,15 @@ SDK** directly — `from graph.sdk import …`, the *stable* surface plugins cal
   (`True` if it existed). Together they make a plugin's arm step a *reconcile* — clear the
   suite ids no longer in your spec set, then create/replace the rest — so a renamed/dropped
   watch spec can't leak a zombie watch. See [Watches](/guides/watches).
+- `spawn_background(prompt, *, subagent_type, origin_session, label=None)` — spawn a
+  **detached background subagent job** ([ADR 0050](/adr/0050-background-subagents-reactive-notifications))
+  that returns a `bg-…` id immediately and rides the full
+  [ADR 0070](/adr/0070-background-results-push-resume) results pipeline (push-resume nudge
+  into `origin_session`, KB-indexed report, console report card). The seam for long
+  campaign work — never reach into `STATE.background_mgr` directly.
+- `background_status(task_id)` — the status-query companion: `{status, description,
+  report?}` for a spawned job (`report` once terminal), so a plugin can render progress
+  on its own surface between launch and the completion nudge.
 
 The **workflows plugin** (`plugins/workflows`) is the reference consumer: its engine
 injects `run_subagent` as the per-step runner. This is the pattern for plugins that tap

--- a/docs/guides/subagents.md
+++ b/docs/guides/subagents.md
@@ -216,7 +216,7 @@ or plugin has a long **deterministic** operation that shouldn't block the turn (
 pipeline — the report card, KB indexing, and the push-resume nudge all land for free — and
 `graph.sdk.background_status(task_id)` reads the job row (`{status, description, report?}`) so a
 plugin dashboard can show progress between launch and the nudge. See
-[Plugins ▸ Tapping core deeper](/guides/plugins#tapping-core-deeper--graphsdk-adr-0043).
+[Plugins ▸ Tapping core deeper](/guides/plugins#tapping-core-deeper-graph-sdk-adr-0043).
 
 ## What you get for free
 

--- a/docs/guides/subagents.md
+++ b/docs/guides/subagents.md
@@ -211,6 +211,13 @@ way so a 20-minute transcription never freezes the chat. Reach for `spawn_work` 
 or plugin has a long **deterministic** operation that shouldn't block the turn (vs.
 `run_in_background`, which is for detaching an *LLM subagent* turn).
 
+**From a plugin, use the consumption SDK instead of `STATE`.** `graph.sdk.spawn_background(prompt,
+*, subagent_type, origin_session, label=None)` spawns a detached *subagent* job through the same
+pipeline — the report card, KB indexing, and the push-resume nudge all land for free — and
+`graph.sdk.background_status(task_id)` reads the job row (`{status, description, report?}`) so a
+plugin dashboard can show progress between launch and the nudge. See
+[Plugins ▸ Tapping core deeper](/guides/plugins#tapping-core-deeper--graphsdk-adr-0043).
+
 ## What you get for free
 
 Every subagent call:

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -269,3 +269,102 @@ def clear_watch(watch_id: str) -> bool:
     if controller is None:
         return False
     return controller.clear(watch_id)
+
+
+# ── background jobs (ADR 0050 spawn + ADR 0070 results pipeline) ───────────────────────
+# Detached campaign work — "chart the frontier and report back" — is naturally a
+# background subagent job, but the manager only had a tool-path consumer: a plugin had to
+# reach into ``runtime.state.STATE.background_mgr`` and mirror what the ``task`` tool
+# does. This thin pair closes that hole. A job spawned here rides the FULL ADR 0070
+# results pipeline for free: push-resume nudge into ``origin_session`` at completion,
+# KB-indexed report (``source_type="background_report"``), the console report card, and
+# the ``GET /api/background/{id}`` route.
+
+
+async def spawn_background(
+    prompt: str,
+    *,
+    subagent_type: str,
+    origin_session: str,
+    label: str | None = None,
+) -> dict:
+    """Spawn a detached background subagent job (ADR 0050) and return immediately.
+
+    The job runs as its own detached A2A turn under the ``subagent_type`` role; when it
+    finishes, the ADR 0070 pipeline delivers the report — a push-resume nudge into
+    ``origin_session``, the notified-gated ``<task-notification>`` drain, knowledge-store
+    indexing, and the console report card. Poll in between with
+    :func:`background_status` (e.g. to render campaign progress on a plugin dashboard).
+
+    Args:
+        prompt: detailed instructions for the background worker.
+        subagent_type: which subagent role runs the job — one of the registered roster
+            (:func:`subagent_types`), plugin-contributed subagents included.
+        origin_session: the chat session the report drains back into (and gets the
+            completion nudge). Required — a job with no origin has nowhere to report.
+        label: short human description for the job card / report heading. Defaults to
+            the first line of ``prompt`` (clipped).
+
+    Returns ``{"ok", "task_id", "message"}`` — ``task_id`` is the ``bg-…`` job id (the
+    handle for :func:`background_status`, cancel, and the by-id API route); ``ok=False``
+    with a readable message when the background subsystem is off or the inputs are bad.
+    """
+    mgr = STATE.background_mgr
+    if mgr is None:
+        return {"ok": False, "task_id": None, "message": "background subsystem unavailable (no background_mgr)"}
+    if not (prompt or "").strip():
+        return {"ok": False, "task_id": None, "message": "prompt is required"}
+    if not (origin_session or "").strip():
+        return {"ok": False, "task_id": None, "message": "origin_session is required"}
+    from graph.subagents.config import SUBAGENT_REGISTRY
+
+    if subagent_type not in SUBAGENT_REGISTRY:
+        available = ", ".join(sorted(SUBAGENT_REGISTRY)) or "(none configured)"
+        return {"ok": False, "task_id": None, "message": f"unknown subagent {subagent_type!r} — available: {available}"}
+    description = (label or "").strip() or prompt.strip().splitlines()[0][:80]
+    task_id = await mgr.spawn(
+        origin_session=origin_session,
+        subagent_type=subagent_type,
+        description=description,
+        prompt=prompt,
+    )
+    return {
+        "ok": True,
+        "task_id": task_id,
+        "message": (
+            f"background job {task_id} spawned ({subagent_type}: {description}) — it runs detached; "
+            f"the report is delivered to session {origin_session!r} on completion"
+        ),
+    }
+
+
+def background_status(task_id: str) -> dict:
+    """Look up a background job by its ``bg-…`` id — the status-query companion to
+    :func:`spawn_background`, so a plugin can render campaign progress on its own
+    surface instead of being blind between launch and the ADR 0070 completion nudge.
+
+    Returns ``{"ok", "task_id", "status", "subagent_type", "description", "created_at",
+    "completed_at", "message"}`` plus — only once the job is terminal
+    (completed/failed/canceled) — ``"report"`` with the full result text. An unknown id
+    (or the subsystem being off) returns ``ok=False`` with ``status="unknown"`` and a
+    readable message. Reads the durable jobs store directly (cheap local SQLite).
+    """
+    mgr = STATE.background_mgr
+    if mgr is None:
+        return {"ok": False, "status": "unknown", "message": "background subsystem unavailable (no background_mgr)"}
+    job = mgr.store.get((task_id or "").strip())
+    if job is None:
+        return {"ok": False, "status": "unknown", "message": f"no background job {task_id!r}"}
+    out = {
+        "ok": True,
+        "task_id": job.id,
+        "status": job.status,
+        "subagent_type": job.subagent_type,
+        "description": job.description,
+        "created_at": job.created_at,
+        "completed_at": job.completed_at,
+        "message": f"background job {job.id} is {job.status}",
+    }
+    if job.status != "running":
+        out["report"] = job.result
+    return out

--- a/tests/test_sdk_background.py
+++ b/tests/test_sdk_background.py
@@ -1,0 +1,154 @@
+"""graph.sdk.spawn_background / background_status — the plugin↔background channel
+(ADR 0043 consumption SDK over ADR 0050 spawn + the ADR 0070 results pipeline)."""
+
+from __future__ import annotations
+
+import pytest
+
+from background.store import BackgroundStore
+
+
+class _FakeManager:
+    """Captures spawn kwargs and exposes a REAL jobs store, so status reads exercise
+    the actual row shape (created_at/completed_at/result) rather than a stub's."""
+
+    def __init__(self, store: BackgroundStore):
+        self.store = store
+        self.spawn_calls: list[dict] = []
+
+    async def spawn(self, **kw) -> str:
+        self.spawn_calls.append(kw)
+        return self.store.create(
+            agent_name="a",
+            origin_session=kw["origin_session"],
+            subagent_type=kw["subagent_type"],
+            description=kw["description"],
+            prompt=kw["prompt"],
+        )
+
+
+@pytest.fixture
+def mgr(tmp_path, monkeypatch):
+    from graph import sdk
+
+    m = _FakeManager(BackgroundStore(str(tmp_path / "jobs.db")))
+    monkeypatch.setattr(sdk.STATE, "background_mgr", m, raising=False)
+    return m
+
+
+# ── spawn_background ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_spawn_background_round_trip(mgr):
+    from graph import sdk
+
+    out = await sdk.spawn_background(
+        "Chart the frontier and report discoveries.",
+        subagent_type="researcher",
+        origin_session="chat-1",
+        label="Frontier campaign",
+    )
+    assert out["ok"] is True
+    assert out["task_id"].startswith("bg-")
+    assert "chat-1" in out["message"]
+    assert mgr.spawn_calls == [
+        {
+            "origin_session": "chat-1",
+            "subagent_type": "researcher",
+            "description": "Frontier campaign",
+            "prompt": "Chart the frontier and report discoveries.",
+        }
+    ]
+    # The job landed in the durable store as a running row for the origin session.
+    job = mgr.store.get(out["task_id"])
+    assert job is not None and job.status == "running" and job.origin_session == "chat-1"
+
+
+@pytest.mark.asyncio
+async def test_spawn_background_label_defaults_to_first_prompt_line(mgr):
+    from graph import sdk
+
+    out = await sdk.spawn_background(
+        "Survey every uncharted system.\nThen report back.",
+        subagent_type="researcher",
+        origin_session="chat-1",
+    )
+    assert out["ok"] is True
+    assert mgr.spawn_calls[0]["description"] == "Survey every uncharted system."
+
+
+@pytest.mark.asyncio
+async def test_spawn_background_rejects_bad_inputs(mgr):
+    from graph import sdk
+
+    out = await sdk.spawn_background("", subagent_type="researcher", origin_session="chat-1")
+    assert out["ok"] is False and "prompt" in out["message"]
+
+    out = await sdk.spawn_background("go", subagent_type="researcher", origin_session=" ")
+    assert out["ok"] is False and "origin_session" in out["message"]
+
+    out = await sdk.spawn_background("go", subagent_type="no-such-role", origin_session="chat-1")
+    assert out["ok"] is False and "no-such-role" in out["message"]
+    assert mgr.spawn_calls == []  # nothing fired
+
+
+@pytest.mark.asyncio
+async def test_spawn_background_degrades_without_a_manager(monkeypatch):
+    from graph import sdk
+
+    monkeypatch.setattr(sdk.STATE, "background_mgr", None, raising=False)
+    out = await sdk.spawn_background("go", subagent_type="researcher", origin_session="chat-1")
+    assert out["ok"] is False and "unavailable" in out["message"]
+
+
+# ── background_status ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_background_status_running_then_finished(mgr):
+    from graph import sdk
+
+    spawned = await sdk.spawn_background(
+        "Chart the frontier.", subagent_type="researcher", origin_session="chat-1"
+    )
+    task_id = spawned["task_id"]
+
+    running = sdk.background_status(task_id)
+    assert running["ok"] is True
+    assert running["status"] == "running"
+    assert running["description"] == "Chart the frontier."
+    assert running["subagent_type"] == "researcher"
+    assert "report" not in running  # no report until the job is terminal
+
+    mgr.store.mark_complete(task_id, "completed", "Charted 12 systems.")
+    done = sdk.background_status(task_id)
+    assert done["status"] == "completed"
+    assert done["report"] == "Charted 12 systems."
+    assert done["completed_at"]
+
+
+def test_background_status_failed_carries_the_report(mgr):
+    from graph import sdk
+
+    task_id = mgr.store.create(
+        agent_name="a", origin_session="chat-1", subagent_type="researcher", description="d", prompt="p"
+    )
+    mgr.store.mark_complete(task_id, "failed", "Gateway timed out.")
+    out = sdk.background_status(task_id)
+    assert out["ok"] is True and out["status"] == "failed" and out["report"] == "Gateway timed out."
+
+
+def test_background_status_unknown_id(mgr):
+    from graph import sdk
+
+    out = sdk.background_status("bg-nope")
+    assert out == {"ok": False, "status": "unknown", "message": "no background job 'bg-nope'"}
+
+
+def test_background_status_degrades_without_a_manager(monkeypatch):
+    from graph import sdk
+
+    monkeypatch.setattr(sdk.STATE, "background_mgr", None, raising=False)
+    out = sdk.background_status("bg-x")
+    assert out["ok"] is False and out["status"] == "unknown" and "unavailable" in out["message"]


### PR DESCRIPTION
## Problem

`STATE.background_mgr` (ADR 0050 background subagents) has no `graph.sdk` surface — a plugin that wants detached campaign workers must reach into `runtime.state.STATE` directly and mirror what the `task(run_in_background=…)` tool path does. The consumption SDK (ADR 0043) is supposed to be the stable way plugins tap core; background work was the notable hole. ADR 0070 (push-resume, indexed reports, report cards) merged as #1604, so a wrapper now buys the full results pipeline.

## What this ships

Two thin ADR 0043 consumption-SDK functions in `graph/sdk.py`:

- **`spawn_background(prompt, *, subagent_type, origin_session, label=None) -> {ok, task_id, message}`** — thin over `BackgroundManager.spawn`. SDK conventions throughout: host-missing guard (`ok=False` + readable message when the subsystem is off), `prompt`/`origin_session` required (a job with no origin has nowhere to report), `subagent_type` validated against the live registry (plugin-contributed subagents included), `label` defaults to the prompt's first line (clipped). A job spawned here rides the full ADR 0070 pipeline for free: push-resume nudge into `origin_session`, KB-indexed report (`source_type="background_report"`), console report card, `GET /api/background/{id}`.
- **`background_status(task_id) -> {ok, task_id, status, subagent_type, description, created_at, completed_at, message, report?}`** — the status-query companion over the durable jobs store, per the field note on the issue (spacetraders `st_explore` campaigns): a plugin can render campaign progress on its own dashboard instead of being blind between launch and the completion nudge. `report` (the full result text) appears only once the job is terminal (completed/failed/canceled); unknown id / subsystem-off → `ok=False, status="unknown"`. Sync, matching `run_in_session`/`create_watch` (cheap local SQLite read).

## Tests

`tests/test_sdk_background.py` (10 tests): spawn round-trip against a fake manager backed by a **real** `BackgroundStore` (captures spawn kwargs and exercises the actual row shape), label defaulting, bad-input rejection (empty prompt/origin, unknown subagent — nothing fired), host-missing degradation; status for running → completed transitions (no `report` while running), failed jobs carrying the failure text as `report`, unknown ids, and subsystem-off.

## Docs

- `docs/guides/plugins.md` — two new bullets in the consumption-SDK list.
- `docs/guides/subagents.md` — background-jobs section now points plugins at the SDK path instead of `STATE`.
- ADR 0043 — "grown since" note; ADR 0070 — consequences note that the pipeline is plugin-reachable.
- `CHANGELOG.md` [Unreleased] ▸ Added.

## Gates

- `ruff check .` ✅
- `lint-imports` ✅ (3 contracts kept)
- `python -m pytest tests/ -q` ✅ 2838 passed, 5 skipped

Fixes #1635

🤖 Generated with [Claude Code](https://claude.com/claude-code)