### PR TITLE
feat(sdk): plugin-owned recurring jobs — schedule_recurring + uninstall/disable cleanup (#1642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trailing-edge debounce (the last event's prompt wins; skipped events don't extend the
   window). Returns an unsubscribe fn mirroring `registry.on`; degrades to a warned no-op
   without a host bus.
+- **Plugins own their recurring cadence — and it dies with them** (#1642). The
+  consumption SDK (ADR 0043) adds `sdk.schedule_recurring(prompt, cron, *,
+  plugin_id, job_id, session="", timezone=None)` — a cron job namespaced
+  `plugin:<plugin_id>:<job_id>`, idempotent by id (a re-call replaces, so
+  `register()` re-arms and a cadence knob change just re-schedules), firing
+  into the Activity thread by default — plus `sdk.cancel_scheduled(job_id, *,
+  plugin_id)` and `sdk.cancel_plugin_jobs(plugin_id)`. The ownership tag closes
+  the orphan-job gap: **disabling** a plugin now sweeps its `plugin:<id>:*`
+  jobs on the reload and **uninstalling** sweeps them with the code removal
+  (`jobs_cancelled` in the uninstall report), so no job keeps firing prompts
+  about a plugin that's gone. The ADR 0004 `agent_name` instance scoping is
+  untouched — plugin ownership is a new dimension on the job id, inside one
+  instance's jobs.db.
 - **Plugins can now enumerate and remove watches** (#1638). The consumption SDK
   (ADR 0043) grows the lifecycle half of the ADR 0067 watch surface:
   `sdk.list_watches(prefix="")` (each `{id, condition, status, verifier}`,

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -229,7 +229,7 @@ def register(registry):
     registry.register_surface(lambda: _gateway(_on_message), name="my-gateway")
 ```
 
-### Tapping core deeper — `graph.sdk` (ADR 0043)
+### Tapping core deeper — `graph.sdk` (ADR 0043) {#consumption-sdk}
 
 `registry.host` covers the common cases. For deeper capability, import the **consumption
 SDK** directly — `from graph.sdk import …`, the *stable* surface plugins call into core
@@ -269,6 +269,13 @@ SDK** directly — `from graph.sdk import …`, the *stable* surface plugins cal
   into ONE turn (trailing-edge; the last event's prompt wins), `session` defaults to the
   Activity thread. Returns an unsubscribe fn. The one-call form of the canonical
   `registry.on` → `run_in_session` composition — see [Events](#events-the-plugin-bus-adr-0039).
+- `schedule_recurring(prompt, cron, *, plugin_id, job_id, session="", timezone=None)` — a
+  plugin-owned **recurring** cadence (#1642): a cron job whose id is namespaced
+  `plugin:<plugin_id>:<job_id>` so the host cancels it on disable/uninstall (no orphan
+  cadence outlives its plugin). Idempotent by id (a re-call replaces), fires into Activity
+  by default; pass `plugin_id=registry.plugin_id`. One-shot turns stay on `run_in_session`.
+  With `cancel_scheduled(job_id, *, plugin_id)` and `cancel_plugin_jobs(plugin_id)` — see
+  [Scheduler ▸ Plugin-owned recurring jobs](/guides/scheduler#plugin-owned-recurring-jobs).
 
 The **workflows plugin** (`plugins/workflows`) is the reference consumer: its engine
 injects `run_subagent` as the per-step runner. This is the pattern for plugins that tap

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -63,6 +63,38 @@ cancel. It's backed by these operator-API endpoints:
 
 A malformed `schedule` returns `400` and leaves the job untouched.
 
+## Plugin-owned recurring jobs
+
+A plugin arms its own cadence through the [consumption SDK](/guides/plugins#consumption-sdk)
+(#1642) rather than asking the operator to wire a cron job:
+
+```python
+from graph import sdk
+
+def register(registry):
+    sdk.schedule_recurring(
+        "Run the strategist OODA tick.", "0 9 * * *",
+        plugin_id=registry.plugin_id, job_id="strategist-tick",
+    )
+```
+
+- `sdk.schedule_recurring(prompt, cron, *, plugin_id, job_id, session="", timezone=None)`
+  — a **recurring** cron cadence (one-shot turns stay on `sdk.run_in_session`; an ISO
+  datetime is rejected here). Fires into the Activity thread by default; pass `session`
+  to target a chat context. **Idempotent by id** — re-calling with the same `job_id`
+  replaces the pending job, so `register()` can re-arm on every (re)load and a cadence
+  knob change just re-schedules.
+- `sdk.cancel_scheduled(job_id, *, plugin_id)` / `sdk.cancel_plugin_jobs(plugin_id)` —
+  remove one cadence / all of them.
+
+The job id is namespaced **`plugin:<plugin_id>:<job_id>`** — that ownership tag is what
+lets the host clean up: **disabling** a plugin sweeps its `plugin:<id>:*` jobs on the
+reload, and **uninstalling** sweeps them in the same pass that removes the code — no
+orphan job keeps firing prompts about a plugin that's gone. Re-enabling relies on the
+plugin re-arming in `register()` (which is why the idempotent-replace shape matters).
+The `AGENT_NAME` scoping below is untouched — plugin ownership rides on the id *within*
+an instance's jobs.db; it never crosses instances.
+
 ## Multi-agent isolation
 
 Every job is namespaced by `AGENT_NAME` so spinning up

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -647,9 +647,30 @@ def uninstall(plugin_id: str, *, purge: bool = False) -> dict:
 
     if not removed:
         raise InstallError(f"plugin {plugin_id!r} is not installed.")
+
+    # Plugin-owned scheduler jobs (#1642): cancel `plugin:<id>:*` so an uninstalled
+    # plugin's recurring cadence can't keep firing prompts about a plugin that's gone.
+    # The loader's disable-sweep can't cover this case — the manifest is gone from
+    # disk. Best-effort: in a CLI process there's no live scheduler (STATE.scheduler
+    # is None → 0); the console uninstall route runs in the live server where it works.
+    try:
+        from graph.sdk import cancel_plugin_jobs
+
+        jobs_cancelled = cancel_plugin_jobs(plugin_id)
+    except Exception:  # noqa: BLE001 — job hygiene must never fail the uninstall
+        jobs_cancelled = 0
+    if jobs_cancelled:
+        removed.append("jobs")
+
     _audit("uninstall", {"id": plugin_id, "purge": purge}, f"uninstalled {plugin_id} ({', '.join(removed)})")
     log.info("[plugins] uninstalled %s (%s)", plugin_id, ", ".join(removed))
-    return {"id": plugin_id, "removed": removed, "deps_left": deps_left, "purged": purge}
+    return {
+        "id": plugin_id,
+        "removed": removed,
+        "deps_left": deps_left,
+        "purged": purge,
+        "jobs_cancelled": jobs_cancelled,
+    }
 
 
 def _validate_pip_specs(plugin_id: str, deps: list[str]) -> None:

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -282,6 +282,19 @@ def _warn_unserved_views(manifest: PluginManifest, routers: list[dict]) -> None:
             )
 
 
+def _sweep_plugin_jobs(plugin_id: str) -> None:
+    """Cancel a not-enabled plugin's ``plugin:<id>:*`` scheduler jobs (#1642) —
+    best-effort, never breaks a load. See ``sdk.cancel_plugin_jobs``."""
+    try:
+        from graph.sdk import cancel_plugin_jobs
+
+        cancelled = cancel_plugin_jobs(plugin_id)
+    except Exception:  # noqa: BLE001 — hygiene must never break plugin loading
+        return
+    if cancelled:
+        log.info("[plugins] %s is disabled — cancelled %d scheduled job(s) it owned", plugin_id, cancelled)
+
+
 def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLoadResult:
     """Load enabled plugins and collect their contributions.
 
@@ -323,6 +336,14 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
         }
 
         if not enabled:
+            # Lifecycle hygiene (#1642): a disabled plugin must not keep a recurring
+            # cadence firing — sweep its `plugin:<id>:*` scheduler jobs on every
+            # (re)load. The console disable toggle and a hand-edited config both
+            # funnel through a (re)load, so this one hook covers both; uninstall is
+            # covered by the installer (the manifest is gone from disk, so this loop
+            # can't see it). Pre-setup loads run before the scheduler is wired
+            # (STATE.scheduler is None → no-op).
+            _sweep_plugin_jobs(manifest.id)
             result.meta.append(entry)
             continue
 

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -600,7 +600,8 @@ def cancel_scheduled(job_id: str, *, plugin_id: str) -> bool:
     if scheduler is None:
         return False
     plugin_id = (plugin_id or "").strip()
-    if not plugin_id or not (job_id or "").strip():
+    # Same ':' guard as schedule_recurring — plugin "a:b" must not reach into "a"'s namespace.
+    if not plugin_id or ":" in plugin_id or not (job_id or "").strip():
         return False
     return bool(scheduler.cancel_job(f"{plugin_job_prefix(plugin_id)}{job_id.strip()}"))
 

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -494,3 +494,134 @@ def react_on(
             timer.cancel()
 
     return _unsubscribe
+
+
+# ── plugin-owned recurring jobs (#1642) ─────────────────────────────────────────────
+# run_in_session covers one-shot turns; a RECURRING cadence (spacetraders' daily
+# strategist tick) had no plugin-owned path — the operator wired a cron job manually, and
+# nothing tied it to the plugin, so uninstall/disable left an orphan job firing prompts
+# about a plugin that's gone. These helpers namespace the job id `plugin:<plugin_id>:<job_id>`
+# so the lifecycle hooks (loader disable sweep + installer uninstall) can cancel exactly the
+# plugin's jobs. The ADR 0004 `agent_name` scoping is untouched — the scheduler still
+# namespaces per instance underneath; this adds a *plugin* ownership dimension on the id.
+
+_PLUGIN_JOB_PREFIX = "plugin:"
+
+
+def plugin_job_prefix(plugin_id: str) -> str:
+    """The id prefix every scheduler job owned by ``plugin_id`` carries."""
+    return f"{_PLUGIN_JOB_PREFIX}{plugin_id}:"
+
+
+def schedule_recurring(
+    prompt: str,
+    cron: str,
+    *,
+    plugin_id: str,
+    job_id: str,
+    session: str = "",
+    timezone: str | None = None,
+) -> dict:
+    """Schedule ``prompt`` as a RECURRING agent turn on a ``cron`` cadence, owned by
+    ``plugin_id``.
+
+    Thin over ``STATE.scheduler.add_job`` with the id namespaced
+    ``plugin:<plugin_id>:<job_id>`` — that ownership tag is what lets the host cancel
+    the plugin's jobs on disable/uninstall (and :func:`cancel_scheduled` /
+    :func:`cancel_plugin_jobs` find them). Idempotent by id: re-calling with the same
+    ``job_id`` REPLACES the pending job, so a plugin re-arms its cadence in
+    ``register()`` (or when a cadence knob changes) without colliding.
+
+    There is no ambient plugin identity in the SDK (functions are plain imports, not
+    registry-bound), so ``plugin_id`` is an explicit required kwarg — pass
+    ``registry.plugin_id``. Note: a *disable* cancels the plugin's jobs; re-enabling
+    relies on the plugin re-arming in ``register()``, which runs after the scheduler
+    is wired on both boot and hot-reload.
+
+    Args:
+        prompt: the message the agent processes each fire.
+        cron: a 5-field cron expression (e.g. ``"0 9 * * *"``). One-shot turns belong
+            to :func:`run_in_session`, so an ISO datetime is rejected here.
+        plugin_id: the owning plugin's id (``registry.plugin_id``).
+        job_id: a stable plugin-local id for this cadence (e.g. ``"strategist-tick"``).
+        session: the A2A contextId to fire into; empty → the durable Activity thread
+            (the default for scheduled work).
+        timezone: IANA name the cron is evaluated in (None = UTC).
+
+    Returns ``{"ok", "job_id", "next_fire", "message"}`` — ``job_id`` is the full
+    namespaced id; ``ok=False`` with a readable message when the scheduler is
+    unavailable or the inputs are bad.
+    """
+    from scheduler.interface import is_cron
+
+    scheduler = STATE.scheduler
+    if scheduler is None:
+        return {"ok": False, "job_id": None, "message": "scheduler unavailable — cannot schedule a recurring job"}
+    plugin_id = (plugin_id or "").strip()
+    if not plugin_id or ":" in plugin_id:
+        return {"ok": False, "job_id": None, "message": "plugin_id is required (and must not contain ':')"}
+    if not (job_id or "").strip():
+        return {"ok": False, "job_id": None, "message": "job_id is required"}
+    if not (prompt or "").strip():
+        return {"ok": False, "job_id": None, "message": "prompt is required"}
+    cron = (cron or "").strip()
+    if not is_cron(cron):
+        return {
+            "ok": False,
+            "job_id": None,
+            "message": f"schedule {cron!r} is not a 5-field cron expression — "
+            "for a one-shot turn use run_in_session",
+        }
+    full_id = f"{plugin_job_prefix(plugin_id)}{job_id.strip()}"
+    # Idempotent replace: add_job RAISES on a duplicate id, so drop any pending job
+    # with this id first — a re-arm (register() re-run, cadence knob change) updates
+    # rather than collides (mirrors run_in_session).
+    scheduler.cancel_job(full_id)
+    try:
+        job = scheduler.add_job(
+            prompt, cron, job_id=full_id, timezone=timezone, context_id=(session or "").strip() or None
+        )
+    except ValueError as e:
+        return {"ok": False, "job_id": full_id, "message": f"could not schedule: {e}"}
+    return {
+        "ok": True,
+        "job_id": job.id,
+        "next_fire": getattr(job, "next_fire", None),
+        "message": f"recurring job {job.id!r} scheduled ({cron!r})",
+    }
+
+
+def cancel_scheduled(job_id: str, *, plugin_id: str) -> bool:
+    """Cancel the plugin-owned recurring job ``job_id`` (the same plugin-local id passed
+    to :func:`schedule_recurring` — namespacing is applied here, never by the caller).
+    Returns ``True`` if a job was removed; ``False`` when there was none — or when the
+    scheduler is unavailable."""
+    scheduler = STATE.scheduler
+    if scheduler is None:
+        return False
+    plugin_id = (plugin_id or "").strip()
+    if not plugin_id or not (job_id or "").strip():
+        return False
+    return bool(scheduler.cancel_job(f"{plugin_job_prefix(plugin_id)}{job_id.strip()}"))
+
+
+def cancel_plugin_jobs(plugin_id: str) -> int:
+    """Cancel EVERY scheduler job owned by ``plugin_id`` (ids ``plugin:<plugin_id>:*``).
+    Returns how many were cancelled (0 when the scheduler is unavailable).
+
+    This is the lifecycle hygiene hook (#1642): the loader sweeps a disabled plugin's
+    jobs on (re)load and the installer sweeps on uninstall, so an orphan cadence can't
+    keep firing prompts about a plugin that's gone. Only jobs under this instance's
+    ``agent_name`` are visible (``list_jobs`` filters), so the ADR 0004 scoping holds.
+    Also useful to a plugin that wants to tear down its whole cadence at once."""
+    scheduler = STATE.scheduler
+    plugin_id = (plugin_id or "").strip()
+    if scheduler is None or not plugin_id:
+        return 0
+    prefix = plugin_job_prefix(plugin_id)
+    cancelled = 0
+    for job in scheduler.list_jobs():
+        jid = getattr(job, "id", "") or ""
+        if jid.startswith(prefix) and scheduler.cancel_job(jid):
+            cancelled += 1
+    return cancelled

--- a/tests/test_sdk_scheduler.py
+++ b/tests/test_sdk_scheduler.py
@@ -1,0 +1,275 @@
+"""sdk.schedule_recurring / cancel_scheduled / cancel_plugin_jobs (#1642) — plugin-owned
+recurring jobs with `plugin:<plugin_id>:<job_id>` ownership tagging, plus the lifecycle
+hygiene hooks: the loader sweeps a disabled plugin's jobs on (re)load and the installer
+sweeps on uninstall, so no orphan cadence outlives its plugin.
+
+The ADR 0004 `agent_name` scoping is orthogonal and untouched — the LocalScheduler
+round-trip test exercises the real backend to prove the namespaced ids ride the normal
+per-instance jobs.db path.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graph import sdk
+from runtime.state import STATE
+from scheduler.interface import is_cron
+
+
+class _Job:
+    def __init__(self, jid, schedule="", prompt="", context_id=None, timezone=None):
+        self.id = jid
+        self.schedule = schedule
+        self.prompt = prompt
+        self.context_id = context_id
+        self.timezone = timezone
+        self.next_fire = "2026-07-03T09:00:00+00:00"
+
+
+class _Scheduler:
+    """Protocol-shaped fake — add/cancel/list against an in-memory dict."""
+
+    def __init__(self, seed: tuple[str, ...] = ()):
+        self.jobs: dict[str, _Job] = {jid: _Job(jid) for jid in seed}
+        self.cancelled: list[str] = []
+
+    def add_job(self, prompt, schedule, *, job_id=None, timezone=None, context_id=None):
+        jid = job_id or "auto-1"
+        if jid in self.jobs:
+            raise ValueError(f"job id {jid!r} already exists")
+        job = _Job(jid, schedule, prompt, context_id, timezone)
+        self.jobs[jid] = job
+        return job
+
+    def cancel_job(self, job_id):
+        self.cancelled.append(job_id)
+        return self.jobs.pop(job_id, None) is not None
+
+    def list_jobs(self):
+        return list(self.jobs.values())
+
+
+@pytest.fixture
+def sched(monkeypatch):
+    s = _Scheduler()
+    monkeypatch.setattr(STATE, "scheduler", s)
+    return s
+
+
+# --- schedule_recurring ------------------------------------------------------
+
+
+def test_schedule_recurring_namespaces_and_defaults_to_activity(sched):
+    res = sdk.schedule_recurring(
+        "Run the strategist OODA tick.", "0 9 * * *", plugin_id="spacetraders", job_id="strategist-tick"
+    )
+    assert res["ok"] is True
+    assert res["job_id"] == "plugin:spacetraders:strategist-tick"  # ownership tag on the id
+    job = sched.jobs[res["job_id"]]
+    assert is_cron(job.schedule)  # recurring, not a one-shot ISO
+    assert job.context_id is None  # None → the durable Activity thread
+    assert res["next_fire"]
+
+
+def test_schedule_recurring_targets_a_session_and_timezone(sched):
+    res = sdk.schedule_recurring(
+        "tick", "*/5 * * * *", plugin_id="st", job_id="t", session="sess-7", timezone="America/Chicago"
+    )
+    job = sched.jobs[res["job_id"]]
+    assert job.context_id == "sess-7"
+    assert job.timezone == "America/Chicago"
+
+
+def test_schedule_recurring_rejects_non_cron(sched):
+    # One-shot ISO fire times belong to run_in_session; garbage is refused too.
+    for schedule in ("2026-07-03T09:00:00+00:00", "tomorrow", ""):
+        res = sdk.schedule_recurring("p", schedule, plugin_id="st", job_id="t")
+        assert res["ok"] is False and "cron" in res["message"]
+    assert sched.jobs == {}  # nothing enqueued
+
+
+def test_schedule_recurring_replaces_by_id(sched):
+    sdk.schedule_recurring("p", "0 9 * * *", plugin_id="st", job_id="tick")
+    res = sdk.schedule_recurring("p", "0 */2 * * *", plugin_id="st", job_id="tick")  # cadence knob changed
+    assert res["ok"] is True
+    assert "plugin:st:tick" in sched.cancelled  # idempotent: dropped before re-adding
+    assert len(sched.jobs) == 1
+    assert sched.jobs["plugin:st:tick"].schedule == "0 */2 * * *"
+
+
+def test_schedule_recurring_validates_inputs(monkeypatch):
+    monkeypatch.setattr(STATE, "scheduler", None)
+    assert not sdk.schedule_recurring("p", "0 9 * * *", plugin_id="st", job_id="t")["ok"]  # no scheduler
+    s = _Scheduler()
+    monkeypatch.setattr(STATE, "scheduler", s)
+    assert not sdk.schedule_recurring("p", "0 9 * * *", plugin_id="", job_id="t")["ok"]  # no plugin_id
+    # ':' would let one plugin's id shadow another's namespace (plugin "a" sweeps "a:b"'s jobs).
+    assert not sdk.schedule_recurring("p", "0 9 * * *", plugin_id="a:b", job_id="t")["ok"]
+    assert not sdk.schedule_recurring("p", "0 9 * * *", plugin_id="st", job_id=" ")["ok"]  # no job_id
+    assert not sdk.schedule_recurring(" ", "0 9 * * *", plugin_id="st", job_id="t")["ok"]  # no prompt
+    assert s.jobs == {}  # nothing enqueued on bad input
+
+
+# --- cancel_scheduled --------------------------------------------------------
+
+
+def test_cancel_scheduled_round_trip(sched):
+    sdk.schedule_recurring("p", "0 9 * * *", plugin_id="st", job_id="tick")
+    assert sdk.cancel_scheduled("tick", plugin_id="st") is True  # plugin-local id, namespaced inside
+    assert sched.jobs == {}
+    assert sdk.cancel_scheduled("tick", plugin_id="st") is False  # already gone
+
+
+def test_cancel_scheduled_unavailable_or_bad_input(monkeypatch):
+    monkeypatch.setattr(STATE, "scheduler", None)
+    assert sdk.cancel_scheduled("t", plugin_id="st") is False
+    monkeypatch.setattr(STATE, "scheduler", _Scheduler())
+    assert sdk.cancel_scheduled("", plugin_id="st") is False
+    assert sdk.cancel_scheduled("t", plugin_id="") is False
+
+
+# --- cancel_plugin_jobs ------------------------------------------------------
+
+
+def test_cancel_plugin_jobs_cancels_only_the_plugins_jobs(monkeypatch):
+    s = _Scheduler(
+        seed=(
+            "plugin:st:tick",
+            "plugin:st:watchdog",
+            "plugin:st2:tick",  # prefix-adjacent plugin id must NOT match
+            "plugin:other:tick",
+            "operator-manual-job",
+        )
+    )
+    monkeypatch.setattr(STATE, "scheduler", s)
+    assert sdk.cancel_plugin_jobs("st") == 2
+    assert set(s.jobs) == {"plugin:st2:tick", "plugin:other:tick", "operator-manual-job"}
+    assert sdk.cancel_plugin_jobs("st") == 0  # nothing left to cancel
+
+
+def test_cancel_plugin_jobs_unavailable_or_blank(monkeypatch):
+    monkeypatch.setattr(STATE, "scheduler", None)
+    assert sdk.cancel_plugin_jobs("st") == 0
+    monkeypatch.setattr(STATE, "scheduler", _Scheduler(seed=("plugin:st:tick",)))
+    assert sdk.cancel_plugin_jobs("") == 0  # a blank id must not sweep anything
+
+
+# --- real LocalScheduler round-trip (agent_name scoping stays underneath) ----
+
+
+def test_local_scheduler_round_trip(tmp_path, monkeypatch):
+    from scheduler.local import LocalScheduler
+
+    real = LocalScheduler(
+        agent_name="sdk-test-agent",
+        invoke_url="http://127.0.0.1:7870",
+        api_key="k",
+        bearer_token="b",
+        db_dir=tmp_path,
+    )
+    monkeypatch.setattr(STATE, "scheduler", real)
+    res = sdk.schedule_recurring("daily tick", "0 9 * * *", plugin_id="st", job_id="tick")
+    assert res["ok"] is True and res["next_fire"]
+    jobs = real.list_jobs()
+    assert [j.id for j in jobs] == ["plugin:st:tick"]
+    assert jobs[0].agent_name == "sdk-test-agent"  # ADR 0004 instance scoping untouched
+    assert sdk.cancel_scheduled("tick", plugin_id="st") is True
+    assert real.list_jobs() == []
+
+
+# --- loader hygiene: disabled plugin's jobs are swept on (re)load ------------
+
+
+def _make_plugin_dir(root, pid, *, enabled):
+    d = root / pid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "protoagent.plugin.yaml").write_text(
+        f"id: {pid}\nname: {pid}\nversion: 0.1.0\nenabled: {'true' if enabled else 'false'}\n",
+        encoding="utf-8",
+    )
+    (d / "__init__.py").write_text("def register(registry):\n    pass\n", encoding="utf-8")
+    return d
+
+
+def test_loader_sweeps_disabled_plugins_jobs(tmp_path, monkeypatch):
+    from graph.config import LangGraphConfig
+    from graph.plugins import loader as plugin_loader
+    from graph.plugins.loader import load_plugins
+
+    root = tmp_path / "plugins"
+    _make_plugin_dir(root, "offplug", enabled=False)
+    _make_plugin_dir(root, "onplug", enabled=True)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    s = _Scheduler(seed=("plugin:offplug:tick", "plugin:onplug:tick", "operator-manual-job"))
+    monkeypatch.setattr(STATE, "scheduler", s)
+
+    load_plugins(LangGraphConfig())
+
+    # The disabled plugin's cadence is gone; the enabled plugin's and the operator's survive.
+    assert set(s.jobs) == {"plugin:onplug:tick", "operator-manual-job"}
+
+
+def test_loader_sweep_noops_without_scheduler(tmp_path, monkeypatch):
+    # Pre-setup / boot-ordering safety: no scheduler wired → the sweep must not blow up a load.
+    from graph.config import LangGraphConfig
+    from graph.plugins import loader as plugin_loader
+    from graph.plugins.loader import load_plugins
+
+    root = tmp_path / "plugins"
+    _make_plugin_dir(root, "offplug", enabled=False)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    monkeypatch.setattr(STATE, "scheduler", None)
+    res = load_plugins(LangGraphConfig())
+    assert res.meta[0]["enabled"] is False  # load completed normally
+
+
+# --- installer hygiene: uninstall cancels the plugin's jobs ------------------
+
+
+def test_uninstall_cancels_plugin_jobs(tmp_path, monkeypatch):
+    from graph.plugins import installer
+
+    # Point the installer at a temp area (mirrors test_plugin_installer's env fixture);
+    # a hand-placed (untracked) plugin dir is enough — uninstall removes it as "code".
+    import graph.config_io as cio
+
+    monkeypatch.setattr(installer, "lock_path", lambda: tmp_path / "plugins.lock")
+    monkeypatch.setenv("PROTOAGENT_PLUGINS_DIR", str(tmp_path / "installed"))
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: tmp_path / "langgraph-config.yaml")
+    monkeypatch.setattr(cio, "secrets_yaml_path", lambda: tmp_path / "secrets.yaml")
+    _make_plugin_dir(installer.live_plugins_dir(), "demo_sweep", enabled=True)
+
+    s = _Scheduler(seed=("plugin:demo_sweep:tick", "plugin:other:tick"))
+    monkeypatch.setattr(STATE, "scheduler", s)
+
+    rep = installer.uninstall("demo_sweep")
+    assert rep["jobs_cancelled"] == 1 and "jobs" in rep["removed"]
+    assert set(s.jobs) == {"plugin:other:tick"}  # ONLY the uninstalled plugin's jobs
+
+
+def test_uninstall_reports_zero_jobs_without_scheduler(tmp_path, monkeypatch):
+    # CLI-process posture: no live scheduler → uninstall still succeeds, jobs_cancelled=0.
+    from graph.plugins import installer
+
+    import graph.config_io as cio
+
+    monkeypatch.setattr(installer, "lock_path", lambda: tmp_path / "plugins.lock")
+    monkeypatch.setenv("PROTOAGENT_PLUGINS_DIR", str(tmp_path / "installed"))
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: tmp_path / "langgraph-config.yaml")
+    monkeypatch.setattr(cio, "secrets_yaml_path", lambda: tmp_path / "secrets.yaml")
+    _make_plugin_dir(installer.live_plugins_dir(), "demo_sweep", enabled=True)
+    monkeypatch.setattr(STATE, "scheduler", None)
+
+    rep = installer.uninstall("demo_sweep")
+    assert rep["jobs_cancelled"] == 0 and "jobs" not in rep["removed"]
+
+
+# --- surface ------------------------------------------------------------------
+
+
+def test_sdk_module_exposes_recurring_surface():
+    assert callable(sdk.schedule_recurring)
+    assert callable(sdk.cancel_scheduled)
+    assert callable(sdk.cancel_plugin_jobs)
+    assert sdk.plugin_job_prefix("st") == "plugin:st:"

--- a/tests/test_sdk_scheduler.py
+++ b/tests/test_sdk_scheduler.py
@@ -127,6 +127,10 @@ def test_cancel_scheduled_unavailable_or_bad_input(monkeypatch):
     monkeypatch.setattr(STATE, "scheduler", _Scheduler())
     assert sdk.cancel_scheduled("", plugin_id="st") is False
     assert sdk.cancel_scheduled("t", plugin_id="") is False
+    # Same ':' guard as schedule_recurring: plugin "a:b" can't reach into "a"'s namespace
+    # (plugin "a" may legitimately hold a job whose plugin-local id contains ':').
+    monkeypatch.setattr(STATE, "scheduler", _Scheduler(seed=("plugin:a:b:t",)))
+    assert sdk.cancel_scheduled("t", plugin_id="a:b") is False
 
 
 # --- cancel_plugin_jobs ------------------------------------------------------


### PR DESCRIPTION
## Problem

Plugins can enqueue **one-shot** turns (`sdk.run_in_session`) but a **recurring** cadence (spacetraders' daily strategist OODA tick) has no plugin-owned path — the operator wires a cron job manually. So the plugin can't set up or repair its own cadence, and nothing ties the job to the plugin: **uninstall/disable leaves an orphan job firing prompts about a plugin that's gone** — the scheduler twin of the watch-lifecycle gap (#1638 / #1654).

## Change

### SDK surface (`graph/sdk.py`, ADR 0043)

- **`sdk.schedule_recurring(prompt, cron, *, plugin_id, job_id, session="", timezone=None) -> dict`** — thin over `STATE.scheduler.add_job` with the id namespaced **`plugin:<plugin_id>:<job_id>`**. Idempotent by id (a re-call replaces the pending job, mirroring `run_in_session`'s job_id semantics) so `register()` re-arms on every load and a cadence-knob change just re-schedules. Rejects non-cron schedules (one-shot turns stay on `run_in_session`). `session` empty → fires into the durable Activity thread (the scheduler's `context_id=None` default). Returns `{ok, job_id, next_fire, message}`.
- **`sdk.cancel_scheduled(job_id, *, plugin_id) -> bool`** — plugin-local id; namespacing is applied inside, never by the caller.
- **`sdk.cancel_plugin_jobs(plugin_id) -> int`** — cancel every `plugin:<id>:*` job; the hygiene primitive the lifecycle hooks call (also lets a plugin tear down its own cadence wholesale).

**How plugin identity is threaded:** there is no ambient plugin identity in the SDK — `graph/sdk.py` functions are plain module imports, not registry-bound, and no contextvar carries a plugin id anywhere in `graph/` (registry-side state like `registry.emit`'s namespace guard lives on the `PluginRegistry` instance, which the SDK never sees). Per the issue's fallback, **`plugin_id` is an explicit required kwarg** — callers pass `registry.plugin_id`. A `:` in `plugin_id` is rejected so plugin `a` can never sweep a hypothetical `a:b`'s namespace.

### Lifecycle hygiene

- **Disable** — `load_plugins` (`graph/plugins/loader.py`) now sweeps a discovered-but-not-enabled plugin's `plugin:<id>:*` jobs on every (re)load. The console disable toggle and a hand-edited config both funnel through a reload, so one hook covers both. Pre-setup/boot-order safe: `STATE.scheduler is None` → no-op; on the normal boot path `agent_init` wires the scheduler **before** `load_plugins`, so an enabled plugin's `register()` can (re)arm its cadence immediately.
- **Uninstall** — `installer.uninstall` cancels the plugin's jobs in the same pass that removes the code (the loader sweep can't cover this: the manifest is gone from disk). The report gains `jobs_cancelled`, and `"jobs"` joins `removed` for the audit line. Best-effort: a CLI-process uninstall has no live scheduler and honestly reports 0 (the console route runs in the live server, where it works).

### ADR 0004 untouched

The `agent_name` owner-lock/instance scoping is not modified: `list_jobs` filters on `agent_name`, so a sweep can only ever touch **this instance's** jobs; plugin ownership is a new dimension on the job **id** inside one instance's jobs.db, not an agent one.

## Tests

`tests/test_sdk_scheduler.py` (+15):

- schedule → cancel round-trip; namespaced id; cron-not-ISO enforced; Activity default (`context_id=None`) + session/timezone passthrough
- idempotent replace on re-arm (cadence knob change)
- input + host-missing guards (`ok=False` / `False` / `0`, nothing enqueued on bad input; `:` in plugin_id rejected)
- `cancel_plugin_jobs` sweeps ONLY the plugin's jobs — a prefix-adjacent plugin id (`st` vs `st2`) does not match, operator-manual jobs survive
- real `LocalScheduler` round-trip (tmp sqlite) proving the namespaced id rides the normal per-instance path with `agent_name` intact
- loader: disabled plugin's jobs swept on load, enabled plugin's + operator's survive; no-scheduler load no-ops
- installer: uninstall cancels only the uninstalled plugin's jobs (`jobs_cancelled`/`removed`); no-scheduler CLI posture reports 0

Full suite: 2851 passed, 5 skipped. `ruff check .`, `lint-imports` (3 contracts kept), and `npm run docs:build` all pass locally.

## Docs

- `docs/guides/scheduler.md` — new **Plugin-owned recurring jobs** section (usage, replace semantics, disable/uninstall cleanup, ADR 0004 note)
- `docs/guides/plugins.md` — consumption-SDK list entry + a stable `{#consumption-sdk}` anchor on the ADR 0043 section (now cross-linked from the scheduler guide)
- `CHANGELOG.md` [Unreleased] ▸ Added

Fixes #1642

🤖 Generated with [Claude Code](https://claude.com/claude-code)