### PR TITLE
feat(sdk): react_on — reactive-rule sugar over registry.on + run_in_session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`graph.sdk.react_on` — reactive-rule sugar** (#1633). The canonical reactive
+  composition `registry.on(topic, handler)` → `sdk.run_in_session(session, prompt)` made
+  every plugin write identical glue (missing-host guard, prompt-from-payload, idempotent
+  job id, burst debounce). `react_on(topic, *, prompt, job_id, session=<Activity>,
+  debounce_s=0)` is that glue in one call: `prompt(event)` returning `None`/empty skips
+  the event, `job_id` makes re-fires replace rather than stack (run_in_session
+  semantics), and `debounce_s > 0` coalesces a burst into ONE turn with a thread-safe
+  trailing-edge debounce (the last event's prompt wins; skipped events don't extend the
+  window). Returns an unsubscribe fn mirroring `registry.on`; degrades to a warned no-op
+  without a host bus.
 - **Plugins can now enumerate and remove watches** (#1638). The consumption SDK
   (ADR 0043) grows the lifecycle half of the ADR 0067 watch surface:
   `sdk.list_watches(prefix="")` (each `{id, condition, status, verifier}`,

--- a/docs/adr/0039-plugin-event-bus.md
+++ b/docs/adr/0039-plugin-event-bus.md
@@ -76,6 +76,13 @@ publish is the gated one (namespace-stamped, rate-limited for iframes).
 - **artifact-plugin v0.2.0.** `show_artifact` emits `artifact.created` ⇒ the dot lights even when the
   panel is closed. (History/download are local plugin features, unrelated to the bus.)
 
+> **Grown since:** the dominant server-side subscriber pattern turned out to be *event →
+> agent turn* ("when X happens, have the agent react" — engine emissions, watch trips).
+> That composition — `subscribe_handler` + prompt-from-payload + `run_in_session` with an
+> idempotent job id and thread-safe burst debouncing — ships as consumption-SDK sugar:
+> `graph.sdk.react_on(topic, *, prompt, job_id, session=…, debounce_s=…)` (#1633,
+> ADR 0043). Pure composition; no new bus semantics or persistent state.
+
 ## Options considered
 
 **Topology** — *(chosen)* extend the one server bus, server-authoritative; vs a client-only UI bus

--- a/docs/adr/0043-plugin-consumption-sdk-workflows-extraction.md
+++ b/docs/adr/0043-plugin-consumption-sdk-workflows-extraction.md
@@ -46,6 +46,12 @@ deliberately as more plugins tap core; this is the seam we lean on going forward
 > nudge, KB-indexed report, report card), and poll its jobs-store row in between. Closes
 > the hole where a plugin with campaign-scale work had to reach into
 > `STATE.background_mgr` directly. First consumer: spacetraders exploration campaigns.
+>
+> `react_on(topic, *, prompt, job_id, session=…, debounce_s=0)` (#1633) — reactive-rule
+> sugar over `registry.on` + `run_in_session` (ADR 0039): prompt-from-payload
+> (`None`/empty skips the event), idempotent replace via `job_id`, thread-safe
+> trailing-edge debounce (a burst coalesces into ONE turn; the last event's prompt wins).
+> Returns an unsubscribe fn. First consumer: spacetraders engine-event → turn rules.
 
 **2. Workflows becomes an opt-in plugin (`plugins/workflows`, `enabled: false`).**
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -262,6 +262,13 @@ SDK** directly — `from graph.sdk import …`, the *stable* surface plugins cal
 - `background_status(task_id)` — the status-query companion: `{status, description,
   report?}` for a spawned job (`report` once terminal), so a plugin can render progress
   on its own surface between launch and the completion nudge.
+- `react_on(topic, *, prompt, job_id, session=…, debounce_s=0)` — **reactive-rule sugar**:
+  when a bus event matching `topic` fires, build a prompt from the payload and enqueue a
+  follow-up turn (`run_in_session`). `prompt(event) -> str | None` (`None`/empty skips the
+  event), `job_id` makes re-fires replace rather than stack, `debounce_s` coalesces a burst
+  into ONE turn (trailing-edge; the last event's prompt wins), `session` defaults to the
+  Activity thread. Returns an unsubscribe fn. The one-call form of the canonical
+  `registry.on` → `run_in_session` composition — see [Events](#events-the-plugin-bus-adr-0039).
 
 The **workflows plugin** (`plugins/workflows`) is the reference consumer: its engine
 injects `run_subagent` as the per-step runner. This is the pattern for plugins that tap
@@ -288,6 +295,9 @@ def register(registry):
   rail icon (a **notification dot**) until the user opens that surface.
 - Fire-and-forget + topic-filtered + exception-isolated: a slow or broken subscriber can't affect the
   publisher or other subscribers. Ephemeral (a ring buffer covers SSE reconnects; no durable log).
+- The most common subscriber is "when X happens, have the **agent** react" — that composition
+  (`on` → prompt-from-payload → `run_in_session`, with an idempotent job id and burst debouncing)
+  ships as one consumption-SDK call: `sdk.react_on(…)` ([above](#tapping-core-deeper-graph-sdk-adr-0043)).
 
 > Cross-process note: under the **ACP runtime**, a tool runs in the operator-MCP process where the
 > bus isn't wired, so `emit` from a tool won't reach the server bus there. Under the default runtime

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -17,9 +17,14 @@ its engine injects ``run_subagent`` as the per-step runner).
 from __future__ import annotations
 
 import asyncio
+import logging
+from collections.abc import Callable
 from typing import Any
 
+from events import ACTIVITY_CONTEXT
 from runtime.state import STATE
+
+log = logging.getLogger(__name__)
 
 # Re-export the supervised background-task helper as part of the consumption surface, so a
 # plugin writes `from graph.sdk import supervise` for a self-perpetuating, watchdog-backed
@@ -368,3 +373,124 @@ def background_status(task_id: str) -> dict:
     if job.status != "running":
         out["report"] = job.result
     return out
+
+
+# ── reactive rules (ADR 0039 events → one-shot turns) ──────────────────────────────────
+# The canonical reactive composition is ``registry.on(topic, handler)`` →
+# :func:`run_in_session` — and every plugin that wants "when X happens, have the agent
+# react" writes the same glue: guard for a missing host, build the prompt from the event
+# payload, pick an idempotent job_id, debounce bursts so ten events don't enqueue ten
+# turns. ``react_on`` is that glue, once (#1633). Pure composition of
+# ``EventBus.subscribe_handler`` (via the plugin host seam) + ``run_in_session`` —
+# no new persistent state.
+
+
+def react_on(
+    topic: str,
+    *,
+    prompt: Callable[[dict], str | None],
+    job_id: str,
+    session: str = ACTIVITY_CONTEXT,
+    debounce_s: float = 0.0,
+) -> Callable[[], None]:
+    """When a bus event matching ``topic`` fires, enqueue a follow-up agent turn.
+
+    ``prompt`` is called with the full event payload (``{"event", "data", "seq"}``)
+    at delivery time; return the turn's prompt text, or ``None``/empty to **skip**
+    that event (cheap filtering). The turn is enqueued via :func:`run_in_session`
+    with ``job_id``, so a rule re-fires idempotently (a pending turn is REPLACED,
+    never duplicated)::
+
+        unsub = sdk.react_on(
+            "spacetraders.opportunity",
+            prompt=lambda ev: f"A {ev['data']['margin']}% route appeared. Evaluate it.",
+            job_id="spacetraders-opportunity",
+            debounce_s=30,
+        )
+
+    Args:
+        topic: bus topic pattern (``*`` = one segment, ``#`` = tail — any namespace;
+            subscribing is read-only, like ``registry.on``).
+        prompt: ``(payload) -> str | None`` — the prompt builder / filter.
+        job_id: stable id for the enqueued turn (``run_in_session``'s
+            idempotent-replace key). Required — it's what keeps a chatty rule from
+            stacking turns.
+        session: the session the turn runs in; defaults to the durable Activity
+            thread (``ACTIVITY_CONTEXT``).
+        debounce_s: > 0 coalesces a burst into ONE turn — trailing-edge: the timer
+            re-arms on every qualifying event, fires ``debounce_s`` after the LAST
+            one, and that last event's prompt text wins. Skipped events (``prompt``
+            returned ``None``/empty) neither fire nor extend the window. Note a
+            sustained stream arriving faster than ``debounce_s`` keeps deferring
+            the turn (classic debounce). Thread-safe — the bus may deliver from
+            worker threads.
+
+    Returns an **unsubscribe** callable (mirroring ``registry.on``'s seam): it stops
+    delivery and cancels any pending debounce timer. When no host bus is wired
+    (tests, headless), logs a warning and returns a no-op unsubscribe.
+    """
+    import threading
+
+    from graph.plugins.host import HOST
+
+    if not callable(prompt):
+        raise TypeError("react_on: prompt must be a callable (event payload) -> str | None")
+    if not (job_id or "").strip():
+        raise ValueError("react_on: a stable job_id is required (the idempotent-replace key)")
+    subscribe = HOST.on
+    if subscribe is None:
+        log.warning("[sdk] react_on(%r) dropped — no event bus wired (non-server context)", topic)
+        return lambda: None
+
+    # Debounce state — guarded by a lock because the bus publish path is threadsafe
+    # (handlers may be delivered from worker threads, e.g. a sync middleware hook).
+    lock = threading.Lock()
+    pending: dict[str, Any] = {"timer": None, "text": None}
+
+    def _enqueue(text: str) -> None:
+        res = run_in_session(session, text, job_id=job_id)
+        if not res.get("ok"):
+            log.warning("[sdk] react_on(%r): could not enqueue turn — %s", topic, res.get("message"))
+
+    def _fire() -> None:  # timer thread — never let an exception die silently there
+        with lock:
+            text = pending["text"]
+            pending["timer"] = None
+            pending["text"] = None
+        if not text:
+            return
+        try:
+            _enqueue(text)
+        except Exception:  # noqa: BLE001
+            log.exception("[sdk] react_on(%r): debounced enqueue failed", topic)
+
+    def _handler(payload: dict) -> None:
+        text = prompt(payload)
+        if not (text or "").strip():
+            return  # filtered — a skipped event doesn't extend the debounce window
+        if debounce_s <= 0:
+            _enqueue(text)
+            return
+        with lock:
+            pending["text"] = text  # last event in the burst wins
+            timer = pending["timer"]
+            if timer is not None:
+                timer.cancel()
+            timer = threading.Timer(debounce_s, _fire)
+            timer.daemon = True
+            pending["timer"] = timer
+            timer.start()
+
+    unsubscribe = subscribe(topic, _handler)
+
+    def _unsubscribe() -> None:
+        if callable(unsubscribe):
+            unsubscribe()
+        with lock:
+            timer = pending["timer"]
+            pending["timer"] = None
+            pending["text"] = None
+        if timer is not None:
+            timer.cancel()
+
+    return _unsubscribe

--- a/tests/test_sdk_react_on.py
+++ b/tests/test_sdk_react_on.py
@@ -1,0 +1,195 @@
+"""graph.sdk.react_on — reactive-rule sugar over registry.on + run_in_session (#1633).
+
+Uses a REAL EventBus (with no running loop, ``publish`` delivers inline on the calling
+thread — exactly the threaded delivery path the debounce must survive) and a captured
+``run_in_session``. Debounce assertions are event-driven (``threading.Event``), not
+wall-clock guesses.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from events.bus import EventBus
+
+
+@pytest.fixture
+def rig(monkeypatch):
+    """A real bus wired into HOST.on + a captured run_in_session; yields (bus, calls, fired)."""
+    from graph import sdk
+    from graph.plugins.host import HOST
+
+    bus = EventBus()
+    monkeypatch.setattr(HOST, "on", bus.subscribe_handler)
+
+    calls: list[tuple] = []
+    fired = threading.Event()
+
+    def fake_run_in_session(session_id, prompt, *, delay_seconds=0.0, job_id=None):
+        calls.append((session_id, prompt, job_id))
+        fired.set()
+        return {"ok": True, "job_id": job_id, "fires_at": "now", "message": "enqueued"}
+
+    monkeypatch.setattr(sdk, "run_in_session", fake_run_in_session)
+    return bus, calls, fired
+
+
+def test_react_on_enqueues_a_turn_from_an_event(rig):
+    from graph import sdk
+
+    bus, calls, _ = rig
+    unsub = sdk.react_on(
+        "spacetraders.opportunity",
+        session="chat-1",
+        prompt=lambda ev: f"Route {ev['data']['route']} appeared. Evaluate it.",
+        job_id="st-opportunity",
+    )
+    bus.publish("spacetraders.opportunity", {"route": "X1->X2"})
+    assert calls == [("chat-1", "Route X1->X2 appeared. Evaluate it.", "st-opportunity")]
+    unsub()
+
+
+def test_react_on_defaults_to_the_activity_session(rig):
+    from events import ACTIVITY_CONTEXT
+    from graph import sdk
+
+    bus, calls, _ = rig
+    unsub = sdk.react_on("notes.*", prompt=lambda ev: "react", job_id="j1")
+    bus.publish("notes.created", {})
+    assert calls == [(ACTIVITY_CONTEXT, "react", "j1")]
+    unsub()
+
+
+def test_react_on_skips_when_prompt_returns_none_or_empty(rig):
+    from graph import sdk
+
+    bus, calls, _ = rig
+    unsub = sdk.react_on("st.*", prompt=lambda ev: ev["data"].get("text"), job_id="j1")
+    bus.publish("st.tick", {})  # prompt -> None
+    bus.publish("st.tick", {"text": "  "})  # whitespace-only counts as empty
+    assert calls == []
+    bus.publish("st.tick", {"text": "go"})
+    assert [c[1] for c in calls] == ["go"]
+    unsub()
+
+
+def test_react_on_debounce_coalesces_a_burst_into_one_turn_last_event_wins(rig):
+    from graph import sdk
+
+    bus, calls, fired = rig
+    unsub = sdk.react_on(
+        "st.opportunity",
+        prompt=lambda ev: f"margin {ev['data']['margin']}",
+        job_id="st-opp",
+        debounce_s=0.08,
+    )
+    for margin in (5, 9, 42):
+        bus.publish("st.opportunity", {"margin": margin})
+    assert calls == []  # nothing fires inside the window
+    assert fired.wait(3.0), "debounced turn never fired"
+    assert calls == [(sdk.ACTIVITY_CONTEXT, "margin 42", "st-opp")]  # ONE turn, last event wins
+    unsub()
+
+
+def test_react_on_debounce_is_threadsafe_under_concurrent_delivery(rig):
+    """The bus publish path is threadsafe — with no loop bound, each thread delivers
+    the handler inline, so this exercises real concurrent timer-reset contention."""
+    from graph import sdk
+
+    bus, calls, fired = rig
+    unsub = sdk.react_on("st.*", prompt=lambda ev: f"n={ev['data']['n']}", job_id="j", debounce_s=0.15)
+
+    n_threads = 8
+    barrier = threading.Barrier(n_threads)
+
+    def _publish(i: int) -> None:
+        barrier.wait()
+        bus.publish("st.burst", {"n": i})
+
+    threads = [threading.Thread(target=_publish, args=(i,)) for i in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert fired.wait(3.0), "debounced turn never fired"
+    assert len(calls) == 1  # the whole concurrent burst coalesced into one turn
+    unsub()
+
+
+def test_react_on_skipped_events_do_not_extend_or_clobber_the_debounce_window(rig):
+    from graph import sdk
+
+    bus, calls, fired = rig
+    unsub = sdk.react_on("st.*", prompt=lambda ev: ev["data"].get("text"), job_id="j", debounce_s=0.05)
+    bus.publish("st.a", {"text": "real"})
+    bus.publish("st.a", {})  # filtered — must not clobber or re-arm the pending text
+    assert fired.wait(3.0)
+    assert [c[1] for c in calls] == ["real"]
+    unsub()
+
+
+def test_react_on_unsubscribe_stops_delivery(rig):
+    from graph import sdk
+
+    bus, calls, _ = rig
+    unsub = sdk.react_on("st.*", prompt=lambda ev: "go", job_id="j")
+    bus.publish("st.a", {})
+    assert len(calls) == 1
+    unsub()
+    bus.publish("st.a", {})
+    assert len(calls) == 1  # no further delivery
+    unsub()  # idempotent
+
+
+def test_react_on_unsubscribe_cancels_a_pending_debounce_timer(rig):
+    from graph import sdk
+
+    bus, calls, fired = rig
+    unsub = sdk.react_on("st.*", prompt=lambda ev: "go", job_id="j", debounce_s=0.05)
+    bus.publish("st.a", {})
+    unsub()  # inside the window — the armed timer must be canceled
+    assert not fired.wait(0.3), "canceled debounce timer still fired"
+    assert calls == []
+
+
+def test_react_on_without_a_host_bus_is_a_warned_noop(monkeypatch, caplog):
+    import logging
+
+    from graph import sdk
+    from graph.plugins.host import HOST
+
+    monkeypatch.setattr(HOST, "on", None)
+    with caplog.at_level(logging.WARNING, logger="graph.sdk"):
+        unsub = sdk.react_on("st.*", prompt=lambda ev: "go", job_id="j")
+    assert "no event bus wired" in caplog.text
+    unsub()  # callable no-op, nothing raises
+
+
+def test_react_on_validates_inputs(rig):
+    from graph import sdk
+
+    with pytest.raises(TypeError):
+        sdk.react_on("st.*", prompt="not-callable", job_id="j")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        sdk.react_on("st.*", prompt=lambda ev: "go", job_id="  ")
+
+
+def test_react_on_logs_but_survives_an_enqueue_failure(rig, monkeypatch, caplog):
+    import logging
+
+    from graph import sdk
+
+    bus, _calls, _ = rig
+    monkeypatch.setattr(
+        sdk,
+        "run_in_session",
+        lambda *a, **kw: {"ok": False, "message": "scheduler unavailable — cannot enqueue a turn"},
+    )
+    unsub = sdk.react_on("st.*", prompt=lambda ev: "go", job_id="j")
+    with caplog.at_level(logging.WARNING, logger="graph.sdk"):
+        bus.publish("st.a", {})
+        bus.publish("st.a", {})  # the rule survives — still subscribed after a failure
+    assert caplog.text.count("could not enqueue turn") == 2
+    unsub()


### PR DESCRIPTION
## Problem

The canonical reactive composition is `registry.on(topic, handler)` → `sdk.run_in_session(session, prompt)` — and every plugin that wants "when X happens, have the agent react" writes the same glue: guard for a missing host, build the prompt from the event payload, pick an idempotent `job_id`, debounce bursts so ten events don't enqueue ten turns. (Proven by spacetraders SDK round-2: v1.7 engine emissions + v1.8 watches both want event→turn rules with identical glue.)

## What this ships

One ADR 0043 consumption-SDK function in `graph/sdk.py`:

```python
unsub = sdk.react_on(
    "spacetraders.opportunity",           # topic pattern (*/# wildcards, any namespace — read-only)
    prompt=lambda ev: f"A {ev['data']['margin']}% route appeared. Evaluate it.",
    job_id="spacetraders-opportunity",    # idempotent replace (run_in_session semantics)
    debounce_s=30,                        # coalesce bursts into one turn
)                                          # session defaults to the Activity thread
```

- **`prompt(payload) -> str | None`** over the full bus payload `{event, data, seq}`; `None`/empty → **skip** (cheap filtering).
- **Idempotent replace** — `job_id` rides `run_in_session`'s cancel-then-add semantics: a re-fire replaces the pending turn, never stacks.
- **Debounce semantics (exact contract)** — `debounce_s > 0` is a **thread-safe trailing-edge debounce** (lock + timer-reset; the bus publish path is threadsafe and may deliver from worker threads): the timer re-arms on every *qualifying* event, the turn fires `debounce_s` after the **last** event of the burst, and that **last event's prompt text wins**. Skipped events (`prompt` returned `None`/empty) neither fire nor extend the window. A sustained stream faster than `debounce_s` keeps deferring (classic debounce — documented in the docstring).
- **Returns an unsubscribe fn** (mirrors the `registry.on` seam — `HOST.on` is `EventBus.subscribe_handler`, which returns the unsubscribe): stops delivery *and* cancels a pending debounce timer. Missing host bus → warned no-op unsubscribe.
- **Pure composition** of `EventBus.subscribe_handler` + `run_in_session` — no new persistent state. (`LocalScheduler` opens a fresh SQLite connection per call, so the timer-thread enqueue is safe.)

## Tests

`tests/test_sdk_react_on.py` (11 tests) runs against a **real `EventBus`** with no bound loop — `publish` then delivers inline on the calling thread, which is exactly the threaded delivery path the debounce must survive. No flaky sleeps: all waits are `threading.Event`-driven; the concurrency test uses an 8-thread `threading.Barrier` burst. Covers: basic wiring + Activity-session default, skip-on-`None`/empty, burst coalescing with last-event-wins, concurrent threaded delivery → exactly one turn, skipped events not clobbering/extending the pending window, unsubscribe stopping delivery and cancelling an armed timer (negative-fire assertion), warned no-op without a host, `TypeError`/`ValueError` input validation, and survival of enqueue failures (rule stays subscribed, warning logged).

## Docs

- `docs/guides/plugins.md` — consumption-SDK bullet + a pointer from the Events (ADR 0039) section.
- ADR 0039 + ADR 0043 — grown-since notes (the composition is now one call; no new bus semantics).
- `CHANGELOG.md` [Unreleased] ▸ Added.

## Gates

- `ruff check .` ✅
- `lint-imports` ✅ (3 contracts kept)
- `python -m pytest tests/ -q` ✅ 2855 passed, 5 skipped

Fixes #1633

🤖 Generated with [Claude Code](https://claude.com/claude-code)