### PR TITLE
feat(plugins): typed event contracts — emits: entries may declare payload schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plugin state. Retention is capped per series (90 days / 10k points, trimmed on
   write). `plugin_id` is an explicit required kwarg with `':'` rejected (the #1642/#1656
   precedent), so one plugin can't reach another's namespace.
+- **Typed event contracts — `emits:` entries can declare payload schemas** (#1636).
+  The event bus (ADR 0039) is the only inter-plugin channel, but the manifest's
+  `emits:` list was names-only — a cross-plugin consumer (a Discord feed
+  subscribing `spacetraders.#`) had no payload-shape contract and
+  reverse-engineered the emitter. An `emits:` entry may now be `{topic,
+  summary?, schema?}` — the schema inline JSON Schema, or a `$ref` to a file
+  inside the plugin repo (resolved relative to the plugin dir, read at manifest
+  load). Purely declarative, like `capabilities`: the shapes surface in
+  `/api/runtime/status` as a per-plugin `emits_schemas` map (`topic →
+  {summary?, schema?}`); bare-string entries and the names-only `emits` list
+  are unchanged everywhere, and a missing/invalid/escaping ref warns and
+  degrades that entry to names-only — it never fails the plugin load.
+  Dev-channel publish-time validation is deliberately deferred (follow-up,
+  developer-flag-gated).
 - **`graph.sdk.react_on` — reactive-rule sugar** (#1633). The canonical reactive
   composition `registry.on(topic, handler)` → `sdk.run_in_session(session, prompt)` made
   every plugin write identical glue (missing-host guard, prompt-from-payload, idempotent

--- a/docs/adr/0039-plugin-event-bus.md
+++ b/docs/adr/0039-plugin-event-bus.md
@@ -66,6 +66,16 @@ structurally, not by etiquette:
   tooling), but undeclared subscriptions are allowed — the guard is on *publishing*, which is the
   only direction that can spoof or spam.
 
+> **Grown since (typed event contracts, #1636):** as the first real cross-plugin consumers appeared
+> (a Discord feed subscribing `spacetraders.#`), names-only `emits:` proved to be the composition
+> bottleneck — the consumer reverse-engineers the emitter's payload and silently breaks. An `emits:`
+> entry may now optionally be `{topic, summary?, schema?}` (JSON Schema inline, or a `$ref` to a
+> file inside the plugin repo, read at manifest load). Purely declarative, like `capabilities`: the
+> shapes ride `/api/runtime/status` as a per-plugin `emits_schemas` map (`topic → {summary?,
+> schema?}`) so consumers/console can discover them; nothing validates payloads at publish time, and
+> a broken schema/ref warns and degrades that entry to names-only — never a load failure. A
+> dev-channel warn-on-mismatch validator (developer-flag-gated) remains a possible later slice.
+
 This maps onto the ADR 0038 threat model: **subscribe is safe; publish is the risky direction**, so
 publish is the gated one (namespace-stamped, rate-limited for iframes).
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -44,7 +44,9 @@ requires_env: []          # env vars the plugin needs (missing → skipped + log
 capabilities:             # declarative, for transparency (not yet enforced)
   network: []
   filesystem: none
-emits: []                 # event-bus topics this plugin broadcasts (ADR 0039) — its public API
+emits: []                 # event-bus topics this plugin broadcasts (ADR 0039) — its public API.
+                          # An entry is a bare topic name, or {topic, summary?, schema?} to
+                          # declare the payload shape — see "Typed event contracts" below
 subscribes: []            # topics it listens for (declarative — for discoverability)
 ```
 
@@ -311,6 +313,9 @@ def register(registry):
   publish under your own namespace. **Subscribing is read-only** and may match any topic.
 - **Declare your contract** in the manifest (`emits:` / `subscribes:`) — your events are your public
   API, discoverable in `/api/runtime/status`.
+- **Type your contract** (optional) — an `emits:` entry may declare the payload shape so a
+  cross-plugin consumer doesn't reverse-engineer your source. See
+  [Typed event contracts](#typed-event-contracts) below.
 - A console **view** (sandboxed iframe) talks to the bus over the bridge — see
   [Building a plugin view](/guides/building-react-plugin-views). Any event under `<plugin_id>.*` lights your plugin's
   rail icon (a **notification dot**) until the user opens that surface.
@@ -323,6 +328,38 @@ def register(registry):
 > Cross-process note: under the **ACP runtime**, a tool runs in the operator-MCP process where the
 > bus isn't wired, so `emit` from a tool won't reach the server bus there. Under the default runtime
 > (tool runs in-server) it does.
+
+### Typed event contracts
+
+A names-only `emits:` list tells a consumer *that* a topic exists, not what the payload looks
+like — the consumer reverse-engineers the emitter and silently breaks when a field changes. An
+`emits:` entry may therefore declare its **payload shape** (#1636): a mapping with `topic` plus an
+optional `summary` and/or `schema` (JSON Schema — inline, or a `$ref` to a file inside the plugin
+repo, resolved relative to the plugin directory and read at load):
+
+```yaml
+emits:
+  - spacetraders.window_closed              # bare topic name — still fine
+  - topic: spacetraders.trade_executed
+    summary: A hauler completed a buy→sell leg
+    schema:
+      type: object
+      required: [route, profit]
+      properties: { route: {type: string}, profit: {type: integer}, ship: {type: string} }
+  - topic: spacetraders.ship_purchased
+    schema: { $ref: events/ship_purchased.json }   # file in the plugin repo
+```
+
+- **Purely declarative** (like `capabilities`): the declared shapes ride `/api/runtime/status` as a
+  per-plugin `emits_schemas` map (`topic → {summary?, schema?}`), so consumers and the console can
+  discover payload shapes. Nothing validates payloads at publish time. (A dev-channel *warn on
+  mismatch* validator is a possible later step, gated by a developer flag — deliberately not built
+  yet.)
+- **Backward compatible**: bare-string entries keep working unchanged, and `emits` stays the
+  names-only topic list everywhere it's already consumed.
+- **Never load-bearing**: a missing/invalid `$ref`, a ref that escapes the plugin directory, or a
+  malformed `schema` logs a warning and degrades that entry to names-only — it never fails the
+  plugin load.
 
 ## Performance — keep the burden in your plugin
 

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -333,6 +333,11 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
             # surfaced for discoverability (the console can show a plugin's event catalog).
             "emits": list(manifest.emits) if enabled else [],
             "subscribes": list(manifest.subscribes) if enabled else [],
+            # Typed event contracts (#1636) — topic → {summary?, schema?} for emits
+            # entries that declared a payload shape. Rides /api/runtime/status so a
+            # cross-plugin consumer can discover the contract instead of reverse-
+            # engineering the emitter. Declarative only — no publish-time validation.
+            "emits_schemas": dict(manifest.emits_schemas) if enabled else {},
         }
 
         if not enabled:

--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -80,6 +80,14 @@ class PluginManifest:
     # subscribing to any topic is allowed.
     emits: list[str] = field(default_factory=list)
     subscribes: list[str] = field(default_factory=list)
+    # Typed event contracts (#1636) — topic → {"summary": str, "schema": dict} for
+    # `emits:` entries that declared more than a bare name. `emits` above stays the
+    # names-only topic list (every entry, bare or typed), so existing consumers are
+    # untouched; this map carries the optional payload contract a cross-plugin
+    # consumer can discover instead of reverse-engineering the emitter. Purely
+    # declarative (like `capabilities`) — payloads are NOT validated at publish
+    # time. See `_parse_emits`.
+    emits_schemas: dict[str, dict] = field(default_factory=dict)
     # Distribution (ADR 0027) — for plugins installed from a git URL.
     #   requires_pip: declared pip deps. NOT auto-installed (install ≠ code exec);
     #     the operator installs them explicitly. Missing → clear error on enable.
@@ -192,6 +200,114 @@ def _view_public_paths(views: list[dict]) -> list[str]:
     return out
 
 
+def _load_schema_ref(ref: str, plugin_dir: Path, plugin_id: str, topic: str) -> dict | None:
+    """Read a schema ``$ref`` file from inside the plugin directory → mapping.
+
+    The ref is resolved relative to the plugin dir and must stay inside it (a
+    ``../…`` escape is refused — the manifest must not read arbitrary host files).
+    The file is parsed with ``yaml.safe_load`` (JSON is a YAML subset, so plain
+    ``.json`` schema files work). Every failure — escape, missing file, parse
+    error, non-mapping content — warns and returns ``None`` so the entry keeps its
+    names-only behavior; a bad ref never fails the plugin load.
+    """
+    root = plugin_dir.resolve()
+    try:
+        target = (root / ref).resolve()
+        if not target.is_relative_to(root):
+            log.warning(
+                "[plugins] %s: emits %r schema $ref %r escapes the plugin directory — ignored",
+                plugin_id, topic, ref,
+            )
+            return None
+        loaded = yaml.safe_load(target.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError, ValueError) as exc:
+        log.warning(
+            "[plugins] %s: emits %r schema $ref %r is unreadable (%s) — keeping the "
+            "topic name only",
+            plugin_id, topic, ref, exc,
+        )
+        return None
+    if not isinstance(loaded, dict):
+        log.warning(
+            "[plugins] %s: emits %r schema $ref %r is not a mapping — keeping the topic name only",
+            plugin_id, topic, ref,
+        )
+        return None
+    return loaded
+
+
+def _resolve_emit_schema(schema, plugin_dir: Path, plugin_id: str, topic: str) -> dict | None:
+    """One entry's ``schema:`` value → JSON-schema mapping (or ``None``, warned).
+
+    Accepted forms: an inline mapping (kept verbatim), a mapping whose ONLY key is
+    ``$ref`` pointing to a file inside the plugin dir, or a bare string as
+    shorthand for that ``$ref``.
+    """
+    if isinstance(schema, str):
+        return _load_schema_ref(schema.strip(), plugin_dir, plugin_id, topic)
+    if isinstance(schema, dict):
+        ref = schema.get("$ref")
+        if set(schema.keys()) == {"$ref"} and isinstance(ref, str):
+            return _load_schema_ref(ref.strip(), plugin_dir, plugin_id, topic)
+        return schema
+    log.warning(
+        "[plugins] %s: emits %r schema must be a mapping or a $ref path, got %s — "
+        "keeping the topic name only",
+        plugin_id, topic, type(schema).__name__,
+    )
+    return None
+
+
+def _parse_emits(entries, plugin_dir: Path, plugin_id: str) -> tuple[list[str], dict[str, dict]]:
+    """Parse ``emits:`` → ``(topic names, topic → declared contract)`` (#1636).
+
+    An entry is either a bare topic string (today's behavior, unchanged) or a
+    mapping with ``topic`` plus an optional ``summary`` and/or ``schema``:
+
+    .. code-block:: yaml
+
+        emits:
+          - spacetraders.window_closed          # bare name — still fine
+          - topic: spacetraders.trade_executed
+            summary: A hauler completed a buy→sell leg
+            schema: {type: object, required: [route, profit], properties: {...}}
+          - topic: spacetraders.ship_purchased
+            schema: {$ref: events/ship_purchased.json}   # file inside the plugin repo
+
+    Both forms contribute the topic NAME to the first return (what ``emits``
+    consumers already read); entries that declare a summary/schema also land in
+    the contract map. Purely declarative — nothing validates payloads at publish
+    time. Malformed entries warn and degrade to names-only (or are skipped when
+    there's no usable topic); they never fail the manifest load.
+    """
+    if not isinstance(entries, (list, tuple)):
+        return [], {}
+    names: list[str] = []
+    schemas: dict[str, dict] = {}
+    for entry in entries:
+        if isinstance(entry, dict):
+            topic = str(entry.get("topic", "") or "").strip()
+            if not topic:
+                log.warning(
+                    "[plugins] %s: emits entry %r has no 'topic' — skipped", plugin_id, entry
+                )
+                continue
+            names.append(topic)
+            contract: dict = {}
+            summary = entry.get("summary")
+            if summary:
+                contract["summary"] = str(summary)
+            if "schema" in entry:
+                schema = _resolve_emit_schema(entry["schema"], plugin_dir, plugin_id, topic)
+                if schema is not None:
+                    contract["schema"] = schema
+            if contract:
+                schemas[topic] = contract
+        else:
+            names.append(str(entry))
+    return names, schemas
+
+
 def load_manifest(plugin_dir: Path) -> PluginManifest | None:
     """Parse ``<plugin_dir>/protoagent.plugin.yaml`` → ``PluginManifest``.
 
@@ -244,7 +360,7 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
             ]
         )
     )
-    emits = data.get("emits")
+    emits, emits_schemas = _parse_emits(data.get("emits"), plugin_dir, pid)
     subscribes = data.get("subscribes")
     requires_pip = data.get("requires_pip")
     return PluginManifest(
@@ -266,7 +382,8 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
         guide_url=str(data.get("guide_url", "") or "").strip(),
         views=views,
         public_paths=public_paths,
-        emits=[str(x) for x in emits] if isinstance(emits, (list, tuple)) else [],
+        emits=emits,
+        emits_schemas=emits_schemas,
         subscribes=[str(x) for x in subscribes] if isinstance(subscribes, (list, tuple)) else [],
         requires_pip=[str(x) for x in requires_pip] if isinstance(requires_pip, (list, tuple)) else [],
         repository=str(data.get("repository", "")).strip(),

--- a/graph/plugins/scaffold.py
+++ b/graph/plugins/scaffold.py
@@ -73,8 +73,12 @@ description: >-
   {summary}
 enabled: false
 config_section: {id_us}
-# Event bus (ADR 0039) — topics this plugin broadcasts / listens for (optional, for discovery):
+# Event bus (ADR 0039) — topics this plugin broadcasts / listens for (optional, for discovery).
+# An emits entry may also declare its payload shape (typed event contracts, #1636):
 # emits: ["{id_us}.something"]
+#   # - topic: {id_us}.something
+#   #   summary: One-line meaning of the event
+#   #   schema: {{type: object}}          # inline JSON Schema, or {{$ref: events/foo.json}}
 # subscribes: ["other-plugin.*"]
 {views_block}"""
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -57,6 +57,125 @@ def test_manifest_parse(tmp_path) -> None:
     assert load_manifest(tmp_path / "bad") is None  # missing id
 
 
+# --- Typed event contracts (#1636) — `emits:` entries may carry a payload schema ---
+
+
+def test_emits_bare_strings_unchanged(tmp_path) -> None:
+    # Today's names-only form keeps working verbatim — no contract map.
+    _make_plugin(tmp_path, "ev0", enabled=True, manifest_extra='emits: ["ev0.created", "ev0.closed"]\n')
+    m = load_manifest(tmp_path / "ev0")
+    assert m.emits == ["ev0.created", "ev0.closed"]
+    assert m.emits_schemas == {}
+
+
+def test_emits_inline_schema(tmp_path) -> None:
+    # A dict entry contributes its topic to the names list AND its declared
+    # summary/schema to the contract map; bare siblings stay names-only.
+    _make_plugin(
+        tmp_path, "ev1", enabled=True,
+        manifest_extra=(
+            "emits:\n"
+            "  - ev1.plain\n"
+            "  - topic: ev1.trade_executed\n"
+            "    summary: A hauler completed a buy-sell leg\n"
+            "    schema:\n"
+            "      type: object\n"
+            "      required: [route, profit]\n"
+            "      properties:\n"
+            "        route: {type: string}\n"
+            "        profit: {type: integer}\n"
+        ),
+    )
+    m = load_manifest(tmp_path / "ev1")
+    assert m.emits == ["ev1.plain", "ev1.trade_executed"]
+    contract = m.emits_schemas["ev1.trade_executed"]
+    assert contract["summary"] == "A hauler completed a buy-sell leg"
+    assert contract["schema"]["required"] == ["route", "profit"]
+    assert contract["schema"]["properties"]["profit"] == {"type": "integer"}
+    assert "ev1.plain" not in m.emits_schemas
+
+
+def test_emits_schema_ref_file(tmp_path) -> None:
+    # `schema: {$ref: <path>}` (and the bare-string shorthand) reads a JSON/YAML
+    # schema file from INSIDE the plugin dir at manifest-load time.
+    d = _make_plugin(
+        tmp_path, "ev2", enabled=True,
+        manifest_extra=(
+            "emits:\n"
+            "  - topic: ev2.ship_purchased\n"
+            "    schema: {$ref: events/ship.json}\n"
+            "  - topic: ev2.window_closed\n"
+            "    schema: events/ship.json\n"
+        ),
+    )
+    (d / "events").mkdir()
+    (d / "events" / "ship.json").write_text(
+        '{"type": "object", "properties": {"ship": {"type": "string"}}}', encoding="utf-8"
+    )
+    m = load_manifest(d)
+    assert m.emits == ["ev2.ship_purchased", "ev2.window_closed"]
+    assert m.emits_schemas["ev2.ship_purchased"]["schema"]["type"] == "object"
+    assert m.emits_schemas["ev2.window_closed"]["schema"]["properties"]["ship"] == {"type": "string"}
+
+
+def test_emits_invalid_ref_warns_not_fails(tmp_path, caplog) -> None:
+    # Every bad-schema mode degrades to names-only for THAT entry with a warning
+    # — a broken contract must never fail the plugin load (issue #1636).
+    import logging as _logging
+
+    d = _make_plugin(
+        tmp_path, "ev3", enabled=True,
+        manifest_extra=(
+            "emits:\n"
+            "  - topic: ev3.missing\n"
+            "    summary: still has a summary\n"
+            "    schema: {$ref: events/nope.json}\n"   # file doesn't exist
+            "  - topic: ev3.escape\n"
+            "    schema: {$ref: ../../outside.json}\n"  # path traversal → refused
+            "  - topic: ev3.badtype\n"
+            "    schema: 7\n"                           # not a mapping / ref
+            "  - summary: no topic here\n"              # unusable entry → skipped
+            "  - ev3.ok\n"
+        ),
+    )
+    with caplog.at_level(_logging.WARNING, logger="protoagent.plugins"):
+        m = load_manifest(d)
+    assert m is not None  # the load itself never fails
+    assert m.emits == ["ev3.missing", "ev3.escape", "ev3.badtype", "ev3.ok"]
+    # the summary survives a broken ref; the schema key is simply absent
+    assert m.emits_schemas["ev3.missing"] == {"summary": "still has a summary"}
+    assert "ev3.escape" not in m.emits_schemas
+    assert "ev3.badtype" not in m.emits_schemas
+    assert "unreadable" in caplog.text
+    assert "escapes the plugin directory" in caplog.text
+
+
+def test_emits_schemas_flow_to_runtime_status(tmp_path, monkeypatch) -> None:
+    # The loader meta carries `emits_schemas`, and /api/runtime/status passes the
+    # plugins block through verbatim — the discovery surface for consumers.
+    root = tmp_path / "plugins"
+    extra = (
+        "emits:\n"
+        "  - topic: evp.trade_executed\n"
+        "    summary: A trade completed\n"
+        "    schema: {type: object, required: [profit]}\n"
+    )
+    _make_plugin(root, "evp", enabled=True, tool="evp_tool", manifest_extra=extra)
+    _make_plugin(root, "evoff", enabled=False, tool="evoff_tool", manifest_extra=extra)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    res = load_plugins(_cfg())
+    meta = {m["id"]: m for m in res.meta}
+    assert meta["evp"]["emits"] == ["evp.trade_executed"]
+    assert meta["evp"]["emits_schemas"]["evp.trade_executed"]["schema"]["required"] == ["profit"]
+    assert meta["evoff"]["emits_schemas"] == {}  # disabled → not advertised
+
+    from operator_api.runtime import build_runtime_status
+
+    status = build_runtime_status(config=None, setup_complete=True, graph_loaded=False, plugins=res.meta)
+    by_id = {p["id"]: p for p in status["plugins"]}
+    assert by_id["evp"]["emits_schemas"] == meta["evp"]["emits_schemas"]
+
+
 def test_public_paths_namespace_scoped(tmp_path) -> None:
     # A plugin may declare auth-exempt paths only under its OWN namespace; anything
     # else (a core path, another plugin's path) is dropped by the parser.


### PR DESCRIPTION
Fixes #1636

## What

The event bus (ADR 0039) is the only inter-plugin channel, but the manifest's `emits:` list was names-only — a cross-plugin consumer (e.g. a Discord feed subscribing `spacetraders.#`) had no payload-shape contract; it reverse-engineered the emitter's source and silently broke when a field changed.

An `emits:` entry may now optionally declare its payload shape:

```yaml
emits:
  - spacetraders.window_closed              # bare topic name — unchanged
  - topic: spacetraders.trade_executed
    summary: A hauler completed a buy→sell leg
    schema:
      type: object
      required: [route, profit]
      properties: { route: {type: string}, profit: {type: integer}, ship: {type: string} }
  - topic: spacetraders.ship_purchased
    schema: { $ref: events/ship_purchased.json }   # file inside the plugin repo
```

## How

- **`graph/plugins/manifest.py`** — `_parse_emits()` returns `(names, topic → {summary?, schema?})`. `manifest.emits` stays the names-only topic list (every entry, bare or typed) so existing consumers are untouched; the new `manifest.emits_schemas` map carries the contracts. `schema:` accepts an inline mapping, a mapping whose only key is `$ref`, or a bare-string ref shorthand. Refs resolve relative to the plugin dir, are refused if they escape it (path traversal), and are parsed with `yaml.safe_load` (JSON files are valid YAML). Every failure mode — missing/unreadable/escaping ref, non-mapping schema, entry without a topic — warns and degrades to names-only; it **never fails the plugin load**.
- **`graph/plugins/loader.py`** — the per-plugin meta entry gains `emits_schemas` (empty when disabled), which flows through `STATE.plugin_meta` → `build_runtime_status` → **`/api/runtime/status`** verbatim, exactly like `emits`/`views`. No layering change: `graph/` still never imports `server/`/`operator_api/`.
- **`graph/plugins/scaffold.py`** — manifest stub comment shows the typed form.
- **Docs** — `docs/guides/plugins.md` (manifest snippet + a "Typed event contracts" section under Events), ADR 0039 "grown since" amendment, CHANGELOG `[Unreleased]`.

## Deliberately NOT in this PR

- **Publish-time validation** — a dev-channel *warn on mismatch* validator (developer-flag-gated per ADR 0068) is a follow-up, per the issue ("purely declarative at first, like `capabilities`").
- **Console surfacing** — the console plugin row renders no manifest event metadata today (no capabilities-like row to piggyback on), so showing the event catalog is a new UI feature; it lands as a separate draft PR under the UI local-test gate. The data is already on `/api/runtime/status` for it.

## Tests

`tests/test_plugins.py` (+5, suite 2875 passed / 5 skipped):
- bare-string `emits:` unchanged (no contract map)
- inline schema + summary parse; bare siblings stay names-only
- `$ref` file (dict form + string shorthand) read from a tmp plugin dir
- invalid ref / traversal escape / non-mapping schema / topicless entry → warn, degrade, never fail the load (summary survives a broken ref)
- loader-meta + `/api/runtime/status` round-trip via `build_runtime_status` (disabled plugin advertises `{}`)

Gates: `ruff check .` ✅ · `lint-imports` (3 contracts kept) ✅ · `python -m pytest tests/ -q` → 2875 passed, 5 skipped ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin event declarations can now include optional structured metadata and JSON Schema for better discovery.
  * Runtime status now exposes per-plugin event schema details when available.

* **Bug Fixes**
  * Invalid, missing, or unsafe schema references no longer block plugin loading.
  * Unsupported event definitions safely fall back to simple topic names with warnings.

* **Documentation**
  * Updated plugin guides and setup templates with examples for typed event contracts and schema usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->