### PR TITLE
feat(sdk): plugin metric timeseries — record_metric / metric_history / metric_last (#1632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Plugin metric timeseries — `sdk.record_metric` / `metric_history` / `metric_last`**
+  (#1632). Plugins with background engines need small named numeric series (treasury,
+  net worth, fleet size) for history-dependent watch verifiers (ADR 0067
+  drawdown-vs-high-water, flatline detection — a verifier only sees live state) and
+  dashboard sparklines, and each hand-rolled its own persistence. The consumption SDK
+  (ADR 0043) now owns it: `record_metric(name, value, *, ts=None, plugin_id)` appends a
+  sample to the series `<plugin_id>:<name>` (Unix-epoch `ts`, defaults to now; NaN/inf
+  rejected), `metric_history(name, *, since=None, limit=500, plugin_id)` returns the
+  newest `limit` points oldest→newest as `(ts, value)` tuples, `metric_last` the latest
+  point. Backed by a new always-on per-instance `metrics.db`
+  (`observability/metrics_store.py`, connection-per-call WAL sqlite) — deliberately NOT
+  the `telemetry.enabled`-gated turn-rollup store, since metric series are functional
+  plugin state. Retention is capped per series (90 days / 10k points, trimmed on
+  write). `plugin_id` is an explicit required kwarg with `':'` rejected (the #1642/#1656
+  precedent), so one plugin can't reach another's namespace.
 - **`graph.sdk.react_on` — reactive-rule sugar** (#1633). The canonical reactive
   composition `registry.on(topic, handler)` → `sdk.run_in_session(session, prompt)` made
   every plugin write identical glue (missing-host guard, prompt-from-payload, idempotent

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -106,6 +106,10 @@ curl localhost:7870/api/telemetry/insights
 
 `summary` returns `{turns, input_tokens, output_tokens, total_tokens, cache_read_input_tokens, cache_creation_input_tokens, cost_usd, llm_calls, tool_calls, avg_duration_ms, p50_duration_ms, p95_duration_ms, success_rate, cache_hit_ratio, by_model[]}`. `insights` flags turns ≥ 5× the rolling-median cost/latency and proves the cache lever (`{levers: {cache: {hit_ratio, est_savings_usd}, …}}`) — **advise-only**, no autonomous config changes. The operator console surfaces all of this under **Settings ▸ Overview** (Slices 3–4). History is pruned by `telemetry.retention_days` (default 90; `TelemetryStore.prune` runs on the maintenance loop), and `/api/telemetry/export` downloads it as CSV.
 
+::: tip Plugin metric timeseries are a separate store
+Named numeric series a plugin records (`sdk.record_metric` — treasury, net worth, fleet size, #1632) live in their own always-on per-instance `metrics.db`, **not** in this turn-rollup store: they're functional plugin state (history-dependent watch verifiers read them), so the `telemetry.enabled` toggle never affects them. See [Plugins ▸ consumption SDK](/guides/plugins#consumption-sdk).
+:::
+
 ## Audit log
 
 Every tool call is written to `/sandbox/audit/audit.jsonl`. One line per call:

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -276,6 +276,20 @@ SDK** directly — `from graph.sdk import …`, the *stable* surface plugins cal
   by default; pass `plugin_id=registry.plugin_id`. One-shot turns stay on `run_in_session`.
   With `cancel_scheduled(job_id, *, plugin_id)` and `cancel_plugin_jobs(plugin_id)` — see
   [Scheduler ▸ Plugin-owned recurring jobs](/guides/scheduler#plugin-owned-recurring-jobs).
+- `record_metric(name, value, *, ts=None, plugin_id)` / `metric_history(name, *,
+  since=None, limit=500, plugin_id)` / `metric_last(name, *, plugin_id)` — a plugin
+  **metric timeseries** (#1632): small named numeric series (treasury, net worth, fleet
+  size), namespaced `<plugin_id>:<name>` into one per-instance SQLite store
+  (`metrics.db`), retention-capped per series (90 days / 10k points, trimmed on write —
+  record freely from an engine tick). This is the *history* a live-state watch verifier
+  (ADR 0067) can't get any other way — drawdown vs high-water mark, flatline detection —
+  and the substrate for dashboard sparklines. Timestamps are Unix epoch seconds
+  (`ts=None` → now); `metric_history` returns the newest `limit` points (optionally at/after
+  `since`) **oldest→newest** as `(ts, value)` tuples; `metric_last` returns the latest
+  `(ts, value)` or `None`. Pass `plugin_id=registry.plugin_id` (explicit, like
+  `schedule_recurring` — the SDK has no ambient plugin identity; `':'` is rejected so one
+  plugin can't reach another's namespace). Point-in-time snapshots stay on `telemetry()`;
+  per-turn cost rollups stay on the [operator telemetry store](/guides/observability#local-telemetry-store).
 
 The **workflows plugin** (`plugins/workflows`) is the reference consumer: its engine
 injects `run_subagent` as the per-step runner. This is the pattern for plugins that tap

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -716,8 +716,8 @@ def metric_history(
     ``since`` (Unix epoch seconds) when given — returned **oldest→newest** as
     ``(ts, value)`` tuples: chronological order, ready for verifier math
     (``high_water = max(v for _, v in points)``) or a sparkline. Returns ``[]`` when
-    the store is unavailable, the inputs are bad, or the series has no samples.
-    Same namespacing + ``plugin_id`` contract as :func:`record_metric`."""
+    the store is unavailable, ``name``/``plugin_id`` are invalid, or the series has no
+    samples. Same namespacing + ``plugin_id`` contract as :func:`record_metric`."""
     store = getattr(STATE, "metrics_store", None)
     series = _metric_series(name, plugin_id)
     if store is None or series is None:

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -626,3 +626,113 @@ def cancel_plugin_jobs(plugin_id: str) -> int:
         if jid.startswith(prefix) and scheduler.cancel_job(jid):
             cancelled += 1
     return cancelled
+
+
+# ── plugin metric timeseries (#1632) ────────────────────────────────────────────────
+# History-dependent watch verifiers (ADR 0067: drawdown-vs-high-water, flatline
+# detection) and dashboard sparklines need PRIOR values — but a verifier only sees live
+# state and sdk.telemetry() is a point-in-time envelope, so every plugin with a
+# background engine hand-rolled its own persistence (a knobs JSON here, a private
+# sqlite there). These three calls are that store, once: small named numeric series,
+# namespaced `<plugin_id>:<name>`, SQLite-backed in the instance dir
+# (observability/metrics_store.py), retention-capped per series (90d / 10k points).
+
+
+def _metric_series(name: str, plugin_id: str) -> str | None:
+    """The namespaced metric series key ``<plugin_id>:<name>``, or ``None`` on bad
+    input. Same ``':'`` guard as :func:`schedule_recurring` — plugin ``a:b`` must not
+    be able to reach into plugin ``a``'s namespace. (The SDK has no ambient plugin
+    identity — functions are plain imports, not registry-bound — so ``plugin_id`` is an
+    explicit required kwarg on every metric call; pass ``registry.plugin_id``.)"""
+    plugin_id = (plugin_id or "").strip()
+    name = (name or "").strip()
+    if not plugin_id or ":" in plugin_id or not name:
+        return None
+    return f"{plugin_id}:{name}"
+
+
+def record_metric(name: str, value: float, *, ts: float | None = None, plugin_id: str) -> dict:
+    """Append one sample to the plugin metric timeseries ``name`` (#1632).
+
+    Small named numeric series — treasury, net worth, fleet size — are what
+    history-dependent watch verifiers (ADR 0067 drawdown-vs-high-water, flatline
+    detection) and dashboard sparklines need, and a verifier can only see *live* state
+    (``sdk.telemetry()`` is point-in-time). Series are namespaced
+    ``<plugin_id>:<name>``, SQLite-backed in the instance dir
+    (``observability/metrics_store.py``), and retention-capped per series (90 days /
+    10k points, trimmed on write) — record freely from an engine tick.
+
+    Args:
+        name: the plugin-local series name (e.g. ``"credits"``). Namespacing is
+            applied here, never by the caller.
+        value: the sample — any real number (NaN/inf are rejected; they poison
+            drawdown math downstream).
+        ts: Unix epoch seconds for the sample; ``None`` → now. Useful for backfill
+            and deterministic tests.
+        plugin_id: the owning plugin's id (``registry.plugin_id``) — explicit, like
+            :func:`schedule_recurring`; ``':'`` is rejected.
+
+    Returns ``{"ok", "series", "message"}`` — ``ok=False`` with a readable message
+    when the store is unavailable (non-server context) or the inputs are bad; a write
+    failure never raises into an engine loop.
+    """
+    import math
+
+    store = getattr(STATE, "metrics_store", None)
+    if store is None:
+        return {"ok": False, "series": None, "message": "metrics store unavailable (non-server context)"}
+    series = _metric_series(name, plugin_id)
+    if series is None:
+        return {
+            "ok": False,
+            "series": None,
+            "message": "name and plugin_id are required (and plugin_id must not contain ':')",
+        }
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return {"ok": False, "series": series, "message": f"value must be numeric, got {value!r}"}
+    if not math.isfinite(value):
+        return {"ok": False, "series": series, "message": f"value must be finite, got {value!r}"}
+    if ts is not None:
+        try:
+            ts = float(ts)
+        except (TypeError, ValueError):
+            return {"ok": False, "series": series, "message": f"ts must be Unix epoch seconds, got {ts!r}"}
+        if not math.isfinite(ts):
+            return {"ok": False, "series": series, "message": f"ts must be finite, got {ts!r}"}
+    try:
+        store.record(series, value, ts=ts)
+    except Exception as e:  # noqa: BLE001 — best-effort: a disk hiccup must not kill an engine tick
+        log.exception("[sdk] record_metric(%r) failed", series)
+        return {"ok": False, "series": series, "message": f"could not record: {e}"}
+    return {"ok": True, "series": series, "message": f"recorded {series}={value:g}"}
+
+
+def metric_history(
+    name: str, *, since: float | None = None, limit: int = 500, plugin_id: str
+) -> list[tuple[float, float]]:
+    """The newest ``limit`` samples of the plugin metric series ``name`` — at/after
+    ``since`` (Unix epoch seconds) when given — returned **oldest→newest** as
+    ``(ts, value)`` tuples: chronological order, ready for verifier math
+    (``high_water = max(v for _, v in points)``) or a sparkline. Returns ``[]`` when
+    the store is unavailable, the inputs are bad, or the series has no samples.
+    Same namespacing + ``plugin_id`` contract as :func:`record_metric`."""
+    store = getattr(STATE, "metrics_store", None)
+    series = _metric_series(name, plugin_id)
+    if store is None or series is None:
+        return []
+    return store.history(series, since=since, limit=limit)
+
+
+def metric_last(name: str, *, plugin_id: str) -> tuple[float, float] | None:
+    """The most recent ``(ts, value)`` of the plugin metric series ``name``, or
+    ``None`` when there is no sample (never recorded / fully aged out / store
+    unavailable). The cheap read for "what did I last see?" checks — e.g. a verifier
+    comparing the live reading against the last recorded one. Same namespacing +
+    ``plugin_id`` contract as :func:`record_metric`."""
+    store = getattr(STATE, "metrics_store", None)
+    series = _metric_series(name, plugin_id)
+    if store is None or series is None:
+        return None
+    return store.last(series)

--- a/observability/metrics_store.py
+++ b/observability/metrics_store.py
@@ -1,0 +1,143 @@
+"""Plugin metric timeseries store — small named numeric series (#1632).
+
+One row per ``(series, ts, value)`` sample: the persistence behind
+``graph.sdk.record_metric`` / ``metric_history`` / ``metric_last``. Series keys are
+namespaced ``<plugin_id>:<name>`` by the SDK (never here), so one instance-dir file
+(``metrics.db``) holds every plugin's series without collisions. Timestamps are Unix
+epoch seconds (REAL) — the natural unit for verifier math (drawdown windows, flatline
+gaps) and sparkline rendering.
+
+This is deliberately NOT the per-turn :class:`~observability.telemetry_store.TelemetryStore`:
+that store is cost/latency rollups behind the ``telemetry.enabled`` operator toggle and a
+configurable path, while metric series are *functional* plugin state — a
+history-dependent watch verifier (ADR 0067) goes blind without them — so they live in
+their own always-on store, never gated by an observability preference.
+
+Concurrency: connection-per-call + WAL + busy_timeout (the TelemetryStore /
+BackgroundStore pattern). Plugin engines record from worker threads and background
+loops; the FTS-index race (#1500) is why a single shared connection is never held
+across threads here.
+
+Retention is capped per series (defaults: 90 days AND 10k points) and trimmed inside
+the same write transaction — a metric series is a sparkline/verifier substrate, not an
+archive, so the file stays small without a maintenance loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+# Hardcoded retention defaults (per the issue: ~90d / 10k points per series). Not a
+# config knob yet — hosts that want different caps pass them to the constructor.
+RETENTION_DAYS = 90
+MAX_POINTS = 10_000
+
+
+class MetricsStore:
+    def __init__(
+        self,
+        db_path: str,
+        *,
+        retention_days: int = RETENTION_DAYS,
+        max_points: int = MAX_POINTS,
+    ) -> None:
+        self.path = str(db_path)
+        # <= 0 disables the corresponding cap (age / point-count).
+        self.retention_days = int(retention_days)
+        self.max_points = int(max_points)
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        db = sqlite3.connect(self.path)
+        db.execute("PRAGMA journal_mode=WAL")  # concurrent reads during writes
+        db.execute("PRAGMA busy_timeout=5000")  # wait (don't error) on lock contention
+        db.row_factory = sqlite3.Row
+        return db
+
+    def _init_db(self) -> None:
+        db = self._connect()
+        try:
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS metrics (
+                    series TEXT NOT NULL,
+                    ts     REAL NOT NULL,
+                    value  REAL NOT NULL
+                )
+                """
+            )
+            # (series, ts) drives every query: history range scans, last(), and the
+            # per-series retention trims below.
+            db.execute("CREATE INDEX IF NOT EXISTS ix_metrics_series_ts ON metrics(series, ts)")
+            db.commit()
+        finally:
+            db.close()
+
+    def record(self, series: str, value: float, ts: float | None = None) -> None:
+        """Append one sample to ``series`` (``ts`` defaults to now) and trim the series
+        to the retention caps in the same transaction. Duplicate timestamps are allowed
+        (two samples in the same second are both kept, insert order preserved)."""
+        now = time.time()
+        ts = now if ts is None else float(ts)
+        db = self._connect()
+        try:
+            db.execute(
+                "INSERT INTO metrics (series, ts, value) VALUES (?, ?, ?)",
+                (series, ts, float(value)),
+            )
+            if self.retention_days > 0:
+                db.execute(
+                    "DELETE FROM metrics WHERE series = ? AND ts < ?",
+                    (series, now - self.retention_days * 86400.0),
+                )
+            if self.max_points > 0:
+                # Keep the newest max_points rows (rowid breaks ts ties so exactly
+                # max_points survive); LIMIT -1 OFFSET n = "everything past the newest n".
+                db.execute(
+                    "DELETE FROM metrics WHERE rowid IN ("
+                    " SELECT rowid FROM metrics WHERE series = ?"
+                    " ORDER BY ts DESC, rowid DESC LIMIT -1 OFFSET ?)",
+                    (series, self.max_points),
+                )
+            db.commit()
+        finally:
+            db.close()
+
+    def history(self, series: str, *, since: float | None = None, limit: int = 500) -> list[tuple[float, float]]:
+        """The newest ``limit`` samples of ``series`` (at/after ``since`` when given),
+        returned **oldest→newest** as ``(ts, value)`` tuples — chronological order is
+        what verifier math and sparklines consume."""
+        where, params = "series = ?", [series]
+        if since is not None:
+            where += " AND ts >= ?"
+            params.append(float(since))
+        params.append(max(1, int(limit)))
+        db = self._connect()
+        try:
+            rows = db.execute(
+                f"SELECT ts, value FROM metrics WHERE {where} ORDER BY ts DESC, rowid DESC LIMIT ?",
+                params,
+            ).fetchall()
+        finally:
+            db.close()
+        rows.reverse()  # window is the NEWEST `limit`; presentation is chronological
+        return [(row["ts"], row["value"]) for row in rows]
+
+    def last(self, series: str) -> tuple[float, float] | None:
+        """The most recent ``(ts, value)`` of ``series``, or ``None`` when it has no
+        samples (never recorded, or fully aged out)."""
+        db = self._connect()
+        try:
+            row = db.execute(
+                "SELECT ts, value FROM metrics WHERE series = ? ORDER BY ts DESC, rowid DESC LIMIT 1",
+                (series,),
+            ).fetchone()
+            return (row["ts"], row["value"]) if row else None
+        finally:
+            db.close()

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -30,6 +30,9 @@ class AppState:
     workflow_registry: Any = None  # set by the workflows plugin (None = plugin disabled)
     workflow_run: Any = None  # async (name, inputs, on_step) -> result; set by the workflows plugin
     telemetry_store: Any = None
+    # Plugin metric timeseries (#1632) — behind sdk.record_metric / metric_history /
+    # metric_last. Wired once at boot (path isn't reloadable config); survives reloads.
+    metrics_store: Any = None
     # Async engine behind the durable A2A task store — held so the periodic
     # prune loop can re-run the 24h TTL sweep (it used to run only at boot, so
     # an always-on agent accumulated task rows forever between restarts).

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -125,6 +125,13 @@ def _init_langgraph_agent(headless_setup: bool = False):
     # compile time below — a checkpointer in the invoke config is ignored.
     STATE.checkpointer = _build_checkpointer(STATE.graph_config)
 
+    # Plugin metric timeseries (#1632) — sdk.record_metric / metric_history / metric_last.
+    # Wired BEFORE any plugin load (including the pre-setup routes/surfaces load below)
+    # so a plugin's register() can already record. Not config-dependent, so it survives
+    # hot-reloads untouched (like tasks_store / background_mgr) — and it is never
+    # threaded into the graph build, so the #1630 reload-drop class doesn't apply.
+    STATE.metrics_store = _build_metrics_store()
+
     if not is_setup_complete():
         if headless_setup:
             # No wizard in this tier — auto-complete from a validated config,
@@ -993,6 +1000,25 @@ def _build_telemetry_store(config):
         return store
     except Exception:
         log.exception("[telemetry] failed to build store at %s; telemetry disabled", path)
+        return None
+
+
+def _build_metrics_store():
+    """Plugin metric timeseries store (#1632) — behind ``sdk.record_metric`` /
+    ``metric_history`` / ``metric_last``. Always on, no config gate: unlike the turn
+    telemetry store (an observability preference), metric series are *functional*
+    plugin state — history-dependent watch verifiers go blind without them — so they
+    get their own per-instance ``metrics.db`` (retention is capped per series inside
+    the store). Best-effort: a build failure degrades the SDK calls to no-ops."""
+    from observability.metrics_store import MetricsStore
+
+    db = instance_paths().store("metrics.db")
+    try:
+        store = MetricsStore(str(db))
+        log.info("[metrics] plugin metric store ready at %s", db)
+        return store
+    except Exception:
+        log.exception("[metrics] failed to build plugin metric store at %s; sdk metrics disabled", db)
         return None
 
 

--- a/tests/test_sdk_metrics.py
+++ b/tests/test_sdk_metrics.py
@@ -1,0 +1,191 @@
+"""sdk.record_metric / metric_history / metric_last (#1632) — plugin metric timeseries:
+small named numeric series (treasury, net worth, fleet size), namespaced
+``<plugin_id>:<name>`` into one instance-dir ``metrics.db``, retention-capped per
+series. The history a live-state watch verifier can't get any other way (drawdown vs
+high-water, flatline detection) and the substrate for dashboard sparklines.
+
+Exercises the REAL MetricsStore on a tmp path (connection-per-call — the concurrency
+smoke below is the point: plugin engines record from worker threads, and #1500 taught
+us what a shared sqlite conn across threads does)."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from graph import sdk
+from observability.metrics_store import MetricsStore
+from runtime.state import STATE
+
+# All sample timestamps ride on a recent base: the age trim is WALL-CLOCK based (by
+# design — backfill older than the retention window is dropped on the next write), so
+# bare values like ts=100.0 would be 1970 samples and age out immediately.
+T0 = round(time.time() - 1000.0, 3)
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    s = MetricsStore(str(tmp_path / "metrics.db"))
+    monkeypatch.setattr(STATE, "metrics_store", s)
+    return s
+
+
+# --- record + history round-trip ----------------------------------------------------
+
+
+def test_record_and_history_round_trip(store):
+    for ts, value in ((T0 + 100.0, 10.0), (T0 + 200.0, 12.5), (T0 + 300.0, 11.0)):
+        res = sdk.record_metric("credits", value, ts=ts, plugin_id="spacetraders")
+        assert res["ok"] is True
+        assert res["series"] == "spacetraders:credits"  # namespaced key surfaced
+    # Chronological (oldest→newest) (ts, value) tuples — verifier/sparkline order.
+    assert sdk.metric_history("credits", plugin_id="spacetraders") == [
+        (T0 + 100.0, 10.0),
+        (T0 + 200.0, 12.5),
+        (T0 + 300.0, 11.0),
+    ]
+
+
+def test_history_since_is_inclusive(store):
+    for off in (100.0, 200.0, 300.0):
+        sdk.record_metric("m", off, ts=T0 + off, plugin_id="p")
+    assert sdk.metric_history("m", since=T0 + 200.0, plugin_id="p") == [(T0 + 200.0, 200.0), (T0 + 300.0, 300.0)]
+    assert sdk.metric_history("m", since=T0 + 301.0, plugin_id="p") == []
+
+
+def test_history_limit_keeps_the_newest_window(store):
+    for i in range(1, 8):  # 1..7
+        sdk.record_metric("m", float(i), ts=T0 + i, plugin_id="p")
+    # limit=3 → the NEWEST 3 points, still returned oldest→newest.
+    assert sdk.metric_history("m", limit=3, plugin_id="p") == [(T0 + 5, 5.0), (T0 + 6, 6.0), (T0 + 7, 7.0)]
+
+
+def test_history_same_ts_keeps_insert_order(store):
+    sdk.record_metric("m", 1.0, ts=T0, plugin_id="p")
+    sdk.record_metric("m", 2.0, ts=T0, plugin_id="p")
+    assert sdk.metric_history("m", plugin_id="p") == [(T0, 1.0), (T0, 2.0)]
+    assert sdk.metric_last("m", plugin_id="p") == (T0, 2.0)  # rowid breaks the tie
+
+
+# --- last -----------------------------------------------------------------------------
+
+
+def test_metric_last(store):
+    assert sdk.metric_last("credits", plugin_id="spacetraders") is None  # never recorded
+    sdk.record_metric("credits", 10.0, ts=T0 + 100.0, plugin_id="spacetraders")
+    sdk.record_metric("credits", 12.0, ts=T0 + 200.0, plugin_id="spacetraders")
+    assert sdk.metric_last("credits", plugin_id="spacetraders") == (T0 + 200.0, 12.0)
+
+
+def test_ts_defaults_to_now(store):
+    before = time.time()
+    sdk.record_metric("m", 1.0, plugin_id="p")
+    after = time.time()
+    ts, value = sdk.metric_last("m", plugin_id="p")
+    assert before <= ts <= after
+    assert value == 1.0
+
+
+# --- namespacing isolation --------------------------------------------------------------
+
+
+def test_namespacing_isolates_plugins(store):
+    # Two plugins record the SAME metric name — neither sees the other's series.
+    sdk.record_metric("treasury", 100.0, ts=T0, plugin_id="spacetraders")
+    sdk.record_metric("treasury", 999.0, ts=T0, plugin_id="prototrader")
+    assert sdk.metric_history("treasury", plugin_id="spacetraders") == [(T0, 100.0)]
+    assert sdk.metric_history("treasury", plugin_id="prototrader") == [(T0, 999.0)]
+    assert sdk.metric_last("treasury", plugin_id="spacetraders") == (T0, 100.0)
+
+
+def test_colon_in_plugin_id_cannot_cross_namespaces(store):
+    # Plugin "a" records under name "b:credits" → series "a:b:credits". A malicious
+    # plugin_id "a:b" is REJECTED outright (the #1656 precedent), so it can never
+    # write or read "a:b:credits" — or anything else.
+    sdk.record_metric("b:credits", 7.0, ts=T0, plugin_id="a")
+    res = sdk.record_metric("credits", 666.0, plugin_id="a:b")
+    assert res["ok"] is False and ":" in res["message"]
+    assert sdk.metric_history("credits", plugin_id="a:b") == []
+    assert sdk.metric_last("credits", plugin_id="a:b") is None
+    assert sdk.metric_history("b:credits", plugin_id="a") == [(T0, 7.0)]  # untouched
+
+
+# --- retention ---------------------------------------------------------------------------
+
+
+def test_retention_caps_points_per_series(tmp_path, monkeypatch):
+    s = MetricsStore(str(tmp_path / "metrics.db"), max_points=5)
+    monkeypatch.setattr(STATE, "metrics_store", s)
+    for i in range(1, 9):  # 8 points into a 5-point cap
+        sdk.record_metric("m", float(i), ts=T0 + i, plugin_id="p")
+    points = sdk.metric_history("m", plugin_id="p")
+    assert points == [(T0 + 4, 4.0), (T0 + 5, 5.0), (T0 + 6, 6.0), (T0 + 7, 7.0), (T0 + 8, 8.0)]  # oldest trimmed
+    # The cap is PER SERIES — a busy sibling series doesn't evict this one.
+    sdk.record_metric("other", 1.0, ts=T0, plugin_id="p")
+    assert len(sdk.metric_history("m", plugin_id="p")) == 5
+
+
+def test_retention_ages_out_old_points(tmp_path, monkeypatch):
+    s = MetricsStore(str(tmp_path / "metrics.db"), retention_days=1)
+    monkeypatch.setattr(STATE, "metrics_store", s)
+    stale = time.time() - 2 * 86400.0  # two days old, one-day cap
+    sdk.record_metric("m", 1.0, ts=stale, plugin_id="p")
+    sdk.record_metric("m", 2.0, plugin_id="p")  # the write that triggers the trim
+    points = sdk.metric_history("m", plugin_id="p")
+    assert len(points) == 1
+    assert points[0][1] == 2.0
+
+
+# --- input validation + degradation ------------------------------------------------------
+
+
+def test_validates_inputs(store):
+    assert not sdk.record_metric("", 1.0, plugin_id="p")["ok"]  # no name
+    assert not sdk.record_metric("m", 1.0, plugin_id=" ")["ok"]  # no plugin_id
+    assert not sdk.record_metric("m", float("nan"), plugin_id="p")["ok"]  # NaN poisons drawdown math
+    assert not sdk.record_metric("m", float("inf"), plugin_id="p")["ok"]
+    assert not sdk.record_metric("m", "not-a-number", plugin_id="p")["ok"]
+    assert not sdk.record_metric("m", 1.0, ts="yesterday", plugin_id="p")["ok"]
+    assert not sdk.record_metric("m", 1.0, ts=float("nan"), plugin_id="p")["ok"]
+    assert sdk.metric_history("", plugin_id="p") == []
+    assert sdk.metric_last("m", plugin_id="") is None
+    assert sdk.metric_history("m", plugin_id="p") == []  # nothing slipped through
+
+
+def test_degrades_without_a_store(monkeypatch):
+    monkeypatch.setattr(STATE, "metrics_store", None)
+    res = sdk.record_metric("m", 1.0, plugin_id="p")
+    assert res["ok"] is False and "unavailable" in res["message"]
+    assert sdk.metric_history("m", plugin_id="p") == []
+    assert sdk.metric_last("m", plugin_id="p") is None
+
+
+# --- concurrency smoke --------------------------------------------------------------------
+
+
+def test_two_threads_recording_concurrently(store):
+    # Connection-per-call + WAL + busy_timeout: two engine threads hammering the same
+    # file (same series AND different series) must lose nothing and raise nothing.
+    errors: list[Exception] = []
+
+    def hammer(plugin_id: str) -> None:
+        try:
+            for i in range(50):
+                res = sdk.record_metric("shared", float(i), ts=T0 + i, plugin_id=plugin_id)
+                assert res["ok"] is True, res["message"]
+                res = sdk.record_metric("own", float(i), plugin_id=plugin_id)
+                assert res["ok"] is True, res["message"]
+        except Exception as e:  # noqa: BLE001 — surfaced to the main thread below
+            errors.append(e)
+
+    threads = [threading.Thread(target=hammer, args=(pid,)) for pid in ("alpha", "beta")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert errors == []
+    for pid in ("alpha", "beta"):
+        assert len(sdk.metric_history("shared", limit=1000, plugin_id=pid)) == 50
+        assert len(sdk.metric_history("own", limit=1000, plugin_id=pid)) == 50


### PR DESCRIPTION
## What

Plugins with background engines need small named numeric timeseries — treasury, net worth, fleet size — for (1) **history-dependent watch verifiers** (ADR 0067: drawdown-vs-high-water-mark, flatline detection — a verifier only sees live state) and (2) **dashboard sparklines**. Today each plugin hand-rolls persistence (spacetraders: a knobs JSON + its own prices sqlite); `STATE.telemetry_store` has no plugin-facing named-series write API and `sdk.telemetry()` is point-in-time.

The consumption SDK (ADR 0043) now owns it:

- `sdk.record_metric(name, value, *, ts=None, plugin_id) -> dict` — append a sample to the series `<plugin_id>:<name>`. `ts` is Unix epoch seconds (`None` → now, floats accepted for backfill/tests); NaN/inf values are rejected (they poison drawdown math); ok-dict degradation (`ok=False` + readable message) so a disk hiccup never kills an engine tick.
- `sdk.metric_history(name, *, since=None, limit=500, plugin_id) -> list[tuple[ts, float]]` — the newest `limit` points (at/after `since`), returned **oldest→newest**: chronological order, ready for `high_water = max(v for _, v in points)` or a sparkline. `[]` on no store / bad input / empty series.
- `sdk.metric_last(name, *, plugin_id) -> tuple[ts, float] | None` — the cheap "what did I last see?" read.

**Identity contract = the #1642/#1656 precedent, exactly:** the SDK has no ambient plugin identity, so `plugin_id` is an explicit required kwarg (`registry.plugin_id`), and `':'` is rejected in `plugin_id` so plugin `a:b` can never reach plugin `a`'s namespace.

## Where the store landed, and why

**New module `observability/metrics_store.py` (`MetricsStore`), its own per-instance `metrics.db`** — not an extension of `TelemetryStore`, though it lives beside it:

- `TelemetryStore` is per-turn cost/latency rollups behind the **`telemetry.enabled` operator toggle** and a configurable `telemetry.db_path`. Metric series are **functional plugin state** — a drawdown/flatline watch verifier goes blind without them — so tying them to an observability preference would mean "operator turns off cost telemetry → the plugin's watch suite silently breaks". The metrics store is always on, no config gate.
- Path: `instance_paths().store("metrics.db")` — the same instance-dir pattern as `telemetry.db` / background `jobs.db` (ADR 0004 scoping for free: default, dev sandbox, and fleet members each get their own).
- **Concurrency:** connection-per-call + WAL + `busy_timeout` — the TelemetryStore/BackgroundStore pattern, chosen deliberately over shared-conn-with-locking after the #1500 FTS-race class. Engines record from worker threads; the test suite includes a two-thread smoke.

## Retention semantics

Capped **per series**, hardcoded defaults `90 days` AND `10k points` (both constructor-tunable; `<= 0` disables a cap), trimmed **inside the same write transaction** — no maintenance loop needed and the file stays small. No config field, per the "hardcoded defaults first" pattern (also: zero `test_config_roundtrip` golden churn). The age cap is wall-clock based by design: backfill older than the window is dropped on the next write. Duplicate timestamps are allowed (rowid breaks ties so ordering + `metric_last` stay deterministic).

## Wiring (boot + hot-reload)

`STATE.metrics_store`, built by `_build_metrics_store()` in `_init_langgraph_agent` **before any plugin load** — including the pre-setup routes/surfaces load — so a plugin's `register()` can already record. It's not config-dependent, so it survives hot-reloads untouched (like `tasks_store` / `background_mgr`), and it is never threaded into the graph build, so the #1630 reload-drop class doesn't apply (the SDK reads `STATE` directly). Best-effort: a build failure logs and degrades the SDK calls to no-ops.

## Tests (`tests/test_sdk_metrics.py`, real store on tmp paths — 13 new)

- record + history round-trip (chronological order, namespaced series key surfaced)
- `since` inclusive filter; `limit` keeps the **newest** window (still ascending); same-ts tie-break order
- `metric_last` (empty → `None`; latest wins)
- `ts` override + default-now
- namespacing isolation between plugins; the `':'`-in-`plugin_id` rejection can't cross into `a:b:*` series
- retention: point-cap trim (per series — a busy sibling doesn't evict), age-out trim
- input validation (empty name/plugin_id, NaN/inf value, bad/non-finite ts) + no-store degradation
- concurrency smoke: two threads hammering the same file (same + different series), nothing lost, nothing raised

## Docs

- `docs/guides/plugins.md` § consumption SDK — the three calls + semantics
- `docs/guides/observability.md` — tip box distinguishing plugin metric series from the turn-rollup telemetry store
- `CHANGELOG.md` [Unreleased]

## Out of scope

The issue's optional **DS sparkline helper** for iframe dashboards is cross-repo (protoContent plugin-kit) — not included here; worth a protoContent issue once spacetraders adopts the series API. Possible follow-up on this side: sweep a plugin's series on uninstall (mirroring `cancel_plugin_jobs`) — retention caps bound growth meanwhile.

## Gates

- `ruff check .` ✅ · `lint-imports` ✅ (3 contracts kept) · `python -m pytest tests/ -q` ✅ 2883 passed / 5 skipped

Fixes #1632

🤖 Generated with [Claude Code](https://claude.com/claude-code)