### PR TITLE
feat(sdk): knowledge lifecycle — knowledge_purge + epoch scoping (#1634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   degrades that entry to names-only — it never fails the plugin load.
   Dev-channel publish-time validation is deliberately deferred (follow-up,
   developer-flag-gated).
+- **Knowledge lifecycle — `sdk.knowledge_purge` + epoch scoping** (#1634). The plugin
+  knowledge channel (ADR 0043) was add-and-search only, so a long-running plugin's
+  knowledge could go actively wrong with no way to retire it (spacetraders: weekly
+  universe wipes → recalled routes reference dead markets).
+  `sdk.knowledge_purge(domain, *, before=None) -> int` hard-deletes a domain's chunks
+  (optionally only those created before an ISO-8601 timestamp), consistently across
+  every index — main rows, FTS, and the hybrid store's vectors (layered stores purge
+  the private tier only; the commons stays curated). And `knowledge_add(...,
+  epoch="2026-06-29")` tags a chunk with the era it was learned in:
+  `knowledge_search(..., epoch=...)` then filters BOTH rankings to exactly that era
+  (other epochs and untagged chunks excluded), so a wipe becomes a new tag — old
+  lessons stay for post-mortems but stop polluting retrieval. Additive `epoch` column
+  migration; pre-existing ADR 0031 backends keep working (purge degrades to a 0-count
+  no-op; `epoch` is only forwarded when passed).
 - **`graph.sdk.react_on` — reactive-rule sugar** (#1633). The canonical reactive
   composition `registry.on(topic, handler)` → `sdk.run_in_session(session, prompt)` made
   every plugin write identical glue (missing-host guard, prompt-from-payload, idempotent

--- a/docs/adr/0043-plugin-consumption-sdk-workflows-extraction.md
+++ b/docs/adr/0043-plugin-consumption-sdk-workflows-extraction.md
@@ -52,6 +52,18 @@ deliberately as more plugins tap core; this is the seam we lean on going forward
 > (`None`/empty skips the event), idempotent replace via `job_id`, thread-safe
 > trailing-edge debounce (a burst coalesces into ONE turn; the last event's prompt wins).
 > Returns an unsubscribe fn. First consumer: spacetraders engine-event → turn rules.
+>
+> `knowledge_search(query, *, k=5, domain=None, epoch=None)` /
+> `knowledge_add(content, *, domain="general", heading=None, epoch=None)` (#1089) +
+> `knowledge_purge(domain, *, before=None)` (#1634) — the knowledge channel and its
+> **lifecycle** half. Add-and-search alone let a long-running plugin's knowledge go
+> actively wrong with no way to retire it (spacetraders: weekly universe wipes → recalled
+> routes reference dead markets). `knowledge_purge` hard-deletes a domain (optionally only
+> rows older than an ISO timestamp), consistently across every index (rows, FTS, vectors;
+> layered = private tier only — the commons stays curated); the optional `epoch` tag scopes
+> a chunk to the era it was learned in, and an epoch-filtered search excludes other eras
+> *and* untagged chunks from both rankings — a wipe becomes a new tag, not a delete.
+> First consumer: spacetraders route/lesson memory.
 
 **2. Workflows becomes an opt-in plugin (`plugins/workflows`, `enabled: false`).**
 

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -213,6 +213,34 @@ D9) instead of judging it with a model at write time:
   inspector's DELETE routes remove rows outright — explicit operator intent
   beats history-keeping. Supersession is only for the *automatic* write paths.
 
+### Plugin knowledge lifecycle
+
+Supersession covers facts that get *revised*; a long-running **plugin's** knowledge can
+become wrong wholesale — spacetraders' game universe wipes weekly, so last week's route
+lessons reference markets that no longer exist. The consumption SDK
+([ADR 0043](/adr/0043-plugin-consumption-sdk-workflows-extraction)) gives plugins two
+lifecycle tools for that (#1634):
+
+- **Purge a domain** — `sdk.knowledge_purge(domain, *, before=None) -> int`
+  hard-deletes every chunk in a domain (optionally only those created before an
+  ISO-8601 timestamp) and returns the count. The delete is consistent across **every
+  index** — main rows, the FTS index, and the hybrid store's vectors — so a purged
+  chunk can't linger as a vector-only hit. On a layered store only the **private**
+  tier is purged; the shared commons is curated (promote/forget), never bulk-deleted.
+  An empty domain or an unparseable `before` refuses (returns 0) rather than risk
+  deleting the wrong rows.
+- **Scope by epoch** — `sdk.knowledge_add(..., epoch="2026-06-29")` tags a chunk with
+  the era it was learned in (an opaque string, typically a reset date), and
+  `sdk.knowledge_search(..., epoch=...)` filters **both rankings** (FTS + vector, and
+  both layered tiers) to exactly that era — other epochs *and* untagged chunks don't
+  match. A wipe becomes a new tag: old lessons stay stored for post-mortem analysis
+  but stop polluting retrieval. Unfiltered search (`epoch=None`) still sees every era.
+
+Both work on the store API too (`purge_domain`, the `epoch` kwarg on
+`add_chunk`/`add_document`/`search`). A custom [ADR 0031](/adr/0031-pluggable-knowledge-backend)
+backend that predates this surface keeps working: `knowledge_purge` degrades to a
+0-count no-op, and the SDK only forwards `epoch` when a caller passes one.
+
 ### The Memory inspector (console)
 
 The **Memory** rail view is the operator half of all of the above — a security

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -241,6 +241,22 @@ SDK** directly — `from graph.sdk import …`, the *stable* surface plugins cal
   completion (vs `host.invoke`, which runs a full lead-agent *chat turn*).
 - `subagent_types()` — the configured subagent ids.
 - `config()` — the live `LangGraphConfig`.
+- `knowledge_search(query, *, k=5, domain=None, epoch=None)` /
+  `knowledge_add(content, *, domain="general", heading=None, epoch=None)` — the
+  plugin↔knowledge channel: search the agent's knowledge graph (hybrid FTS5 +
+  embeddings) and write chunks back, scoped to a `domain` bucket. Both degrade to a
+  no-op (`[]` / `None`) without a store. `epoch` (#1634) tags a chunk with the **era**
+  it was learned in (an opaque string — typically a reset date); passing `epoch=` to
+  `knowledge_search` filters **both** rankings to exactly that era, so a plugin in a
+  resettable world (spacetraders' weekly wipes) retires old lessons by just searching
+  with the new tag — they stay stored for post-mortems but stop polluting retrieval.
+- `knowledge_purge(domain, *, before=None) -> int` — the knowledge **lifecycle**
+  primitive (#1634): hard-delete every chunk in a domain (optionally only those
+  created before an ISO-8601 timestamp) and return the count. Deletes consistently
+  from every index (rows, FTS, vectors); on a layered store only the **private** tier
+  is purged (the commons is curated, never bulk-deleted). Refuses (returns 0) on an
+  empty domain or an unparseable `before`. See
+  [Knowledge ▸ Plugin knowledge lifecycle](/guides/knowledge#plugin-knowledge-lifecycle).
 - `run_in_session(session_id, prompt, *, delay_seconds=0, job_id=None)` — enqueue a
   **non-blocking one-shot agent turn** in a session (that session's memory + full tools).
   The primitive behind "when a goal fires, prompt the agent" — call it from a

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -108,31 +108,70 @@ async def complete(prompt: str, *, system: str | None = None, model_name: str | 
 # ── knowledge graph (the plugin↔knowledge channel, ADR 0043 — "shared knowledge") ──
 # The consumption SDK exposed run_subagent/complete but not the knowledge store, so a
 # plugin couldn't ground its work in (or contribute to) what the agent knows. These
-# two thin accessors close that: the coding loop reads distilled lessons to inject into
+# thin accessors close that: the coding loop reads distilled lessons to inject into
 # a coder's prompt; the loop-retro writes recurring failures back as searchable chunks.
-# Both degrade to a no-op ([] / None) when no store is configured, and run the
-# (HTTP-embedding) store call off the event loop.
+# knowledge_purge + the epoch tag (#1634) are the LIFECYCLE half — a long-running
+# plugin's knowledge can become actively wrong (spacetraders: weekly universe wipes),
+# so it needs a way to retire a bucket (purge) or scope retrieval to the current era
+# (epoch) without core knowing the plugin's reset semantics. All degrade to a no-op
+# ([] / None / 0) when no store is configured, and run the (HTTP-embedding) store
+# call off the event loop.
 
 
-async def knowledge_search(query: str, *, k: int = 5, domain: str | None = None) -> list[dict]:
+async def knowledge_search(
+    query: str, *, k: int = 5, domain: str | None = None, epoch: str | None = None
+) -> list[dict]:
     """Search the agent's knowledge graph (hybrid FTS5 + embeddings); return the top-``k``
     matching chunks (each a dict with ``preview``/``content``, ``domain``, ``score`` …),
     or ``[]`` when no store is configured. ``domain`` scopes to one bucket
-    (e.g. ``"loop-lessons"``)."""
+    (e.g. ``"loop-lessons"``); ``epoch`` (#1634) scopes to chunks tagged with exactly
+    that era via ``knowledge_add(..., epoch=...)`` — out-of-era and untagged chunks
+    don't match (both search modes filter). ``None`` = unfiltered."""
     store = getattr(STATE, "knowledge_store", None)
     if store is None:
         return []
-    return await asyncio.to_thread(store.search, query, k=k, domain=domain)
+    if epoch is None:
+        # Only pass epoch when set — an ADR 0031 plugin backend predating the epoch
+        # kwarg keeps working untouched on the common unfiltered path.
+        return await asyncio.to_thread(store.search, query, k=k, domain=domain)
+    return await asyncio.to_thread(store.search, query, k=k, domain=domain, epoch=epoch)
 
 
-async def knowledge_add(content: str, *, domain: str = "general", heading: str | None = None) -> int | None:
+async def knowledge_add(
+    content: str, *, domain: str = "general", heading: str | None = None, epoch: str | None = None
+) -> int | None:
     """Add one chunk to the agent's knowledge graph; return its id, or ``None`` when no
     store is configured / it was a no-op. ``domain`` is the bucket, ``heading`` an
-    optional title — e.g. ``knowledge_add(lesson, domain="loop-lessons", heading=cls)``."""
+    optional title — e.g. ``knowledge_add(lesson, domain="loop-lessons", heading=cls)``.
+    ``epoch`` (#1634) tags the chunk with the era it was learned in — an opaque string,
+    typically a reset date (``epoch="2026-06-29"``). On the next wipe the plugin just
+    searches with the NEW epoch: old lessons stay for post-mortems but stop matching."""
     store = getattr(STATE, "knowledge_store", None)
     if store is None:
         return None
-    return await asyncio.to_thread(store.add_chunk, content, domain=domain, heading=heading)
+    if epoch is None:
+        return await asyncio.to_thread(store.add_chunk, content, domain=domain, heading=heading)
+    return await asyncio.to_thread(store.add_chunk, content, domain=domain, heading=heading, epoch=epoch)
+
+
+async def knowledge_purge(domain: str, *, before: str | None = None) -> int:
+    """HARD-delete every chunk in ``domain`` — optionally only those created strictly
+    before ``before`` (an ISO-8601 timestamp) — and return how many were removed.
+
+    The knowledge-lifecycle primitive (#1634): retire a bucket of now-wrong lessons
+    (``knowledge_purge("st-routes")``) or expire just the stale tail
+    (``knowledge_purge("st-routes", before="2026-06-01")``). Deletes consistently from
+    every index (main rows, FTS, vectors); on a layered store only the PRIVATE tier is
+    purged — the shared commons is curated, never bulk-deleted. Keep-for-audit
+    retirement is the ``epoch`` tag instead (see :func:`knowledge_add`). Returns 0 when
+    no store is configured (or the backend has no ``purge_domain``), when ``domain`` is
+    empty, or when ``before`` is unparseable — it refuses rather than risk deleting the
+    wrong rows."""
+    store = getattr(STATE, "knowledge_store", None)
+    purge = getattr(store, "purge_domain", None)
+    if store is None or not callable(purge):
+        return 0
+    return await asyncio.to_thread(purge, domain, before=before)
 
 
 # ── goal-driven recurring loop (the OODA pattern) ──────────────────────────────────────

--- a/knowledge/backend.py
+++ b/knowledge/backend.py
@@ -22,7 +22,15 @@ from typing import Protocol, runtime_checkable
 class KnowledgeBackend(Protocol):
     """The methods the agent calls on the knowledge store. Implement these for a
     custom backend; ``factory(config) -> KnowledgeBackend`` is what a plugin
-    registers."""
+    registers.
+
+    Optional (not part of the required protocol, so pre-existing backends stay
+    conformant): ``purge_domain(domain, *, before=None) -> int`` — the knowledge
+    lifecycle primitive (#1634). ``graph.sdk.knowledge_purge`` degrades to a
+    0-count no-op on a backend without it; implement it to support plugins that
+    retire stale knowledge. Likewise the ``epoch: str`` kwarg on ``add_chunk`` /
+    ``search`` (era scoping) — the SDK only forwards it when a caller passes one.
+    """
 
     def add_chunk(self, content: str, domain: str = "general", **kwargs) -> int | None:
         """Store a chunk; return its id (or None if not stored)."""

--- a/knowledge/hybrid_store.py
+++ b/knowledge/hybrid_store.py
@@ -30,7 +30,7 @@ import sqlite3
 import time
 from collections.abc import Callable
 
-from knowledge.store import KnowledgeStore, _namespace_clause
+from knowledge.store import KnowledgeStore, _namespace_clause, _normalize_before
 
 log = logging.getLogger(__name__)
 
@@ -257,6 +257,38 @@ class HybridKnowledgeStore(KnowledgeStore):
                 db.close()
         return super().delete_by_namespace(namespace)
 
+    def purge_domain(self, domain: str, *, before=None) -> int:
+        """Purge the domain's chunks AND their vectors (#1634) — the
+        :meth:`delete_by_namespace` pattern: no FK cascade on the side table, so
+        the vectors go first (under the SAME cutoff — the base delete's FTS
+        trigger covers ``chunks_fts``, nothing covers ``chunk_vectors``). A
+        purged chunk must vanish from BOTH search modes, not linger as a
+        vector-only hit."""
+        if not domain or not domain.strip():
+            return 0
+        try:
+            cutoff = _normalize_before(before)
+        except ValueError:
+            # Mirror the base refusal BEFORE touching vectors — a bad cutoff must
+            # not strip embeddings off rows that then survive the row delete.
+            log.warning("[knowledge] purge_domain(%r): unparseable before=%r — refusing to purge", domain, before)
+            return 0
+        db = self._get_db()
+        if db is not None:
+            try:
+                sql = "DELETE FROM chunk_vectors WHERE chunk_id IN (SELECT id FROM chunks WHERE domain = ?"
+                params: list = [domain]
+                if cutoff is not None:
+                    sql += " AND created_at < ?"
+                    params.append(cutoff)
+                db.execute(sql + ")", params)
+                db.commit()
+            except sqlite3.DatabaseError as exc:
+                log.warning("[knowledge] purge_domain vectors failed: %s", exc)
+            finally:
+                db.close()
+        return super().purge_domain(domain, before=cutoff)
+
     def _vector_search(
         self,
         query_vec: list[float],
@@ -264,6 +296,7 @@ class HybridKnowledgeStore(KnowledgeStore):
         domain: str | None,
         namespace: str | list[str] | None = None,
         include_invalidated: bool = False,
+        epoch: str | None = None,
     ) -> list[int]:
         """Return chunk ids ranked by cosine similarity (brute force)."""
         db = self._get_db()
@@ -276,6 +309,9 @@ class HybridKnowledgeStore(KnowledgeStore):
         if domain:
             where.append("c.domain = ?")
             params.append(domain)
+        if epoch:
+            where.append("c.epoch = ?")
+            params.append(epoch)
         ns_sql, ns_params = _namespace_clause(namespace, col="c.namespace")
         if ns_sql:
             where.append(ns_sql)
@@ -318,6 +354,7 @@ class HybridKnowledgeStore(KnowledgeStore):
         domain: str | None = None,
         namespace: str | list[str] | None = None,
         include_invalidated: bool = False,
+        epoch: str | None = None,
     ) -> list[dict]:
         """RRF-fuse the FTS5 ranking with a vector ranking.
 
@@ -327,19 +364,25 @@ class HybridKnowledgeStore(KnowledgeStore):
         never come from outside the requested scope. Superseded rows
         (``invalidated_at``, ADR 0069 D9) are likewise excluded from BOTH
         rankings by default; ``include_invalidated=True`` is the audit escape
-        hatch.
+        hatch. ``epoch`` (#1634) likewise filters BOTH rankings — an
+        out-of-era chunk can't surface as a vector-only hit.
         """
         if not query or not query.strip():
             return []
 
         base = super().search(
-            query, k=self._vector_k, domain=domain, namespace=namespace, include_invalidated=include_invalidated
+            query,
+            k=self._vector_k,
+            domain=domain,
+            namespace=namespace,
+            include_invalidated=include_invalidated,
+            epoch=epoch,
         )
         query_vec = self._embed(query)
         if query_vec is None:
             return base[:k]
 
-        vec_ids = self._vector_search(query_vec, self._vector_k, domain, namespace, include_invalidated)
+        vec_ids = self._vector_search(query_vec, self._vector_k, domain, namespace, include_invalidated, epoch)
         if not vec_ids:
             return base[:k]
 

--- a/knowledge/layered.py
+++ b/knowledge/layered.py
@@ -41,8 +41,9 @@ class LayeredKnowledgeStore:
 
     def __getattr__(self, name):
         # Everything not overridden below (add_chunk/add_finding/add_document, the
-        # delete_* family, get_hot_memory, stats, find_chunk_containing, reset_embed_breaker,
-        # path, close, …) targets the PRIVATE store — writes never touch the commons.
+        # delete_*/purge_domain family, get_hot_memory, stats, find_chunk_containing,
+        # reset_embed_breaker, path, close, …) targets the PRIVATE store — writes
+        # (and purges) never touch the commons; it's curated via promote/forget only.
         return getattr(self._private, name)
 
     # ── read: commons ∪ private, fused with RRF over rank ─────────────────────
@@ -54,14 +55,20 @@ class LayeredKnowledgeStore:
         domain: str | None = None,
         namespace: str | list[str] | None = None,
         include_invalidated: bool = False,
+        epoch: str | None = None,
     ) -> list[dict]:
         """Top-k across BOTH tiers, fused by RRF over each tier's rank, tier-tagged.
         A chunk promoted into the commons (same content as its private original) is
         de-duped — the private record wins (it's editable) but keeps the summed score.
-        ``namespace`` (ADR 0069 D3a) and ``include_invalidated`` (ADR 0069 D9 —
-        superseded rows are excluded by default) are passed through to both tiers."""
-        priv = self._private.search(query, k, domain=domain, namespace=namespace, include_invalidated=include_invalidated)
-        comm = self._commons.search(query, k, domain=domain, namespace=namespace, include_invalidated=include_invalidated)
+        ``namespace`` (ADR 0069 D3a), ``include_invalidated`` (ADR 0069 D9 —
+        superseded rows are excluded by default), and ``epoch`` (#1634 — era
+        scoping) are passed through to both tiers."""
+        priv = self._private.search(
+            query, k, domain=domain, namespace=namespace, include_invalidated=include_invalidated, epoch=epoch
+        )
+        comm = self._commons.search(
+            query, k, domain=domain, namespace=namespace, include_invalidated=include_invalidated, epoch=epoch
+        )
 
         fused: dict[str, dict] = {}
         scores: dict[str, float] = {}

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -88,6 +88,7 @@ class Chunk:
     updated_at: str
     namespace: str | None = None
     invalidated_at: str | None = None
+    epoch: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -99,6 +100,7 @@ class Chunk:
             "source_type": self.source_type,
             "finding_type": self.finding_type,
             "namespace": self.namespace,
+            "epoch": self.epoch,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
             "invalidated_at": self.invalidated_at,
@@ -138,6 +140,22 @@ def _resolve_path(db_path: str | Path | None, *, scoped: bool = True) -> Path:
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _normalize_before(before: str | datetime | None) -> str | None:
+    """Normalize a purge cutoff to the stored ``created_at`` format (UTC ISO-8601)
+    so string comparison in SQL is well-defined. ``None`` passes through (no
+    cutoff). Raises ``ValueError`` on an unparseable value — the caller refuses
+    to purge rather than deleting the wrong rows."""
+    if before is None:
+        return None
+    if isinstance(before, datetime):
+        dt = before
+    else:
+        dt = datetime.fromisoformat(str(before).strip())  # ValueError on junk
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)  # naive input = UTC (the stored convention)
+    return dt.astimezone(UTC).isoformat()
 
 
 # Preview length in the hot-write event payload — enough for a console toast /
@@ -245,6 +263,7 @@ CREATE TABLE IF NOT EXISTS chunks (
     source_type   TEXT,
     finding_type  TEXT,
     namespace     TEXT,
+    epoch         TEXT,
     created_at    TEXT NOT NULL,
     updated_at    TEXT NOT NULL,
     invalidated_at TEXT
@@ -365,6 +384,18 @@ class KnowledgeStore:
                 db.execute("CREATE INDEX IF NOT EXISTS idx_chunks_invalidated_at ON chunks(invalidated_at)")
             except sqlite3.DatabaseError as exc:
                 log.debug("[knowledge] invalidated_at migration skipped: %s", exc)
+            # Migration: add the epoch column (#1634 — knowledge lifecycle). Same
+            # additive+nullable pattern; an epoch tag ("2026-06-29") scopes a chunk
+            # to one era of a resettable world, so a wipe is a new tag rather than
+            # a delete — old lessons stay for post-mortems but stop matching an
+            # epoch-filtered search.
+            try:
+                cols = {r[1] for r in db.execute("PRAGMA table_info(chunks)")}
+                if "epoch" not in cols:
+                    db.execute("ALTER TABLE chunks ADD COLUMN epoch TEXT")
+                db.execute("CREATE INDEX IF NOT EXISTS idx_chunks_epoch ON chunks(epoch)")
+            except sqlite3.DatabaseError as exc:
+                log.debug("[knowledge] epoch migration skipped: %s", exc)
             self._fts_available = _has_fts5(db)
             if self._fts_available:
                 db.executescript(_FTS_SCHEMA)
@@ -437,6 +468,7 @@ class KnowledgeStore:
         source_type: str | None = None,
         finding_type: str | None = None,
         namespace: str | None = None,
+        epoch: str | None = None,
     ) -> int | None:
         """Insert a chunk. Returns the new row id, or None on failure.
 
@@ -445,6 +477,10 @@ class KnowledgeStore:
         store. We strip ``<scratch_pad>``/``<think>`` defensively — covering all
         writers (memory tools, ingest, harvest, future ones), not just the ones
         that remember to clean their input.
+
+        ``epoch`` (#1634) tags the chunk with the era it was learned in (an
+        opaque string, e.g. a reset date) so ``search(epoch=...)`` can scope
+        retrieval to the current era of a resettable world.
         """
         if not content or not content.strip():
             return None
@@ -459,8 +495,8 @@ class KnowledgeStore:
             cur = db.execute(
                 "INSERT INTO chunks "
                 "(content, domain, heading, source, source_type, finding_type, "
-                "namespace, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (content, domain, heading, source, source_type, finding_type, namespace, now, now),
+                "namespace, epoch, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (content, domain, heading, source, source_type, finding_type, namespace, epoch, now, now),
             )
             db.commit()
             chunk_id = int(cur.lastrowid)
@@ -507,6 +543,7 @@ class KnowledgeStore:
         source_type: str | None = None,
         finding_type: str | None = None,
         namespace: str | None = None,
+        epoch: str | None = None,
         max_chars: int | None = None,
         overlap_chars: int | None = None,
         min_chars: int | None = None,
@@ -549,6 +586,7 @@ class KnowledgeStore:
                 source_type=source_type,
                 finding_type=finding_type,
                 namespace=namespace,
+                epoch=epoch,
             )
             if cid is not None:
                 ids.append(cid)
@@ -626,6 +664,7 @@ class KnowledgeStore:
         domain: str | None = None,
         namespace: str | list[str] | None = None,
         include_invalidated: bool = False,
+        epoch: str | None = None,
     ) -> list[dict[str, Any]]:
         """Top-k chunks matching ``query``. Shape matches what the
         ``KnowledgeMiddleware`` consumes: each result has ``table``,
@@ -640,6 +679,10 @@ class KnowledgeStore:
         Superseded rows (``invalidated_at`` set — ADR 0069 D9) are excluded
         by default; ``include_invalidated=True`` is the escape hatch for
         audit tooling that needs the full history.
+
+        ``epoch`` (#1634) restricts hits to chunks tagged with exactly that
+        epoch (see :meth:`add_chunk`) — chunks from other eras, and untagged
+        chunks, don't match. ``None`` = unfiltered (today's behavior).
         """
         if not query or not query.strip():
             return []
@@ -648,9 +691,9 @@ class KnowledgeStore:
             return []
         try:
             rows = (
-                self._search_fts(db, query, k, domain, namespace, include_invalidated)
+                self._search_fts(db, query, k, domain, namespace, include_invalidated, epoch)
                 if self._fts_available
-                else self._search_like(db, query, k, domain, namespace, include_invalidated)
+                else self._search_like(db, query, k, domain, namespace, include_invalidated, epoch)
             )
         except sqlite3.DatabaseError as exc:
             log.warning("[knowledge] search failed: %s", exc)
@@ -678,6 +721,7 @@ class KnowledgeStore:
         domain: str | None,
         namespace: str | list[str] | None = None,
         include_invalidated: bool = False,
+        epoch: str | None = None,
     ) -> list[sqlite3.Row]:
         # Sanitize to FTS5-safe tokens; OR them so a multi-word query
         # matches any of the keywords (closer to LIKE behaviour).
@@ -696,6 +740,9 @@ class KnowledgeStore:
         if domain:
             where.append("c.domain = ?")
             params.append(domain)
+        if epoch:
+            where.append("c.epoch = ?")
+            params.append(epoch)
         ns_sql, ns_params = _namespace_clause(namespace, col="c.namespace")
         if ns_sql:
             where.append(ns_sql)
@@ -717,6 +764,7 @@ class KnowledgeStore:
         domain: str | None,
         namespace: str | list[str] | None = None,
         include_invalidated: bool = False,
+        epoch: str | None = None,
     ) -> list[sqlite3.Row]:
         tokens = [t for t in re.findall(r"[\w']+", query) if t]
         if not tokens:
@@ -738,6 +786,9 @@ class KnowledgeStore:
         if domain:
             sql += " AND domain = ?"
             params.append(domain)
+        if epoch:
+            sql += " AND epoch = ?"
+            params.append(epoch)
         ns_sql, ns_params = _namespace_clause(namespace)
         if ns_sql:
             sql += f" AND {ns_sql}"
@@ -999,6 +1050,43 @@ class KnowledgeStore:
             return int(cur.rowcount)
         except sqlite3.DatabaseError as exc:
             log.warning("[knowledge] delete_by_namespace failed: %s", exc)
+            return 0
+        finally:
+            db.close()
+
+    def purge_domain(self, domain: str, *, before: str | datetime | None = None) -> int:
+        """HARD-delete every chunk in ``domain`` — optionally only those created
+        strictly before ``before`` (an ISO-8601 timestamp or a datetime; naive =
+        UTC). The knowledge-lifecycle primitive (#1634): a long-running plugin
+        retires a whole bucket of now-wrong lessons (or just the old ones) in one
+        call. Returns the count removed.
+
+        Explicit-intent path like :meth:`delete_by_id` — rows are removed
+        outright (the FTS delete trigger keeps ``chunks_fts`` in sync); for
+        keep-for-audit retirement, tag writes with ``epoch`` instead. An empty
+        ``domain`` or an unparseable ``before`` refuses to purge (returns 0)
+        rather than risk deleting the wrong rows."""
+        if not domain or not domain.strip():
+            return 0
+        try:
+            cutoff = _normalize_before(before)
+        except ValueError:
+            log.warning("[knowledge] purge_domain(%r): unparseable before=%r — refusing to purge", domain, before)
+            return 0
+        db = self._get_db()
+        if db is None:
+            return 0
+        try:
+            sql = "DELETE FROM chunks WHERE domain = ?"
+            params: list[Any] = [domain]
+            if cutoff is not None:
+                sql += " AND created_at < ?"
+                params.append(cutoff)
+            cur = db.execute(sql, params)
+            db.commit()
+            return int(cur.rowcount)
+        except sqlite3.DatabaseError as exc:
+            log.warning("[knowledge] purge_domain failed: %s", exc)
             return 0
         finally:
             db.close()

--- a/tests/test_knowledge_lifecycle.py
+++ b/tests/test_knowledge_lifecycle.py
@@ -1,0 +1,228 @@
+"""Knowledge lifecycle (#1634): purge_domain + epoch scoping.
+
+Long-running plugins accumulate knowledge that becomes actively wrong
+(spacetraders: weekly universe wipes). purge_domain retires a bucket outright —
+consistently from EVERY index (main rows, FTS via the delete trigger, vectors on
+the hybrid store) — and the epoch tag scopes retrieval to the current era so old
+lessons stay for post-mortems without polluting search.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from knowledge.hybrid_store import HybridKnowledgeStore
+from knowledge.layered import LayeredKnowledgeStore
+from knowledge.store import KnowledgeStore
+
+
+def _backdate(path, chunk_id: int, created_at: str) -> None:
+    """Rewrite a row's created_at (every insert stamps 'now', so age is simulated)."""
+    db = sqlite3.connect(str(path))
+    db.execute("UPDATE chunks SET created_at = ? WHERE id = ?", (created_at, chunk_id))
+    db.commit()
+    db.close()
+
+
+# ── purge_domain: base store ────────────────────────────────────────────────
+
+
+def test_purge_domain_deletes_only_that_domain(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("dead market route", domain="st-routes")
+    store.add_chunk("another dead route", domain="st-routes")
+    store.add_chunk("still-good fact", domain="general")
+
+    assert store.purge_domain("st-routes") == 2
+    assert store.search("route", domain="st-routes") == []
+    assert store.list_chunks(domain="st-routes") == []
+    # The other domain is untouched.
+    assert [c.content for c in store.list_chunks(domain="general")] == ["still-good fact"]
+
+
+def test_purge_domain_with_before_deletes_only_the_stale_tail(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    old = store.add_chunk("old lesson", domain="st-routes")
+    store.add_chunk("fresh lesson", domain="st-routes")
+    _backdate(store.path, old, "2026-01-15T00:00:00+00:00")
+
+    assert store.purge_domain("st-routes", before="2026-02-01") == 1
+    remaining = [c.content for c in store.list_chunks(domain="st-routes")]
+    assert remaining == ["fresh lesson"]
+    # The purged chunk is gone from search too.
+    assert all("old" not in r["content"] for r in store.search("lesson", domain="st-routes"))
+
+
+def test_purge_domain_before_accepts_iso_variants(tmp_path):
+    # A date-only string and a 'Z'-suffixed timestamp both normalize to the
+    # stored UTC ISO format — strictly-before semantics on the boundary.
+    store = KnowledgeStore(tmp_path / "kb.db")
+    a = store.add_chunk("jan lesson", domain="d")
+    b = store.add_chunk("feb lesson", domain="d")
+    _backdate(store.path, a, "2026-01-15T12:00:00+00:00")
+    _backdate(store.path, b, "2026-02-15T12:00:00+00:00")
+
+    assert store.purge_domain("d", before="2026-02-01T00:00:00Z") == 1
+    assert [c.content for c in store.list_chunks(domain="d")] == ["feb lesson"]
+    assert store.purge_domain("d", before="2026-03-01") == 1
+    assert store.list_chunks(domain="d") == []
+
+
+def test_purge_domain_refuses_bad_input(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("keep me", domain="d")
+    # Unparseable cutoff → refuse (0 deleted) rather than purge the wrong rows.
+    assert store.purge_domain("d", before="not-a-timestamp") == 0
+    # Empty domain → refuse (never a wipe-everything predicate).
+    assert store.purge_domain("") == 0
+    assert store.purge_domain("   ") == 0
+    assert len(store.list_chunks(domain="d")) == 1
+
+
+# ── purge_domain: hybrid store (vectors must go too) ────────────────────────
+
+
+def _const_embed(text: str) -> list[float]:
+    return [1.0, 0.0]  # every text maps to the same vector → cosine 1.0 hits
+
+
+def test_hybrid_purge_removes_chunk_from_both_search_modes(tmp_path):
+    path = tmp_path / "kb.db"
+    store = HybridKnowledgeStore(path, embed_fn=_const_embed)
+    cid = store.add_chunk("alpha beta gamma", domain="st-routes")
+    # Present via BOTH modes before the purge: lexical (FTS) …
+    assert any(r["id"] == cid for r in store.search("alpha", k=5))
+    # … and vector-only (no shared tokens; const embedding surfaces it).
+    assert any(r["id"] == cid for r in store.search("zzzzz", k=5))
+
+    assert store.purge_domain("st-routes") == 1
+    # Absent from BOTH modes after — no FTS ghost, no vector-only resurrection.
+    assert not any(r.get("id") == cid for r in store.search("alpha", k=5))
+    assert not any(r.get("id") == cid for r in store.search("zzzzz", k=5))
+    # And the vector row itself is gone (no orphan in the side table).
+    db = sqlite3.connect(str(path))
+    n = db.execute("SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id = ?", (cid,)).fetchone()[0]
+    db.close()
+    assert n == 0
+
+
+def test_hybrid_purge_with_before_keeps_fresh_vectors(tmp_path):
+    path = tmp_path / "kb.db"
+    store = HybridKnowledgeStore(path, embed_fn=_const_embed)
+    old = store.add_chunk("old era route", domain="d")
+    fresh = store.add_chunk("fresh era route", domain="d")
+    _backdate(path, old, "2026-01-01T00:00:00+00:00")
+
+    assert store.purge_domain("d", before="2026-02-01") == 1
+    db = sqlite3.connect(str(path))
+    left = {r[0] for r in db.execute("SELECT chunk_id FROM chunk_vectors")}
+    db.close()
+    assert left == {fresh}
+
+
+def test_hybrid_purge_refuses_bad_cutoff_without_touching_vectors(tmp_path):
+    path = tmp_path / "kb.db"
+    store = HybridKnowledgeStore(path, embed_fn=_const_embed)
+    cid = store.add_chunk("keep my vector", domain="d")
+    assert store.purge_domain("d", before="garbage") == 0
+    db = sqlite3.connect(str(path))
+    n = db.execute("SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id = ?", (cid,)).fetchone()[0]
+    db.close()
+    assert n == 1  # the refusal happened BEFORE the vector delete
+
+
+# ── purge_domain: layered store (private-only — the commons is curated) ─────
+
+
+def test_layered_purge_targets_private_never_commons(tmp_path):
+    private = KnowledgeStore(tmp_path / "private.db")
+    commons = KnowledgeStore(tmp_path / "commons.db")
+    layered = LayeredKnowledgeStore(private, commons)
+    private.add_chunk("my stale lesson", domain="d")
+    commons.add_chunk("fleet-curated lesson", domain="d")
+
+    assert layered.purge_domain("d") == 1  # __getattr__ → private
+    assert private.list_chunks(domain="d") == []
+    assert [c.content for c in commons.list_chunks(domain="d")] == ["fleet-curated lesson"]
+
+
+# ── epoch scoping ────────────────────────────────────────────────────────────
+
+
+def test_epoch_tagged_add_and_filtered_search(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("route via market X", domain="st-routes", epoch="2026-06-22")
+    store.add_chunk("route via market Y", domain="st-routes", epoch="2026-06-29")
+    store.add_chunk("route wisdom, untagged", domain="st-routes")
+
+    # Unfiltered search still sees every era (today's behavior).
+    assert len(store.search("route", k=10)) == 3
+    # Epoch-filtered search sees ONLY that era — other epochs AND untagged excluded.
+    hits = store.search("route", k=10, epoch="2026-06-29")
+    assert [r["content"] for r in hits] == ["route via market Y"]
+    assert hits[0]["epoch"] == "2026-06-29"
+    # A never-used epoch matches nothing.
+    assert store.search("route", k=10, epoch="2099-01-01") == []
+
+
+def test_epoch_filter_on_the_like_fallback(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("fallback lesson one", domain="d", epoch="e1")
+    store.add_chunk("fallback lesson two", domain="d", epoch="e2")
+    store._fts_available = False  # force the LIKE path
+    hits = store.search("fallback", k=10, epoch="e2")
+    assert [r["content"] for r in hits] == ["fallback lesson two"]
+
+
+def test_epoch_filters_the_vector_ranking_too(tmp_path):
+    # A vector-only hit (const embedding, no shared tokens) from another era must
+    # not leak through an epoch-filtered hybrid search.
+    store = HybridKnowledgeStore(tmp_path / "kb.db", embed_fn=_const_embed)
+    store.add_chunk("alpha beta", domain="d", epoch="e1")
+    cid2 = store.add_chunk("gamma delta", domain="d", epoch="e2")
+    hits = store.search("zzzzz", k=5, epoch="e2")  # vector-only path
+    assert [r["id"] for r in hits] == [cid2]
+
+
+def test_epoch_passes_through_the_layered_store(tmp_path):
+    private = KnowledgeStore(tmp_path / "private.db")
+    commons = KnowledgeStore(tmp_path / "commons.db")
+    layered = LayeredKnowledgeStore(private, commons)
+    private.add_chunk("private era lesson", domain="d", epoch="e1")
+    commons.add_chunk("commons era lesson", domain="d", epoch="e2")
+
+    assert [r["content"] for r in layered.search("lesson", epoch="e1")] == ["private era lesson"]
+    assert [r["content"] for r in layered.search("lesson", epoch="e2")] == ["commons era lesson"]
+
+
+def test_epoch_persists_on_the_chunk_and_add_document(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_document("doc-sized lesson", domain="d", epoch="e1")
+    c = store.list_chunks(domain="d", limit=1)[0]
+    assert c.epoch == "e1"
+    assert c.as_dict()["epoch"] == "e1"
+
+
+def test_epoch_migration_on_preexisting_db(tmp_path):
+    """A DB created without the epoch column gets it added on next open."""
+    path = tmp_path / "old.db"
+    # Simulate a pre-#1634 schema: chunks table with no epoch column.
+    db = sqlite3.connect(str(path))
+    db.execute(
+        "CREATE TABLE chunks (id INTEGER PRIMARY KEY AUTOINCREMENT, content TEXT NOT NULL, "
+        "domain TEXT NOT NULL DEFAULT 'general', heading TEXT, source TEXT, source_type TEXT, "
+        "finding_type TEXT, namespace TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, "
+        "invalidated_at TEXT)"
+    )
+    db.execute("INSERT INTO chunks (content, domain, created_at, updated_at) VALUES ('old row', 'd', 'x', 'x')")
+    db.commit()
+    db.close()
+
+    store = KnowledgeStore(path)
+    store.add_chunk("new era row", domain="d", epoch="e1")
+    rows = {c.content: c.epoch for c in store.list_chunks(domain="d", limit=10)}
+    assert rows["old row"] is None
+    assert rows["new era row"] == "e1"
+    # Old (untagged) rows drop out of an epoch-filtered search, stay in unfiltered.
+    assert [r["content"] for r in store.search("row", k=10, epoch="e1")] == ["new era row"]
+    assert len(store.search("row", k=10)) == 2

--- a/tests/test_sdk_knowledge.py
+++ b/tests/test_sdk_knowledge.py
@@ -1,4 +1,5 @@
-"""graph.sdk.knowledge_search / knowledge_add — the plugin↔knowledge channel (ADR 0043)."""
+"""graph.sdk.knowledge_search / knowledge_add / knowledge_purge — the plugin↔knowledge
+channel (ADR 0043) + its lifecycle half (#1634: purge + epoch scoping)."""
 
 from __future__ import annotations
 
@@ -6,6 +7,10 @@ import pytest
 
 
 class _FakeStore:
+    """A minimal ADR 0031 backend — deliberately PRE-#1634 (no epoch kwarg, no
+    purge_domain), so these tests double as the backward-compat proof: the SDK's
+    unfiltered paths must never forward the new kwargs at an old backend."""
+
     def __init__(self):
         self.calls = []
 
@@ -16,6 +21,22 @@ class _FakeStore:
     def add_chunk(self, content, domain="general", heading=None):
         self.calls.append(("add", content, domain, heading))
         return 42
+
+
+class _LifecycleStore(_FakeStore):
+    """A backend with the #1634 lifecycle surface: epoch-aware add/search + purge."""
+
+    def search(self, query, k=5, *, domain=None, epoch=None):
+        self.calls.append(("search", query, k, domain, epoch))
+        return [{"preview": "an era lesson", "domain": domain or "general", "epoch": epoch}]
+
+    def add_chunk(self, content, domain="general", heading=None, *, epoch=None):
+        self.calls.append(("add", content, domain, heading, epoch))
+        return 43
+
+    def purge_domain(self, domain, *, before=None):
+        self.calls.append(("purge", domain, before))
+        return 7
 
 
 @pytest.mark.asyncio
@@ -47,3 +68,46 @@ async def test_knowledge_ops_degrade_to_noop_without_a_store(monkeypatch):
     monkeypatch.setattr(sdk.STATE, "knowledge_store", None, raising=False)
     assert await sdk.knowledge_search("x") == []
     assert await sdk.knowledge_add("x", domain="loop-lessons") is None
+    assert await sdk.knowledge_purge("loop-lessons") == 0
+
+
+@pytest.mark.asyncio
+async def test_knowledge_add_and_search_pass_epoch_when_set(monkeypatch):
+    from graph import sdk
+
+    store = _LifecycleStore()
+    monkeypatch.setattr(sdk.STATE, "knowledge_store", store, raising=False)
+    cid = await sdk.knowledge_add("route lesson", domain="st-routes", epoch="2026-06-29")
+    out = await sdk.knowledge_search("route", k=2, domain="st-routes", epoch="2026-06-29")
+    assert cid == 43
+    assert out and out[0]["epoch"] == "2026-06-29"
+    assert store.calls == [
+        ("add", "route lesson", "st-routes", None, "2026-06-29"),
+        ("search", "route", 2, "st-routes", "2026-06-29"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_purge_wraps_the_store(monkeypatch):
+    from graph import sdk
+
+    store = _LifecycleStore()
+    monkeypatch.setattr(sdk.STATE, "knowledge_store", store, raising=False)
+    assert await sdk.knowledge_purge("st-routes") == 7
+    assert await sdk.knowledge_purge("st-routes", before="2026-06-01") == 7
+    assert store.calls == [
+        ("purge", "st-routes", None),
+        ("purge", "st-routes", "2026-06-01"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_purge_degrades_on_a_backend_without_purge_domain(monkeypatch):
+    # An ADR 0031 backend predating #1634 has no purge_domain — the SDK returns a
+    # 0-count no-op instead of raising at the plugin.
+    from graph import sdk
+
+    store = _FakeStore()
+    monkeypatch.setattr(sdk.STATE, "knowledge_store", store, raising=False)
+    assert await sdk.knowledge_purge("loop-lessons") == 0
+    assert store.calls == []  # never touched


### PR DESCRIPTION
Fixes #1634

## What

The plugin knowledge channel (ADR 0043: `sdk.knowledge_add` / `knowledge_search`) was add-and-search only — no delete, no expiry, no scoping. A long-running plugin's knowledge can become **actively wrong** (spacetraders: the game universe wipes weekly, so recalled routes reference markets that no longer exist). This PR ships the lifecycle half:

- **`sdk.knowledge_purge(domain, *, before=None) -> int`** — hard-delete every chunk in a domain, optionally only those created strictly before an ISO-8601 timestamp; returns the count removed.
- **Epoch scoping** — `sdk.knowledge_add(..., epoch="2026-06-29")` tags a chunk with the era it was learned in (opaque string, typically a reset date); `sdk.knowledge_search(..., epoch=...)` filters to exactly that era. A wipe becomes a new tag: old lessons stay stored for post-mortem analysis but stop polluting retrieval.

## Semantics (the load-bearing details)

**Purge is consistent across every index.** The base delete's FTS trigger keeps `chunks_fts` in sync; the hybrid store overrides `purge_domain` to delete `chunk_vectors` first under the **same cutoff** (the `delete_by_namespace` pattern — no FK cascade on the side table), so a purged chunk can't linger as a vector-only hit. Store locking discipline is untouched: every operation opens/closes its own connection (`busy_timeout=5000`, WAL), same as all existing writes.

**Purge refuses on ambiguous input.** Empty domain → 0 (never a wipe-everything predicate). Unparseable `before` → 0 with a warning, checked **before** the vector delete so a bad cutoff can't strip embeddings off rows that then survive. `before` is normalized to the stored `created_at` format (UTC ISO-8601; naive input = UTC; accepts `str` or `datetime` at the store layer) so SQL string comparison is well-defined.

**Layered stores purge the private tier only** (via the existing `__getattr__` delegation) — the shared commons is curated (promote/forget), never bulk-deleted.

**Epoch filters BOTH rankings** — FTS *and* vector on the hybrid store, and both tiers on the layered store — so an out-of-era chunk can't surface as a vector-only hit. Exact-match semantics: other epochs **and untagged chunks** are excluded; `epoch=None` = unfiltered (today's behavior). Additive nullable `epoch` column + index, migrated on open exactly like `namespace` / `invalidated_at` (no config field → no config golden change).

**Backward compatible with ADR 0031 plugin backends.** The SDK only forwards `epoch` when a caller passes one, and `knowledge_purge` degrades to a 0-count no-op on a backend without `purge_domain` (documented as optional in the `KnowledgeBackend` protocol — not added to the required surface, so pre-existing backends stay `isinstance`-conformant).

## Tests (17 new)

- `tests/test_knowledge_lifecycle.py` (13): purge by domain / with `before=` / ISO-variant cutoffs / bad-input refusal (base + hybrid + layered); **index consistency** — purged chunk absent from both FTS and vector-only search modes, `chunk_vectors` rows gone; epoch-tagged add + epoch-filtered vs unfiltered search (FTS, LIKE fallback, vector ranking, layered pass-through, `add_document`); epoch column migration on a pre-existing DB.
- `tests/test_sdk_knowledge.py` (4 new): epoch pass-through, purge wrapping + `before=`, no-store degradation, and a pre-#1634 fake backend proving the unfiltered paths never see the new kwargs.

## Docs

- `docs/guides/plugins.md` — consumption-SDK list gains the knowledge channel + lifecycle bullets (the pair was never listed).
- `docs/guides/knowledge.md` — new **Plugin knowledge lifecycle** section after *Staleness: supersede, don't delete*.
- ADR 0043 — *Grown since* note for the knowledge channel (#1089) + lifecycle (#1634).
- `CHANGELOG.md` [Unreleased].

## Gates

- `ruff check .` ✅ · `lint-imports` ✅ (3 kept, 0 broken) · `pytest tests/ -q` ✅ (2887 passed, 5 skipped pre-rebase; re-run post-rebase) · `scripts/live_smoke.py` ✅ (LIVE SMOKE PASSED). Console untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added knowledge lifecycle support, including search, add, and purge actions for plugin-managed knowledge.
  * Introduced optional epoch tagging so knowledge can be grouped and filtered by era.
  * Added support for purging knowledge by domain, with an optional cutoff date.

* **Bug Fixes**
  * Ensured purge operations remove matching content across search indexes and stored vectors.
  * Improved handling of older data so existing knowledge remains searchable without breaking compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->