### PR TITLE
feat(console): iframe event bridge — replay-on-subscribe (since/seq) + hidden delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lessons stay for post-mortems but stop polluting retrieval. Additive `epoch` column
   migration; pre-existing ADR 0031 backends keep working (purge degrades to a 0-count
   no-op; `epoch` is only forwarded when passed).
+- **Plugin-view event bridge: replay-on-subscribe + hidden delivery** (#1640). The iframe
+  bridge's `protoagent:subscribe` accepts optional `since` — the host immediately replays
+  retained bus events newer than that seq (from the console's client-side mirror of the
+  `events/bus.py` ring buffer), then continues live with seq-dedupe so nothing drops or
+  duplicates across the handoff — and every relayed `protoagent:event` now carries `seq`,
+  the page's high-water mark for its next `since`. A dashboard that was hidden (or just
+  mounted) catches up instead of polling its state route. `background: true` on subscribe
+  opts a view into hidden delivery: the console keeps its iframe mounted (hidden) across
+  surface switches so a live model keeps updating off-screen. The unmount +
+  notification-dot default is unchanged for everyone else, and plain `{patterns}`
+  subscribes behave exactly as before.
 - **`graph.sdk.react_on` — reactive-rule sugar** (#1633). The canonical reactive
   composition `registry.on(topic, handler)` → `sdk.run_in_session(session, prompt)` made
   every plugin write identical glue (missing-host guard, prompt-from-payload, idempotent

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -82,6 +82,10 @@ async function readBody(req) {
 // Git-installed plugins (ADR 0027) — mutable so install/uninstall round-trip in e2e.
 let INSTALLED_PLUGINS = [];
 
+// Bus seq for /api/events frames (#1640) — module-global so it stays monotonic across
+// SSE reconnects, matching the real bus (events/bus.py assigns one counter per process).
+let eventSeq = 0;
+
 // Per-plugin update fixtures, keyed by id — seeds non-default freshness states
 // (behind / pinned / errored) for any pre-seeded plugin. After a successful
 // `POST /{id}/update` the entry is cleared so the row flips to "up to date".
@@ -413,8 +417,10 @@ const server = createServer(async (req, res) => {
     });
     res.write(": connected\n\n");
     // Frames are unnamed SSE events carrying the topic in the payload (ADR 0039) — the
-    // client routes by topic with wildcard matching.
-    const frame = (topic, data) => res.write(`data: ${JSON.stringify({ topic, data })}\n\n`);
+    // client routes by topic with wildcard matching. Each frame carries the bus `seq`
+    // (globally monotonic across connections, like events/bus.py) so the plugin-bridge
+    // ring-buffer replay + high-water dedupe (#1640) are testable.
+    const frame = (topic, data) => res.write(`data: ${JSON.stringify({ topic, data, seq: ++eventSeq })}\n\n`);
     // Push periodically so the unread badge (off-surface), live append (on-surface), and
     // the plugin notification dot (a `boardy.*` event) are all deterministically testable.
     const t = setInterval(() => {
@@ -757,18 +763,26 @@ const server = createServer(async (req, res) => {
     return sendJson(res, { ok: true });
   }
   // Plugin-served pages (ADR 0026) — a tiny listener page so the e2e can assert
-  // the console's post-load init handshake (token + theme via postMessage).
+  // the console's post-load init handshake (token + theme via postMessage) and the
+  // event bridge (#1640): the page subscribes with `since: 0` (replay everything the
+  // host retains) and records each delivered frame's seq into `data-events`.
   if (pathname.startsWith("/plugins/") && req.method === "GET") {
     res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
     res.end(
-      `<!doctype html><html><body data-bridge="pending">` +
+      `<!doctype html><html><body data-bridge="pending" data-events="">` +
       `<p id="p">${pathname}</p><script>` +
       `window.addEventListener("message",function(e){var m=e.data||{};` +
-      `if(m.type!=="protoagent:init")return;` +
-      `document.body.setAttribute("data-bridge",m.token?"authed":"anon");});` +
+      `if(m.type==="protoagent:init"){` +
+      `document.body.setAttribute("data-bridge",m.token?"authed":"anon");}` +
+      `else if(m.type==="protoagent:event"&&typeof m.seq==="number"){` +
+      `var s=document.body.getAttribute("data-events")||"";` +
+      `document.body.setAttribute("data-events",s?s+","+m.seq:String(m.seq));}});` +
       // Like the real plugin-kit: announce readiness so the console (re-)sends the
       // bearer + theme, closing the race where load-time init beats our listener.
       `try{parent&&parent!==window&&parent.postMessage({type:"protoagent:ready"},"*");}catch(_){}` +
+      // The recommended #1640 pattern: subscribe with a `since` high-water mark so a
+      // freshly (re)mounted page catches up from the host's ring instead of polling.
+      `try{parent&&parent!==window&&parent.postMessage({type:"protoagent:subscribe",patterns:["boardy.#"],since:0},"*");}catch(_){}` +
       `</script></body></html>`,
     );
     return;

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -59,6 +59,78 @@ test("console hands the plugin view a bearer + theme via postMessage", async ({ 
   await expect(body).toHaveAttribute("data-bridge", "authed");
 });
 
+test("subscribe with `since` replays missed bus events on reopen — no poll needed (#1640)", async ({ page }) => {
+  // The mock plugin page subscribes `{patterns:["boardy.#"], since: 0}` and records every
+  // delivered frame's seq into body[data-events]. The mock bus emits a seq'd boardy event
+  // every 500ms. Replay is the ONLY way an already-emitted seq can reach a fresh iframe —
+  // live relay never re-sends an old seq — so seq containment proves the ring catch-up.
+  await page.goto("/app/", { waitUntil: "load" });
+  const rail = page.locator(".pl-rail");
+  await rail.getByRole("button", { name: "Board", exact: true }).click();
+  const body = page.frameLocator(".plugin-view-frame").locator("body");
+  await expect(body).toHaveAttribute("data-events", /\d/); // live delivery, each frame seq'd
+  const firstSeqs = ((await body.getAttribute("data-events")) ?? "").split(",").map(Number);
+
+  // Hide the view (unmounted — the pre-#1640 default) while the bus keeps emitting.
+  await rail.getByRole("button", { name: "Chat", exact: true }).click();
+  await expect(page.locator(".plugin-view-frame")).toHaveCount(0);
+  await page.waitForTimeout(1200); // ≥2 mock ticks arrive while hidden
+
+  // Reopen: a FRESH page subscribes with since:0 → the host immediately replays what the
+  // console retains, including everything from before + during the hidden window.
+  await rail.getByRole("button", { name: "Board", exact: true }).click();
+  const body2 = page.frameLocator(".plugin-view-frame").locator("body");
+  await expect
+    .poll(async () => ((await body2.getAttribute("data-events")) ?? "").split(",").map(Number))
+    .toEqual(expect.arrayContaining(firstSeqs));
+
+  // Replay-then-live must not duplicate: wait for a live frame past the replay, then
+  // check every recorded seq is unique and strictly increasing.
+  const replayed = ((await body2.getAttribute("data-events")) ?? "").split(",").map(Number);
+  await expect
+    .poll(async () => ((await body2.getAttribute("data-events")) ?? "").split(",").length)
+    .toBeGreaterThan(replayed.length);
+  const seqs = ((await body2.getAttribute("data-events")) ?? "").split(",").map(Number);
+  expect(new Set(seqs).size).toBe(seqs.length);
+  expect([...seqs].sort((a, b) => a - b)).toEqual(seqs);
+});
+
+test("subscribe with background:true keeps the view mounted + receiving while hidden (#1640)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const rail = page.locator(".pl-rail");
+  await rail.getByRole("button", { name: "Board", exact: true }).click();
+  const frame = page.locator(".plugin-view-frame");
+  await expect(frame).toBeVisible();
+
+  // The page opts into hidden delivery (per-subscribe, plugin-declared) — posted from
+  // INSIDE the iframe so the host's e.source check accepts it.
+  await page.frameLocator(".plugin-view-frame").locator("body").evaluate(() => {
+    window.parent.postMessage(
+      { type: "protoagent:subscribe", patterns: ["boardy.#"], background: true },
+      "*",
+    );
+  });
+
+  // Switch away: unlike the default (unmount — see the first test), the view stays
+  // mounted, just hidden.
+  await rail.getByRole("button", { name: "Chat", exact: true }).click();
+  await expect(frame).toHaveCount(1);
+  await expect(frame).toBeHidden();
+
+  // …and bus events keep landing in the hidden page (no dropped delivery off-screen).
+  const body = page.frameLocator(".plugin-view-frame").locator("body");
+  const before = ((await body.getAttribute("data-events")) ?? "").split(",").filter(Boolean).length;
+  await expect
+    .poll(async () => ((await body.getAttribute("data-events")) ?? "").split(",").filter(Boolean).length)
+    .toBeGreaterThan(before);
+
+  // Reopening never reloads a background view's iframe — same page, same recorded state.
+  await rail.getByRole("button", { name: "Board", exact: true }).click();
+  await expect(frame).toBeVisible();
+  expect(((await body.getAttribute("data-events")) ?? "").split(",").filter(Boolean).length)
+    .toBeGreaterThanOrEqual(before);
+});
+
 test("a plugin bus event lights the rail notification dot, cleared on open", async ({ page }) => {
   // ADR 0039 — the mock pushes a `boardy.created` event on the /api/events stream; the
   // console routes it by topic and lights the boardy surface's rail icon until it's opened.

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -634,6 +634,47 @@ export function App() {
     }
   }
 
+  // Background event delivery (#1640): a plugin view whose iframe subscribed with
+  // `background: true` stays MOUNTED (hidden) when another surface is active, so the
+  // bridge keeps relaying bus events to it (a live map / dashboard keeps its model warm;
+  // everyone else keeps the unmount + notification-dot default). Session-scoped: the set
+  // only ever contains views the operator opened this session (the page can't ask before
+  // its iframe exists), and it empties on reload.
+  const pluginBackground = useUI((s) => s.pluginBackground);
+  const backgroundViews = allPluginViews.filter((v) => pluginBackground[v.key]);
+  const bgViewsFor = (side: "left" | "right" | "bottom") =>
+    backgroundViews.filter((v) => railOrder[side].includes(v.key));
+  // On mobile every dock's surfaces render in the one mobile pane — keep any DOCKED
+  // background view mounted there (never one parked in the hidden bucket).
+  const bgViewsDocked = backgroundViews.filter(
+    (v) =>
+      railOrder.left.includes(v.key) ||
+      railOrder.right.includes(v.key) ||
+      railOrder.bottom.includes(v.key),
+  );
+
+  // Render a dock's active surface, keeping that dock's background-delivery views
+  // mounted-but-hidden. The active view renders INSIDE its persistent slot (a display
+  // swap, the ChatSlot #613 pattern) so toggling visibility never reloads its iframe.
+  function renderDock(activeId: string, bgViews: typeof allPluginViews): ReactNode {
+    return (
+      <>
+        {bgViews.map((v) => (
+          <div
+            key={v.key}
+            className="plugin-bg-slot"
+            style={{ display: activeId === v.key ? "contents" : "none" }}
+          >
+            <PluginView view={v} />
+          </div>
+        ))}
+        {activeId !== "chat" && !bgViews.some((v) => v.key === activeId)
+          ? renderSurface(activeId)
+          : null}
+      </>
+    );
+  }
+
   // Keep plugin views as first-class railOrder members (ADR 0036) — append new ones, prune gone.
   // Keyed on a stable signature so the effect only fires when the view set actually changes.
   // GATED on the runtime status having RESOLVED: on boot `runtime` is null → zero views →
@@ -1003,9 +1044,10 @@ export function App() {
                 enabledPluginIds={enabledPluginIds}
               />
             ) : null}
-            {(isMobile ? mobileActive : leftActive) !== "chat"
-              ? renderSurface(isMobile ? mobileActive : leftActive)
-              : null}
+            {renderDock(
+              isMobile ? mobileActive : leftActive,
+              isMobile ? bgViewsDocked : bgViewsFor("left"),
+            )}
           </>
         }
         rightContent={
@@ -1018,7 +1060,9 @@ export function App() {
                 enabledPluginIds={enabledPluginIds}
               />
             ) : null}
-            {rightActive !== "chat" ? renderSurface(rightActive) : null}
+            {/* On mobile the right dock's surfaces render in the mobile pane instead —
+                pass no bg views here so a background iframe is never mounted twice. */}
+            {renderDock(rightActive, isMobile ? [] : bgViewsFor("right"))}
           </>
         }
         bottomContent={
@@ -1034,7 +1078,7 @@ export function App() {
                 enabledPluginIds={enabledPluginIds}
               />
             ) : null}
-            {bottomActive && bottomActive !== "chat" ? renderSurface(bottomActive) : null}
+            {renderDock(bottomActive, isMobile ? [] : bgViewsFor("bottom"))}
           </>
         }
         utilityBar={

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -3,7 +3,9 @@ import { AlertTriangle } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { apiUrl, authToken } from "../lib/api";
-import { onTopic, topicMatches } from "../lib/events";
+import { onTopic, replaySince } from "../lib/events";
+import { createPluginEventRelay, parseSubscribe } from "../lib/pluginEventRelay";
+import { useUI } from "../state/uiStore";
 import { Tabs } from "@protolabsai/ui/navigation";
 import type { PluginView as PluginViewType } from "../lib/types";
 
@@ -51,6 +53,10 @@ export function PluginView({ view }: { view: PluginViewType }) {
   // Pending init re-post timers (see handleLoad) — cleared on unmount / src change.
   const initTimers = useRef<number[]>([]);
   const pluginId = useMemo(() => pluginIdFromPath(view.path), [view.path]);
+  // Background delivery (#1640): a `background: true` subscribe from the page asks App
+  // to keep this view mounted (hidden) when another surface is active. Store-reported;
+  // App owns the mount policy.
+  const setPluginBackground = useUI((s) => s.setPluginBackground);
 
   // Post the bearer + theme to the iframe. Idempotent on the kit side (applyTheme just
   // re-sets CSS vars), so it's safe to call repeatedly — which the handshake relies on.
@@ -118,11 +124,16 @@ export function PluginView({ view }: { view: PluginViewType }) {
     };
   }, [src, view.pluginLoaded, view.pluginError]);
 
-  // Event-bus relay across the sandbox (ADR 0039). The page subscribes via
-  // `protoagent:subscribe {patterns}`; the host forwards matching bus events in
-  // (`protoagent:event`) and accepts `protoagent:publish {topic,data}` back, forcing the
-  // topic into this plugin's namespace before POSTing. Only the *visible* plugin's iframe
-  // is mounted, so this relay is naturally scoped to it.
+  // Event-bus relay across the sandbox (ADR 0039, extended #1640). The page subscribes via
+  // `protoagent:subscribe {patterns, since?, background?}`; the host forwards matching bus
+  // events in (`protoagent:event {topic, data, seq}`) and accepts `protoagent:publish
+  // {topic,data}` back, forcing the topic into this plugin's namespace before POSTing.
+  // `since` triggers an immediate replay of retained ring-buffer events newer than that seq
+  // (the console's client-side mirror — lib/events.ts), so a freshly (re)mounted page can
+  // catch up on what it missed instead of polling; `seq` on every relayed frame is the
+  // page's high-water mark for its next `since`. Normally only the *visible* plugin's
+  // iframe is mounted, so the relay is scoped to it; `background: true` asks App (via the
+  // ui store) to keep this view mounted-but-hidden so delivery continues off-screen.
   useEffect(() => {
     const origin = (() => {
       try {
@@ -131,11 +142,13 @@ export function PluginView({ view }: { view: PluginViewType }) {
         return window.location.origin;
       }
     })();
-    let patterns: string[] = [];
-
-    function matches(topic: string): boolean {
-      return patterns.some((p) => topicMatches(p, topic));
-    }
+    // Pattern matching + since-replay + seq dedupe live in the pure relay
+    // (lib/pluginEventRelay.ts) — this effect only wires postMessage to it.
+    const relay = createPluginEventRelay({
+      post: (frame) =>
+        frameRef.current?.contentWindow?.postMessage({ type: "protoagent:event", ...frame }, origin),
+      replaySince,
+    });
 
     const onWindowMessage = (e: MessageEvent) => {
       // Only trust messages from THIS iframe's window.
@@ -149,8 +162,13 @@ export function PluginView({ view }: { view: PluginViewType }) {
         // listening, so it themes immediately. (Older kits don't ping; handleLoad's
         // retry covers those.)
         if (frameRef.current?.contentWindow) postInit(frameRef.current.contentWindow);
-      } else if (m.type === "protoagent:subscribe" && Array.isArray(m.patterns)) {
-        patterns = m.patterns.filter((p: unknown) => typeof p === "string");
+      } else if (m.type === "protoagent:subscribe") {
+        const req = parseSubscribe(m);
+        if (!req) return;
+        // Hidden-delivery opt-in/out (#1640) — only an explicit boolean toggles it, so
+        // pre-#1640 subscribes (no `background` field) never touch the mount policy.
+        if (req.background !== undefined && view.key) setPluginBackground(view.key, req.background);
+        relay.subscribe(req);
       } else if (m.type === "protoagent:publish" && typeof m.topic === "string") {
         // Force the plugin's namespace — a page can only publish under its own id.
         const bare = m.topic.replace(/^.*?\./, "");
@@ -167,13 +185,7 @@ export function PluginView({ view }: { view: PluginViewType }) {
     };
     window.addEventListener("message", onWindowMessage);
 
-    const off = onTopic("#", (data, topic) => {
-      if (!matches(topic)) return;
-      frameRef.current?.contentWindow?.postMessage(
-        { type: "protoagent:event", topic, data },
-        origin,
-      );
-    });
+    const off = onTopic("#", (data, topic, seq) => relay.deliver(topic, data, seq));
 
     return () => {
       window.removeEventListener("message", onWindowMessage);
@@ -182,7 +194,7 @@ export function PluginView({ view }: { view: PluginViewType }) {
       initTimers.current.forEach(clearTimeout);
       initTimers.current = [];
     };
-  }, [src, pluginId]);
+  }, [src, pluginId, view.key, setPluginBackground]);
 
   // Live re-theme (ADR 0026/0042). The console fires a `protoagent:theme` window event on
   // any theme/accent change (watchThemeChanges in agentTheme.ts observes the root's

--- a/apps/web/src/lib/events.test.ts
+++ b/apps/web/src/lib/events.test.ts
@@ -106,6 +106,48 @@ describe("connect handshake", () => {
   });
 });
 
+describe("client ring buffer + seq (#1640 — plugin-bridge replay)", () => {
+  it("hands listeners the frame's seq as a third argument", async () => {
+    const { onTopic } = await loadEvents();
+    const seen: Array<number | undefined> = [];
+    onTopic("job.*", (_data, _topic, seq) => seen.push(seq));
+    await vi.waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    const es = FakeEventSource.instances[0];
+    es.emit({ topic: "job.start", data: {}, seq: 7 });
+    es.emit({ topic: "job.end", data: {} }); // no seq → undefined, still delivered
+    expect(seen).toEqual([7, undefined]);
+  });
+
+  it("retains seq'd frames and replays only those newer than since, in order", async () => {
+    const { onTopic, replaySince } = await loadEvents();
+    onTopic("#", () => {});
+    await vi.waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    const es = FakeEventSource.instances[0];
+    es.emit({ topic: "a.one", data: { n: 1 }, seq: 1 });
+    es.emit({ topic: "b.two", data: { n: 2 }, seq: 2 });
+    es.emit({ topic: "a.three", data: { n: 3 } }); // seq-less → NOT retained (unreplayable)
+    es.emit({ topic: "a.four", data: { n: 4 }, seq: 4 });
+    expect(replaySince(1)).toEqual([
+      { topic: "b.two", data: { n: 2 }, seq: 2 },
+      { topic: "a.four", data: { n: 4 }, seq: 4 },
+    ]);
+    expect(replaySince(4)).toEqual([]);
+    expect(replaySince(0).map((f) => f.seq)).toEqual([1, 2, 4]);
+  });
+
+  it("caps retention (drop-oldest) so replay is best-effort like the server ring", async () => {
+    const { onTopic, replaySince } = await loadEvents();
+    onTopic("#", () => {});
+    await vi.waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    const es = FakeEventSource.instances[0];
+    for (let i = 1; i <= 300; i++) es.emit({ topic: "t.x", data: {}, seq: i });
+    const frames = replaySince(0);
+    expect(frames.length).toBe(256); // RING_MAX
+    expect(frames[0].seq).toBe(300 - 256 + 1); // oldest were dropped
+    expect(frames[frames.length - 1].seq).toBe(300);
+  });
+});
+
 describe("reconnect", () => {
   it("on error, refreshes the token and replays via ?since=<lastSeq>", async () => {
     vi.useFakeTimers();

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -13,9 +13,12 @@ import { api, apiUrl } from "./api";
 // token, passing `?since=<lastSeq>` so the server still replays missed events from its
 // ring buffer. In open mode the token is "" and the server accepts a tokenless stream.
 
-type Listener = (data: Record<string, unknown>, topic: string) => void;
+type Listener = (data: Record<string, unknown>, topic: string, seq?: number) => void;
 
 type Sub = { pattern: string; fn: Listener };
+
+/** A bus frame as retained client-side: topic + payload + the server-assigned seq. */
+export type BusFrame = { topic: string; data: Record<string, unknown>; seq: number };
 
 const subs = new Set<Sub>();
 const connListeners = new Set<(connected: boolean) => void>();
@@ -24,6 +27,14 @@ let connected = false;
 let connecting = false;
 // Highest bus seq we've dispatched — replayed via `?since=` on reconnect.
 let lastSeq: number | null = null;
+// Client-side mirror of the server's ring buffer (events/bus.py retains 128): every seq'd
+// frame this console has received, so the plugin-view bridge can replay "what did I miss?"
+// to an iframe that re-subscribes with `since` (#1640) WITHOUT a second server fetch. Sized
+// past the server's ring so replay from here is never worse than a server-side reconnect
+// for anything observed while this console was open. Best-effort like the server's: a seq
+// from before this console connected (or past the horizon) yields only what's retained.
+const RING_MAX = 256;
+const ring: BusFrame[] = [];
 let reconnectAttempts = 0;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -59,10 +70,24 @@ function dispatch(raw: string): number | null {
   const topic = frame.topic;
   if (!topic) return null;
   const data = (frame.data as Record<string, unknown>) || {};
-  for (const sub of subs) {
-    if (topicMatches(sub.pattern, topic)) sub.fn(data, topic);
+  const seq = typeof frame.seq === "number" ? frame.seq : undefined;
+  // Retain BEFORE fanning out, so anything a listener saw live is also replayable —
+  // the invariant the bridge's replay-then-live dedupe (#1640) rests on.
+  if (seq !== undefined) {
+    ring.push({ topic, data, seq });
+    if (ring.length > RING_MAX) ring.shift();
   }
-  return typeof frame.seq === "number" ? frame.seq : null;
+  for (const sub of subs) {
+    if (topicMatches(sub.pattern, topic)) sub.fn(data, topic, seq);
+  }
+  return seq ?? null;
+}
+
+/** Retained frames newer than `since`, oldest→newest — the client-side counterpart of
+ *  `GET /api/events?since=` (#1640). Best-effort: only what this console has received
+ *  and still retains. */
+export function replaySince(since: number): BusFrame[] {
+  return ring.filter((f) => f.seq > since);
 }
 
 /** Build the EventSource URL, appending `?token=` (auth) and `?since=` (replay)

--- a/apps/web/src/lib/pluginEventRelay.test.ts
+++ b/apps/web/src/lib/pluginEventRelay.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import { createPluginEventRelay, parseSubscribe, type RelayFrame } from "./pluginEventRelay";
+
+// The plugin-view iframe bridge's pure relay half (#1640): subscribe parsing,
+// ring-buffer replay via `since`, seq on every relayed frame, and the
+// replay-then-live dedupe (never the same seq twice, nothing dropped between
+// the buffer read and the live stream).
+
+function harness(buffer: RelayFrame[] = []) {
+  const posted: RelayFrame[] = [];
+  const relay = createPluginEventRelay({
+    post: (f) => posted.push(f),
+    replaySince: (since) => buffer.filter((f) => (f.seq ?? -1) > since),
+  });
+  return { posted, relay };
+}
+
+describe("parseSubscribe", () => {
+  it("parses a plain pre-#1640 subscribe (patterns only)", () => {
+    expect(parseSubscribe({ type: "protoagent:subscribe", patterns: ["a.#", "b.*"] })).toEqual({
+      patterns: ["a.#", "b.*"],
+    });
+  });
+
+  it("rejects non-subscribe messages and missing/invalid patterns", () => {
+    expect(parseSubscribe(null)).toBeNull();
+    expect(parseSubscribe("protoagent:subscribe")).toBeNull();
+    expect(parseSubscribe({ type: "protoagent:event", patterns: [] })).toBeNull();
+    expect(parseSubscribe({ type: "protoagent:subscribe", patterns: "a.#" })).toBeNull();
+  });
+
+  it("filters non-string patterns (untrusted postMessage payload)", () => {
+    expect(
+      parseSubscribe({ type: "protoagent:subscribe", patterns: ["a.#", 7, null, "b"] }),
+    ).toEqual({ patterns: ["a.#", "b"] });
+  });
+
+  it("parses since and background; drops malformed values instead of rejecting", () => {
+    expect(
+      parseSubscribe({ type: "protoagent:subscribe", patterns: ["a.#"], since: 42, background: true }),
+    ).toEqual({ patterns: ["a.#"], since: 42, background: true });
+    // Malformed optionals degrade to the plain subscribe — old behavior, not an error.
+    expect(
+      parseSubscribe({ type: "protoagent:subscribe", patterns: ["a.#"], since: "42", background: 1 }),
+    ).toEqual({ patterns: ["a.#"] });
+    expect(
+      parseSubscribe({ type: "protoagent:subscribe", patterns: ["a.#"], since: Number.NaN }),
+    ).toEqual({ patterns: ["a.#"] });
+    // since: 0 is a real mark ("replay everything you have"), not a missing value.
+    expect(
+      parseSubscribe({ type: "protoagent:subscribe", patterns: ["a.#"], since: 0, background: false }),
+    ).toEqual({ patterns: ["a.#"], since: 0, background: false });
+  });
+});
+
+describe("live relay (no since — the pre-#1640 path, now with seq)", () => {
+  it("relays matching topics with their seq, drops non-matching", () => {
+    const { posted, relay } = harness();
+    relay.subscribe({ patterns: ["board.#"] });
+    relay.deliver("board.created", { id: "b1" }, 5);
+    relay.deliver("other.created", { id: "x" }, 6);
+    relay.deliver("board.moved", { id: "b1" }, 7);
+    expect(posted).toEqual([
+      { topic: "board.created", data: { id: "b1" }, seq: 5 },
+      { topic: "board.moved", data: { id: "b1" }, seq: 7 },
+    ]);
+  });
+
+  it("relays nothing before any subscribe", () => {
+    const { posted, relay } = harness();
+    relay.deliver("board.created", {}, 1);
+    expect(posted).toEqual([]);
+  });
+
+  it("a re-subscribe replaces the pattern set", () => {
+    const { posted, relay } = harness();
+    relay.subscribe({ patterns: ["board.#"] });
+    relay.subscribe({ patterns: ["stats.#"] });
+    relay.deliver("board.created", {}, 1);
+    relay.deliver("stats.tick", {}, 2);
+    expect(posted).toEqual([{ topic: "stats.tick", data: {}, seq: 2 }]);
+  });
+
+  it("relays a seq-less frame as-is (no dedupe possible, nothing silently dropped)", () => {
+    const { posted, relay } = harness();
+    relay.subscribe({ patterns: ["#"] });
+    relay.deliver("board.created", { id: "b1" });
+    relay.deliver("board.created", { id: "b1" }, 3);
+    expect(posted).toEqual([
+      { topic: "board.created", data: { id: "b1" } },
+      { topic: "board.created", data: { id: "b1" }, seq: 3 },
+    ]);
+  });
+});
+
+describe("replay on subscribe (since)", () => {
+  const buffer: RelayFrame[] = [
+    { topic: "board.created", data: { id: "b1" }, seq: 1 },
+    { topic: "other.noise", data: {}, seq: 2 },
+    { topic: "board.moved", data: { id: "b1" }, seq: 3 },
+    { topic: "board.done", data: { id: "b1" }, seq: 4 },
+  ];
+
+  it("replays retained matching frames newer than since, in order, each with seq", () => {
+    const { posted, relay } = harness(buffer);
+    relay.subscribe({ patterns: ["board.#"], since: 1 });
+    expect(posted).toEqual([
+      { topic: "board.moved", data: { id: "b1" }, seq: 3 },
+      { topic: "board.done", data: { id: "b1" }, seq: 4 },
+    ]);
+  });
+
+  it("since: 0 replays the whole retained buffer (matching topics)", () => {
+    const { posted, relay } = harness(buffer);
+    relay.subscribe({ patterns: ["board.#"], since: 0 });
+    expect(posted.map((f) => f.seq)).toEqual([1, 3, 4]);
+  });
+
+  it("no since → no replay (backward compatible)", () => {
+    const { posted, relay } = harness(buffer);
+    relay.subscribe({ patterns: ["board.#"] });
+    expect(posted).toEqual([]);
+  });
+
+  it("live events after a replay continue without a drop or a duplicate", () => {
+    const { posted, relay } = harness(buffer);
+    relay.subscribe({ patterns: ["board.#"], since: 1 });
+    // A frame the replay already delivered must not repeat…
+    relay.deliver("board.done", { id: "b1" }, 4);
+    // …and the next new one flows straight through.
+    relay.deliver("board.archived", { id: "b1" }, 5);
+    expect(posted.map((f) => f.seq)).toEqual([3, 4, 5]);
+    expect(posted[2]).toEqual({ topic: "board.archived", data: { id: "b1" }, seq: 5 });
+  });
+
+  it("non-matching buffered frames advance nothing (their seqs stay deliverable-adjacent)", () => {
+    const { posted, relay } = harness(buffer);
+    relay.subscribe({ patterns: ["board.done"], since: 3 });
+    expect(posted.map((f) => f.seq)).toEqual([4]);
+    // seq 5 live still flows (highWater ended at 4, not confused by skipped topics).
+    relay.subscribe({ patterns: ["#"] }); // widen patterns, keep the mark
+    relay.deliver("other.noise", {}, 5);
+    expect(posted.map((f) => f.seq)).toEqual([4, 5]);
+  });
+
+  it("re-subscribing with an older since is page-authoritative: replays again", () => {
+    const { posted, relay } = harness(buffer);
+    relay.subscribe({ patterns: ["board.#"], since: 3 });
+    expect(posted.map((f) => f.seq)).toEqual([4]);
+    // The page reloaded its model from seq 1 — it may ask for the older window again.
+    relay.subscribe({ patterns: ["board.#"], since: 1 });
+    expect(posted.map((f) => f.seq)).toEqual([4, 3, 4]);
+  });
+
+  it("a since past everything retained replays nothing but still gates live dupes", () => {
+    const { posted, relay } = harness(buffer);
+    relay.subscribe({ patterns: ["board.#"], since: 99 });
+    relay.deliver("board.created", {}, 42); // stale relative to the page's own mark
+    expect(posted).toEqual([]);
+    relay.deliver("board.created", {}, 100);
+    expect(posted.map((f) => f.seq)).toEqual([100]);
+  });
+
+  it("a plain re-subscribe (no since) keeps the dedupe mark", () => {
+    const { posted, relay } = harness(buffer);
+    relay.subscribe({ patterns: ["board.#"], since: 1 });
+    expect(posted.map((f) => f.seq)).toEqual([3, 4]);
+    relay.subscribe({ patterns: ["board.#"] }); // e.g. a background toggle re-send
+    relay.deliver("board.moved", { id: "b1" }, 3); // dup of a replayed frame
+    relay.deliver("board.next", {}, 5);
+    expect(posted.map((f) => f.seq)).toEqual([3, 4, 5]);
+  });
+});

--- a/apps/web/src/lib/pluginEventRelay.ts
+++ b/apps/web/src/lib/pluginEventRelay.ts
@@ -1,0 +1,96 @@
+import { topicMatches } from "./events";
+
+// The pure half of the PluginView iframe event bridge (#1640): parse an untrusted
+// `protoagent:subscribe` postMessage, then relay ring-buffer replay + live bus events
+// to the sandboxed page with seq-based dedupe. Extracted from PluginView so the
+// replay-then-live ordering contract is unit-testable without a DOM.
+//
+// Protocol (page → host):
+//   { type: "protoagent:subscribe", patterns: ["a.#"], since?: <seq>, background?: <bool> }
+// - `patterns` replace the previous set (as before #1640).
+// - `since` asks for immediate replay of retained events with seq > since (the console's
+//   client-side mirror of the server ring, lib/events.ts `replaySince`).
+// - `background` requests hidden delivery — handled by the HOST (PluginView reports it to
+//   the ui store; the App keeps the view mounted), not here.
+//
+// Host → page: every relayed frame is `{ type: "protoagent:event", topic, data, seq }` —
+// `seq` is the page's high-water mark for its next `since`.
+
+export type RelayFrame = { topic: string; data: Record<string, unknown>; seq?: number };
+
+export type SubscribeRequest = {
+  patterns: string[];
+  since?: number;
+  background?: boolean;
+};
+
+/** Parse a `protoagent:subscribe` postMessage payload. Returns null when the message
+ *  isn't a subscribe at all; malformed optional fields are dropped, not rejected —
+ *  a pre-#1640 subscribe (`{patterns}` only) parses to exactly the old behavior. */
+export function parseSubscribe(m: unknown): SubscribeRequest | null {
+  if (!m || typeof m !== "object") return null;
+  const msg = m as Record<string, unknown>;
+  if (msg.type !== "protoagent:subscribe" || !Array.isArray(msg.patterns)) return null;
+  const req: SubscribeRequest = {
+    patterns: msg.patterns.filter((p): p is string => typeof p === "string"),
+  };
+  if (typeof msg.since === "number" && Number.isFinite(msg.since)) req.since = msg.since;
+  if (typeof msg.background === "boolean") req.background = msg.background;
+  return req;
+}
+
+export type PluginEventRelay = {
+  /** Apply a subscribe: replace patterns; when `since` is present, replay retained
+   *  matching frames newer than it (and reset the dedupe mark to the page's `since` —
+   *  the page is authoritative about what it has). */
+  subscribe: (req: SubscribeRequest) => void;
+  /** Offer a live bus event; relayed iff it matches a pattern and its seq is above the
+   *  high-water mark (never the same seq twice past a replay). */
+  deliver: (topic: string, data: Record<string, unknown>, seq?: number) => void;
+};
+
+export function createPluginEventRelay(opts: {
+  /** Post one `protoagent:event` frame to the page. */
+  post: (frame: RelayFrame) => void;
+  /** Retained frames with seq > since, oldest→newest (lib/events.ts `replaySince`). */
+  replaySince: (since: number) => RelayFrame[];
+}): PluginEventRelay {
+  let patterns: string[] = [];
+  // Highest seq relayed to (or claimed by) the page — the replay/live dedupe line.
+  // null until the page names a `since` or a seq'd live event is relayed.
+  let highWater: number | null = null;
+  const matches = (topic: string) => patterns.some((p) => topicMatches(p, topic));
+
+  return {
+    subscribe(req) {
+      patterns = req.patterns;
+      if (req.since === undefined) return;
+      // Page-authoritative reset: replay everything retained past ITS mark, even if a
+      // prior subscription already relayed some of it — a page that re-subscribes with
+      // an older `since` is saying its model only reflects up to that seq.
+      let hw = req.since;
+      for (const f of opts.replaySince(req.since)) {
+        if (typeof f.seq !== "number" || f.seq <= hw) continue;
+        if (!matches(f.topic)) continue;
+        opts.post({ topic: f.topic, data: f.data, seq: f.seq });
+        hw = f.seq;
+      }
+      highWater = hw;
+    },
+    deliver(topic, data, seq) {
+      if (!matches(topic)) return;
+      if (typeof seq === "number") {
+        // Replay in `subscribe` runs synchronously inside the message handler, and
+        // dispatch retains-before-fanout — so a live frame is either ≤ highWater
+        // (already replayed) or new. Drop the former, advance on the latter.
+        if (highWater !== null && seq <= highWater) return;
+        highWater = seq;
+        opts.post({ topic, data, seq });
+        return;
+      }
+      // A frame without a seq (not produced by the server bus) can't be deduped or
+      // tracked — relay as-is so nothing is silently dropped.
+      opts.post({ topic, data });
+    },
+  };
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -104,6 +104,11 @@ export type PluginView = {
   label: string;
   icon?: string; // a lucide-react icon name
   path: string;
+  // The console surface key (`plugin:<pluginId>:<viewId>`) — stamped on by App when it
+  // builds the view list from runtime status. The view host needs it to report per-view
+  // state upward (a `background: true` subscribe → the ui store, #1640). Optional:
+  // absent on raw manifest-shaped views that never passed through App's mapping.
+  key?: string;
   tabs?: { id: string; label: string; path: string }[];
   // "rail" (default) = a left-rail surface; "right" = a right-sidebar panel
   // alongside Notes/Tasks/Goals/Schedule (ADR 0026); "bottom" = the bottom dock.

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -137,6 +137,13 @@ type UIState = {
   // bus activity shows a rail dot until opened. Persisted so the dot survives a refresh.
   pluginDots: Record<string, boolean>;
   setPluginDot: (key: string, on: boolean) => void;
+  // Background event delivery (#1640) — surface keys whose iframe subscribed with
+  // `background: true` over the bridge. App keeps these views MOUNTED (hidden) when
+  // another surface is active, so the bridge keeps relaying bus events to them.
+  // EPHEMERAL — partialized out: the page re-requests on every load, and persisting it
+  // would silently keep iframes alive from boot that the operator never opened.
+  pluginBackground: Record<string, boolean>;
+  setPluginBackground: (key: string, on: boolean) => void;
   // Chat display: show the per-turn token/cost + context-window footer under each answer
   // (#1372). On by default; operators who want a cleaner transcript turn it off (this device).
   showChatUsage: boolean;
@@ -461,6 +468,15 @@ export const useUI = create<UIState>()(
           else delete next[key];
           return { pluginDots: next };
         }),
+      pluginBackground: {},
+      setPluginBackground: (key, on) =>
+        set((s) => {
+          if (Boolean(s.pluginBackground[key]) === on) return s; // no-op → no rerender
+          const next = { ...s.pluginBackground };
+          if (on) next[key] = true;
+          else delete next[key];
+          return { pluginBackground: next };
+        }),
       showChatUsage: true,
       setShowChatUsage: (showChatUsage) => set({ showChatUsage }),
     }),
@@ -470,9 +486,10 @@ export const useUI = create<UIState>()(
       version: 14, // …v12 Settings→utility pill · v13 railOrder.hidden bucket · v14 drop dead settingsScope (domain-first IA, ADR 0048)
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
       // Ephemeral overlay state — dropped from persistence so a refresh never reopens it
-      // (the Global settings overlay, the per-plugin Configure dialog, and the pending
-      // rail-menu Update/Uninstall action).
-      partialize: ({ globalSettingsOpen: _o, globalSettingsSection: _s, configurePlugin: _c, pluginUpdate: _pu, pluginUninstall: _pun, ...rest }) => rest,
+      // (the Global settings overlay, the per-plugin Configure dialog, the pending
+      // rail-menu Update/Uninstall action, and the per-session background-delivery set
+      // (#1640) — a view's page re-requests it on every load).
+      partialize: ({ globalSettingsOpen: _o, globalSettingsSection: _s, configurePlugin: _c, pluginUpdate: _pu, pluginUninstall: _pun, pluginBackground: _pb, ...rest }) => rest,
     },
   ),
 );

--- a/docs/adr/0039-plugin-event-bus.md
+++ b/docs/adr/0039-plugin-event-bus.md
@@ -54,6 +54,13 @@ def register(registry):
   (`postMessage {type:"protoagent:event", topic, data}`) and accepts publishes back
   (`{type:"protoagent:publish", topic, data}` → `POST /api/events/publish`). One bus, the browser is
   a mirror; client publishes go *up* to the server then fan back out.
+- *Amended by #1640:* every relayed `protoagent:event` also carries the bus `seq`;
+  `protoagent:subscribe` accepts optional `since` (immediate best-effort replay of retained
+  events newer than that seq — from the console's client-side mirror of the ring buffer,
+  seq-deduped against the live stream) and `background: true` (the console keeps that view
+  mounted-but-hidden so delivery continues off-screen; the notification-dot default is
+  unchanged for everyone else). See the
+  [plugin views guide](../guides/building-react-plugin-views.md#replay-and-hidden-delivery-1640).
 
 ### Tier 3 — The contract (the no-cross-dependency clause)
 

--- a/docs/guides/building-react-plugin-views.md
+++ b/docs/guides/building-react-plugin-views.md
@@ -228,7 +228,7 @@ def register(registry):
 parent.postMessage({ type: "protoagent:subscribe", patterns: ["artifact.#"] }, "*");
 window.addEventListener("message", (e) => {
   const m = e.data || {};
-  if (m.type === "protoagent:event") { /* m.topic, m.data */ }   // 2. delivered events
+  if (m.type === "protoagent:event") { /* m.topic, m.data, m.seq */ } // 2. delivered events
 });
 // 3. publish — the host FORCES your plugin's namespace + gates it
 parent.postMessage({ type: "protoagent:publish", topic: "created", data: { id: "a1" } }, "*");
@@ -244,6 +244,58 @@ subscribes: ["notes.changed"]
 **Notification dots come for free:** any event under `<plugin_id>.*` lights your plugin's rail icon
 until the user opens that surface — no badge endpoint, no polling. Subscribing is always safe;
 publishing is the gated direction (namespace-forced).
+
+### Replay and hidden delivery (#1640)
+
+By default your iframe exists **only while its surface is visible** — switch away and the page is
+torn down; unseen activity becomes a rail dot. Two subscribe options refine that for event-driven
+views:
+
+```js
+parent.postMessage({
+  type: "protoagent:subscribe",
+  patterns: ["boardy.#"],
+  since: lastSeq,        // optional — replay retained events with seq > lastSeq, NOW
+  background: true,      // optional — keep this view mounted + receiving while hidden
+}, "*");
+```
+
+- **`seq` on every event.** Each `protoagent:event` carries the bus sequence number. Track the
+  highest one you've applied — it's your high-water mark.
+- **`since` — replay on subscribe.** When present, the host immediately relays the retained
+  events **newer than that seq** that match your patterns (from the console's mirror of the
+  server ring buffer — the same catch-up the console itself uses on SSE reconnect), then
+  continues live with **no gap and no duplicate** (the host dedupes by seq). `since: 0` means
+  "everything you still have". Replay is **best-effort**, exactly like the server ring: seqs
+  older than the retention horizon (or from before this console tab connected) are gone —
+  treat an empty replay after a long absence as "do one full state fetch", not as "nothing
+  happened".
+- **`background: true` — hidden delivery.** Per-subscribe opt-in: the console keeps your view
+  mounted (hidden) when the operator switches away, so events keep flowing to your live model
+  (a map, a running chart). Your page is **not** reloaded on re-open. `background: false`
+  opts back out; omitting the field never changes the current mode. The notification dot
+  still lights either way. Use it only when you genuinely keep state — a hidden iframe still
+  costs memory and timers; session-scoped, so ask on every load.
+
+**The recommended pattern** for a dashboard that used to poll:
+
+```js
+let lastSeq = Number(sessionStorage.getItem("myview.seq") || 0);
+const subscribe = () => parent.postMessage(
+  { type: "protoagent:subscribe", patterns: ["myplugin.#"], since: lastSeq }, "*");
+window.addEventListener("message", (e) => {
+  const m = e.data || {};
+  if (m.type !== "protoagent:event") return;
+  apply(m.topic, m.data);                       // update your model
+  if (typeof m.seq === "number") { lastSeq = m.seq; sessionStorage.setItem("myview.seq", String(m.seq)); }
+});
+subscribe();
+```
+
+Your plugin page is same-origin, so `sessionStorage` survives the hide→unmount→reopen cycle
+within a console tab — a reopened view catches up from its stored mark instead of refetching or
+polling. On hosts that predate #1640 the extra fields are ignored and events carry no `seq`;
+if you need to support them, keep a poll fallback and disarm it the first time a `seq` arrives.
 
 ## Trust & the sandbox split
 


### PR DESCRIPTION
Fixes #1640

## What

The PluginView iframe event bridge relayed live bus events only while the plugin surface was visible (deliberate — it powers the hidden-view notification dot), so an event-driven dashboard had to keep a poll alive to cover hidden/remount gaps (spacetraders v1.7 keeps a 60s poll for exactly this). Two additive, backward-compatible subscribe options close them:

### Bridge protocol (page → host)

```js
parent.postMessage({
  type: "protoagent:subscribe",
  patterns: ["myplugin.#"],
  since: 42,          // optional — replay retained events with seq > 42, immediately
  background: true,   // optional — keep this view mounted + receiving while hidden
}, "*");
```

### Host → page

```js
{ type: "protoagent:event", topic, data, seq }   // seq now on EVERY relayed event
```

- **`since` — replay on subscribe.** The console's SSE client (`lib/events.ts`) now retains a client-side mirror of the `events/bus.py` ring buffer (last 256 seq'd frames it dispatched — retained *before* fan-out, so anything a view saw live is replayable). On a `since` subscribe the host immediately replays matching retained frames newer than that seq, then continues live with seq-dedupe at the relay (page-authoritative: an explicit `since` resets the mark) — no drop, no duplicate across the handoff. Best-effort like the server ring: an empty replay after a long absence means "do one full state fetch".
- **`seq` on every event** — the page tracks its high-water mark (e.g. in `sessionStorage`, which survives the hide→unmount→reopen cycle same-origin) and re-subscribes with it on next mount. Poll fallback can be dropped on hosts that send `seq`.
- **`background: true` — hidden delivery.** Per-view, per-subscribe opt-in: App keeps that view mounted (display-swapped, the ChatSlot #613 pattern — reopening never reloads the iframe) when another surface is active. Session-scoped (`uiStore.pluginBackground`, partialized out of persistence). The unmount + notification-dot default is unchanged for everyone else; `background: false` opts back out; omitting the field never changes the mode.

The relay's pure half (subscribe parsing, replay ordering, seq dedupe) is extracted to `lib/pluginEventRelay.ts` for unit testing; `PluginView` only wires postMessage to it.

## Tests

- **vitest** (+14, 318 total): `pluginEventRelay.test.ts` (parse validation, replay order/filtering, replay-then-live no-drop/no-dupe, page-authoritative re-subscribe, seq-less frames) and `events.test.ts` additions (listener seq arg, `replaySince` windowing, ring cap drop-oldest).
- **e2e** (+2, 188 total, all green): mock bus frames now carry a monotonic `seq`; the mock plugin page subscribes `{since: 0}` and records delivered seqs. One spec proves ring replay on reopen (an already-emitted seq can only reach a fresh iframe via replay) + uniqueness/ordering; the other proves `background: true` keeps the iframe mounted, hidden, and receiving, and that reopening doesn't reload it.

## Docs

- `docs/guides/building-react-plugin-views.md` — new "Replay and hidden delivery" section: `since`/`seq`/`background`, the recommended high-water-mark pattern (with the sessionStorage snippet), retention caveats, and old-host detection (no `seq` ⇒ keep the poll).
- `docs/adr/0039-plugin-event-bus.md` — Tier-2 amendment note.
- CHANGELOG under [Unreleased].

No Python changes — the bus already retains + serves `since`; replay reuses the console client's own machinery (no extra server fetch).

## Gates

- `npm run test:unit --workspace @protoagent/web` — 318 passed
- `npm run build --workspace @protoagent/web` — green (tsc + vite)
- `npx playwright test` (fresh dist) — 188 passed
- `npm run docs:build` — green
- Rebased onto origin/main after sibling merges (#1658/#1659/#1661); gates re-run post-rebase.

## Manual test plan (please verify locally — this PR stays draft)

Use the dev instance (`scripts/dev.sh`, :7871) with any plugin that has a console view (spacetraders dashboard is the motivating case), or quickly with the in-tree notes/docs plugin + devtools:

1. **seq on events**: open a plugin view, in its iframe console run
   `window.addEventListener("message", e => e.data?.type === "protoagent:event" && console.log(e.data.topic, e.data.seq));`
   then `parent.postMessage({type:"protoagent:subscribe", patterns:["#"]}, "*")`. Trigger any bus event (e.g. send a chat message → `activity.*`). Every logged event should carry an increasing `seq`.
2. **Replay**: note the last seq N. Switch to Chat, trigger a few more events, reopen the view, and in the fresh iframe run the listener plus
   `parent.postMessage({type:"protoagent:subscribe", patterns:["#"], since: N}, "*")`.
   → the events you missed while hidden arrive immediately (seqs N+1…), followed by live ones, no duplicates.
3. **Background delivery**: in the visible view run
   `parent.postMessage({type:"protoagent:subscribe", patterns:["#"], background: true}, "*")`,
   switch to Chat → in the top-level devtools, `document.querySelector(".plugin-view-frame")` still exists (hidden). Trigger events, reopen the view → the iframe was NOT reloaded (console log history intact) and logged events during the hidden window.
4. **Default unchanged**: with a plain `{patterns}` subscribe, switching away unmounts the iframe and unseen `<plugin>.*` events still light the rail dot; reopening loads a fresh page.
5. **spacetraders v1.7 dashboard** (real-world): with this console build, the dashboard's event bridge works as before (no `since` sent yet — its 60s poll still covers gaps until the plugin adopts the new fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin views can now keep receiving updates in the background while hidden.
  * Reopening a plugin view now restores missed events instead of starting over.

* **Bug Fixes**
  * Improved event delivery so replayed and live updates are not duplicated.
  * Event history is now preserved more reliably for recent updates.

* **Documentation**
  * Updated plugin view guidance to cover event replay and hidden background delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->