### PR TITLE
fix(hitl): parallel gated tool calls — resume interrupts by id, skip answered ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `report` once terminal) instead of reaching into `STATE.background_mgr` directly.
 
 ### Fixed
+- **Parallel approval-gated tool calls no longer crash the resume.** The model is free
+  to call two gated tools (`run_command` approvals, `request_user_input` forms) in one
+  assistant turn; both `interrupt()` concurrently, and answering the surfaced one then
+  died with LangGraph's `RuntimeError: When there are multiple pending interrupts, you
+  must specify the interrupt id when resuming`. Resumes now carry the id-keyed form
+  (`Command(resume={interrupt_id: answer})`) targeting exactly the surfaced interrupt,
+  and pending-interrupt detection skips tasks that already completed — a super-step
+  doesn't commit until all its parallel tasks finish, so an already-answered interrupt
+  otherwise resurfaces and loops the operator on a question they answered. Multiple
+  interrupts drain one at a time: answer the first, the next surfaces.
 - **Re-installing a plugin from its own origin converges instead of erroring.**
   `plugin install` of an already-installed plugin from the SAME recorded source is
   now a no-op at the same commit (`up_to_date` in the summary) and an in-place

--- a/server/chat.py
+++ b/server/chat.py
@@ -372,36 +372,60 @@ def _interrupt_payload(val) -> dict:
     return {"question": (str(val) if val is not None else "Input required.")}
 
 
-async def _pending_interrupt_value(config: dict):
-    """Return the value of a pending LangGraph interrupt (ask_human / HITL) for
-    this thread, or ``None``. Both chat paths read the same snapshot to detect a
-    turn that paused for human input instead of producing a final answer.
+async def _pending_interrupt(config: dict):
+    """The FIRST pending LangGraph interrupt for this thread as ``(interrupt_id, value)``,
+    or ``None``. Both chat paths read the same snapshot to detect a turn that paused for
+    human input instead of producing a final answer.
 
-    Returns a single value because the graph only ever has one interrupt pending:
-    ``create_agent`` / ``ToolNode`` runs an assistant turn's tool calls SEQUENTIALLY, so the
-    first ask_human / request_user_input ``interrupt()`` halts the tool node before the next
-    tool runs (verified). Multiple HITL calls therefore surface as back-to-back pauses — each
-    drained on its own resume by the lead/autonomous turn loop — not as one batch."""
+    A turn can pend SEVERAL interrupts at once: the tool node runs an assistant turn's
+    tool calls concurrently, so two approval-gated tools called in one turn both hit
+    ``interrupt()`` before either resolves. They drain one at a time — the first is
+    surfaced, the operator's answer resumes exactly that one BY ID (a bare resume with
+    more than one pending is a hard LangGraph error), and the graph re-pauses on the
+    next still-unanswered interrupt, which surfaces on the following pass."""
     try:
         snapshot = await STATE.graph.aget_state(config)
     except Exception:
         return None
-    pending = list(getattr(snapshot, "interrupts", None) or [])
+    # Task-level first, SKIPPING completed tasks: a super-step doesn't commit until all
+    # its parallel tasks finish, so an already-ANSWERED interrupt stays in the snapshot
+    # (its task carries a ``result``) alongside the still-unanswered ones. Surfacing it
+    # again would loop the operator on a question they already answered.
+    pending = []
+    for t in getattr(snapshot, "tasks", ()) or ():
+        if getattr(t, "result", None) is not None:
+            continue
+        pending.extend(getattr(t, "interrupts", ()) or ())
     if not pending:
-        for t in getattr(snapshot, "tasks", ()) or ():
-            pending.extend(getattr(t, "interrupts", ()) or ())
+        # Fallback for snapshot shapes without task-level interrupts.
+        pending = list(getattr(snapshot, "interrupts", None) or [])
     if not pending:
         return None
     if len(pending) > 1:
-        # Tripwire: with sequential tool execution this can't happen. If a LangGraph change
-        # ever makes interrupts pend simultaneously, surfacing only pending[0] would silently
-        # drop the rest — warn loudly so we build real multi-interrupt handling instead.
-        log.warning(
-            "[hitl] %d pending interrupts at once — only the first is surfaced; tool execution "
-            "is expected to be sequential, so this signals a behavior change to handle.",
+        log.info(
+            "[hitl] %d interrupts pending at once (parallel gated tool calls) — surfacing "
+            "one at a time; each resume targets its interrupt id.",
             len(pending),
         )
-    return getattr(pending[0], "value", pending[0])
+    first = pending[0]
+    return (getattr(first, "id", None), getattr(first, "value", first))
+
+
+async def _pending_interrupt_value(config: dict):
+    """Just the pending interrupt's value (the payload the console renders), or ``None``."""
+    found = await _pending_interrupt(config)
+    return None if found is None else found[1]
+
+
+async def _resume_payload(config: dict, resume_value):
+    """What ``Command(resume=…)`` should carry: the id-keyed form ``{interrupt_id: value}``
+    answering exactly the surfaced (first-pending) interrupt. The bare value is only a
+    fallback for an unreadable snapshot / an id-less interrupt — safe there, since with a
+    single pending interrupt both forms are equivalent, and multi-pending implies modern
+    LangGraph whose interrupts always carry ids."""
+    found = await _pending_interrupt(config)
+    iid = found[0] if found else None
+    return {iid: resume_value} if iid else resume_value
 
 
 async def _clear_pending_interrupt(config: dict) -> None:
@@ -468,7 +492,7 @@ async def _run_turn_stream(
         human = HumanMessage(content=message)
 
     graph_input = (
-        Command(resume=resume_value)
+        Command(resume=await _resume_payload(config, resume_value))
         if resume_value is not None
         # Prepend any completed background-job notifications (ADR 0050) so the model
         # learns of detached work that finished since this session last ran a turn.
@@ -1493,7 +1517,7 @@ async def _chat_langgraph(
                 if hold is _HITL_RESUME:
                     from langgraph.types import Command
 
-                    graph_input = Command(resume=message)
+                    graph_input = Command(resume=await _resume_payload(config, message))
                 else:
                     graph_input = {
                         "messages": [HumanMessage(content=message)],

--- a/tests/test_hitl_forms.py
+++ b/tests/test_hitl_forms.py
@@ -185,21 +185,23 @@ async def test_autonomous_turn_force_completes_after_cap(monkeypatch):
     assert len(cleared) == 1  # the stray interrupt was cleared exactly once
 
 
-# ── multiple-pending-interrupt tripwire ───────────────────────────────────────
-# create_agent runs an assistant turn's tool calls sequentially, so only ONE interrupt ever
-# pends; _pending_interrupt_value returns it. If multiple ever pend (a LangGraph behavior
-# change), it warns rather than silently dropping the rest.
+# ── multiple pending interrupts (parallel gated tool calls) ───────────────────
+# The tool node runs an assistant turn's tool calls concurrently, so several interrupts
+# can pend at once. _pending_interrupt surfaces the first UNANSWERED one (a completed
+# task's interrupt must not resurface) with its id, so the resume can target it; the
+# end-to-end drain lives in test_hitl_hold.py.
 
 
 class _FakeInterrupt:
-    def __init__(self, value):
+    def __init__(self, value, id="i-" + "0" * 30):
         self.value = value
+        self.id = id
 
 
 class _FakeSnapshot:
-    def __init__(self, interrupts):
+    def __init__(self, interrupts, tasks=()):
         self.interrupts = interrupts
-        self.tasks = ()
+        self.tasks = tasks
 
 
 class _FakeGraph:
@@ -217,13 +219,42 @@ async def test_single_pending_interrupt_returns_value(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_multiple_pending_interrupts_warn_and_return_first(monkeypatch, caplog):
-    import logging
-
+async def test_multiple_pending_interrupts_return_first_with_id(monkeypatch):
     monkeypatch.setattr(
-        STATE, "graph", _FakeGraph([_FakeInterrupt("first"), _FakeInterrupt("second")]), raising=False
+        STATE,
+        "graph",
+        _FakeGraph([_FakeInterrupt("first", id="aaa"), _FakeInterrupt("second", id="bbb")]),
+        raising=False,
     )
-    with caplog.at_level(logging.WARNING, logger="protoagent.server"):
-        val = await chat_mod._pending_interrupt_value({"configurable": {"thread_id": "t"}})
-    assert val == "first"  # still surfaces the first; never drops silently or raises
-    assert any("pending interrupts at once" in r.getMessage() for r in caplog.records)
+    cfg = {"configurable": {"thread_id": "t"}}
+    assert await chat_mod._pending_interrupt_value(cfg) == "first"  # never drops silently or raises
+    assert await chat_mod._pending_interrupt(cfg) == ("aaa", "first")
+    # …and the resume payload targets exactly that interrupt, by id.
+    assert await chat_mod._resume_payload(cfg, "yes") == {"aaa": "yes"}
+
+
+class _FakeTask:
+    def __init__(self, interrupts, result=None):
+        self.interrupts = interrupts
+        self.result = result
+
+
+@pytest.mark.asyncio
+async def test_answered_interrupt_does_not_resurface(monkeypatch):
+    """A super-step doesn't commit until ALL its parallel tasks finish, so an already-
+    answered interrupt stays in the snapshot next to the unanswered one — its task
+    carries a ``result``. Surfacing must skip it, else the operator loops on a
+    question they already answered."""
+    answered = _FakeTask([_FakeInterrupt("first", id="aaa")], result={"messages": []})
+    waiting = _FakeTask([_FakeInterrupt("second", id="bbb")])
+    graph = _FakeGraph([_FakeInterrupt("first", id="aaa"), _FakeInterrupt("second", id="bbb")])
+    graph._snapshot_tasks = (answered, waiting)
+
+    async def aget_state(config):
+        return _FakeSnapshot(graph._interrupts, tasks=graph._snapshot_tasks)
+
+    graph.aget_state = aget_state
+    monkeypatch.setattr(STATE, "graph", graph, raising=False)
+    cfg = {"configurable": {"thread_id": "t"}}
+    assert await chat_mod._pending_interrupt(cfg) == ("bbb", "second")
+    assert await chat_mod._resume_payload(cfg, "us-east-1") == {"bbb": "us-east-1"}

--- a/tests/test_hitl_hold.py
+++ b/tests/test_hitl_hold.py
@@ -282,3 +282,55 @@ async def test_nonstreaming_chat_holds_and_resumes(monkeypatch):
         i for i, m in enumerate(history) if isinstance(m, HumanMessage) and "typed while form open" in str(m.content)
     )
     assert tool_idx < fold_idx
+
+
+# ── parallel gated tool calls: several interrupts pend at once, drain by id ───
+
+
+def _two_form_calls() -> AIMessage:
+    """One assistant turn calling ``request_user_input`` TWICE — the tool node runs a
+    turn's tool calls concurrently, so BOTH interrupts pend at once. Resuming bare
+    (no interrupt id) in that state is a hard LangGraph RuntimeError."""
+
+    def call(cid: str, title: str) -> dict:
+        return {
+            "name": "request_user_input",
+            "args": {"title": title, "steps": _FORM_STEPS},
+            "id": cid,
+            "type": "tool_call",
+        }
+
+    return AIMessage(content="", tool_calls=[call("c1", "Pick env"), call("c2", "Pick region")])
+
+
+async def _pending_count(session_id: str) -> int:
+    snap = await STATE.graph.aget_state(_cfg(session_id))
+    pend = list(getattr(snap, "interrupts", None) or [])
+    if not pend:
+        for t in getattr(snap, "tasks", ()) or ():
+            pend.extend(getattr(t, "interrupts", ()) or ())
+    return len(pend)
+
+
+@pytest.mark.asyncio
+async def test_parallel_interrupts_drain_one_at_a_time_by_id(monkeypatch):
+    sid = "multi-1"
+    _install_graph(monkeypatch, [_two_form_calls(), AIMessage(content="Both picked.")])
+
+    # Turn 1: both gated tools interrupt concurrently — TWO pending; the first surfaces.
+    frames = await _frames("configure the deploy", sid)
+    assert frames[-1][0] == "input_required"
+    assert frames[-1][1].get("title") == "Pick env"
+    assert await _pending_count(sid) == 2
+
+    # Answer 1 resumes exactly the surfaced interrupt BY ID — a bare resume here is
+    # "RuntimeError: When there are multiple pending interrupts, you must specify the
+    # interrupt id". The still-unanswered second interrupt surfaces on the next pass.
+    frames = await _frames('{"env": "prod"}', sid, request_metadata={"hitl_resume": True})
+    assert frames[-1][0] == "input_required"
+    assert frames[-1][1].get("title") == "Pick region"
+
+    # Answer 2 drains the last interrupt; the turn completes normally.
+    frames = await _frames('{"env": "us-east-1"}', sid, request_metadata={"hitl_resume": True})
+    assert any(kind == "done" for kind, _ in frames)
+    assert await chat_mod._pending_interrupt_value(_cfg(sid)) is None


### PR DESCRIPTION
## The crash

The model can call two approval-gated tools in one assistant turn (parallel tool calls). Both hit `interrupt()` concurrently → two pending interrupts. The console surfaces the first approval; the operator answers; the resume sent a bare `Command(resume=answer)` → current LangGraph hard-errors:

```
RuntimeError: When there are multiple pending interrupts, you must specify the interrupt id when resuming.
```

Hit live on a Portfolio Manager member (session `chat-1782981216015-3xd8vp`): roxy issued two `run_command` calls in one turn while debugging a failed `portfolio_spinup_team`; approving one killed the a2a-stream turn. The code's own tripwire predicted this: *"tool execution is expected to be sequential, so this signals a behavior change to handle"* — the behavior change arrived.

## The fix

1. **Resume by id** — `_resume_payload()` builds `Command(resume={interrupt_id: answer})` targeting exactly the surfaced interrupt (both resume sites: streaming + non-streaming fallback). Bare resume only remains as the id-less fallback, where it's equivalent.
2. **Skip answered interrupts when surfacing** — a super-step doesn't commit until ALL its parallel tasks finish, so an already-answered interrupt stays in `snapshot.interrupts` (and `snapshot.tasks`) next to the unanswered one; its task carries a `result`. Without the filter, the operator loops forever on the first question (verified against langgraph 1.2.4 with a minimal two-`Send` repro). `_pending_interrupt()` now aggregates from result-less tasks first.
3. The tripwire warning becomes handled behavior: interrupts **drain one at a time** — answer the first, the next surfaces as its own input_required pause. Works for operator turns and the autonomous auto-answer loop alike.

## Tests

- `test_parallel_interrupts_drain_one_at_a_time_by_id` — end-to-end through `_chat_langgraph_stream` with a real graph + two `request_user_input` calls in one turn: two pending at once, answer→second surfaces→answer→done. (Crashes with RuntimeError before the fix.)
- `test_multiple_pending_interrupts_return_first_with_id` + `test_answered_interrupt_does_not_resurface` — the helper contracts, incl. the completed-task filter.
- Replaces `test_multiple_pending_interrupts_warn_and_return_first` (the tripwire is now handled behavior).

39 chat/HITL tests pass; ruff clean; CHANGELOG under [Unreleased].

🤖 Generated with [Claude Code](https://claude.com/claude-code)