### PR TITLE
feat(console): subagent descriptions in the panel + kind badges in the slash palette (#1660)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **The console now says what each subagent does** (#1660). The Runtime → Subagents
+  panel shows every subagent's plain-language description (from the registry — the
+  same text the lead agent reads) under its name, and the composer's slash palette
+  badges each server command with its kind (`subagent` / `workflow` / `skill` /
+  `plugin`) and prefers the description over the bare usage line — so "what does
+  /antagonist do?" is answered at the point of use, before picking it.
 - **Plugin metric timeseries — `sdk.record_metric` / `metric_history` / `metric_last`**
   (#1632). Plugins with background engines need small named numeric series (treasury,
   net worth, fleet size) for history-dependent watch verifiers (ADR 0067

--- a/apps/web/src/app/SubagentsPanel.tsx
+++ b/apps/web/src/app/SubagentsPanel.tsx
@@ -24,6 +24,7 @@ function SubagentsBody() {
             <div className="subagent-row" key={subagent.name}>
               <div>
                 <strong>{subagent.name}</strong>
+                <span className="subagent-desc">{subagent.description}</span>
                 <span>{subagent.tools.join(", ") || "no tools"}</span>
               </div>
               <StatusPill label={`${subagent.max_turns} turns`} tone={subagent.enabled ? "success" : "muted"} />

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1171,6 +1171,19 @@ textarea {
   font-size: 13px;
 }
 
+/* What the subagent DOES (#1660) — plain prose (not the mono tools line), clamped:
+   the registry descriptions are written for the model and run several sentences. */
+.subagent-row span.subagent-desc {
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .notes-editor {
   height: 100%;
   border: 0;

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1553,8 +1553,13 @@ function ChatSessionSlot({
                   onMouseEnter={() => setSlashIndex(index)}
                   onClick={() => completeCommand(cmd)}
                 >
-                  <span className="slash-name">/{cmd.name}</span>
-                  <span className="slash-desc">{cmd.usage || cmd.description}</span>
+                  <span className="slash-title">
+                    <span className="slash-name">/{cmd.name}</span>
+                    {cmd.kind ? (
+                      <span className="slash-kind">{cmd.kind === "plugin_command" ? "plugin" : cmd.kind}</span>
+                    ) : null}
+                  </span>
+                  <span className="slash-desc">{cmd.description || cmd.usage}</span>
                 </button>
               ))}
             </div>

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -471,9 +471,28 @@
   font-size: 13px;
   color: var(--brand-violet-light);
 }
+.slash-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.slash-kind {
+  flex: 0 0 auto;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+}
 .slash-desc {
   font-size: 11px;
   color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Delete-chat dialog: the opt-in harvest checkbox (harvest is never automatic). */

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -242,6 +242,10 @@ export type SlashCommand = {
   name: string;
   description: string;
   usage?: string;
+  // What the token dispatches to (server-resolved: "workflow" | "subagent" | "skill" |
+  // "plugin_command"…) — shown as a badge in the composer palette so the operator knows
+  // what kind of thing /name runs (#1660). Client-registered commands carry none.
+  kind?: string;
 };
 
 export type SettingsField = {


### PR DESCRIPTION
Closes #1660.

## What

1. **Runtime → Subagents panel**: each row now shows the subagent's plain-language description (the registry text the lead agent already reads — the API has always returned it; the panel just never rendered it). Clamped to two lines.
2. **Composer slash palette**: every server-resolved command gets a **kind badge** (`subagent` / `workflow` / `skill` / `plugin`), and the second line prefers the **description** over the bare usage string — so you know what a command is and does before picking it. Client-registered commands (`/new`, `/clear`, `/effort`) are unbadged core verbs.

No server changes — `kind` + `description` were already in the commands payload; the client type just dropped `kind`.

Context: we considered removing subagents from the palette entirely (they're also invokable via the lead's `task` delegation), but kept them with explicit labeling instead — some (antagonist, verifier, synthesizer) read as research-pipeline internals, and a `user_facing` registry flag to hide those from the palette is a possible follow-up.

## Verified

323 web unit tests pass; console builds clean; e2e palette assertions (`.slash-name`/`.slash-item`) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)