### PR TITLE
chore: release v0.82.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.82.0] - 2026-07-02
+
 ### Added
 - **The console now says what each subagent does** (#1660). The Runtime → Subagents
   panel shows every subagent's plain-language description (from the registry — the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.81.0"
+version = "0.82.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,23 @@
 [
   {
+    "version": "v0.82.0",
+    "date": "2026-07-02",
+    "changes": [
+      "The console now says what each subagent does",
+      "Plugin metric timeseries — sdk.record_metric / metric_history / metric_last",
+      "Typed event contracts — emits: entries can declare payload schemas",
+      "Knowledge lifecycle — sdk.knowledge_purge + epoch scoping",
+      "Plugin-view event bridge: replay-on-subscribe + hidden delivery",
+      "graph.sdk.react_on — reactive-rule sugar",
+      "Plugins own their recurring cadence — and it dies with them",
+      "Plugins can now enumerate and remove watches",
+      "graph.sdk.spawn_background + graph.sdk.background_status",
+      "Parallel approval-gated tool calls no longer crash the resume.",
+      "Re-installing a plugin from its own origin converges instead of erroring.",
+      "Testkit FakeRegistry now mirrors the full PluginRegistry surface"
+    ]
+  },
+  {
     "version": "v0.81.0",
     "date": "2026-07-02",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.82.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.82.0 -m 'Release v0.82.0' && git push origin v0.82.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).