### PR TITLE
fix(plugins): release-tag pins see newer releases + Update moves the pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Release-tag-pinned plugins now see updates.** The update check ls-remoted the
+  SAME tag a plugin was installed at — tags are immutable, so a tag-pinned plugin
+  (every pm-stack member) could never report "behind" and the console never offered
+  an Update. A `vX.Y.Z` pin now scans the remote's tags for a **newer semver
+  release** (numeric ordering, peeled SHAs, prereleases ignored) and reports it as
+  `latest_ref`; the Update action installs that tag instead of pointlessly
+  re-fetching the recorded one. A force-moved tag still reads as behind, and
+  branch-ref plugins are unchanged.
+
 ## [0.82.0] - 2026-07-02
 
 ### Added

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -216,12 +216,15 @@ export type McpCatalogEntry = {
 // the network; the rest ls-remote their ref. `behind` ⇒ the recorded
 // `current_sha` lags `latest_sha`; a per-entry `error` is non-fatal (the check
 // failed, the row stays usable). `latest_sha` is null when pinned or on error.
+// `latest_ref` is set when a release-tag pin has a NEWER semver tag to move to
+// (the update installs that tag); null for branch refs / moved-tag cases.
 export type PluginUpdate = {
   id: string;
   behind: boolean;
   pinned: boolean;
   current_sha: string;
   latest_sha: string | null;
+  latest_ref?: string | null;
   error?: string | null;
 };
 

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -88,7 +88,7 @@ function PluginRow({
               variant="ghost"
               loading={updating}
               onClick={() => onUpdate(p)}
-              title={`Update ${p.name} to the latest commit`}
+              title={update.latest_ref ? `Update ${p.name} to ${update.latest_ref}` : `Update ${p.name} to the latest commit`}
               aria-label={`Update ${p.name}`}
             >
               <RefreshCw size={15} />

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -826,12 +826,64 @@ def _ls_remote_sha(source_url: str, ref: str) -> str:
     return sha
 
 
+# A release tag per the ADR 0049 pin lifecycle — `v1.2.3` / `1.2.3`. Prereleases and
+# anything fancier deliberately don't match (they fall back to the moving-ref compare).
+_SEMVER_TAG_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
+
+
+def _semver_key(tag: str) -> tuple[int, int, int] | None:
+    """``(major, minor, patch)`` for a release tag, or ``None`` if not one."""
+    m = _SEMVER_TAG_RE.match((tag or "").strip())
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3))) if m else None
+
+
+def is_release_tag(ref: str) -> bool:
+    """True when ``ref`` is a semver release tag (``v1.2.3`` / ``1.2.3``) — the pin
+    shape whose update moves tag → NEWER tag instead of re-fetching the same ref."""
+    return _semver_key(ref) is not None
+
+
+# `git ls-remote --tags` cache — same TTL/timeout regime as _lsremote_cache, its own
+# dict because the value is a {tag: sha} map, not a single sha.
+_lstags_cache: dict[str, tuple[float, dict[str, str]]] = {}
+
+
+def _ls_remote_tags(source_url: str) -> dict[str, str]:
+    """``{tag: commit_sha}`` for every tag at ``source_url`` (TTL-cached, one
+    timeout-bounded ``ls-remote --tags``). An annotated tag lists twice — the bare
+    ref (tag-object SHA) and the peeled ``<ref>^{}`` (commit SHA); the peeled one
+    wins, mirroring _ls_remote_sha's compare semantics (ADR 0049)."""
+    now = time.monotonic()
+    hit = _lstags_cache.get(source_url)
+    if hit is not None and (now - hit[0]) < _LSREMOTE_TTL_S:
+        return hit[1]
+    out = _git("ls-remote", "--tags", source_url, timeout=_LSREMOTE_TIMEOUT_S)
+    tags: dict[str, str] = {}
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 2 or not parts[0].strip():
+            continue
+        sha, ref = parts[0].strip(), parts[1].strip()
+        if not ref.startswith("refs/tags/"):
+            continue
+        name = ref[len("refs/tags/") :]
+        if name.endswith("^{}"):
+            tags[name[:-3]] = sha  # peeled commit — overwrite the tag-object sha
+        else:
+            tags.setdefault(name, sha)
+    _lstags_cache[source_url] = (now, tags)
+    return tags
+
+
 def check_plugin_update(entry: dict) -> dict:
     """Update status for one ``plugins.lock`` entry. A *pinned* plugin (its
     ``requested_ref`` is a full/abbrev commit SHA per ``_SHA_RE``) never
-    auto-updates — we skip the network call entirely. Otherwise compare the
-    stored ``resolved_sha`` against the latest remote SHA for its ref. Any
-    network/timeout/lookup failure is reported in ``error`` (non-fatal)."""
+    auto-updates — we skip the network call entirely. A RELEASE-TAG ref
+    (``vX.Y.Z``) is immutable, so "behind" there means a NEWER semver tag exists
+    on the remote (reported as ``latest_ref`` — the pin-lifecycle signal, ADR
+    0049) — with a moved-tag compare as the fallback. Any other ref compares the
+    stored ``resolved_sha`` against the latest remote SHA. Any network/timeout/
+    lookup failure is reported in ``error`` (non-fatal)."""
     pid = entry.get("id", "")
     source_url = entry.get("source_url", "")
     requested_ref = entry.get("requested_ref", "") or ""
@@ -844,6 +896,7 @@ def check_plugin_update(entry: dict) -> dict:
         "requested_ref": requested_ref,
         "current_sha": current_sha,
         "latest_sha": None,
+        "latest_ref": None,
         "behind": False,
         "pinned": pinned,
         "error": None,
@@ -853,8 +906,24 @@ def check_plugin_update(entry: dict) -> dict:
             result["error"] = "no source_url recorded — cannot check for updates"
         return result
 
+    tag_key = _semver_key(requested_ref)
     try:
-        latest = _ls_remote_sha(source_url, requested_ref)
+        if tag_key is not None:
+            tags = _ls_remote_tags(source_url)
+            newest_key, newest = tag_key, None
+            for name, sha in tags.items():
+                k = _semver_key(name)
+                if k is not None and k > newest_key:
+                    newest_key, newest = k, (name, sha)
+            if newest is not None:
+                result["latest_ref"], result["latest_sha"] = newest
+                result["behind"] = True
+                return result
+            # No newer release — fall through to the moved-tag compare: the SAME
+            # tag re-pointed at a different commit still counts as behind.
+            latest = tags.get(requested_ref, "")
+        else:
+            latest = _ls_remote_sha(source_url, requested_ref)
     except subprocess.TimeoutExpired:
         result["error"] = f"ls-remote timed out after {_LSREMOTE_TIMEOUT_S:.0f}s"
         return result

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -358,13 +358,16 @@ def register_plugin_routes(app) -> None:
 
     @app.post("/api/plugins/{plugin_id}/update")
     async def _update(plugin_id: str):
-        """Pull the latest code for an installed plugin at its recorded ref, then
-        hot-reload via the SAME path the enable toggle uses so the new code mounts.
+        """Pull the latest code for an installed plugin, then hot-reload via the
+        SAME path the enable toggle uses so the new code mounts.
 
-        Re-installs ``source_url`` at ``requested_ref`` (force) — this rewrites the
-        lock with the new ``resolved_sha``. If the plugin is currently ENABLED we
-        reload (so tools/middleware/MCP rebuild and the router re-mounts, #822); if
-        it's installed-but-disabled we just re-install (nothing to reload yet).
+        The target ref is the update check's ``latest_ref`` when one exists (a
+        release-tag pin moves tag → newer tag; re-installing the RECORDED tag would
+        be a no-op forever — tags are immutable), else the recorded ``requested_ref``
+        (a branch pulls its newest commit). Rewrites the lock with the new ref +
+        ``resolved_sha``. If the plugin is currently ENABLED we reload (so tools/
+        middleware/MCP rebuild and the router re-mounts, #822); if it's
+        installed-but-disabled we just re-install (nothing to reload yet).
         """
         entry = next((e for e in installer.list_installed() if e.get("id") == plugin_id), None)
         if entry is None:
@@ -376,6 +379,15 @@ def register_plugin_routes(app) -> None:
                 detail=f"plugin {plugin_id!r} has no source_url — cannot update",
             )
         ref = entry.get("requested_ref", "") or None
+        if ref and installer.is_release_tag(ref):
+            # A release-tag pin is immutable — the update target is the newest
+            # semver tag (the check's latest_ref), not the recorded one. Branch
+            # refs skip this: re-installing the branch already pulls its head.
+            try:
+                status = await asyncio.to_thread(installer.check_plugin_update, entry)
+                ref = status.get("latest_ref") or ref
+            except Exception:  # noqa: BLE001 — best-effort; fall back to the recorded ref
+                pass
         try:
             summary = await asyncio.to_thread(
                 installer.install, source_url, ref, force=True, by="console", allow=_sources_allowlist()

--- a/tests/test_plugin_updates.py
+++ b/tests/test_plugin_updates.py
@@ -24,10 +24,12 @@ _LATEST = "b" * 40
 
 @pytest.fixture(autouse=True)
 def _clear_cache():
-    """The ls-remote TTL cache is module-level — wipe it around every test."""
+    """The ls-remote TTL caches are module-level — wipe them around every test."""
     installer._lsremote_cache.clear()
+    installer._lstags_cache.clear()
     yield
     installer._lsremote_cache.clear()
+    installer._lstags_cache.clear()
 
 
 def _lock(monkeypatch, plugins: list[dict], *, bundles: list[dict] | None = None):
@@ -130,9 +132,9 @@ def test_empty_ref_uses_head(monkeypatch):
 
 
 def test_annotated_tag_compares_peeled_commit(monkeypatch):
-    """An ANNOTATED tag's bare refspec resolves to the tag-object SHA — never equal
-    to the lock's commit SHA, so the naive compare reported a permanent false
-    "behind" (ADR 0049). The peeled ``<ref>^{}`` line must win the compare."""
+    """An ANNOTATED tag lists twice in ``ls-remote --tags`` — the bare ref (tag-object
+    SHA, never equal to the lock's commit SHA) and the peeled ``^{}`` line. The peeled
+    commit must win the moved-tag compare (ADR 0049), else a permanent false "behind"."""
     tag_object = "c" * 40
     _lock(
         monkeypatch,
@@ -150,13 +152,14 @@ def test_annotated_tag_compares_peeled_commit(monkeypatch):
     row = installer.check_updates()[0]
     assert row["latest_sha"] == _CUR
     assert row["behind"] is False
-    # both the bare and the peeled refspec are requested in ONE ls-remote call
-    assert seen[0] == ("ls-remote", "https://x/y.git", "v1.2.3", "v1.2.3^{}")
+    # a release-tag pin lists the remote's TAGS (one call) instead of ls-remoting
+    # the immutable tag itself — that's what makes newer releases visible at all
+    assert seen[0] == ("ls-remote", "--tags", "https://x/y.git")
 
 
-def test_lightweight_tag_or_branch_falls_back_to_bare_line(monkeypatch):
-    """A branch / lightweight tag matches only the bare refspec — no peeled line —
-    and the compare keeps working off it."""
+def test_moved_lightweight_tag_still_reads_as_behind(monkeypatch):
+    """No NEWER release, but the SAME tag re-pointed at a different commit (a
+    force-moved lightweight tag) — the moved-tag compare stays in force."""
     _lock(
         monkeypatch,
         [
@@ -167,6 +170,47 @@ def test_lightweight_tag_or_branch_falls_back_to_bare_line(monkeypatch):
     row = installer.check_updates()[0]
     assert row["latest_sha"] == _LATEST
     assert row["behind"] is True
+    assert row["latest_ref"] is None  # same tag, new commit — not a tag move
+
+
+def test_release_tag_pin_reports_newer_semver_tag(monkeypatch):
+    """The pin-lifecycle signal (ADR 0049): a release-tag pin is 'behind' when a NEWER
+    semver tag exists — the immutable tag itself can never show it. Ordering is
+    numeric (v0.14.10 > v0.14.3), peeled SHAs win, prerelease/junk tags are ignored."""
+    _lock(
+        monkeypatch,
+        [
+            {"id": "demo", "source_url": "https://x/y.git", "requested_ref": "v0.14.2", "resolved_sha": _CUR},
+        ],
+    )
+    out = "\n".join(
+        [
+            f"{_CUR}\trefs/tags/v0.14.2",
+            f"{'d' * 40}\trefs/tags/v0.14.3",
+            f"{'e' * 40}\trefs/tags/v0.14.10",  # annotated: tag object…
+            f"{_LATEST}\trefs/tags/v0.14.10^{{}}",  # …and the peeled commit, which wins
+            f"{'f' * 40}\trefs/tags/v0.15.0-rc1",  # prerelease — not a release tag
+            f"{'0' * 40}\trefs/tags/nightly",  # non-semver — ignored
+        ]
+    )
+    monkeypatch.setattr(installer, "_git", lambda *a, **k: out)
+    row = installer.check_updates()[0]
+    assert row["behind"] is True
+    assert row["latest_ref"] == "v0.14.10"
+    assert row["latest_sha"] == _LATEST
+
+
+def test_release_tag_pin_with_no_newer_tag_is_up_to_date(monkeypatch):
+    _lock(
+        monkeypatch,
+        [
+            {"id": "demo", "source_url": "https://x/y.git", "requested_ref": "v0.14.2", "resolved_sha": _CUR},
+        ],
+    )
+    monkeypatch.setattr(installer, "_git", lambda *a, **k: f"{_CUR}\trefs/tags/v0.14.2")
+    row = installer.check_updates()[0]
+    assert row["behind"] is False
+    assert row["latest_ref"] is None
 
 
 def test_error_when_ls_remote_fails(monkeypatch):
@@ -372,6 +416,71 @@ def test_update_route_reinstalls_and_reloads(monkeypatch):
     assert install_calls == [("https://x/y.git", "main", True)]
     # reloaded via the same _apply_settings_changes path the enable route uses
     assert captured["config"]["plugins"]["enabled"] == ["demo"]
+
+
+def test_update_route_moves_a_release_tag_pin_to_the_newest_tag(monkeypatch):
+    """A tag-pinned plugin (requested_ref vX.Y.Z) must update to the check's
+    ``latest_ref`` — re-installing the RECORDED tag is a no-op forever (immutable)."""
+    _lock(
+        monkeypatch,
+        [
+            {
+                "id": "demo",
+                "source_url": "https://x/y.git",
+                "requested_ref": "v0.14.2",
+                "resolved_sha": _CUR,
+                "present": True,
+            },
+        ],
+    )
+    monkeypatch.setattr(installer, "live_plugins_dir", lambda: __import__("pathlib").Path("/tmp/none"))
+    _wire_state(monkeypatch, enabled=[], disabled=[], meta=[{"id": "demo", "views": []}])
+    monkeypatch.setattr(
+        installer,
+        "check_plugin_update",
+        lambda e: {"id": "demo", "behind": True, "latest_ref": "v0.14.3", "latest_sha": _LATEST},
+    )
+
+    install_calls: list = []
+
+    def _install(url, ref=None, *, force=False, by="cli", allow=None):
+        install_calls.append((url, ref, force))
+        return {"id": "demo", "version": "0.14.3", "resolved_sha": _LATEST}
+
+    monkeypatch.setattr(installer, "install", _install)
+
+    body = _client().post("/api/plugins/demo/update").json()
+    assert body["ok"] is True and body["version"] == "0.14.3"
+    assert install_calls == [("https://x/y.git", "v0.14.3", True)]
+
+
+def test_update_route_tag_pin_without_newer_tag_reinstalls_recorded(monkeypatch):
+    """No newer release (or the check errored) → fall back to the recorded tag."""
+    _lock(
+        monkeypatch,
+        [
+            {
+                "id": "demo",
+                "source_url": "https://x/y.git",
+                "requested_ref": "v0.14.2",
+                "resolved_sha": _CUR,
+                "present": True,
+            },
+        ],
+    )
+    monkeypatch.setattr(installer, "live_plugins_dir", lambda: __import__("pathlib").Path("/tmp/none"))
+    _wire_state(monkeypatch, enabled=[], disabled=[], meta=[{"id": "demo", "views": []}])
+    monkeypatch.setattr(installer, "check_plugin_update", lambda e: {"id": "demo", "behind": False, "latest_ref": None})
+
+    install_calls: list = []
+
+    def _install(url, ref=None, *, force=False, by="cli", allow=None):
+        install_calls.append((url, ref, force))
+        return {"id": "demo", "version": "0.14.2", "resolved_sha": _CUR}
+
+    monkeypatch.setattr(installer, "install", _install)
+    assert _client().post("/api/plugins/demo/update").json()["ok"] is True
+    assert install_calls == [("https://x/y.git", "v0.14.2", True)]
 
 
 def test_update_route_disabled_plugin_reinstalls_without_reload(monkeypatch):


### PR DESCRIPTION
## The bug

`check_plugin_update` ls-remoted the **same tag** a plugin was installed at. Tags are immutable, so a tag-pinned plugin could **never** report `behind` — and the whole pm-stack installs by release tag (ADR 0049), so portfolio v0.14.2 / project_board v0.24.0 sat silently outdated with v0.14.3 / v0.25.0 released and no Update button in the console. Worse, the Update action re-installed `requested_ref` — the recorded tag — so even a manual update was a permanent no-op for tag pins.

## The fix

1. **Check**: a `vX.Y.Z` pin lists the remote's tags (one TTL-cached, timeout-bounded `ls-remote --tags`) and reports the newest semver release as `latest_ref` + `latest_sha`. Numeric ordering (`v0.14.10 > v0.14.3`), peeled SHAs win for annotated tags, prereleases/non-semver tags ignored. No newer tag → the existing **moved-tag compare** still applies (a force-moved tag reads as behind). Branch refs keep the old path untouched.
2. **Update**: `POST /api/plugins/{id}/update` on a release-tag pin installs `latest_ref` — the pin moves tag → newer tag, exactly like the bundle bump lifecycle.
3. **Console**: the update tooltip names the target version when known (`Update Portfolio to v0.14.3`).

## Tests

56 pass across `test_plugin_updates.py` + `test_plugin_installer.py` — new: newer-tag detection (ordering/peeled/prerelease), tag-pin up-to-date, moved-lightweight-tag, and two route tests (update installs `latest_ref`; falls back to the recorded tag when none). The two prior semver-tag tests were updated to the tags-listing contract (their peeled-compare intent preserved). 323 web unit tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin update checks now better recognize newer release-tag versions and show the most relevant update target.
  * The update button tooltip now includes the specific version or tag when available.

* **Bug Fixes**
  * Improved handling for plugins pinned to tags, including cases where a tag has moved.
  * Updates now reinstall the newest matching release tag when one is available, otherwise they use the pinned tag as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->