### PR TITLE
fix(console): one-line background results render as an inline note, not a report card (#1651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **One-line background results render as a compact inline note, not a report card**
+  (#1651). A short single-line success (e.g. "Ingested 'notes.md' → 15 chunk(s)")
+  arrives complete in the completion event — the full-height report card and its
+  Open-report CTA added nothing but bulk. Such results now inject as a
+  success-tinted system note; multi-line, long, truncated, or failed results keep
+  the card (and failures keep their explicit failed lede).
 - **Desktop no longer aborts on launch when a global hotkey is already taken**
   (#1670). Hotkey registration lived in the global-shortcut plugin's init, so a
   hotkey another app owns (Discord, PowerToys, AutoHotkey, …) became a

--- a/apps/web/e2e/report-card.spec.ts
+++ b/apps/web/e2e/report-card.spec.ts
@@ -22,6 +22,11 @@ const FULL = `# ${TITLE}\n\n${FULL_MARKER}\n\nThe untruncated report body.`;
 const SHORT_JOB_ID = "bg-abcdefabcd99";
 const SHORT_TITLE = "Quick store check";
 const SHORT_PREVIEW = "All 4 stores match the drive.\n\nNothing to fix.";
+// A ONE-LINE success skips the card entirely (#1651): the preview IS the whole result,
+// so it renders as a compact inline note — no card wrapper, no open-report CTA.
+const NOTE_JOB_ID = "bg-oneliner77";
+const NOTE_TITLE = "ingest youtube video";
+const NOTE_RESULT = "Ingested 'YouTube: uD4-uy0GmHE' → 15 chunk(s)";
 
 test("report card: clamped fading excerpt, Open CTA → docviewer, fetched by id", async ({ page }) => {
   // An open chat session whose id matches the job's origin_session — BackgroundWatch
@@ -63,6 +68,16 @@ test("report card: clamped fading excerpt, Open CTA → docviewer, fetched by id
         status: "completed",
         description: SHORT_TITLE,
         result: SHORT_PREVIEW,
+      },
+    },
+    {
+      topic: "background.completed",
+      data: {
+        job_id: NOTE_JOB_ID,
+        origin_session: SESSION,
+        status: "completed",
+        description: NOTE_TITLE,
+        result: NOTE_RESULT,
       },
     },
   ];
@@ -130,6 +145,14 @@ test("report card: clamped fading excerpt, Open CTA → docviewer, fetched by id
       return s.maskImage === "none" ? "" : s.maskImage || s.webkitMaskImage || "";
     }),
   ).not.toContain("linear-gradient");
+
+  // A ONE-LINE success renders as a compact inline note (#1651): the desc + result
+  // in a `.chat-note`, success-tinted, with NO report card and NO open-report CTA.
+  const note = page.locator(".chat-note").filter({ hasText: "15 chunk(s)" });
+  await expect(note).toBeVisible();
+  await expect(note).toContainText(NOTE_TITLE);
+  await expect(note).toHaveClass(/chat-note--success/);
+  await expect(page.locator(".chat-report-card").filter({ hasText: NOTE_TITLE })).toHaveCount(0);
 
   // The CTA opens the document viewer with the FULL report — which only the by-id
   // route serves, so its presence + the recorded hit prove the fetch path.

--- a/apps/web/src/app/BackgroundJobs.test.ts
+++ b/apps/web/src/app/BackgroundJobs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { applyProgress, byRecency, fmtElapsed } from "./background-jobs";
+import { applyProgress, byRecency, fmtElapsed, isShortResult } from "./background-jobs";
 import type { BackgroundJobDTO } from "../lib/types";
 
 function job(p: Partial<BackgroundJobDTO>): BackgroundJobDTO {
@@ -68,5 +68,20 @@ describe("applyProgress", () => {
     // a later frame without output for the same tool keeps the captured value
     p = applyProgress(p, { phase: "tool_end", tool: "web_search", tool_call_id: "tc1" });
     expect(p[0].output).toBe("found 3 results");
+  });
+});
+
+describe("isShortResult", () => {
+  it("one-line untruncated success renders inline", () => {
+    expect(isShortResult("Ingested 'notes.md' → 15 chunk(s)", false)).toBe(true);
+  });
+  it("failures always keep the card", () => {
+    expect(isShortResult("boom", true)).toBe(false);
+  });
+  it("multi-line, long, truncated, and empty results keep the card", () => {
+    expect(isShortResult("line one\nline two", false)).toBe(false);
+    expect(isShortResult("x".repeat(121), false)).toBe(false);
+    expect(isShortResult("short but cut\n\n…_[truncated]_", false)).toBe(false);
+    expect(isShortResult("   ", false)).toBe(false);
   });
 });

--- a/apps/web/src/app/BackgroundWatch.tsx
+++ b/apps/web/src/app/BackgroundWatch.tsx
@@ -2,6 +2,7 @@ import { useToast } from "@protolabsai/ui/overlays";
 import { useEffect } from "react";
 
 import { chatStore } from "../chat/chat-store";
+import { isShortResult } from "./background-jobs";
 import { onTopic } from "../lib/events";
 import { notifyIfHidden } from "../lib/notify";
 import type { ChatMessage } from "../lib/types";
@@ -40,8 +41,14 @@ function markNotified(key: string) {
 
 /** Append a display-only system message to a session IF that session is still open in
  *  this window. Returns false when the chat is gone (the model still learns via drain).
- *  `report` (when set) lets the card open the FULL report in the document viewer. */
-function appendSystem(sessionId: string, content: string, report?: ChatMessage["report"]): boolean {
+ *  `report` (when set) renders the message as the report CARD with an open-full-report
+ *  CTA; without it the message renders as a compact inline note (`noteTone` tints it). */
+function appendSystem(
+  sessionId: string,
+  content: string,
+  report?: ChatMessage["report"],
+  noteTone?: ChatMessage["noteTone"],
+): boolean {
   const session = chatStore.getSnapshot().sessions.find((s) => s.id === sessionId);
   if (!session) return false;
   const msg: ChatMessage = {
@@ -51,6 +58,7 @@ function appendSystem(sessionId: string, content: string, report?: ChatMessage["
     createdAt: Date.now(),
     status: "done",
     ...(report ? { report } : {}),
+    ...(noteTone ? { noteTone } : {}),
   };
   chatStore.updateMessages(sessionId, [...session.messages, msg]);
   return true;
@@ -87,11 +95,16 @@ export function BackgroundWatch() {
       // ADR 0070 D4) — a finished job injects just the result preview as the card's
       // excerpt so the lede isn't duplicated. Failures keep the explicit failed-lede
       // (the card header alone doesn't convey the outcome); no result → lede only.
-      const injected = appendSystem(
-        session,
-        failed && result ? `${header}\n\n${result}` : result || header,
-        jobId ? { jobId, title: desc } : undefined,
-      );
+      // A short one-line success skips the card entirely (#1651): the preview IS the
+      // full result (untruncated), so the open-report CTA adds nothing but bulk —
+      // render it as a compact inline note instead.
+      const injected = isShortResult(result, failed)
+        ? appendSystem(session, `${desc} — ${result.trim()}`, undefined, "success")
+        : appendSystem(
+            session,
+            failed && result ? `${header}\n\n${result}` : result || header,
+            jobId ? { jobId, title: desc } : undefined,
+          );
       toast({
         tone: failed ? "error" : "success",
         title: failed ? "Background task failed" : "Background task finished",

--- a/apps/web/src/app/background-jobs.ts
+++ b/apps/web/src/app/background-jobs.ts
@@ -58,3 +58,19 @@ export function byRecency(a: BackgroundJobDTO, b: BackgroundJobDTO): number {
   const bt = Date.parse(b.completed_at || b.created_at || "") || 0;
   return bt - at;
 }
+
+/** Whether a completed job's result should render as a compact inline note instead of
+ *  the report card (#1651). Short = a successful single line that arrived complete
+ *  (the server truncates previews at 2000 chars with a `…_[truncated]_` suffix, so an
+ *  untruncated one-liner IS the whole result — the card's open-report CTA adds
+ *  nothing). Failures, multi-line, long, or truncated results keep the card. */
+export function isShortResult(result: string, failed: boolean): boolean {
+  const trimmed = result.trim();
+  return (
+    !failed &&
+    trimmed.length > 0 &&
+    trimmed.length <= 120 &&
+    !trimmed.includes("\n") &&
+    !result.includes("…_[truncated]_")
+  );
+}


### PR DESCRIPTION
Closes #1651.

A short single-line success (e.g. `Ingested 'YouTube: …' → 15 chunk(s)`) arrives **complete** in the `background.completed` event — the server only truncates previews past 2000 chars (with a `…_[truncated]_` marker), so for a one-liner the preview *is* the whole result and the report card's Open-report CTA adds nothing but bulk.

**The branch lives at the injection point** (`BackgroundWatch`): `isShortResult()` (≤120 chars · single line · untruncated · not failed) routes the result to the **existing** compact system-note renderer (`.chat-note`, success-tinted, `desc — result`); everything else keeps the card, and failures keep their explicit failed lede. The renderer stays a pure `report ? card : note` — no new component, no threshold logic in the view layer.

## Tests
- Unit: `isShortResult` matrix (one-liner ✓, failed ✗, multi-line/long/truncated/empty ✗) — 326 web unit tests pass.
- E2E: `report-card.spec.ts` gains a one-liner frame asserting `.chat-note--success` renders and no `.chat-report-card` exists for it — **verified passing locally** alongside the existing long/short card cases (the existing 'short' case is multi-line and correctly keeps its card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)