### PR TITLE
test(e2e): gate the explicit-nesting expand on turn settle (#1621)

### DIFF
--- a/apps/web/e2e/tool-nesting-explicit.spec.ts
+++ b/apps/web/e2e/tool-nesting-explicit.spec.ts
@@ -17,6 +17,11 @@ test("a subagent tool nests under the task even when its frames arrive after the
   await expect(card).toBeVisible();
   await expect(card.locator(".pl-toolcard__name")).toContainText("task");
   await expect(card.locator(".pl-toolcard__name")).toContainText("1 tool");
+  // Settle the turn BEFORE expanding: on settle the live-parts view regroups into the
+  // history card, which REMOUNTS the toolcard — an expansion clicked mid-stream is
+  // silently dropped (same latent race the sibling nesting.spec.ts gated; #1621).
+  await expect(page.getByText("Delegated; the child frame arrived after the task closed.")).toBeVisible();
+
   // It's nested in the body (revealed on expand), not a stray top-level sibling.
   await card.locator(".pl-toolcard__head").click();
   await expect(card.locator(".pl-toolcard__children .pl-toolcard__name")).toHaveText("web_search");


### PR DESCRIPTION
Closes #1621.

The root cause of the #1621 flake: while streaming, the task card renders in the `.tool-spotlight` slot (key `__spotlight__`); the terminal frame regroups it into the settled path with a **fresh React key**, which remounts the DS ToolCard and resets its **uncontrolled** disclosure to collapsed — an expand clicked mid-stream is silently discarded, and the awaited `.pl-toolcard__children` node never reappears (auto-retry can't save a one-shot click on an unmounted instance).

`nesting.spec.ts` itself was already gated as a rider on #1630 (same mechanism, same comment). This applies the identical settle gate to `tool-nesting-explicit.spec.ts`, which carried the same ungated expand-then-assert pattern — the last remaining instance of the race.

Verified: both specs × 10 repeats green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)