### PR TITLE
feat(background): per-subagent tool fences apply to detached jobs (#1639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Open-report CTA added nothing but bulk. Such results now inject as a
   success-tinted system note; multi-line, long, truncated, or failed results keep
   the card (and failures keep their explicit failed lede).
+- **Per-subagent tool fences now apply to detached background jobs** (#1639). A
+  background run of a registry subagent executed the full lead graph with the FULL
+  toolset — the subagent's `tools` allowlist was role guidance only (the in-graph
+  `task` path enforced it; the detached path enforced nothing), so an unattended
+  explorer could buy ships. The fire now stamps the resolved allowlist (registry
+  tools ⊕ config override — the same fence the inline path applies) into the turn's
+  state via the fire metadata, and a new `SubagentFenceMiddleware` blocks any tool
+  call outside it with the enforcement-style ToolMessage denial the model can read
+  and adapt to. Non-registry types and ordinary turns are untouched.
 - **Desktop no longer aborts on launch when a global hotkey is already taken**
   (#1670). Hotkey registration lived in the global-shortcut plugin's init, so a
   hotkey another app owns (Discord, PowerToys, AutoHotkey, …) became a

--- a/background/manager.py
+++ b/background/manager.py
@@ -113,7 +113,8 @@ class BackgroundManager:
             origin_incognito=origin_incognito,
         )
         fired_prompt = _build_fired_prompt(subagent_type, description, prompt)
-        t = asyncio.create_task(self._fire(job_id, fired_prompt), name=f"background.fire.{job_id}")
+        fence = _subagent_fence(subagent_type)
+        t = asyncio.create_task(self._fire(job_id, fired_prompt, fence), name=f"background.fire.{job_id}")
         self._fire_tasks.add(t)
         t.add_done_callback(self._fire_tasks.discard)
         log.info("[background] spawned %s (%s): %s", job_id, subagent_type, description)
@@ -326,7 +327,7 @@ class BackgroundManager:
         if r.status_code >= 400:
             raise RuntimeError(f"HTTP {r.status_code}: {r.text[:200]}")
 
-    async def _fire(self, job_id: str, prompt: str) -> None:
+    async def _fire(self, job_id: str, prompt: str, fence: list[str] | None = None) -> None:
         """POST the job to our own /a2a as a turn in a dedicated background context.
 
         On any delivery failure (non-2xx / network / timeout), mark the job failed —
@@ -350,6 +351,11 @@ class BackgroundManager:
                         "origin": "background",
                         "trigger": job_id,
                         "background_job_id": job_id,
+                        # Per-subagent tool fence (#1639): the chat entry stamps this on
+                        # the turn's state and SubagentFenceMiddleware enforces it — the
+                        # same allowlist the in-graph task path applies, now on detached
+                        # runs too. Absent for non-registry types (no fence).
+                        **({"subagent_fence": fence} if fence else {}),
                     },
                 )
             except Exception as exc:  # noqa: BLE001
@@ -400,12 +406,37 @@ class BackgroundManager:
             return False
 
 
+def _subagent_fence(subagent_type: str) -> list[str]:
+    """The subagent's resolved tool allowlist for a detached run (#1639): the registry
+    ``tools`` with any config override applied — the SAME fence the in-graph ``task``
+    path enforces (mirrors ``operator_api.subagents.list_subagents``'s resolution).
+    Empty when the type isn't a registry subagent (no fence). Best-effort: a
+    resolution failure means no fence, never a failed fire."""
+    try:
+        from graph.subagents.config import SUBAGENT_REGISTRY
+
+        registry_def = SUBAGENT_REGISTRY.get(subagent_type)
+        if registry_def is None:
+            return []
+        tools = list(registry_def.tools or [])
+        try:
+            from runtime.state import STATE
+
+            override = getattr(STATE.graph_config, subagent_type, None) if STATE.graph_config else None
+            tools = list(getattr(override, "tools", None) or tools)
+        except Exception:  # noqa: BLE001 — config overlay is best-effort
+            pass
+        return tools
+    except Exception:  # noqa: BLE001
+        return []
+
+
 def _build_fired_prompt(subagent_type: str, description: str, prompt: str) -> str:
     """Compose the message the background turn runs.
 
-    The background turn runs the full lead graph (ADR 0050 — self-POST substrate), so the
-    subagent's own system prompt is prepended as role guidance rather than enforced as a
-    tool fence (per-subagent tool scoping for background jobs is deferred)."""
+    The background turn runs the full lead graph (ADR 0050 — self-POST substrate); the
+    subagent's own system prompt is prepended as role guidance, and the tool allowlist
+    is enforced separately via the ``subagent_fence`` fire metadata (#1639)."""
     role = ""
     try:
         from graph.prompts import build_subagent_prompt

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -87,6 +87,14 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
             )
         )
 
+    # Per-turn subagent tool fence for detached background runs (#1639) — sits with
+    # the enforcement gate (block before execution). Always on: it's a no-op unless
+    # the turn's state carries `subagent_fence` (stamped only by the background fire
+    # path for registry subagents), so ordinary turns pay one dict lookup.
+    from graph.middleware.subagent_fence import SubagentFenceMiddleware
+
+    middleware.append(SubagentFenceMiddleware())
+
     # KnowledgeMiddleware also carries the always-on skill index (the
     # <available_skills> injection, ADR 0060). Build it when knowledge OR skills
     # is active, so skills work even on a KB-less agent (the store is None-tolerant).

--- a/graph/middleware/subagent_fence.py
+++ b/graph/middleware/subagent_fence.py
@@ -1,0 +1,57 @@
+"""SubagentFenceMiddleware — per-turn tool fence for detached subagent runs (#1639).
+
+A detached background job runs the FULL lead graph (ADR 0050's self-POST substrate),
+so the per-subagent tool scoping the in-graph ``task`` path enforces never applied —
+the subagent's ``tools`` allowlist was role guidance only. The fire path now stamps
+the resolved allowlist on the turn's state (``subagent_fence`` — carried A2A message
+metadata → request metadata → state, the same per-turn channel ``model``/``incognito``
+ride), and this gate blocks any tool call outside it with the enforcement-style
+``ToolMessage`` block, so the model reads the denial and adapts. A turn without the
+state key is untouched — ordinary chat turns pay one dict lookup.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import ToolMessage
+
+logger = logging.getLogger(__name__)
+
+
+class SubagentFenceMiddleware(AgentMiddleware):
+    """Block tool calls outside the turn's stamped subagent allowlist."""
+
+    def _deny_reason(self, request) -> str | None:
+        state = getattr(request, "state", None) or {}
+        fence = state.get("subagent_fence")
+        if not fence:
+            return None
+        name = request.tool_call.get("name", "")
+        if name in fence:
+            return None
+        return (
+            f"tool '{name}' is outside this background subagent's allowlist "
+            f"({', '.join(sorted(fence))}) — work within the allowed tools."
+        )
+
+    def _blocked(self, request, reason: str) -> ToolMessage:
+        logger.info("[subagent-fence] blocked %s: %s", request.tool_call.get("name", "?"), reason)
+        return ToolMessage(
+            content=f"Blocked by policy: {reason}",
+            tool_call_id=request.tool_call.get("id", ""),
+            status="error",  # render as a failure card, matching the enforcement gate
+        )
+
+    def wrap_tool_call(self, request, handler):
+        reason = self._deny_reason(request)
+        if reason:
+            return self._blocked(request, reason)
+        return handler(request)
+
+    async def awrap_tool_call(self, request, handler):
+        reason = self._deny_reason(request)
+        if reason:
+            return self._blocked(request, reason)
+        return await handler(request)

--- a/graph/state.py
+++ b/graph/state.py
@@ -37,6 +37,12 @@ class ProtoAgentState(AgentState):
     # swap the lead model for this turn; unset → the configured default.
     model: NotRequired[str]
 
+    # Per-turn subagent tool fence (#1639): a detached background job running a
+    # registry subagent stamps the subagent's resolved tool allowlist here (fire
+    # metadata → request metadata → state); SubagentFenceMiddleware blocks any
+    # tool call outside it. Unset → no fence (ordinary turns).
+    subagent_fence: NotRequired[list[str]]
+
     # Knowledge context injected by KnowledgeMiddleware before LLM call
     context: NotRequired[str]
 

--- a/server/chat.py
+++ b/server/chat.py
@@ -463,6 +463,7 @@ async def _run_turn_stream(
     model=None,
     reasoning_effort=None,
     incognito=False,
+    subagent_fence=None,
 ):
     """Run one graph turn over ``astream_events``.
 
@@ -507,6 +508,10 @@ async def _run_turn_stream(
             # both); omit each key when unset so the configured default applies.
             **({"model": model} if model else {}),
             **({"reasoning_effort": reasoning_effort} if reasoning_effort else {}),
+            # Per-subagent tool fence for a detached background run (#1639) —
+            # SubagentFenceMiddleware blocks tool calls outside it. Omitted (not
+            # empty) when unset so ordinary turns carry no fence channel.
+            **({"subagent_fence": [str(t) for t in subagent_fence]} if subagent_fence else {}),
         }
     )
     from observability import metrics
@@ -968,6 +973,11 @@ async def _run_native_turn(message, session_id, config, *, request_metadata=None
     # Incognito thread (ADR 0069 D3b): the console/A2A caller sets metadata
     # `incognito: true` per message — no session persistence, no memory injection.
     _incognito = bool((request_metadata or {}).get("incognito"))
+    # Detached background runs of a registry subagent carry the resolved tool
+    # allowlist in the fire metadata (#1639) — stamped onto the turn's state below.
+    _fence = (request_metadata or {}).get("subagent_fence") or None
+    if _fence is not None and not isinstance(_fence, (list, tuple)):
+        _fence = None
     # When a goal is already active, the whole turn is goal-driven (suppress cross-session
     # prior_sessions on the initial turn + kicker, matching the continuation turns).
     goal_active = STATE.goal_controller is not None and STATE.goal_controller.active_goal(session_id) is not None
@@ -996,6 +1006,7 @@ async def _run_native_turn(message, session_id, config, *, request_metadata=None
                 model=_model,
                 reasoning_effort=_effort,
                 incognito=_incognito,
+                subagent_fence=_fence,
             ):
                 if kind == "__raw__":
                     accumulated_raw = payload

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -227,6 +227,26 @@ class TestManager:
         assert msg["contextId"] == f"background:{jid}"
         assert msg["metadata"]["origin"] == "background"
         assert msg["metadata"]["trigger"] == jid
+        # A registry subagent's detached run carries its tool ALLOWLIST (#1639) —
+        # the chat entry stamps it on the turn's state and SubagentFenceMiddleware
+        # enforces it, closing the "role guidance is the only guard" gap.
+        from graph.subagents.config import SUBAGENT_REGISTRY
+
+        assert msg["metadata"]["subagent_fence"] == list(SUBAGENT_REGISTRY["researcher"].tools)
+
+    async def test_fire_carries_no_fence_for_unknown_types(self, tmp_path, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _FakeClient(_FakeResponse(200)))
+        mgr = _manager(tmp_path)
+        await mgr.spawn(
+            origin_session="s1",
+            subagent_type="totally-custom-role",
+            description="d",
+            prompt="p",
+        )
+        await _drain_fire_tasks(mgr)
+        assert "subagent_fence" not in _FakeClient.captured["json"]["params"]["message"]["metadata"]
 
     async def test_spawn_publishes_started_event(self, tmp_path, monkeypatch):
         import httpx

--- a/tests/test_subagent_fence.py
+++ b/tests/test_subagent_fence.py
@@ -1,0 +1,79 @@
+"""SubagentFenceMiddleware (#1639) — per-turn tool fence for detached subagent runs.
+
+A detached background job runs the full lead graph; the fence rides the turn's state
+(stamped from the fire metadata) and blocks any tool call outside the subagent's
+allowlist with the enforcement-style ToolMessage block. No fence on the state → no-op.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import ToolMessage
+
+from graph.middleware.subagent_fence import SubagentFenceMiddleware
+
+
+def _request(tool_name: str, fence: list[str] | None):
+    state = {"messages": []}
+    if fence is not None:
+        state["subagent_fence"] = fence
+    return SimpleNamespace(tool_call={"name": tool_name, "args": {}, "id": "c1"}, state=state)
+
+
+def _handler(request):
+    return ToolMessage(content="ran", tool_call_id="c1")
+
+
+def test_no_fence_is_a_noop():
+    mw = SubagentFenceMiddleware()
+    out = mw.wrap_tool_call(_request("st_purchase", None), _handler)
+    assert out.content == "ran"
+
+
+def test_allowlisted_tool_passes():
+    mw = SubagentFenceMiddleware()
+    out = mw.wrap_tool_call(_request("web_search", ["web_search", "fetch_url"]), _handler)
+    assert out.content == "ran"
+
+
+def test_foreign_tool_is_blocked_with_a_readable_toolmessage():
+    """The explorer-buys-a-ship case: allowlist chart/scan/travel, model calls a
+    purchase tool — blocked before execution, with the allowlist in the denial so
+    the model can adapt."""
+    mw = SubagentFenceMiddleware()
+    called = []
+
+    def handler(request):
+        called.append(request)
+        return ToolMessage(content="ran", tool_call_id="c1")
+
+    out = mw.wrap_tool_call(_request("st_purchase", ["st_chart", "st_scan"]), handler)
+    assert called == []  # never executed
+    assert isinstance(out, ToolMessage)
+    assert out.status == "error"
+    assert "st_purchase" in out.content and "st_chart" in out.content
+
+
+@pytest.mark.asyncio
+async def test_async_path_blocks_too():
+    mw = SubagentFenceMiddleware()
+
+    async def handler(request):
+        return ToolMessage(content="ran", tool_call_id="c1")
+
+    out = await mw.awrap_tool_call(_request("run_command", ["web_search"]), handler)
+    assert out.status == "error"
+    ok = await mw.awrap_tool_call(_request("web_search", ["web_search"]), handler)
+    assert ok.content == "ran"
+
+
+def test_manager_resolves_the_registry_allowlist():
+    """_subagent_fence mirrors the in-graph task path's resolution: registry tools
+    (plus any config override — covered by the getattr fallback), [] for unknowns."""
+    from background.manager import _subagent_fence
+    from graph.subagents.config import SUBAGENT_REGISTRY
+
+    assert _subagent_fence("researcher") == list(SUBAGENT_REGISTRY["researcher"].tools)
+    assert _subagent_fence("not-a-registry-type") == []


### PR DESCRIPTION
Closes #1639.

## The gap

`_build_fired_prompt` confessed it in its docstring: a detached background job runs the **full lead graph with the full toolset**, the subagent's `tools` allowlist prepended as *role guidance only*. The in-graph `task` path enforces the allowlist via `_run_subagent`'s filtered rebuild; the detached path enforced nothing — the spacetraders `explorer` (chart/scan/travel-only by design) could call `st_purchase` unattended.

## The design (mirrors the ModelOverrideMiddleware seam)

The lead graph is a compiled process-global singleton — you can't rebuild it per turn, and the global `set_disabled_tools` would leak the fence onto concurrent foreground turns. So the fence rides **per-turn state**, exactly like `model`/`incognito`:

1. **Fire** (`background/manager.py`): `spawn` resolves the allowlist — registry `tools` ⊕ config override, the *same* resolution `list_subagents` uses — and the A2A self-POST carries it as `subagent_fence` metadata. Non-registry types carry none.
2. **Stamp** (`server/chat.py`): metadata → the turn's state (`ProtoAgentState.subagent_fence`, a declared channel).
3. **Gate** (`graph/middleware/subagent_fence.py`): `wrap_tool_call`/`awrap_tool_call` block any tool outside the fence with the enforcement-style `ToolMessage(status="error")` denial that **names the allowlist**, so the model reads it and adapts. Always in the chain; a fence-less turn pays one dict lookup.

Not stricter than inline: a job this breaks was already broken as an inline `task` delegation — the change makes detached behavior consistent. `spawn_work` (deterministic) jobs fire no A2A turn and are untouched.

## Tests

- `test_subagent_fence.py`: no-fence no-op, allowlisted pass, foreign tool blocked-not-executed with readable denial, async path, and the manager's registry resolution.
- `test_background.py`: the fire-shape test now pins the `subagent_fence` metadata for a registry type; a new case pins its **absence** for unknown types.
- 87 background + 43 chat/graph-build tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)