### PR TITLE
chore: release v0.83.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.83.0] - 2026-07-02
+
 ### Fixed
 - **One-line background results render as a compact inline note, not a report card**
   (#1651). A short single-line success (e.g. "Ingested 'notes.md' → 15 chunk(s)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.82.0"
+version = "0.83.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "v0.83.0",
+    "date": "2026-07-02",
+    "changes": [
+      "One-line background results render as a compact inline note, not a report card",
+      "Per-subagent tool fences now apply to detached background jobs",
+      "Desktop no longer aborts on launch when a global hotkey is already taken",
+      "Desktop no longer launches into a silently dead window when port 7870 is taken or the server dies",
+      "Release-tag-pinned plugins now see updates."
+    ]
+  },
+  {
     "version": "v0.82.0",
     "date": "2026-07-02",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.83.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.83.0 -m 'Release v0.83.0' && git push origin v0.83.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).