### PR TITLE
chore(desktop): silence Windows-leg build warnings — opener migration + macOS-only mut

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -3002,6 +3002,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-notification",
+ "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
 ]
@@ -4359,6 +4360,28 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e1bea14edce6b793a04e2417e3fd924b9bc4faae83cdee7d714156cceeed29"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "url",
+ "windows",
+ "zbus",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -28,6 +28,9 @@ tauri-plugin-dialog = "2"
 tauri-plugin-global-shortcut = "2.3.2"
 tauri-plugin-log = "2"
 tauri-plugin-notification = "2"
+# External links open in the system browser via the opener plugin; the shell
+# plugin stays for the sidecar (its `open` is deprecated in favor of opener).
+tauri-plugin-opener = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
 # Desktop chat streaming: WKWebView can't read a streaming fetch body, so the

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ use tauri::{
 };
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut, ShortcutState};
+use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_shell::{
     process::{CommandChild, CommandEvent},
     ShellExt,
@@ -556,6 +557,7 @@ pub fn run() {
             focus_main
         ])
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         // In-app updates: checks the latest.json manifest on GitHub Releases,
         // verifies the minisign signature, installs, relaunches.
@@ -647,10 +649,11 @@ pub fn run() {
             // the host to spawn a child window. We don't host child windows, so without
             // a handler WKWebView silently drops the request and the click does nothing
             // — e.g. the GitHub plugin's PR/issue links were dead in the desktop app.
-            // Open external http(s) links in the system browser (shell:allow-open) and
+            // Open external http(s) links in the system browser (the opener plugin) and
             // deny the in-app window. (Browsers handle this implicitly via allow-popups;
             // the desktop shell has to do it explicitly.)
             let link_opener = app.handle().clone();
+            #[allow(unused_mut)] // `mut` is only used on the macOS title-bar branch below.
             let mut win = WebviewWindowBuilder::new(app, "main", app_url())
                 .title("protoAgent")
                 .inner_size(1280.0, 820.0)
@@ -661,7 +664,7 @@ pub fn run() {
                 .on_new_window(move |url, _features| {
                     let target = url.as_str();
                     if target.starts_with("http://") || target.starts_with("https://") {
-                        if let Err(e) = link_opener.shell().open(target, None) {
+                        if let Err(e) = link_opener.opener().open_url(target, None::<&str>) {
                             log::error!("desktop: failed to open external link {target}: {e}");
                         }
                     }


### PR DESCRIPTION
The v0.83.0 Windows desktop build (green, but noisy) flagged two warnings:

1. **`shell().open` deprecation** — external `target="_blank"` links now open via `tauri-plugin-opener`'s `open_url` (the crate tauri deprecated it in favor of). `tauri-plugin-shell` stays — it owns the sidecar spawn.
2. **`unused_mut` on the main-window builder** — the `mut` is only consumed inside the macOS title-bar `cfg` block, so Windows/Linux legs warn. Annotated `#[allow(unused_mut)]` with the same comment convention `spawn_sidecar` already uses for its macOS-only PATH branch.

`cargo check` + `cargo fmt --check` clean, zero warnings (aarch64-darwin; the unused_mut allow is what fixes the Windows leg definitionally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External links now open in the system browser more reliably from the desktop app.
  * Added support for a dedicated link-opening plugin in the desktop runtime.

* **Bug Fixes**
  * Improved handling of `http` and `https` links when opening new windows, ensuring they launch outside the app as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->