### PR TITLE
feat(desktop): rebindable, visible, self-healing OS-global hotkeys (#1675)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Desktop's system-wide hotkeys are now rebindable, visible, and self-healing**
+  (#1675). The shell's two OS-global hotkeys (console toggle, quick launcher) were
+  hardcoded in Rust: a chord another app owned failed silently (a log line at
+  best), couldn't be changed, and stayed lost until restart. Settings ▸ Keyboard
+  gains a **System-wide (desktop)** section that shows each hotkey's live state —
+  including "unavailable — another app owns this shortcut" — and rebinds it with
+  the same press-to-record flow as web bindings (chords persist in the shell's
+  `hotkeys.json`). Registration also retries whenever the app regains focus, so a
+  chord freed by the conflicting app re-acquires without a restart.
+
 ## [0.83.0] - 2026-07-02
 
 ### Fixed

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use tauri::{
     AppHandle, Emitter, Manager, RunEvent, Runtime, WebviewUrl, WebviewWindowBuilder, WindowEvent,
 };
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
-use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut, ShortcutState};
+use tauri_plugin_global_shortcut::{Shortcut, ShortcutState};
 use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_shell::{
     process::{CommandChild, CommandEvent},
@@ -37,14 +37,165 @@ fn choose_port() -> u16 {
         .unwrap_or(DEFAULT_PORT)
 }
 
-/// The quick-launcher hotkey: ⌥Space on macOS (the Raycast-familiar default);
-/// Ctrl+Alt+Space elsewhere — plain Alt+Space is the Windows window system-menu
-/// accelerator (and PowerToys Run's default), a guaranteed conflict (#1670).
-fn launcher_shortcut() -> Shortcut {
-    #[cfg(target_os = "macos")]
-    return Shortcut::new(Some(Modifiers::ALT), Code::Space);
-    #[cfg(not(target_os = "macos"))]
-    return Shortcut::new(Some(Modifiers::CONTROL | Modifiers::ALT), Code::Space);
+/// The shell's OS-global hotkeys (#1675): stable id → default chord, in the
+/// global-hotkey string grammar ("super+shift+p"). The quick launcher is ⌥Space on
+/// macOS (the Raycast-familiar default) and Ctrl+Alt+Space elsewhere — plain
+/// Alt+Space is the Windows window system-menu accelerator (and PowerToys Run's
+/// default), a guaranteed conflict (#1670). Operator overrides persist in
+/// `<app-config>/hotkeys.json`, edited from Settings ▸ Keyboard.
+const HOTKEY_CONSOLE: &str = "console_toggle";
+const HOTKEY_LAUNCHER: &str = "quick_launcher";
+
+fn default_hotkeys() -> Vec<(&'static str, String)> {
+    let launcher = if cfg!(target_os = "macos") {
+        "alt+space"
+    } else {
+        "ctrl+alt+space"
+    };
+    vec![
+        (HOTKEY_CONSOLE, "super+shift+p".to_string()),
+        (HOTKEY_LAUNCHER, launcher.to_string()),
+    ]
+}
+
+/// One OS-global hotkey's live status — what Settings ▸ Keyboard renders: the
+/// chord, whether it's actually registered, and the denial when it isn't
+/// (typically "already registered": another app owns the chord).
+#[derive(Clone, serde::Serialize)]
+struct HotkeyStatus {
+    id: String,
+    chord: String,
+    registered: bool,
+    error: Option<String>,
+}
+
+/// Managed registry of the shell's global hotkeys (#1675).
+#[derive(Default)]
+struct Hotkeys(Mutex<Vec<HotkeyStatus>>);
+
+fn hotkeys_file<R: Runtime>(app: &AppHandle<R>) -> Option<std::path::PathBuf> {
+    app.path()
+        .app_config_dir()
+        .ok()
+        .map(|d| d.join("hotkeys.json"))
+}
+
+/// Operator chord overrides (`{id: chord}`) — best-effort read; absent/garbled
+/// files just mean defaults.
+fn load_hotkey_overrides<R: Runtime>(
+    app: &AppHandle<R>,
+) -> std::collections::HashMap<String, String> {
+    hotkeys_file(app)
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save_hotkey_overrides<R: Runtime>(app: &AppHandle<R>, entries: &[HotkeyStatus]) {
+    let Some(path) = hotkeys_file(app) else {
+        return;
+    };
+    let map: std::collections::HashMap<&str, &str> = entries
+        .iter()
+        .map(|e| (e.id.as_str(), e.chord.as_str()))
+        .collect();
+    if let Ok(json) = serde_json::to_string_pretty(&map) {
+        if let Err(e) = std::fs::write(&path, json) {
+            log::warn!("desktop: could not persist hotkeys to {path:?}: {e}");
+        }
+    }
+}
+
+/// (Re)register every hotkey that isn't currently live. FALLIBLE per hotkey
+/// (#1670): a chord another app owns records `registered:false` + the error in
+/// the managed state (Settings ▸ Keyboard shows it) and the app stays fully
+/// usable via window/tray. Called at setup and again on window focus — a cheap,
+/// user-driven retry moment — so a chord freed by the other app re-acquires
+/// without a restart (#1675).
+fn sync_hotkeys<R: Runtime>(app: &AppHandle<R>) {
+    use tauri_plugin_global_shortcut::GlobalShortcutExt;
+
+    let Some(state) = app.try_state::<Hotkeys>() else {
+        return;
+    };
+    let mut entries = state.0.lock().unwrap();
+    for e in entries.iter_mut() {
+        if e.registered {
+            continue;
+        }
+        match app.global_shortcut().register(e.chord.as_str()) {
+            Ok(()) => {
+                log::info!("desktop: global hotkey {} registered ({})", e.id, e.chord);
+                e.registered = true;
+                e.error = None;
+            }
+            Err(err) => {
+                if e.error.is_none() {
+                    log::warn!(
+                        "desktop: {} hotkey ({}) unavailable ({err}) — another app may own it; \
+                         continuing without the global shortcut",
+                        e.id,
+                        e.chord
+                    );
+                }
+                e.error = Some(err.to_string());
+            }
+        }
+    }
+}
+
+/// Which registered hotkey id a fired shortcut belongs to, from the managed state.
+fn hotkey_id_for<R: Runtime>(app: &AppHandle<R>, fired: &Shortcut) -> Option<String> {
+    let state = app.try_state::<Hotkeys>()?;
+    let entries = state.0.lock().unwrap();
+    entries
+        .iter()
+        .find(|e| {
+            e.chord
+                .parse::<Shortcut>()
+                .map(|s| s == *fired)
+                .unwrap_or(false)
+        })
+        .map(|e| e.id.clone())
+}
+
+/// Settings ▸ Keyboard reads the shell globals' live status (#1675).
+#[tauri::command]
+fn hotkeys_status(state: tauri::State<'_, Hotkeys>) -> Vec<HotkeyStatus> {
+    state.0.lock().unwrap().clone()
+}
+
+/// Rebind one shell global (#1675): validate the chord, release the old one,
+/// persist, then re-register fallibly — a chord another app owns comes back as
+/// `registered:false` + error rather than an exception, matching launch behavior.
+#[tauri::command]
+fn hotkeys_set<R: Runtime>(
+    app: AppHandle<R>,
+    id: String,
+    chord: String,
+) -> Result<Vec<HotkeyStatus>, String> {
+    use tauri_plugin_global_shortcut::GlobalShortcutExt;
+
+    let chord = chord.trim().to_lowercase();
+    chord
+        .parse::<Shortcut>()
+        .map_err(|e| format!("'{chord}' is not a valid chord: {e}"))?;
+    {
+        let state = app.state::<Hotkeys>();
+        let mut entries = state.0.lock().unwrap();
+        let Some(entry) = entries.iter_mut().find(|e| e.id == id) else {
+            return Err(format!("unknown hotkey id '{id}'"));
+        };
+        if entry.registered {
+            let _ = app.global_shortcut().unregister(entry.chord.as_str());
+        }
+        entry.chord = chord;
+        entry.registered = false;
+        entry.error = None;
+        save_hotkey_overrides(&app, &entries);
+    } // drop the lock — sync_hotkeys re-locks
+    sync_hotkeys(&app);
+    Ok(app.state::<Hotkeys>().0.lock().unwrap().clone())
 }
 
 /// Holds the running sidecar so it can be killed when the app exits.
@@ -554,7 +705,9 @@ pub fn run() {
             updater_check,
             updater_install,
             hide_launcher,
-            focus_main
+            focus_main,
+            hotkeys_status,
+            hotkeys_set
         ])
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_opener::init())
@@ -578,10 +731,11 @@ pub fn run() {
                     if event.state != ShortcutState::Pressed {
                         return;
                     }
-                    if shortcut == &launcher_shortcut() {
-                        toggle_launcher(app);
-                    } else {
-                        toggle_main_window(app);
+                    // Chords are rebindable (#1675) — resolve the fired shortcut to
+                    // its hotkey id via the managed registry, not a hardcoded compare.
+                    match hotkey_id_for(app, shortcut).as_deref() {
+                        Some(HOTKEY_LAUNCHER) => toggle_launcher(app),
+                        _ => toggle_main_window(app),
                     }
                 })
                 .build(),
@@ -600,28 +754,26 @@ pub fn run() {
             app.manage(SidecarProcess::default());
 
             // Two global, system-wide hotkeys (fire even when the app is unfocused or
-            // hidden in the menu bar):
-            //   ⌘⇧P / Win⇧P — toggle the full console window.
-            //   ⌥Space (macOS) / Ctrl⌥Space (elsewhere) — the quick launcher.
-            // FALLIBLE by design (#1670): a hotkey another app already owns logs a
-            // warning and the app stays fully usable via the window/tray — it must
-            // never abort the launch. Registered here (after logging init) so the
-            // warning lands on disk.
+            // hidden in the menu bar): the console toggle and the quick launcher —
+            // defaults in default_hotkeys(), operator overrides from hotkeys.json
+            // (Settings ▸ Keyboard, #1675). FALLIBLE by design (#1670): a hotkey
+            // another app already owns records its state for the settings UI and the
+            // app stays fully usable via the window/tray — it must never abort the
+            // launch. Registered here (after logging init) so warnings land on disk;
+            // re-attempted on window focus (sync_hotkeys in the run handler).
             {
-                use tauri_plugin_global_shortcut::GlobalShortcutExt;
-
-                let console_toggle =
-                    Shortcut::new(Some(Modifiers::SUPER | Modifiers::SHIFT), Code::KeyP);
-                for (label, hotkey) in
-                    [("console toggle", console_toggle), ("quick launcher", launcher_shortcut())]
-                {
-                    if let Err(e) = app.global_shortcut().register(hotkey) {
-                        log::warn!(
-                            "desktop: {label} hotkey unavailable ({e}) — another app owns it; \
-                             continuing without the global shortcut"
-                        );
-                    }
-                }
+                let overrides = load_hotkey_overrides(app.handle());
+                let entries: Vec<HotkeyStatus> = default_hotkeys()
+                    .into_iter()
+                    .map(|(id, default_chord)| HotkeyStatus {
+                        id: id.to_string(),
+                        chord: overrides.get(id).cloned().unwrap_or(default_chord),
+                        registered: false,
+                        error: None,
+                    })
+                    .collect();
+                app.manage(Hotkeys(Mutex::new(entries)));
+                sync_hotkeys(app.handle());
             }
 
             // The sidecar prefers the fixed port the web client falls back to in the
@@ -746,6 +898,12 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app_handle, event| {
+            // Re-acquire any global hotkey another app owned earlier but has since
+            // released (#1675) — focus is a cheap, user-driven retry moment (no
+            // polling); sync_hotkeys is a no-op when everything is registered.
+            if let RunEvent::WindowEvent { event: WindowEvent::Focused(true), .. } = &event {
+                sync_hotkeys(app_handle);
+            }
             // Tear the bundled server down with the app rather than orphaning it.
             if let RunEvent::Exit = event {
                 // The kill below fires the sidecar's Terminated event — mark the

--- a/apps/web/src/settings/KeybindingsPanel.tsx
+++ b/apps/web/src/settings/KeybindingsPanel.tsx
@@ -1,7 +1,7 @@
 import "./keybindings.css";
 
 import { Button, Kbd } from "@protolabsai/ui/primitives";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 
 import { registeredKeybindings } from "../ext/keybindingRegistry";
@@ -9,7 +9,10 @@ import type { Keybinding } from "../ext/keybindingRegistry";
 import { eventToCombo, formatCombo } from "../keybindings/combo";
 import { useKbIntents } from "../keybindings/intents";
 import { effectiveCombo, useKeybindingOverrides } from "../keybindings/overrides";
+import { invoke } from "../lib/desktop";
 import { SettingsSubPanel } from "./SettingsSubPanel";
+import { eventToShellChord, formatShellChord, SHELL_HOTKEY_LABELS } from "./shellHotkeys";
+import type { ShellHotkey } from "./shellHotkeys";
 
 // Settings ▸ Keyboard (ADR 0063) — view + rebind every registered keybinding. Click a
 // shortcut to record a new combo; conflicts (same combo in an overlapping scope) are
@@ -19,6 +22,90 @@ import { SettingsSubPanel } from "./SettingsSubPanel";
 // they're the same panel — i.e. they could both be active for one keypress.
 function scopesOverlap(a: string | undefined, b: string | undefined): boolean {
   return !a || !b || a === b;
+}
+
+// ── OS-global (desktop shell) hotkeys (#1675) ────────────────────────────────────
+// The Tauri shell's system-wide hotkeys — they fire with the app unfocused/hidden, so
+// they live in the Rust shell (hotkeys.json), not the web keybinding registry. This
+// section reads their live status (`hotkeys_status`), rebinds via `hotkeys_set`, and
+// surfaces the "another app owns this chord" state the shell records; the shell also
+// retries unregistered chords on window focus, so a freed chord comes back on its own.
+
+function ShellHotkeysSection() {
+  const setCapturing = useKbIntents((s) => s.setCapturing);
+  const [hotkeys, setHotkeys] = useState<ShellHotkey[] | null>(null);
+  const [recordingId, setRecordingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    void invoke<ShellHotkey[]>("hotkeys_status").then((r) => setHotkeys(r ?? null));
+  }, []);
+  if (!hotkeys?.length) return null; // browser / pre-#1675 shell — section stays hidden
+
+  async function rebind(id: string, chord: string) {
+    const next = await invoke<ShellHotkey[]>("hotkeys_set", { id, chord });
+    setHotkeys(next ?? (await invoke<ShellHotkey[]>("hotkeys_status")) ?? hotkeys);
+  }
+
+  return (
+    <div className="kb-group">
+      <div className="kb-group__label">System-wide (desktop)</div>
+      {hotkeys.map((h) => {
+        const recording = recordingId === h.id;
+        return (
+          <div className="kb-row" key={h.id}>
+            <div className="kb-row__label">
+              {SHELL_HOTKEY_LABELS[h.id] ?? h.id}
+              <span className="kb-row__scope">system-wide</span>
+            </div>
+            <div className="kb-row__keys">
+              <button
+                type="button"
+                className={`kb-key${recording ? " kb-key--recording" : ""}`}
+                onClick={() => {
+                  setRecordingId(recording ? null : h.id);
+                  setCapturing(!recording);
+                }}
+                onKeyDown={
+                  recording
+                    ? (e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        if (e.key === "Escape") {
+                          setRecordingId(null);
+                          setCapturing(false);
+                          return;
+                        }
+                        const chord = eventToShellChord(e.nativeEvent);
+                        if (!chord) return; // modifiers only / unregisterable key — keep listening
+                        setRecordingId(null);
+                        setCapturing(false);
+                        void rebind(h.id, chord);
+                      }
+                    : undefined
+                }
+                onBlur={
+                  recording
+                    ? () => {
+                        setRecordingId(null);
+                        setCapturing(false);
+                      }
+                    : undefined
+                }
+              >
+                {recording ? "Press keys… (Esc to cancel)" : formatShellChord(h.chord)}
+              </button>
+            </div>
+            {!h.registered ? (
+              <div className="kb-row__conflict" role="alert">
+                Unavailable — another app owns this shortcut. It retries when the app regains focus,
+                or pick a different chord.
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 export function KeybindingsPanel() {
@@ -81,6 +168,8 @@ export function KeybindingsPanel() {
           Click a shortcut to rebind it. Note: <Kbd>⌘T</Kbd>, <Kbd>⌘1–9</Kbd> and <Kbd>⌃Tab</Kbd> are
           reserved by the browser — they work in the desktop app; in a browser, rebind to a free combo.
         </p>
+
+        <ShellHotkeysSection />
 
         {groups.map((g) => (
           <div className="kb-group" key={g}>

--- a/apps/web/src/settings/shellHotkeys.test.ts
+++ b/apps/web/src/settings/shellHotkeys.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { eventToShellChord, formatShellChord } from "./shellHotkeys";
+
+function ev(init: Partial<KeyboardEvent> & { key: string }): KeyboardEvent {
+  return new KeyboardEvent("keydown", init);
+}
+
+describe("eventToShellChord", () => {
+  it("maps modifiers + key into the global-hotkey grammar", () => {
+    expect(eventToShellChord(ev({ key: "p", metaKey: true, shiftKey: true }))).toBe("super+shift+p");
+    expect(eventToShellChord(ev({ key: " ", ctrlKey: true, altKey: true }))).toBe("ctrl+alt+space");
+    expect(eventToShellChord(ev({ key: "F5", altKey: true }))).toBe("alt+f5");
+  });
+  it("rejects bare keys, bare modifiers, and unregisterable keys", () => {
+    expect(eventToShellChord(ev({ key: "p" }))).toBe(null); // no modifier → would eat typing
+    expect(eventToShellChord(ev({ key: "Shift", shiftKey: true }))).toBe(null);
+    expect(eventToShellChord(ev({ key: "ArrowUp", ctrlKey: true }))).toBe(null);
+  });
+});
+
+describe("formatShellChord", () => {
+  it("renders mac glyphs and win/linux words", () => {
+    expect(formatShellChord("super+shift+p", "MacIntel")).toBe("⌘⇧P");
+    expect(formatShellChord("ctrl+alt+space", "Win32")).toBe("Ctrl+Alt+Space");
+  });
+});

--- a/apps/web/src/settings/shellHotkeys.ts
+++ b/apps/web/src/settings/shellHotkeys.ts
@@ -1,0 +1,42 @@
+// OS-global (desktop shell) hotkey helpers (#1675) — pure, react-free: the chord
+// grammar bridge between DOM KeyboardEvents and the Rust shell's global-hotkey
+// parser ("ctrl+alt+space", "super+shift+p"), plus display formatting.
+
+export type ShellHotkey = { id: string; chord: string; registered: boolean; error: string | null };
+
+export const SHELL_HOTKEY_LABELS: Record<string, string> = {
+  console_toggle: "Toggle console window",
+  quick_launcher: "Quick launcher",
+};
+
+/** KeyboardEvent → the global-hotkey chord grammar. Null while only modifiers are
+ *  held, for keys the shell can't register, or for a bare key (a modifier-less
+ *  chord must never be a SYSTEM-WIDE hotkey — it would eat normal typing). */
+export function eventToShellChord(e: KeyboardEvent): string | null {
+  const mods: string[] = [];
+  if (e.metaKey) mods.push("super");
+  if (e.ctrlKey) mods.push("ctrl");
+  if (e.altKey) mods.push("alt");
+  if (e.shiftKey) mods.push("shift");
+  const k = e.key;
+  let key: string | null = null;
+  if (k === " " || k === "Spacebar") key = "space";
+  else if (/^[a-zA-Z0-9]$/.test(k)) key = k.toLowerCase();
+  else if (/^F([1-9]|1[0-9]|2[0-4])$/.test(k)) key = k.toLowerCase();
+  if (!key || mods.length === 0) return null;
+  return [...mods, key].join("+");
+}
+
+export function formatShellChord(chord: string, platform = navigator.platform): string {
+  const mac = platform.toLowerCase().includes("mac");
+  return chord
+    .split("+")
+    .map((part) => {
+      if (part === "super") return mac ? "⌘" : "Win";
+      if (part === "ctrl") return mac ? "⌃" : "Ctrl";
+      if (part === "alt") return mac ? "⌥" : "Alt";
+      if (part === "shift") return mac ? "⇧" : "Shift";
+      return part.length === 1 ? part.toUpperCase() : part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(mac ? "" : "+");
+}


### PR DESCRIPTION
Closes #1675.

The shell's two system-wide hotkeys (console toggle, quick launcher) were hardcoded in Rust: a chord another app owned failed with only a log line (#1670 made that non-fatal), couldn't be changed, and stayed lost until restart.

## Shell (`lib.rs`)

- **Managed `Hotkeys` registry** — `id → {chord, registered, error}`. Defaults keep the #1670 platform split (`super+shift+p`; `alt+space` on macOS / `ctrl+alt+space` elsewhere); operator overrides persist in `<app-config>/hotkeys.json`.
- **`sync_hotkeys()`** — fallible per-chord registration recording the denial for the UI, re-run on `WindowEvent::Focused(true)`: a chord freed by the conflicting app **re-acquires without a restart** (focus is the cheap, user-driven retry moment — no polling; it's a no-op when everything's registered).
- **`hotkeys_status` / `hotkeys_set` commands** — settings reads live state; rebind validates the chord, releases the old one, persists, re-registers fallibly (an owned chord comes back as `registered:false` + error, never an exception).
- The plugin handler now resolves the fired shortcut through the registry instead of a hardcoded compare — chords are user-defined.

## Web (Settings ▸ Keyboard)

- New **System-wide (desktop)** section — hidden in the browser and on pre-#1675 shells (the invoke returns nothing). Each row shows the live chord and, when unregistered, *"Unavailable — another app owns this shortcut. It retries when the app regains focus, or pick a different chord."* Rebinding reuses the panel's press-to-record flow.
- `shellHotkeys.ts` — pure chord-grammar bridge (KeyboardEvent → global-hotkey string; bare keys and unregisterable keys rejected, since a modifier-less **system-wide** chord would eat normal typing) + platform display formatting. Unit-tested.

## Verified

`cargo check` + `fmt` clean (zero warnings); 329 web unit tests pass; console builds. Live rebind/re-acquire behavior needs a desktop build to exercise — worth a tagless `desktop-build.yml` dispatch before the next release alongside whatever else lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)