### PR TITLE
fix(server): Windows sidecar self-killed ~2s after boot — os.kill(ppid, 0) is not a liveness probe there (#1678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The Windows desktop sidecar no longer self-kills ~2s after boot** (#1678). The
+  parent-death watchdog probed the launcher with `os.kill(ppid, 0)` — a POSIX
+  idiom that on Windows sends `CTRL_C_EVENT` instead of probing: against the GUI
+  launcher it raises `OSError`, which the watchdog misread as "launcher gone" and
+  `os._exit(0)`'d a perfectly healthy server on every launch (window up, backend
+  dead, 7870 idle). Liveness now goes through a real cross-platform
+  `infra.paths.pid_alive` (`OpenProcess`/`GetExitCodeProcess` on Windows; on POSIX
+  only `ProcessLookupError` means gone — `PermissionError` means *exists*, which
+  the old bare `except OSError` also got wrong). The colocated-instance heartbeat
+  and the fleet supervisor's member probe shared the same idiom and now use the
+  same helper.
+
 ### Added
 - **Desktop's system-wide hotkeys are now rebindable, visible, and self-healing**
   (#1675). The shell's two OS-global hotkeys (console toggle, quick launcher) were

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -23,6 +23,8 @@ from pathlib import Path
 
 from filelock import FileLock
 
+from infra.paths import pid_alive
+
 from graph.workspaces import manager
 
 log = logging.getLogger(__name__)
@@ -106,9 +108,12 @@ def _alive(pid: int | None) -> bool:
         return False
     _reap(pid)  # clear a crashed child's zombie first, so the probe below sees it as gone
     try:
-        os.kill(int(pid), 0)  # signal 0 = liveness probe (a reaped zombie → ProcessLookupError)
-        return True
-    except (OSError, ValueError):
+        # pid_alive, not os.kill(pid, 0): the raw idiom isn't a liveness probe on
+        # Windows (signal 0 = CTRL_C_EVENT → OSError on live pids) and misreads a
+        # POSIX PermissionError (exists) as dead (#1678). A reaped zombie is gone
+        # from the table, so it still probes as dead here.
+        return pid_alive(int(pid))
+    except ValueError:
         return False
 
 

--- a/infra/paths.py
+++ b/infra/paths.py
@@ -307,7 +307,45 @@ def instance_uid() -> str:
         return ""
 
 
-def _pid_alive(pid: int) -> bool:
+def _pid_alive_windows(pid: int, kernel32=None) -> bool:
+    """Windows liveness probe: ``OpenProcess`` + ``GetExitCodeProcess == STILL_ACTIVE``.
+    Access-denied means the process EXISTS (we just can't query it); ambiguity leans
+    *alive* — for the callers (parent-death watchdog, heartbeat) a false "dead" is the
+    catastrophic direction (a healthy sidecar self-killing, #1678)."""
+    import ctypes
+
+    process_query_limited_information = 0x1000
+    still_active = 259
+    error_access_denied = 5
+    k32 = kernel32 if kernel32 is not None else ctypes.windll.kernel32  # type: ignore[attr-defined]
+    handle = k32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        return k32.GetLastError() == error_access_denied
+    try:
+        code = ctypes.c_ulong()
+        if not k32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return True  # queryable handle but unreadable exit code — lean alive
+        return code.value == still_active
+    finally:
+        k32.CloseHandle(handle)
+
+
+def pid_alive(pid: int) -> bool:
+    """True when ``pid`` is a running process — a real CROSS-PLATFORM liveness probe.
+
+    ``os.kill(pid, 0)`` is NOT one on Windows: signal 0 is ``CTRL_C_EVENT``
+    (``GenerateConsoleCtrlEvent``), which fails with ``OSError`` for any
+    non-console-group target — reading a LIVE pid as dead. That self-killed the
+    desktop sidecar ~2s after every Windows boot (#1678: the parent-death watchdog
+    read its healthy GUI launcher as gone). On POSIX, only ``ProcessLookupError``
+    means gone; ``PermissionError`` means it exists but isn't ours to signal."""
+    if pid <= 0:
+        return False
+    if os.name == "nt":
+        try:
+            return _pid_alive_windows(pid)
+        except Exception:  # noqa: BLE001 — a probe must never take the caller down
+            return True  # lean alive: false "dead" is the catastrophic direction
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -382,7 +420,7 @@ def colocated_instances() -> list[dict]:
                 continue
             if pid == os.getpid():
                 continue
-            if not _pid_alive(pid) or not _is_protoagent_pid(pid):
+            if not pid_alive(pid) or not _is_protoagent_pid(pid):
                 f.unlink(missing_ok=True)  # stale heartbeat (crash / pid recycled)
                 continue
             try:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -137,14 +137,19 @@ def _install_parent_death_watchdog() -> None:
 
     import threading
 
+    from infra.paths import pid_alive
+
     def _watch() -> None:
+        # pid_alive, NOT os.kill(ppid, 0): on Windows signal 0 is CTRL_C_EVENT, which
+        # fails with OSError against a GUI launcher — the old probe read the healthy
+        # desktop shell as "gone" and self-killed the sidecar ~2s after every Windows
+        # boot (#1678). (It also misread POSIX PermissionError — exists — as dead.)
         while True:
             time.sleep(2)
             try:
-                os.kill(ppid, 0)  # signal 0 = liveness probe; raises if gone
-            except OSError:
-                log.info("[watchdog] launcher pid %d gone — exiting sidecar", ppid)
-                os._exit(0)
+                if not pid_alive(ppid):
+                    log.info("[watchdog] launcher pid %d gone — exiting sidecar", ppid)
+                    os._exit(0)
             except Exception:  # noqa: BLE001 — never let the watchdog crash the server
                 return
 

--- a/tests/test_instance_scope.py
+++ b/tests/test_instance_scope.py
@@ -117,7 +117,7 @@ def test_colocated_sibling_same_instance_is_warned(monkeypatch, tmp_path):
     (d / "12345.json").write_text(
         json.dumps({"pid": 12345, "port": 7871, "identity": "roxy", "instance_root": mine})
     )
-    monkeypatch.setattr(paths, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(paths, "pid_alive", lambda pid: True)
     monkeypatch.setattr(paths, "_is_protoagent_pid", lambda pid: True)
     sibs = paths.colocated_instances()
     assert sibs == [{"pid": 12345, "port": 7871, "identity": "roxy", "instance_root": mine}]
@@ -139,7 +139,7 @@ def test_box_only_coresident_is_not_warned(monkeypatch, tmp_path):
     (d / "12345.json").write_text(
         json.dumps({"pid": 12345, "port": 7871, "identity": "dev", "instance_root": other})
     )
-    monkeypatch.setattr(paths, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(paths, "pid_alive", lambda pid: True)
     monkeypatch.setattr(paths, "_is_protoagent_pid", lambda pid: True)
     # Still discoverable on the box…
     assert paths.colocated_instances()[0]["identity"] == "dev"
@@ -154,7 +154,7 @@ def test_stale_heartbeats_pruned(monkeypatch, tmp_path):
     (d / "12345.json").write_text('{"pid": 12345}')  # dead pid
     (d / "23456.json").write_text('{"pid": 23456}')  # recycled pid (not a server)
     (d / "not-a-pid.json").write_text("{}")  # garbage name → ignored
-    monkeypatch.setattr(paths, "_pid_alive", lambda pid: pid == 23456)
+    monkeypatch.setattr(paths, "pid_alive", lambda pid: pid == 23456)
     monkeypatch.setattr(paths, "_is_protoagent_pid", lambda pid: False)
     assert paths.colocated_instances() == []
     assert not (d / "12345.json").exists() and not (d / "23456.json").exists()

--- a/tests/test_pid_alive.py
+++ b/tests/test_pid_alive.py
@@ -1,0 +1,108 @@
+"""pid_alive (#1678) — the cross-platform process-liveness probe.
+
+`os.kill(pid, 0)` is a POSIX idiom that is NOT a liveness probe on Windows: signal 0
+is CTRL_C_EVENT, which fails with OSError against any non-console-group target — the
+desktop's parent-death watchdog read its healthy GUI launcher as gone and self-killed
+the sidecar ~2s after every Windows boot. These pin the corrected semantics on both
+platforms (the Windows branch via an injected fake kernel32 — CI runs POSIX).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+
+from infra import paths
+
+
+# ── POSIX semantics ───────────────────────────────────────────────────────────────
+def test_posix_running_process_is_alive():
+    assert paths.pid_alive(os.getpid()) is True
+
+
+def test_posix_only_process_lookup_error_means_gone(monkeypatch):
+    def _kill(pid, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(os, "kill", _kill)
+    assert paths.pid_alive(12345) is False
+
+
+def test_posix_permission_error_means_alive(monkeypatch):
+    """EPERM = the process EXISTS but isn't ours to signal — the old watchdog's bare
+    `except OSError` misread this as dead."""
+
+    def _kill(pid, sig):
+        raise PermissionError
+
+    monkeypatch.setattr(os, "kill", _kill)
+    assert paths.pid_alive(12345) is True
+
+
+def test_nonpositive_pids_are_dead():
+    assert paths.pid_alive(0) is False
+    assert paths.pid_alive(-1) is False
+
+
+# ── Windows branch (fake kernel32) ────────────────────────────────────────────────
+class _FakeKernel32:
+    """OpenProcess/GetExitCodeProcess/GetLastError/CloseHandle, scriptable."""
+
+    def __init__(self, *, handle=1, exit_code=259, exit_ok=True, last_error=0):
+        self._handle = handle
+        self._exit_code = exit_code
+        self._exit_ok = exit_ok
+        self._last_error = last_error
+        self.closed = []
+
+    def OpenProcess(self, access, inherit, pid):  # noqa: N802 — win32 casing
+        return self._handle
+
+    def GetLastError(self):  # noqa: N802
+        return self._last_error
+
+    def GetExitCodeProcess(self, handle, code_ref):  # noqa: N802
+        if not self._exit_ok:
+            return 0
+        # ctypes.byref proxies the c_ulong via _obj.
+        code_ref._obj.value = self._exit_code
+        return 1
+
+    def CloseHandle(self, handle):  # noqa: N802
+        self.closed.append(handle)
+        return 1
+
+
+def test_windows_still_active_process_is_alive():
+    k32 = _FakeKernel32(exit_code=259)  # STILL_ACTIVE
+    assert paths._pid_alive_windows(4242, kernel32=k32) is True
+    assert k32.closed == [1]  # handle released
+
+
+def test_windows_exited_process_is_dead():
+    assert paths._pid_alive_windows(4242, kernel32=_FakeKernel32(exit_code=0)) is False
+
+
+def test_windows_access_denied_means_alive():
+    """OpenProcess failing with ERROR_ACCESS_DENIED means the process EXISTS."""
+    k32 = _FakeKernel32(handle=0, last_error=5)
+    assert paths._pid_alive_windows(4242, kernel32=k32) is True
+
+
+def test_windows_invalid_pid_is_dead():
+    k32 = _FakeKernel32(handle=0, last_error=87)  # ERROR_INVALID_PARAMETER
+    assert paths._pid_alive_windows(4242, kernel32=k32) is False
+
+
+def test_windows_unreadable_exit_code_leans_alive():
+    """A queryable handle whose exit code can't be read must NOT read as dead —
+    false 'dead' is the self-kill direction (#1678)."""
+    assert paths._pid_alive_windows(4242, kernel32=_FakeKernel32(exit_ok=False)) is True
+
+
+def test_byref_proxy_matches_ctypes_contract():
+    """The fake's `_obj` poke mirrors real ctypes.byref — pin that assumption."""
+    c = ctypes.c_ulong()
+    ref = ctypes.byref(c)
+    ref._obj.value = 259
+    assert c.value == 259


### PR DESCRIPTION
Closes #1678.

## The bug (reported with the smoking-gun log)

`_install_parent_death_watchdog` probed the launcher with `os.kill(ppid, 0)`. On Windows, signal 0 is `CTRL_C_EVENT` — `GenerateConsoleCtrlEvent`, not a probe. Against the GUI launcher it raises `OSError`; the watchdog's bare `except OSError` read that as "launcher gone" and `os._exit(0)`'d a **healthy** server ~2s after every Windows boot: desktop window up, backend dead, 7870 idle. Secondary defect: even on POSIX the bare except caught `PermissionError` — which means the process **exists** — as dead.

## The fix

**`infra.paths.pid_alive`** — one real cross-platform probe:
- **Windows**: `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetExitCodeProcess == STILL_ACTIVE`; `ERROR_ACCESS_DENIED` ⇒ exists; any ambiguity leans **alive** — a false "dead" is the self-kill direction.
- **POSIX**: only `ProcessLookupError` means gone; `PermissionError` means alive.

All three copies of the idiom now use it: the parent-death watchdog, the colocated-instance heartbeat (`_pid_alive`, promoted to the public `pid_alive`), and the fleet supervisor's member probe (which keeps its targeted zombie-reap first — a reaped zombie probes dead exactly as before, `test_fleet_reap` still green).

## Tests

`tests/test_pid_alive.py` — POSIX semantics + the Windows branch driven through an injected fake kernel32 (STILL_ACTIVE / exited / access-denied / invalid-pid / unreadable-exit-code-leans-alive), including a pin on the `ctypes.byref` proxy contract the fake relies on. CI is POSIX-only, so the fake is what keeps the Windows branch honest. 56 tests across pid_alive/instance-scope/fleet-supervisor/fleet-reap pass; ruff clean.

**Note for the release:** this is the third and deepest layer of the Windows "desktop does nothing" reports (#1668 port/no-diagnostics → #1670 hotkey panic → this). Worth cutting v0.84.0 promptly — every Windows desktop install of ≤0.83.0 has a sidecar that cannot survive its own watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)