### PR TITLE
fix(knowledge): embedding outages can't freeze chat + embeddings ship off by default (#1681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Semantic recall (embeddings) now ships OFF by default** (#1681). Out of the box
+  the app no longer depends on an optional gateway route: a gateway without a
+  working embedding model turned every turn's pre-model recall into a stall
+  ("chat just spins"). Keyword (FTS5) recall works against any gateway; opt back
+  in with one toggle — Settings ▸ Knowledge ▸ "Semantic recall (embeddings)" (or
+  `knowledge.embeddings: true`) once your gateway serves the embed model.
+  Existing configs that set the key explicitly are unaffected.
+
+### Fixed
+- **A hung gateway embedding route can no longer freeze chat** (#1681). The
+  embeddings client carried the OpenAI SDK defaults — 600s timeout, 2 retries —
+  so one Cloudflare-524-style hang blocked a turn for minutes while the knowledge
+  circuit breaker (which only counts *returned* failures) never got to trip. The
+  client now uses a dedicated 8s timeout with no app-side retries (the gateway
+  owns fallbacks), and each hybrid store fires an off-thread route probe at
+  construction that opens the breaker immediately on failure — so the first chat
+  turn of an outage pays nothing and recall degrades straight to keyword-only.
+
 ## [0.84.0] - 2026-07-02
 
 ### Fixed

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -79,11 +79,10 @@ knowledge:
   # shared/layered fleet must share ONE embed_model (the commons is stamped + enforced).
   # scope: scoped
   # Semantic recall: hybrid FTS5 + vector search (RRF-fused) via embed_model.
-  # Off by default (keyword-only) — turn on once your gateway serves an
-  # embedding model. Degrades to keyword search on embedding outage.
-  # Hybrid semantic + keyword recall (RRF). On by default; falls back to
-  # keyword-only via the circuit breaker if the gateway can't embed.
-  embeddings: true
+  # OFF by default (#1681) — keyword recall works against any gateway; turn this
+  # on once yours serves the embedding model below (check GET /v1/models). When
+  # on, a route outage degrades to keyword-only via the circuit breaker.
+  embeddings: false
   # The embedding model your gateway serves (NOT the chat model). Default is the
   # protoLabs gateway's; forks on another gateway set theirs (check GET /v1/models).
   embed_model: qwen3-embedding

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -9,9 +9,11 @@ content see [Ingest documents & media](/guides/ingestion).
 
 ## Which store you get
 
-- **Default:** `HybridKnowledgeStore` (FTS5 + vectors) when `knowledge.embeddings`
-  is on (the default) and `embed_model` resolves on your gateway.
-- **Keyword-only:** set `embeddings: false` → FTS5 only (no embedding calls).
+- **Default:** keyword-only FTS5 — `knowledge.embeddings` ships **off** (#1681:
+  out of the box the app must not depend on an optional gateway route; a gateway
+  without a working embedding model turned every turn's recall into a stall).
+- **Hybrid:** set `embeddings: true` once your gateway serves `embed_model` →
+  `HybridKnowledgeStore` (FTS5 + vectors, RRF-fused).
 - **Pluggable:** a plugin can register an alternate backend (`knowledge.backend`) or
   embedder (`knowledge.embedder`) — see [ADR 0031](/adr/0031-pluggable-knowledge-backend).
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -418,9 +418,12 @@ class LangGraphConfig:
     image_describe_model: str = ""
     # Semantic recall (ADR 0021): when True, the knowledge store is the
     # HybridKnowledgeStore (FTS5 + vector embeddings via `embed_model`, fused
-    # with RRF). On by default — semantic recall finds paraphrases keyword search
-    # misses; the circuit breaker falls back to FTS5 on an embedding outage.
-    knowledge_embeddings: bool = True
+    # with RRF). OFF by default (#1681): out of the box the app must not depend
+    # on an optional gateway route — a gateway without a working embedding model
+    # turned recall (which runs pre-model on every turn) into a per-turn stall.
+    # Opt in when your gateway serves `embed_model`; keyword recall works
+    # everywhere, and the circuit breaker still guards runtime outages when on.
+    knowledge_embeddings: bool = False
     # How many recalled chunks are injected per turn. Bumped 5 → 10 (RAG bake-off:
     # more candidates in-context lifted answer quality at sub-million-chunk scale).
     knowledge_top_k: int = 10

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -169,6 +169,15 @@ def create_llm(
     return _ReasoningChatOpenAI(**kwargs)
 
 
+# Embedding calls run INSIDE the turn (recall precedes every model call), so they get
+# a short dedicated timeout — never the chat request_timeout, and never the OpenAI
+# SDK defaults (600s + 2 retries), which let one hung gateway route freeze every chat
+# turn for minutes while the knowledge breaker couldn't trip (#1681: a Cloudflare-524
+# embedding outage read as "chat is broken"). No client retries: the gateway owns
+# retries/fallbacks; app-side retries only multiply the hang.
+_EMBED_TIMEOUT_S = 8.0
+
+
 def _build_embeddings(config: LangGraphConfig) -> "OpenAIEmbeddings | None":
     """The shared OpenAIEmbeddings client for ``knowledge.embed_model`` against
     the gateway (ADR 0021), or None when no embed model is configured."""
@@ -181,6 +190,8 @@ def _build_embeddings(config: LangGraphConfig) -> "OpenAIEmbeddings | None":
         api_key=api_key,
         model=model,
         default_headers={"User-Agent": _GATEWAY_UA},
+        request_timeout=_EMBED_TIMEOUT_S,
+        max_retries=0,
         # Send the raw string, not client-side-tokenized int arrays. Langchain's
         # default tokenizes with tiktoken and posts `input` as arrays of token
         # ids, which a LiteLLM/vLLM-style gateway rejects with 422 ("input should

--- a/knowledge/hybrid_store.py
+++ b/knowledge/hybrid_store.py
@@ -117,6 +117,39 @@ class HybridKnowledgeStore(KnowledgeStore):
         self._record_embed_success()
         return was_open
 
+    def _probe_once(self) -> bool:
+        """One synchronous embedding-route probe: on failure, open the breaker
+        IMMEDIATELY (not after ``breaker_threshold`` in-turn failures) so no chat
+        turn pays for a dead route. Returns True when the route is healthy."""
+        if self._embed_fn is None:
+            return False
+        try:
+            self._embed_fn("ping")
+            self._record_embed_success()
+            return True
+        except Exception as exc:  # noqa: BLE001 — a probe failure must only open the breaker
+            log.warning(
+                "[knowledge] embedding probe failed — semantic recall paused for %.0fs "
+                "(keyword recall continues): %s",
+                self._breaker_cooldown_s,
+                exc,
+            )
+            self._embed_failures = self._breaker_threshold
+            self._breaker_open_until = time.monotonic() + self._breaker_cooldown_s
+            return False
+
+    def warm_probe(self) -> None:
+        """Fire-and-forget ``_probe_once`` on a daemon thread (#1681). Recall runs
+        BEFORE every model call, so without this the FIRST turns of an embedding
+        outage each ate the full transport timeout before the in-turn breaker could
+        trip — the operator experienced a frozen chat. Probing at construction moves
+        that cost off the user's turn entirely."""
+        if self._embed_fn is None:
+            return
+        import threading
+
+        threading.Thread(target=self._probe_once, daemon=True, name="knowledge-embed-probe").start()
+
     def _embed(self, text: str) -> list[float] | None:
         if self._embed_fn is None or self._breaker_open():
             return None

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -357,7 +357,7 @@ def _build_knowledge_store(config):
             if embed_fn is not None and not force_plain:
                 from knowledge.hybrid_store import HybridKnowledgeStore
 
-                return HybridKnowledgeStore(
+                store = HybridKnowledgeStore(
                     db_path=db_path, scoped=scoped, embed_fn=embed_fn, embed_batch_fn=embed_batch_fn,
                     vector_k=config.knowledge_vector_k, rrf_k=config.knowledge_rrf_k,
                     min_score=config.knowledge_min_score,
@@ -368,6 +368,10 @@ def _build_knowledge_store(config):
                     chunk_overlap_chars=config.knowledge_chunk_overlap_chars,
                     chunk_min_chars=config.knowledge_chunk_min_chars, context_fn=context_fn,
                 )
+                # Off-thread route probe (#1681): a dead embedding route opens the
+                # breaker BEFORE the first chat turn instead of freezing it.
+                store.warm_probe()
+                return store
             return KnowledgeStore(
                 db_path=db_path, scoped=scoped,
                 preview_chars=config.knowledge_recall_preview_chars,

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -115,7 +115,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "knowledge_db_path": "/sandbox/knowledge/agent.db",
     "knowledge_scope": "",
     "knowledge_embedder": "",
-    "knowledge_embeddings": True,
+    "knowledge_embeddings": False,
     "knowledge_facts": True,
     "knowledge_inject_namespaces": [],
     "knowledge_inject_min_trust": 1,

--- a/tests/test_embed_hardening.py
+++ b/tests/test_embed_hardening.py
@@ -1,0 +1,49 @@
+"""Embedding-outage hardening (#1681).
+
+A hung gateway embedding route froze every chat turn: the embeddings client
+carried the OpenAI SDK defaults (600s timeout, 2 retries), recall runs BEFORE
+every model call, and the knowledge breaker can only trip when a call returns.
+These pin the three defenses: a short dedicated client timeout with no
+app-side retries, the constructor-time route probe that opens the breaker
+before the first turn, and keyword-only recall as the shipped default.
+"""
+
+from __future__ import annotations
+
+from graph.config import LangGraphConfig
+from knowledge.hybrid_store import HybridKnowledgeStore
+
+
+def test_embeddings_client_short_timeout_no_retries():
+    from graph.llm import _EMBED_TIMEOUT_S, _build_embeddings
+
+    emb = _build_embeddings(LangGraphConfig(embed_model="qwen3-embedding", api_key="k"))
+    assert emb is not None
+    assert emb.request_timeout == _EMBED_TIMEOUT_S
+    assert emb.max_retries == 0
+
+
+def test_probe_failure_opens_the_breaker_before_any_turn(tmp_path):
+    calls: list[str] = []
+
+    def _broken(text: str) -> list[float]:
+        calls.append(text)
+        raise RuntimeError("HTTP 524")
+
+    store = HybridKnowledgeStore(db_path=str(tmp_path / "k.db"), embed_fn=_broken, breaker_threshold=2)
+    assert store._probe_once() is False
+    assert store._breaker_open() is True  # immediately — not after N in-turn failures
+    # A recall-time embed now short-circuits without touching the dead route.
+    assert store._embed("query") is None
+    assert calls == ["ping"]
+
+
+def test_probe_success_keeps_semantic_recall_live(tmp_path):
+    store = HybridKnowledgeStore(db_path=str(tmp_path / "k.db"), embed_fn=lambda t: [0.1, 0.2])
+    assert store._probe_once() is True
+    assert store._breaker_open() is False
+    assert store._embed("query") == [0.1, 0.2]
+
+
+def test_embeddings_ship_off_by_default():
+    assert LangGraphConfig().knowledge_embeddings is False

--- a/tests/test_embeddings_wiring.py
+++ b/tests/test_embeddings_wiring.py
@@ -82,13 +82,15 @@ def test_create_embed_fn_sends_raw_strings(monkeypatch):
     assert captured.get("check_embedding_ctx_length") is False
 
 
-def test_store_is_hybrid_by_default(tmp_path):
-    # knowledge.embeddings defaults on (ADR 0021); the config helper here mirrors it.
+def test_store_is_keyword_only_by_default(tmp_path):
+    # knowledge.embeddings ships OFF (#1681): out of the box the app must not
+    # depend on an optional gateway route — a dead embedding model froze every
+    # turn's recall. Semantic recall is the operator's opt-in.
     cfg = LangGraphConfig()
     cfg.knowledge_db_path = str(tmp_path / "kb.db")
     cfg.api_base, cfg.api_key = "http://gateway.test/v1", "k"
-    assert cfg.knowledge_embeddings is True
-    assert type(server._build_knowledge_store(cfg)).__name__ == "HybridKnowledgeStore"
+    assert cfg.knowledge_embeddings is False
+    assert type(server._build_knowledge_store(cfg)).__name__ == "KnowledgeStore"
 
 
 def test_store_is_keyword_when_embeddings_off(tmp_path):


### PR DESCRIPTION
Closes #1681 — the Windows saga's problem #4 ("chat spin = gateway embeddings outage").

## Why chat froze

Recall runs **before** every model call. The embeddings client was built with the OpenAI SDK defaults — **600s timeout, 2 retries** — so a hung route (Cloudflare 524: upstream sits ~100s before the proxy kills it) blocked each turn for minutes. The knowledge circuit breaker only counts failures when a call *returns*, so it couldn't trip until several turns had already burned.

## Three defenses

1. **Short dedicated client timeout (8s) + `max_retries=0`** (`graph/llm.py`) — the gateway owns retries/fallbacks; app-side retries only multiply the hang.
2. **Constructor-time route probe** (`HybridKnowledgeStore.warm_probe`) — one tiny embed off-thread when the store is built; on failure the breaker opens **immediately**, so the first chat turn of an outage pays nothing and recall degrades straight to FTS5.
3. **`knowledge.embeddings` ships OFF** — out of the box the app must not depend on an optional gateway route. Opt-in is one toggle (Settings ▸ Knowledge ▸ "Semantic recall (embeddings)", with the gateway-populated model picker next to it); a later successful key "Test connection" still resets the breaker. Configs that set the key explicitly are unaffected.

## Tests

`test_embed_hardening.py`: client timeout/retries pinned; probe-failure opens the breaker before any turn (and `_embed` short-circuits without touching the route); probe-success keeps semantic recall live; off-by-default pinned. `test_embeddings_wiring`'s default-store test updated to the new contract (keyword-only default). 146+ tests across knowledge/memory/config suites pass; golden updated; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)