### PR TITLE
fix(tools): current_time works on Windows — ship tzdata + degrade gracefully without an IANA db (#1683)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Existing configs that set the key explicitly are unaffected.
 
 ### Fixed
+- **`current_time` works on Windows (and database-less hosts)** (#1683). stdlib
+  `zoneinfo` ships no IANA data — Windows has none of its own, so in the frozen
+  sidecar every `ZoneInfo(...)` raised and the tool rejected all timezones,
+  including its own docstring examples. The `tzdata` package is now a declared
+  dependency and explicitly collected into the sidecar bundle (zoneinfo imports
+  it dynamically — the static scan missed it), and the tool itself degrades
+  gracefully when no database exists at all: it answers in UTC, noting the
+  unavailable zone, instead of erroring on "what time is it".
 - **A hung gateway embedding route can no longer freeze chat** (#1681). The
   embeddings client carried the OpenAI SDK defaults — 600s timeout, 2 retries —
   so one Cloudflare-524-style hang blocked a turn for minutes while the knowledge

--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -94,6 +94,10 @@ COLLECT_ALL = [
     "ddgs",
     "langfuse",
     "croniter",
+    # stdlib zoneinfo's fallback IANA database — Windows has no system tz data,
+    # and zoneinfo imports tzdata DYNAMICALLY, so the import-scan misses it;
+    # without the collect every ZoneInfo(...) in the frozen sidecar raised (#1683).
+    "tzdata",
     # A2A 1.0 (ADR 0014): the SDK + the protoLabs conventions layer (git-dep).
     # Both pull submodules/metadata that a bare import-scan misses — without a
     # full collect, the frozen `protolabs_a2a` is missing `build_agent_card`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ requires-python = ">=3.11"
 # core (the `none`/`console` tiers) — mirrors requirements-core.txt:
 dependencies = [
   "httpx>=0.27",
+  # IANA timezone database for stdlib zoneinfo — Windows ships none (every
+  # ZoneInfo(...) raised there, #1683) and slim containers often lack
+  # /usr/share/zoneinfo. Inert wherever system data exists (POSIX prefers it).
+  "tzdata",
   "a2a-sdk[http-server,fastapi,sqlite]>=1.1",
   "protolabs-a2a @ git+https://github.com/protoLabsAI/protolabs-a2a.git@v0.2.0",
   "fastapi>=0.115",

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -5,6 +5,10 @@
 # run in the `console` and `none` UI tiers (ADR 0010). `requirements.txt`
 # installs exactly this list (`-e .`).
 httpx>=0.27
+# IANA timezone database for stdlib zoneinfo — Windows ships none (every
+# ZoneInfo(...) raised in the frozen sidecar, #1683) and slim containers often
+# lack /usr/share/zoneinfo. Inert wherever system data exists.
+tzdata
 # A2A protocol (spec 1.0) — official SDK. Owns JSON-RPC dispatch, SSE streaming,
 # the task lifecycle, the task + push-config stores, and push delivery. The
 # protolabs-a2a package + a2a_executor.py are a thin conventions/bridge layer on

--- a/tests/test_starter_tools.py
+++ b/tests/test_starter_tools.py
@@ -127,3 +127,28 @@ async def test_fetch_url_rejects_non_http_scheme():
     ):
         result = await fetch_url.ainvoke({"url": bad})
         assert result.startswith("Error:"), f"accepted unsafe url: {bad!r}"
+
+
+@pytest.mark.asyncio
+async def test_current_time_survives_a_missing_tz_database(monkeypatch):
+    """Windows ships no IANA data (stdlib zoneinfo needs the bundled tzdata
+    package, #1683): with NO database, every name — including the tool's own
+    docstring examples — raised, and the tool errored on every call. It must
+    instead answer in UTC, noting the unavailable zone for named requests."""
+    import tools.lg_tools as lg
+
+    class _NoDb:
+        def __init__(self, name):
+            raise lg.ZoneInfoNotFoundError(name)
+
+    monkeypatch.setattr(lg, "ZoneInfo", _NoDb)
+
+    default = await lg.current_time.ainvoke({})
+    assert not default.startswith("Error:")
+    assert "(UTC)" in default and "Human:" in default
+    assert "Note:" not in default  # UTC asked, UTC answered — nothing to caveat
+
+    named = await lg.current_time.ainvoke({"timezone": "America/New_York"})
+    assert not named.startswith("Error:")
+    assert "(UTC)" in named
+    assert "no IANA timezone database" in named

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -192,6 +192,22 @@ async def current_time(timezone: str = "UTC") -> str:
     try:
         tz = ZoneInfo(timezone)
     except ZoneInfoNotFoundError:
+        # Two distinct failures share this exception: an unknown NAME, and a host
+        # with NO IANA database at all — Windows ships none (stdlib zoneinfo needs
+        # the bundled `tzdata` package there, #1683) and slim containers often lack
+        # /usr/share/zoneinfo. On a database-less host every name fails — including
+        # this docstring's examples — so answer in UTC rather than erroring the
+        # tool's core job ("what time is it").
+        try:
+            ZoneInfo("UTC")
+        except ZoneInfoNotFoundError:
+            now = datetime.now(UTC)
+            note = (
+                ""
+                if timezone.strip().upper() in ("UTC", "ETC/UTC")
+                else f"\nNote: no IANA timezone database on this host — {timezone!r} unavailable, showing UTC."
+            )
+            return f"{now.isoformat()} (UTC)\nHuman: {now.strftime('%A, %B %d %Y, %H:%M:%S %Z')}{note}"
         return f"Error: unknown timezone {timezone!r}. Use an IANA name like 'UTC' or 'America/New_York'."
 
     now = datetime.now(tz)

--- a/uv.lock
+++ b/uv.lock
@@ -1539,7 +1539,7 @@ wheels = [
 
 [[package]]
 name = "protoagent"
-version = "0.77.0"
+version = "0.84.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["fastapi", "http-server", "sqlite"] },
@@ -1565,6 +1565,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
+    { name = "tzdata" },
     { name = "uvicorn" },
     { name = "websockets" },
     { name = "youtube-transcript-api" },
@@ -1596,6 +1597,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
+    { name = "tzdata" },
     { name = "uvicorn", specifier = ">=0.30" },
     { name = "websockets", specifier = ">=12.0" },
     { name = "youtube-transcript-api", specifier = ">=1.0" },
@@ -2434,6 +2436,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1683.

## Why every timezone failed on Windows

stdlib `zoneinfo` ships **no zone database** — it reads the OS's IANA data (macOS/Linux have it, Windows doesn't) and falls back to the `tzdata` PyPI package, which protoAgent neither declared nor bundled. In the frozen sidecar every `ZoneInfo(...)` raised, so `current_time` rejected all timezones — including `UTC` and its own docstring examples.

## Fix, three layers

1. **`tzdata` declared** in pyproject (+ `uv.lock`). Inert on POSIX (system data wins via TZPATH); also rescues slim/distroless containers that lack `/usr/share/zoneinfo`.
2. **Bundled into the sidecar**: `--collect-all tzdata` — zoneinfo imports it *dynamically*, so PyInstaller's static scan can't see it; declaring alone wouldn't have shipped the zone files.
3. **Graceful degradation in the tool**: when even `UTC` fails to resolve (no database at all), `current_time` answers in UTC — with an explanatory note when a named zone was requested — instead of erroring on "what time is it". Unknown names on a *healthy* database still return the existing error.

## Tests

New: no-database host answers UTC for the default call (no caveat) and for named zones (with the `no IANA timezone database` note), never `Error:`. Existing named-zone/unknown-zone tests unchanged and green (18/18 in `test_starter_tools.py`). Ruff clean.

Note: the Windows behavior itself needs the next desktop build to verify live (grammar of the freeze); the collect + declared dep is the standard PyInstaller-hooks path for tzdata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)