### PR TITLE
fix(desktop): NSIS hooks stop a running sidecar before (un)install (#1685)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Existing configs that set the key explicitly are unaffected.
 
 ### Fixed
+- **Windows reinstall over kept data no longer fails on a running server**
+  (#1685). Tauri's stock NSIS template closes the main app before (un)installing,
+  but the bundled sidecar (`protoagent-server.exe`) is a separate process it
+  never knew about — a live server (including one run standalone) held the
+  install dir and the installer died with a locked-file error that read as "the
+  directory already exists". New NSIS installer hooks stop the sidecar before
+  install and uninstall; the kept `%APPDATA%` data dir is untouched, so
+  uninstall-keep-data → reinstall is now the reconfigure-free upgrade path it
+  was meant to be.
 - **`current_time` works on Windows (and database-less hosts)** (#1683). stdlib
   `zoneinfo` ships no IANA data — Windows has none of its own, so in the frozen
   sidecar every `ZoneInfo(...)` raised and the tool rejected all timezones,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -32,6 +32,11 @@
         "depends": ["libayatana-appindicator3-1"]
       }
     },
+    "windows": {
+      "nsis": {
+        "installerHooks": "./windows/hooks.nsh"
+      }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/apps/desktop/src-tauri/windows/hooks.nsh
+++ b/apps/desktop/src-tauri/windows/hooks.nsh
@@ -1,0 +1,21 @@
+; protoAgent NSIS installer hooks (#1685).
+;
+; The stock Tauri template closes the MAIN app before (un)installing, but the
+; bundled sidecar (protoagent-server.exe) is a separate process it has never
+; heard of — and it also runs STANDALONE (the documented pre-#1678 workaround).
+; A live server holds its exe / the install dir, so a reinstall-over-kept-data
+; died with a locked-file error that read as "the directory already exists".
+; Stopping it first makes keep-data uninstall → reinstall the blessed,
+; reconfigure-free upgrade path. taskkill on a non-running process is a no-op
+; (nsExec swallows the exit code); /T reaps any child tree; the kept %APPDATA%
+; data dir is never touched.
+
+!macro NSIS_HOOK_PREINSTALL
+  nsExec::Exec 'taskkill /F /IM protoagent-server.exe /T'
+  Pop $0
+!macroend
+
+!macro NSIS_HOOK_PREUNINSTALL
+  nsExec::Exec 'taskkill /F /IM protoagent-server.exe /T'
+  Pop $0
+!macroend


### PR DESCRIPTION
Closes #1685.

## The failure
Uninstall (keeping data, correctly expecting a reconfigure-free reinstall) → reinstall → installer errors, presenting as "the directory already exists." Root cause: Tauri's stock NSIS template closes the **main app** before touching files, but the bundled sidecar `protoagent-server.exe` is a separate process it never knew about — and the pre-#1678 workaround era specifically taught users to run it **standalone**. A live server holds the install dir → NSIS locked-file error.

## The fix
`bundle.windows.nsis.installerHooks` → `windows/hooks.nsh`: `NSIS_HOOK_PREINSTALL` + `NSIS_HOOK_PREUNINSTALL` run `taskkill /F /IM protoagent-server.exe /T` (no-op when nothing is running; `/T` reaps the child tree). The kept `%APPDATA%` data dir is untouched — keep-data → reinstall becomes the blessed upgrade path.

## Validation
PR CI doesn't build NSIS; `makensis` compiles the hooks on the Windows desktop leg — I'll dispatch a **tagless** `desktop-build.yml` after merge to prove the installer builds. The behavioral pass (uninstall-keep-data → reinstall with a server deliberately left running) needs one Windows check when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows installers now handle the app’s background process during setup and removal.
* **Bug Fixes**
  * Improved install and uninstall reliability by ensuring the background process is stopped before those steps continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->