### PR TITLE
chore: release v0.85.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.85.0] - 2026-07-02
+
 ### Changed
 - **Semantic recall (embeddings) now ships OFF by default** (#1681). Out of the box
   the app no longer depends on an optional gateway route: a gateway without a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.84.0"
+version = "0.85.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "v0.85.0",
+    "date": "2026-07-02",
+    "changes": [
+      "Semantic recall (embeddings) now ships OFF by default",
+      "Windows reinstall over kept data no longer fails on a running server",
+      "current_time works on Windows (and database-less hosts)",
+      "A hung gateway embedding route can no longer freeze chat"
+    ]
+  },
+  {
     "version": "v0.84.0",
     "date": "2026-07-02",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.85.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.85.0 -m 'Release v0.85.0' && git push origin v0.85.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).