### PR TITLE
fix(chat): decline isn't an error; cap long command/error content (#1692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Declining a command is no longer a scary full-screen error** (#1692). Denying a
+  `run_command` approval raised a `ToolException`, which the chat rendered as a
+  full-bleed red block that read like a crash and couldn't be dismissed. A decline
+  is the operator's deliberate choice, not a failure — it now returns a normal
+  result (naming the command and telling the model not to retry), rendering as an
+  ordinary collapsed tool card.
+- **Long commands and errors scroll instead of filling the chat** (#1692). The HITL
+  approval command preview (`.hitl-detail`) and tool-error blocks (`.tool-error`)
+  weren't height-capped, so an agent-built long command (e.g. a `gh issue create`
+  with a full body) pushed the Approve/Deny buttons off-screen and a long error
+  filled the pane. Both now cap and scroll, matching the tool-output block.
+
 ## [0.85.0] - 2026-07-02
 
 ### Changed

--- a/apps/web/src/chat/hitl.css
+++ b/apps/web/src/chat/hitl.css
@@ -85,6 +85,10 @@
   white-space: pre-wrap;
   word-break: break-all;
   color: var(--fg);
+  /* A long command (e.g. an agent-built `gh issue create` with a full body) must
+     scroll inside the approval card, not push Approve/Deny off-screen (#1691). */
+  max-height: 260px;
+  overflow-y: auto;
 }
 
 .hitl-actions {

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -292,6 +292,14 @@
   color: var(--error);
   font-size: 0.8rem;
   line-height: 1.45;
+  /* Cap like .tool-text — a long error body (a failed command echoing its whole
+     input) must scroll inside the card, not fill the pane (#1691). */
+  max-height: 220px;
+  overflow-y: auto;
+}
+.tool-error span {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 .tool-error svg {
   flex: none;

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -401,14 +401,15 @@ async def test_tool_events_surface_as_tool_call_dataparts():
 @pytest.mark.asyncio
 async def test_errored_tool_end_surfaces_phase_failed():
     """A tool_end flagged error → a phase=\"failed\" tool-call DataPart (the card
-    renders the X), carrying the error text. A declined run_command takes this path."""
+    renders the X), carrying the error text. A genuine command failure takes this
+    path — a DECLINE no longer does (#1692: it returns a normal result now)."""
     import json
 
     async def stream(text, ctx, *, resume=False, caller_trace=None, **kwargs):
-        yield ("tool_start", {"id": "t1", "name": "run_command", "input": {"command": "rm -rf /"}})
+        yield ("tool_start", {"id": "t1", "name": "run_command", "input": {"command": "false"}})
         yield (
             "tool_end",
-            {"id": "t1", "name": "run_command", "output": "Command declined by the operator — not run", "error": True},
+            {"id": "t1", "name": "run_command", "output": "Error: command exited 1", "error": True},
         )
         yield ("done", "ok")
 
@@ -442,7 +443,7 @@ async def test_errored_tool_end_surfaces_phase_failed():
     failed = next((p for p in payloads if p["phase"] == "failed"), None)
     assert failed is not None, [p["phase"] for p in payloads]
     assert failed["name"] == "run_command"
-    assert "declined" in (failed.get("error") or "")
+    assert "exited 1" in (failed.get("error") or "")
 
 
 @pytest.mark.asyncio

--- a/tests/test_fs_tools.py
+++ b/tests/test_fs_tools.py
@@ -152,12 +152,12 @@ def test_run_command_runs_via_shell(workspace):
     assert out.splitlines() == ["one", "two"]
 
 
-def test_run_command_declined_raises(workspace, monkeypatch):
-    """A declined approval RAISES (ToolException) rather than returning a string —
-    so the ToolNode stamps status="error" and the chat card shows the X, not a green
-    'done'. interrupt() is stubbed to the deny decision (no graph runtime needed)."""
+def test_run_command_declined_returns_not_raises(workspace, monkeypatch):
+    """A declined approval RETURNS a plain result — NOT a ToolException. A decline is
+    the operator's deliberate choice, not a failure: raising stamped status="error"
+    and the chat rendered an undismissable full-bleed red block. The result names the
+    declined command and tells the model not to retry. interrupt() is stubbed to deny."""
     import langgraph.types
-    from langchain_core.tools import ToolException
 
     _, a, _ = workspace
     monkeypatch.setattr(langgraph.types, "interrupt", lambda payload: "denied")
@@ -168,8 +168,10 @@ def test_run_command_declined_raises(workspace, monkeypatch):
             filesystem_run_requires_approval=True,
         )
     )
-    with pytest.raises(ToolException):
-        asyncio.run(t["run_command"].ainvoke({"project": "a", "command": "ls"}))
+    out = asyncio.run(t["run_command"].ainvoke({"project": "a", "command": "ls"}))
+    assert "declined by the operator" in out
+    assert "ls" in out
+    assert "Do not re-run" in out
 
 
 def test_run_command_bypass_skips_approval(workspace, monkeypatch):
@@ -196,9 +198,10 @@ def test_run_command_bypass_skips_approval(workspace, monkeypatch):
 
 def test_run_command_bypass_forbidden_by_host_still_gates(workspace, monkeypatch):
     """When the host forbids bypass (filesystem_bypass_allowed=False), caller bypass metadata is
-    IGNORED and the approval gate still fires (here stubbed to deny → raises)."""
+    IGNORED and the approval gate still fires — here stubbed to deny, so the command doesn't run
+    and returns the decline result (the gate firing is the point; the decline handling is
+    covered by test_run_command_declined_returns_not_raises)."""
     import langgraph.types
-    from langchain_core.tools import ToolException
     from graph.middleware.request_context import request_metadata_scope
 
     _, a, _ = workspace
@@ -212,8 +215,8 @@ def test_run_command_bypass_forbidden_by_host_still_gates(workspace, monkeypatch
         )
     )
     with request_metadata_scope({"bypass_permissions": True}):
-        with pytest.raises(ToolException):
-            asyncio.run(t["run_command"].ainvoke({"project": "a", "command": "ls"}))
+        out = asyncio.run(t["run_command"].ainvoke({"project": "a", "command": "ls"}))
+    assert "declined by the operator" in out  # gate fired despite the bypass request
 
 
 # ── config round-trip ──────────────────────────────────────────────────────────

--- a/tools/fs_tools.py
+++ b/tools/fs_tools.py
@@ -288,10 +288,16 @@ def build_fs_tools(config) -> list:
                     }
                 )
                 if not _approved(decision):
-                    # Raise (not return) so the ToolNode stamps the ToolMessage
-                    # status="error": the chat card then renders the declined action
-                    # as a failure (red X) instead of a green "done" with decline text.
-                    raise ToolException(f"Command declined by the operator — not run: {command!r}")
+                    # RETURN (not raise): a decline is the operator's deliberate choice,
+                    # not a tool failure — raising stamped status="error", which the chat
+                    # rendered as a full-bleed red block the operator couldn't dismiss
+                    # (and read as "something broke"). A normal result renders as an
+                    # ordinary collapsed tool card. The message tells the model to stop,
+                    # not retry, so a decline ends the attempt cleanly.
+                    return (
+                        f"Command declined by the operator — not run: {command!r}. "
+                        "Do not re-run it; wait for the operator's next instruction or ask how to proceed."
+                    )
             elif run_requires_approval:
                 # Bypass-permissions mode (the operator's explicit per-turn /bypass toggle): the
                 # approval gate is skipped. AUDIT every command that runs without confirmation.


### PR DESCRIPTION
Closes #1692. Three chat UX failures, all hit driving Roxy (the agent built a long `gh issue create` and I denied it):

## 1. Declining a command rendered as an undismissable full-screen red error
`tools/fs_tools.py` **raised** `ToolException` on decline *specifically* to stamp `status="error"` (the old comment says so). But a decline is the operator's deliberate choice — it rendered as a full-bleed red block that reads like a crash, with no way to dismiss. Now it **returns** a normal result naming the declined command and telling the model not to retry → renders as an ordinary collapsed tool card, and the turn ends cleanly.

## 2 & 3. Long command / error content wasn't height-capped
`.hitl-detail` (the Approve/Deny command preview) and `.tool-error` both missed the `max-height` + scroll that `.tool-text` already has — so a long command pushed the approval buttons off-screen (you had to Tab to reach Apply) and a long error filled the pane. Both now cap (260/220px) and scroll.

## Verified
Rendered the approval card against the built CSS with a 120-line command: the preview caps at **258px and scrolls**, the whole card is **353px** (was 900+), and **Deny/Approve stay visible** — screenshot in the PR thread. `test_run_command_declined_returns_not_raises` + the bypass-gate test updated to the return contract; the a2a-handler error-frame test switched to a genuine failure (a decline no longer takes that path). 329 web unit tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)