### PR TITLE
chore: release v0.86.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.86.0] - 2026-07-03
+
 ### Fixed
 - **Declining a command is no longer a scary full-screen error** (#1692). Denying a
   `run_command` approval raised a `ToolException`, which the chat rendered as a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.85.0"
+version = "0.86.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "v0.86.0",
+    "date": "2026-07-03",
+    "changes": [
+      "Declining a command is no longer a scary full-screen error",
+      "Long commands and errors scroll instead of filling the chat"
+    ]
+  },
+  {
     "version": "v0.85.0",
     "date": "2026-07-02",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.86.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.86.0 -m 'Release v0.86.0' && git push origin v0.86.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).