### PR TITLE
feat(chat): dismiss a hard turn-error bubble in place (#1695)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Dismiss a hard turn-error bubble in place** (#1695). A hard turn error (network
+  drop, backend 500 mid-stream) left an error bubble that could only be cleared by
+  reloading the whole app. The message action row now shows a **Dismiss** action on
+  errored messages that removes the local-only bubble and clears the session's error
+  dot — no reload.
+
 ## [0.86.0] - 2026-07-03
 
 ### Fixed

--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -2,7 +2,7 @@ import { Button } from "@protolabsai/ui/primitives";
 import { Message, MessageAction, MessageActions } from "@protolabsai/ui/ai";
 import { Tooltip } from "@protolabsai/ui/overlays";
 import { Spinner } from "@protolabsai/ui/data";
-import { ArrowDownToLine, Check, Clock, Coins, Copy, FileText, GitBranch, Gauge, History, Maximize2, RotateCcw } from "lucide-react";
+import { ArrowDownToLine, Check, Clock, Coins, Copy, FileText, GitBranch, Gauge, History, Maximize2, RotateCcw, X } from "lucide-react";
 import { useLayoutEffect, useRef, useState } from "react";
 
 import { openDocument } from "../docviewer";
@@ -25,6 +25,9 @@ export type ChatMessageActions = {
   onFork?: (m: ChatMessage) => void;
   onRewind?: (m: ChatMessage) => void;
   onRegenerate?: (id: string) => void;
+  // Remove a local-only errored turn from the transcript (#1695) — the error bubble is
+  // display-only (not backend history), so a reload clears it; this offers a dismiss in place.
+  onDismiss?: (id: string) => void;
   lastAssistantId?: string;
   regenDisabled?: boolean;
 };
@@ -192,6 +195,9 @@ export function ChatMessageView({
               disabled={actions.regenDisabled}
               onClick={() => actions.onRegenerate!(message.id!)}
             />
+          ) : null}
+          {actions.onDismiss && message.status === "error" ? (
+            <MessageAction label="Dismiss" icon={<X size={14} />} onClick={() => actions.onDismiss!(message.id!)} />
           ) : null}
         </MessageActions>
       ) : null}

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -909,6 +909,22 @@ function ChatSessionSlot({
   // then re-run the user message that prompted it via the `hidden` path — no
   // duplicate user bubble, just a fresh streaming assistant. Only offered on the
   // last assistant message when idle.
+  // Drop a local-only errored turn from the transcript (#1695). A hard turn error
+  // parks the assistant bubble at status "error" with the error as content — it's
+  // never backend history (a reload omits it), so removing it here is purely local
+  // and safe. Only errored messages expose the Dismiss action that calls this.
+  function dismissErroredMessage(messageId: string) {
+    if (!session) return;
+    const snap = chatStore.getSnapshot().sessions.find((s) => s.id === session.id);
+    if (!snap) return;
+    chatStore.updateMessages(
+      session.id,
+      snap.messages.filter((m) => m.id !== messageId),
+    );
+    // Clear the session's error dot too (it drove the red status pill).
+    if (status === "error") chatStore.setSessionStatus(session.id, "idle");
+  }
+
   function regenerate(assistantId?: string) {
     if (!assistantId || !session || status === "streaming") return;
     const snap = chatStore.getSnapshot().sessions.find((s) => s.id === session.id);
@@ -1376,6 +1392,7 @@ function ChatSessionSlot({
                 onFork: forkAtMessage,
                 onRewind: rewindAtMessage,
                 onRegenerate: regenerate,
+                onDismiss: dismissErroredMessage,
                 lastAssistantId,
                 regenDisabled: status === "streaming",
               }}


### PR DESCRIPTION
Closes #1695. Follow-up to #1692 — you asked for a way to clear a chat error without reloading.

A hard turn error (network drop, backend 500 mid-stream) parks the assistant bubble at `status="error"` with the error as its content. It's **local-only** — a reload omits it (it's never backend history) — so there's nothing to clean up server-side, but until now the only way to clear it *was* a reload.

- New optional `onDismiss` action on the message action row, gated on `message.status === "error"` so it never appears on normal messages. It filters the bubble out of the local transcript and resets the session's error dot to idle.
- `dismissErroredMessage` reads/writes only the chat store — no backend call, matching how the error bubble got there.

Verified: typecheck + `vite build` clean in a fresh `npm ci` worktree (my local node_modules had stale DS types); 329 web unit tests pass. No isolated e2e error-turn harness exists to assert the button against — building one is disproportionate for an optional action; the render gate + filter are build-verified and trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Dismiss** action for errored assistant messages in chat.
  * Users can now remove a failed message from the visible transcript directly from the message actions menu.
  * When the current chat is in an error state, dismissing the message also clears the session error state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->