### PR TITLE
fix(wait): one pending wait per thread + log every scheduling (#1702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`wait` no longer stacks wake-ups — one pending wait per thread** (#1702). The
+  `wait` tool scheduled a new one-shot resume on every call with no dedup, so an
+  agent that under-waited and re-waited piled up overlapping wakes that all fired
+  into the same thread ("old resume messages catching up"). A new `wait` now
+  supersedes any still-pending wait for the same session (a stable per-thread job
+  id → cancel-then-add), and every scheduling is logged (`[wait] thread=… in Ns …`
+  incl. whether it superseded a prior wait) — previously the loop was invisible in
+  logs.
+
 ### Added
 - **Dismiss a hard turn-error bubble in place** (#1695). A hard turn error (network
   drop, backend 500 mid-stream) left an error bubble that could only be cleared by

--- a/tests/test_wait_yield.py
+++ b/tests/test_wait_yield.py
@@ -76,11 +76,21 @@ class _FakeScheduler:
     def __init__(self):
         self.added: list[tuple[str, str]] = []
         self.last_context_id: str | None = "__unset__"
+        self.jobs: dict[str, str] = {}  # job_id → schedule (models the pending set)
+        self.cancelled: list[str] = []
 
     def add_job(self, prompt, schedule, *, job_id=None, timezone=None, context_id=None):
+        if job_id and job_id in self.jobs:
+            raise ValueError(f"job id {job_id!r} already exists")  # faithful to the real backend
         self.added.append((prompt, schedule))
         self.last_context_id = context_id
+        if job_id:
+            self.jobs[job_id] = schedule
         return _FakeJob(schedule)
+
+    def cancel_job(self, job_id):
+        self.cancelled.append(job_id)
+        return self.jobs.pop(job_id, None) is not None
 
     def list_jobs(self):
         return []
@@ -210,3 +220,38 @@ async def test_wait_in_a_real_graph_stamps_the_turn_session(monkeypatch):
         config={"configurable": {"thread_id": "t1"}},
     )
     assert sched.last_context_id == "sess-XYZ"
+
+
+@pytest.mark.asyncio
+async def test_wait_supersedes_a_pending_wait_for_the_same_thread():
+    """One pending wait per thread (#1702): a second wait for the same session cancels
+    the first, so stacked wakes can't pile up (the 'old resume messages catching up' bug)."""
+    sched = _FakeScheduler()
+    state = {"session_id": "chat-abc"}
+    await _wait_tool(sched).ainvoke({"seconds": 30, "then": "check ship", "state": state})
+    await _wait_tool(sched).ainvoke({"seconds": 200, "then": "check ship again", "state": state})
+    # both waits target the stable per-session id; the second actually superseded the
+    # first (proven by exactly ONE pending job despite two add_jobs — without the
+    # cancel, the second add_job would ValueError on the duplicate id).
+    assert sched.cancelled == ["wait:chat-abc", "wait:chat-abc"]
+    assert list(sched.jobs) == ["wait:chat-abc"]
+    assert len(sched.added) == 2  # both scheduled cleanly (no duplicate-id error)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_different_threads_do_not_supersede_each_other():
+    sched = _FakeScheduler()
+    await _wait_tool(sched).ainvoke({"seconds": 10, "then": "a", "state": {"session_id": "chat-1"}})
+    await _wait_tool(sched).ainvoke({"seconds": 10, "then": "b", "state": {"session_id": "chat-2"}})
+    assert set(sched.jobs) == {"wait:chat-1", "wait:chat-2"}  # both pending, independent
+
+
+@pytest.mark.asyncio
+async def test_wait_logs_the_scheduling(caplog):
+    import logging
+
+    sched = _FakeScheduler()
+    with caplog.at_level(logging.INFO, logger="protoagent.tools"):
+        await _wait_tool(sched).ainvoke({"seconds": 45, "then": "dock and sell", "state": {"session_id": "chat-x"}})
+    line = next((r.getMessage() for r in caplog.records if "[wait]" in r.getMessage()), "")
+    assert "thread=chat-x" in line and "45s" in line and "dock and sell" in line

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import logging
 import operator as _op
 from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
@@ -50,6 +51,8 @@ from langchain_core.tools import tool
 from langgraph.prebuilt import InjectedState
 
 from tools.fallbacks import with_fallback
+
+log = logging.getLogger("protoagent.tools")
 
 
 # ── current_time ─────────────────────────────────────────────────────────────
@@ -1118,10 +1121,30 @@ def _build_scheduler_tools(scheduler) -> list:
         # tracing contextvar — the contextvar reads empty in a tool body under
         # LangGraph, which silently dropped this resume to the Activity thread.
         ctx = _session_id_from(state) or None
+        # ONE pending wait per thread. A stable per-session job id means a new wait
+        # SUPERSEDES a still-pending one instead of stacking beside it — the bug behind
+        # "old resume messages catching up" (#1702): an agent that under-waited then
+        # re-waited scheduled N overlapping wakes that all fired into this thread. The
+        # cancel-then-add is safe because waits within a turn are sequential.
+        wait_job_id = f"wait:{ctx or 'activity'}"
+        superseded = False
         try:
-            await asyncio.to_thread(scheduler.add_job, then, when, context_id=ctx)
+            superseded = await asyncio.to_thread(scheduler.cancel_job, wait_job_id)
+        except Exception:  # noqa: BLE001 — a stale/absent prior wait must not block the new one
+            pass
+        try:
+            await asyncio.to_thread(scheduler.add_job, then, when, job_id=wait_job_id, context_id=ctx)
         except Exception as exc:  # noqa: BLE001
             return f"Error: couldn't schedule the wake-up: {exc}"
+        # Observability (#1702): every wait is logged with its thread, delay, resume
+        # snippet, and whether it replaced a pending wait — so a stacking loop is visible.
+        log.info(
+            "[wait] thread=%s in %ss%s → resume: %.80s",
+            ctx or "activity",
+            secs,
+            " (superseded a pending wait)" if superseded else "",
+            then,
+        )
         # Concise, human-friendly summary — the agent should paraphrase this, not
         # echo it (the old ISO timestamp / "re-invoked at" phrasing read as raw
         # system text when parroted into chat). Machine-relevant facts stay intact:


### PR DESCRIPTION
Refs #1702. Diagnosed from protoTrader: an agent waiting on a ship in multi-minute transit spammed `wait`/`st_ship` and kept saying *"old resume messages catching up"* — stacked wakes firing into the same thread.

## Root cause
`wait` called `scheduler.add_job(...)` **unconditionally** — no per-session dedup. Every `wait` scheduled a NEW one-shot wake for the thread, so an agent that under-waited then re-waited piled up overlapping resumes that all fired. And `wait` logged nothing, so the loop was invisible.

## Fix (the 'wait tracker')
- **One pending wait per thread**: a stable per-session job id `wait:<session>` → cancel-then-add, so a new `wait` **supersedes** a still-pending one instead of stacking. Waits within a turn are sequential, so cancel-then-add is safe; a user `schedule_task` uses its own id and is untouched.
- **Logging**: every scheduling logs `[wait] thread=… in Ns (superseded a pending wait) → resume: …`.

## Field due diligence
The universal guidance is *don't poll in sleep loops; use event-driven yield + state-persist + resume* ([async agent workflows](https://www.augmentcode.com/guides/async-ai-agent-workflows), [agent anti-patterns](https://achan2013.medium.com/ai-agent-anti-patterns-part-1-architectural-pitfalls-that-break-enterprise-agents-before-they-32d211dded43)) — which is exactly what `wait`/interrupt-resume already is. The bug was the missing per-thread dedup, not the mechanism.

## Tests
supersede (two waits for one thread → one pending, both scheduled cleanly), independent threads don't supersede each other, and the log line. 107 scheduler/wait tests pass; ruff clean.

## Complement (separate PR)
The spacetraders-plugin under-wait amplifier — `st_navigate`/`st_travel` return an ISO timestamp, so the agent computes the ETA wrong. Fix there: return the ETA in **seconds** + an explicit `wait(N, …)` nudge so it waits the full duration once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wait scheduling so only one pending wait is kept per thread/session, preventing older waits from interfering with newer ones.
  * Waits for different threads/sessions now stay independent.
  * Added clearer scheduling logs that include the thread/session context, delay, and follow-up message for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->