### PR TITLE
docs(wait): reference section + ADR 0053 dedup/log update (#1702)

### DIFF
--- a/docs/adr/0053-wait-yield-and-resume.md
+++ b/docs/adr/0053-wait-yield-and-resume.md
@@ -93,3 +93,28 @@ chat's next interaction.
 - Follow-up: live UI surfacing of the resumed turn in the originating chat tab
   (per-session push à la ADR 0050), so a watching user sees the continuation
   arrive rather than only the agent picking it up server-side.
+
+## Update (2026-07-03, #1702) — one pending wait per thread + logging
+
+The turn-ending middleware stops the *in-turn* poll loop, but a subtler failure
+survived: an agent that **under-waits** (waits 30s of a 200s transit, wakes
+early, sees "not done", waits again) scheduled a NEW one-shot resume each time —
+`wait` called `scheduler.add_job` unconditionally, with no dedup. The pending
+wakes stacked up and all fired into the same thread, and the agent narrated them
+as "old resume messages catching up". It was also invisible in logs.
+
+Refinement:
+
+- **One pending wait per thread.** `wait` now uses a stable per-session job id
+  `wait:<context_id>` and cancels any still-pending wait for that thread before
+  adding the new one (cancel-then-add; waits within a turn are sequential, so
+  it's safe). A new `wait` therefore *supersedes* the prior one instead of
+  stacking beside it. A user `schedule_task` uses its own generated id and is
+  never touched.
+- **Logging.** Every wait logs its thread, delay, resume snippet, and whether it
+  superseded a pending wait (`[wait] thread=… in Ns (superseded a pending wait)
+  → resume: …`) — so a stacking loop is diagnosable from logs.
+- **Complement (spacetraders-plugin):** the amplifier was a nav tool returning
+  the arrival as an ISO timestamp the agent had to diff against `current_time`
+  (and lowballed). Status/nav tools should hand the agent the ETA in **seconds**
+  plus the exact `wait(N, …)` call, so it waits the full duration once.

--- a/docs/reference/starter-tools.md
+++ b/docs/reference/starter-tools.md
@@ -223,6 +223,43 @@ Cancel a scheduled job by id. Returns `"Canceled <id>."` or `"Error: no such job
 
 Cross-agent cancellation is blocked — `gina-personal` cannot cancel `gina-work`'s jobs even when sharing a sqlite path.
 
+## `wait`
+
+```python
+@tool
+async def wait(seconds: int, then: str) -> str
+```
+
+Yield the turn and resume LATER instead of busy-polling a status tool to wait
+something out ([ADR 0053](/adr/0053-wait-yield-and-resume)). Calling `wait` **ends
+the current turn** (via `WaitYieldMiddleware`) and schedules a one-shot resume
+`seconds` from now; when it fires the agent is re-invoked with `then` as its
+instruction, in the **same conversation thread** (history intact) — so it acts
+exactly once, when the thing is actually ready. This is the right way to run
+long-horizon "do X, wait, do Y" work without burning the recursion budget on a
+poll loop.
+
+`then` is required and **self-contained** — it's the agent's only context on
+resume, so it must name what to do and which entities are involved ("Dock
+NOVAHAUL-5 at X1-UC87-K93, sell the ore, accept the next contract"), not a
+back-reference. `seconds` is clamped to ≥ 1; pass the ETA a status tool gave you
+(e.g. `st_navigate` returns `arriving in Ns` and the exact `wait(N, …)` call) and
+wait the **full** duration in one call — under-waiting just wakes early to wait
+again.
+
+**One pending wait per thread** ([#1702](https://github.com/protoLabsAI/protoAgent/issues/1702)):
+a new `wait` **supersedes** any still-pending wait for the same session (a stable
+`wait:<session>` job id → cancel-then-add), so repeated waits can't stack up into
+a pile of wake-ups that all fire into the thread. A user `schedule_task` uses its
+own id and is untouched. Every scheduling is logged —
+`[wait] thread=… in Ns (superseded a pending wait) → resume: …` — so a stacking
+loop is visible in logs.
+
+**Lead-agent only** (gated on the scheduler; subagents run bounded by `max_turns`
+and don't get it). The yield is durable across restart (a persisted scheduler
+job). For an absolute time or a recurring cadence use `schedule_task` instead —
+`wait` is for "yield for a bit, then pick this back up".
+
 ## `ask_human`
 
 ```python


### PR DESCRIPTION
Follow-up to #1703. Two doc gaps around `wait`:

1. **`wait` was missing from the starter-tools reference.** The scheduler trio (`schedule_task`/`list_schedules`/`cancel_schedule`) is documented but `wait` — a core tool bound in the same builder — wasn't. Added a `## wait` section: signature, yield-resume semantics, the self-contained `then`, waiting the full ETA in one call, the **one-pending-wait-per-thread** supersede, the logging, and lead-only gating.
2. **ADR 0053 predated the #1702 fix.** Added an `## Update (2026-07-03, #1702)` recording the stacking bug the original decision didn't foresee, the per-thread dedup + logging refinement, and the spacetraders ETA-in-seconds complement.

Docs-only — no CHANGELOG entry (the behavior is already logged in #1703's [Unreleased] entry). `docs:build` passes (the vitepress dead-link + parse gate); both new links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)