### PR TITLE
chore: release v0.87.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.87.0] - 2026-07-03
+
 ### Fixed
 - **`wait` no longer stacks wake-ups — one pending wait per thread** (#1702). The
   `wait` tool scheduled a new one-shot resume on every call with no dedup, so an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.86.0"
+version = "0.87.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "v0.87.0",
+    "date": "2026-07-03",
+    "changes": [
+      "wait no longer stacks wake-ups — one pending wait per thread",
+      "Dismiss a hard turn-error bubble in place"
+    ]
+  },
+  {
     "version": "v0.86.0",
     "date": "2026-07-03",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.87.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.87.0 -m 'Release v0.87.0' && git push origin v0.87.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **v0.87.0**.
  * Added a new release note entry for **v0.87.0** with these highlights:
    * Waiting now avoids stacking multiple wake-ups for the same thread.
    * Hard turn-error bubbles can now be dismissed in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->