### PR TITLE
ci(issue-gate): extend heading vocabulary so real issue bodies conform

### DIFF
--- a/.github/workflows/issue-gate.yml
+++ b/.github/workflows/issue-gate.yml
@@ -61,9 +61,9 @@ jobs:
 
             const text = body.replace(/\s+/g, ' ').trim();
             const longEnough = text.length >= 80;
-            const hasProblem = hasSection(/problem|what'?s? wrong|motivation|background|context|summary/i);
-            const hasRepro = hasSection(/repro|reproduce|steps|evidence|expected|actual|observed/i);
-            const hasProposal = hasSection(/propos|solution|approach|direction|fix|design/i);
+            const hasProblem = hasSection(/problem|what'?s? wrong|motivation|background|context|summary|observed|symptom|idea|current behavior|\bwhat\b/i);
+            const hasRepro = hasSection(/repro|reproduce|steps|evidence|expected|actual|observed|symptom|root cause/i);
+            const hasProposal = hasSection(/propos|solution|approach|direction|fix|design|\bwork\b|plan/i);
             const hasAcceptance = hasSection(/acceptance|done when|success criteria|definition of done/i);
 
             const missing = [];


### PR DESCRIPTION
## What / why

The silent issue gate (`.github/workflows/issue-gate.yml`) labeled **5 detailed, well-formed issues** `needs-info` because its heading regexes miss the heading vocabulary actually in use:

- #1709, #1710 — `## Observed (…)` / `## Expected` matched no problem-regex term (`observed` was only in `hasRepro`)
- #1702 (bug) — `## Symptom (…)` and `## Root cause (…)` matched neither the problem regex nor the repro regex
- #1701 (enhancement) — `## Idea` matched no problem-regex term
- #1689 (enhancement) — `## What` matched nothing; `## Context` satisfied the problem check but `## Work` missed the proposal regex

(These are **motivation, not closed by this PR** — no `Fixes` keywords on purpose; they're real bug/feature issues that should stay open.)

## Root cause

The gate's section vocabulary was seeded from the CONTRIBUTING.md template headings (`Problem`, `Steps to reproduce`, `Proposed direction`, …) but real issue authors — human and agent — use a wider, equally-legitimate vocabulary (`Observed`, `Symptom`, `Root cause`, `Idea`, `What`, `Work`). Headings outside the seed list read as "missing section" and trip the false `needs-info`.

## Fix

Additive-only, case-insensitive regex extension — exactly the three regex lines, nothing else:

- `hasProblem` += `observed|symptom|idea|current behavior|\bwhat\b`
- `hasRepro` += `symptom|root cause`
- `hasProposal` += `\bwork\b|plan`

The length gate (>= 80 chars) and the `bug`/`enhancement` conditional logic are unchanged. Generic words (`what`, `work`) are word-bounded to avoid matching inside longer words.

## Test evidence

Scratch node script (deleted before commit) replicating the workflow's `hasSection` + validation logic verbatim with the new regexes, fed the **real** bodies from `gh issue view N --json body,labels` and each issue's actual type labels:

```
#1689 [enhancement] -> CONFORMS
#1701 [enhancement] -> CONFORMS
#1702 [bug] -> CONFORMS
#1709 [no type label] -> CONFORMS
#1710 [no type label] -> CONFORMS
junk body [no type label] -> FLAGGED (a substantive description (>= 80 chars); a Problem / What-is-wrong / Motivation section)
junk body [bug] -> FLAGGED (a substantive description (>= 80 chars); a Problem / What-is-wrong / Motivation section; Steps to reproduce / Evidence / Expected-vs-actual (bug))
junk body [enhancement] -> FLAGGED (a substantive description (>= 80 chars); a Problem / What-is-wrong / Motivation section; a Proposed-direction or Acceptance section (enhancement))

ALL ASSERTIONS PASSED
```

And the same harness with the OLD regexes reproduces the failures exactly as diagnosed:

```
#1689 OLD regexes -> MISSING: proposal/acceptance
#1701 OLD regexes -> MISSING: problem
#1702 OLD regexes -> MISSING: problem, repro
#1709 OLD regexes -> MISSING: problem
#1710 OLD regexes -> MISSING: problem
```

Refs #1689, #1701, #1702, #1709, #1710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)