### PR TITLE
feat(web): chat quick-wins — Shift+click + for incognito, short composer placeholder, client /help

### DIFF
--- a/apps/web/e2e/chat-incognito-add.spec.ts
+++ b/apps/web/e2e/chat-incognito-add.spec.ts
@@ -41,6 +41,23 @@ test("Shift+Enter on the focused + is the keyboard twin of the gesture", async (
   await expect(page.locator(".pl-tabbar__tab--active .session-incognito-icon")).toHaveCount(0);
 });
 
+test("holding Shift+Enter (key auto-repeat) creates only one incognito session", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const tabs = page.locator(".pl-tabbar__tab");
+  await expect(tabs).toHaveCount(1);
+
+  const addBtn = page.locator(".pl-tabbar__add:visible");
+  await addBtn.focus();
+  // The first keydown (repeat:false) creates the session; the OS then fires further
+  // keydowns with repeat:true for as long as the key is held — those must be ignored,
+  // or holding the key would spawn one incognito tab per repeat event.
+  await addBtn.dispatchEvent("keydown", { key: "Enter", shiftKey: true, repeat: false });
+  await expect(tabs).toHaveCount(2);
+  await addBtn.dispatchEvent("keydown", { key: "Enter", shiftKey: true, repeat: true });
+  await addBtn.dispatchEvent("keydown", { key: "Enter", shiftKey: true, repeat: true });
+  await expect(tabs).toHaveCount(2);
+});
+
 test("the + button's hover hint teaches the Shift+click gesture", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await expect(page.locator(".pl-tabbar__add:visible")).toHaveAttribute(

--- a/apps/web/e2e/chat-incognito-add.spec.ts
+++ b/apps/web/e2e/chat-incognito-add.spec.ts
@@ -24,6 +24,23 @@ test("Shift+click the + opens an incognito chat; plain click stays regular", asy
   await expect(page.locator(".composer-incognito-toggle:visible")).toHaveCount(0);
 });
 
+test("Shift+Enter on the focused + is the keyboard twin of the gesture", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const tabs = page.locator(".pl-tabbar__tab");
+  await expect(tabs).toHaveCount(1);
+
+  await page.locator(".pl-tabbar__add:visible").focus();
+  await page.keyboard.press("Shift+Enter");
+  await expect(tabs).toHaveCount(2);
+  await expect(page.locator(".pl-tabbar__tab--active .session-incognito-icon")).toBeVisible();
+
+  // Plain Enter on the focused + still creates a REGULAR session.
+  await page.locator(".pl-tabbar__add:visible").focus();
+  await page.keyboard.press("Enter");
+  await expect(tabs).toHaveCount(3);
+  await expect(page.locator(".pl-tabbar__tab--active .session-incognito-icon")).toHaveCount(0);
+});
+
 test("the + button's hover hint teaches the Shift+click gesture", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await expect(page.locator(".pl-tabbar__add:visible")).toHaveAttribute(

--- a/apps/web/e2e/chat-incognito-add.spec.ts
+++ b/apps/web/e2e/chat-incognito-add.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+// Shift+click the tab bar's "+" → a NEW INCOGNITO session (#1697): same semantics as the
+// tab context menu's "New incognito chat" (createSession({incognito:true})) — the new tab
+// carries the eye-off glyph and the composer shows the incognito chip. Plain click is
+// unchanged (a regular session, no glyph).
+
+test("Shift+click the + opens an incognito chat; plain click stays regular", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const tabs = page.locator(".pl-tabbar__tab");
+  await expect(tabs).toHaveCount(1);
+
+  // Shift+click the add "+" → the new (active) tab is incognito.
+  await page.locator(".pl-tabbar__add:visible").click({ modifiers: ["Shift"] });
+  await expect(tabs).toHaveCount(2);
+  await expect(page.locator(".pl-tabbar__tab--active .session-incognito-icon")).toBeVisible();
+  // …and the composer shows the incognito chip for that session.
+  await expect(page.locator(".composer-incognito-toggle:visible")).toBeVisible();
+
+  // Plain click still creates a REGULAR session: no glyph on the new active tab, no chip.
+  await page.locator(".pl-tabbar__add:visible").click();
+  await expect(tabs).toHaveCount(3);
+  await expect(page.locator(".pl-tabbar__tab--active .session-incognito-icon")).toHaveCount(0);
+  await expect(page.locator(".composer-incognito-toggle:visible")).toHaveCount(0);
+});
+
+test("the + button's hover hint teaches the Shift+click gesture", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.locator(".pl-tabbar__add:visible")).toHaveAttribute(
+    "title",
+    /Shift\+click for incognito/,
+  );
+});

--- a/apps/web/e2e/commands.spec.ts
+++ b/apps/web/e2e/commands.spec.ts
@@ -6,7 +6,7 @@ import { SLASH_COMMANDS } from "./fixtures.mjs";
 // (GET /api/chat/commands) and autocompletes them as you type "/name".
 
 // Deterministic client-side commands (ADR 0057) surface FIRST, then the server skills.
-const CLIENT_SLASH = ["/new", "/clear", "/compact", "/effort", "/incognito", "/bypass"];
+const CLIENT_SLASH = ["/new", "/clear", "/compact", "/effort", "/incognito", "/help", "/bypass"];
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -177,6 +177,7 @@ export function ChatSurface({
     if (!(e.target as HTMLElement).closest(".pl-tabbar__add")) return;
     e.preventDefault();
     e.stopPropagation();
+    if (e.repeat) return; // held key auto-repeats keydown — only the first press creates a session
     chatStore.createSession({ incognito: true });
   }
 

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -145,6 +145,16 @@ export function ChatSurface({
   // delete directly. Maps the clicked ✕ to its session by sibling index (DOM = sessions order).
   function onTabBarClickCapture(e: ReactMouseEvent) {
     if (!e.shiftKey) return;
+    // Shift+click the add "+" → new INCOGNITO session (#1697): the click-path twin of the
+    // tab context menu's "New incognito chat" (same createSession({incognito:true})
+    // semantics). Intercepted in the capture phase so the DS button's own onClick (the
+    // plain add) never fires; a plain click is untouched.
+    if ((e.target as HTMLElement).closest(".pl-tabbar__add")) {
+      e.preventDefault();
+      e.stopPropagation();
+      chatStore.createSession({ incognito: true });
+      return;
+    }
     const closeBtn = (e.target as HTMLElement).closest(".pl-tabbar__close");
     if (!closeBtn) return;
     const tabEl = closeBtn.closest(".pl-tabbar__tab") as HTMLElement | null;
@@ -225,7 +235,9 @@ export function ChatSurface({
           onReorder={(next) => chatStore.reorderSessions(next.map((t) => t.id))}
           onAdd={() => chatStore.createSession()}
           onTabContextMenu={onTabContextMenu}
-          addLabel="New chat"
+          // The DS TabBar renders this as the + button's native title/aria-label — the
+          // hover hint for the Shift+click incognito gesture (#1697).
+          addLabel="New chat — Shift+click for incognito"
         />
       </div>
 
@@ -517,6 +529,10 @@ function ChatSessionSlot({
       noteToThread,
       setDraft,
       focusComposer: () => textareaRef.current?.focus(),
+      // Registry-enumerating commands (/help) see the HOST's visibility rules + the live
+      // server command list — never a hardcoded copy of either.
+      flagOn,
+      serverCommands: commands,
     });
   }
 
@@ -1476,11 +1492,10 @@ function ChatSessionSlot({
           busy={status === "streaming"}
           onQueue={() => void queueSteer()}
           onStop={() => void stop()}
-          placeholder={
-            status === "streaming"
-              ? "Steer the agent — your message folds into its work at the next step (Enter to queue)"
-              : "Message protoAgent  (/ for commands · Enter to send · ↑ history · ⌘/Ctrl+Enter for newline)"
-          }
+          // Short hints only (#1699) — key/command discoverability lives in /help now, not
+          // in a placeholder wall of text competing with the message being written. ("Steer
+          // the agent" is also an e2e anchor — chat-steer-cancel.spec.ts.)
+          placeholder={status === "streaming" ? "Steer the agent…" : "Message protoAgent…"}
           inputRef={textareaRef}
           onKeyDown={onComposerKeyDown}
           onPaste={(e) => {

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -5,7 +5,7 @@ import { Conversation, Message, PromptInput } from "@protolabsai/ui/ai";
 import { TabBar } from "@protolabsai/ui/navigation";
 import { Check, EyeOff, TerminalSquare } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { MouseEvent as ReactMouseEvent } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { openContextMenu } from "../contextMenu";
@@ -167,6 +167,19 @@ export function ChatSurface({
     closeSession(session.id, false); // false = no knowledge harvest
   }
 
+  // Keyboard twin of the Shift+click incognito gesture (#1697): Shift+Enter/Space on the
+  // focused "+" also creates an incognito session. Keyboard activation synthesizes the
+  // button's click AFTER keydown (Enter) / on keyup (Space), and its modifier state isn't
+  // reliable across browsers — so intercept at keydown-capture and preventDefault, which
+  // stops the synthetic click (and thus the DS onAdd) from ever firing.
+  function onTabBarKeyDownCapture(e: ReactKeyboardEvent) {
+    if (!e.shiftKey || (e.key !== "Enter" && e.key !== " ")) return;
+    if (!(e.target as HTMLElement).closest(".pl-tabbar__add")) return;
+    e.preventDefault();
+    e.stopPropagation();
+    chatStore.createSession({ incognito: true });
+  }
+
   // Right-click a chat tab → context menu (ADR 0036). The DS TabBar's `onTabContextMenu`
   // (@protolabsai/ui@0.53.0) hands us the session id directly — no sibling-index DOM sniffing.
   // Rename opens the TabBar's inline editor via a synthetic dblclick on the tab element (the DS
@@ -207,6 +220,7 @@ export function ChatSurface({
         className={`chat-tabbar-wrap${shiftDel ? " chat-tabbar-wrap--del" : ""}`}
         onContextMenu={onTabBarBackgroundContextMenu}
         onClickCapture={onTabBarClickCapture}
+        onKeyDownCapture={onTabBarKeyDownCapture}
       >
         <TabBar
           ariaLabel="Chat sessions"
@@ -236,8 +250,9 @@ export function ChatSurface({
           onAdd={() => chatStore.createSession()}
           onTabContextMenu={onTabContextMenu}
           // The DS TabBar renders this as the + button's native title/aria-label — the
-          // hover hint for the Shift+click incognito gesture (#1697).
-          addLabel="New chat — Shift+click for incognito"
+          // hover hint for the Shift+click incognito gesture (#1697). Shift+Enter is the
+          // keyboard twin (onTabBarKeyDownCapture), so the label teaches both paths.
+          addLabel="New chat — Shift+click for incognito (Shift+Enter when focused)"
         />
       </div>
 

--- a/apps/web/src/chat/coreSlashCommands.test.ts
+++ b/apps/web/src/chat/coreSlashCommands.test.ts
@@ -10,11 +10,12 @@ function ctx(over: Partial<SlashContext> = {}): SlashContext {
 }
 
 describe("core slash commands (dogfood the seam, ADR 0061)", () => {
-  it("registers /new, /clear, /effort, /compact through the same registry a fork uses", () => {
+  it("registers /new, /clear, /effort, /compact, /help through the same registry a fork uses", () => {
     expect(findSlashCommand("new")).toBeTruthy();
     expect(findSlashCommand("clear")).toBeTruthy();
     expect(findSlashCommand("effort")).toBeTruthy();
     expect(findSlashCommand("compact")).toBeTruthy();
+    expect(findSlashCommand("help")).toBeTruthy();
   });
 
   it("/compact is tagged with the chat.compact developer flag (ADR 0068)", () => {
@@ -24,10 +25,11 @@ describe("core slash commands (dogfood the seam, ADR 0061)", () => {
     expect(findSlashCommand("new")!.flag).toBeUndefined(); // shipped commands stay untagged
   });
 
-  it("/clear, /effort, /compact are no-ops (return false → fall through) without a session", () => {
+  it("/clear, /effort, /compact, /help are no-ops (return false → fall through) without a session", () => {
     expect(findSlashCommand("clear")!.run(ctx())).toBe(false);
     expect(findSlashCommand("effort")!.run(ctx())).toBe(false);
     expect(findSlashCommand("compact")!.run(ctx())).toBe(false);
+    expect(findSlashCommand("help")!.run(ctx())).toBe(false);
   });
 
   it("/effort with an unknown level notes the error and still handles it", () => {
@@ -37,5 +39,51 @@ describe("core slash commands (dogfood the seam, ADR 0061)", () => {
     );
     expect(handled).toBe(true);
     expect(noted).toContain("Unknown effort");
+  });
+});
+
+describe("/help — the live command/shortcut reference card (#1700)", () => {
+  function helpCard(over: Partial<SlashContext> = {}): string {
+    let noted = "";
+    const handled = findSlashCommand("help")!.run(
+      ctx({ sessionId: "s1", noteToThread: (m) => (noted = m), ...over }),
+    );
+    expect(handled).toBe(true);
+    return noted;
+  }
+
+  it("enumerates the LIVE registry, not a hardcoded list", () => {
+    const card = helpCard();
+    for (const name of ["new", "clear", "effort", "incognito", "bypass", "help"]) {
+      expect(card).toContain(`\`/${name}\``);
+    }
+  });
+
+  it("respects the host's flag gate: a flag-tagged command is listed only while its flag is ON", () => {
+    // /compact is tagged chat.compact. Fail-closed with no predicate at all…
+    expect(helpCard()).not.toContain("`/compact`");
+    // …hidden while the flag resolves off…
+    expect(helpCard({ flagOn: () => false })).not.toContain("`/compact`");
+    // …listed while it resolves on (same predicate the slash menu uses).
+    expect(helpCard({ flagOn: (id) => id === "chat.compact" })).toContain("`/compact`");
+  });
+
+  it("lists the host's server commands (installed plugins) and dedupes client-claimed tokens", () => {
+    const card = helpCard({
+      serverCommands: [
+        { name: "goal", description: "Set or check goals" },
+        { name: "help", description: "a server /help must NOT double-list" },
+      ],
+    });
+    expect(card).toContain("`/goal` — Set or check goals");
+    expect(card.match(/`\/help`/g)).toHaveLength(1);
+  });
+
+  it("carries the shortcuts the composer placeholder no longer teaches (#1697/#1699)", () => {
+    const card = helpCard();
+    expect(card).toContain("Shift+click"); // incognito + no-confirm delete gestures
+    expect(card).toContain("incognito");
+    expect(card).toContain("⌘/Ctrl+Enter"); // moved out of the placeholder
+    expect(card).toContain("**Capabilities**");
   });
 });

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -2,10 +2,10 @@
 // uses (`registerSlashCommand`), so the registry is the only path, never a special case
 // (the way the backend's `register_chat_command` has no core bypass). Imported for its
 // side effects by ChatSurface. `/new` opens a tab, `/clear` wipes this tab's history,
-// `/effort` sets this tab's reasoning effort. Behaviour ported verbatim from the old
-// hardcoded `runClientSlash` switch.
+// `/effort` sets this tab's reasoning effort, `/help` prints the command/shortcut
+// reference. Behaviour ported verbatim from the old hardcoded `runClientSlash` switch.
 
-import { registerSlashCommand } from "../ext/slashRegistry";
+import { registeredSlashCommands, registerSlashCommand } from "../ext/slashRegistry";
 import { api } from "../lib/api";
 import type { ChatMessage } from "../lib/types";
 import { chatStore, DEFAULT_REASONING_EFFORT, REASONING_EFFORTS } from "./chat-store";
@@ -147,6 +147,41 @@ registerSlashCommand({
         ? "**Incognito ON** for this tab — every message now carries `incognito`: no session summary, no memory harvest, no memory injection, until you turn it off with `/incognito off`. Messages already sent before this were NOT incognito."
         : "Incognito **off** — turns persist to memory and receive memory again.",
       { tone: "info" },
+    );
+    ctx.focusComposer();
+    return true;
+  },
+});
+
+registerSlashCommand({
+  name: "help",
+  description: "Show available commands & shortcuts",
+  run: (ctx) => {
+    if (!ctx.sessionId) return false; // no thread to print into → fall through
+    // Enumerate the LIVE registry with the host's own visibility rules (ADR 0068):
+    // flag-tagged commands appear only while their flag is on — fail-closed, exactly
+    // like the composer's slash menu — so the card never advertises a dead command.
+    const flagOn = ctx.flagOn ?? (() => false);
+    const client = registeredSlashCommands().filter((c) => !c.flag || flagOn(c.flag));
+    const seen = new Set(client.map((c) => c.name));
+    // Server commands (/goal, plugin commands…) reflect what's actually installed. A
+    // client command CLAIMS its token, so drop server duplicates (menu order: client first).
+    const server = (ctx.serverCommands ?? []).filter((c) => !seen.has(c.name.toLowerCase()));
+    const row = (name: string, description: string) => `- \`/${name}\` — ${description}`;
+    ctx.noteToThread(
+      [
+        "**Commands**",
+        ...client.map((c) => row(c.name, c.description)),
+        ...server.map((c) => row(c.name, c.description)),
+        "",
+        "**Shortcuts**",
+        "- `Enter` send · `⌘/Ctrl+Enter` newline · `↑` recall input history · `/` command menu",
+        "- While the agent is working, `Enter` queues a steer into the running turn",
+        "- `Shift+click` the tab bar's `+` → new incognito chat (also on a tab's right-click menu)",
+        "- `Shift+click` a tab's ✕ → delete the chat without the confirm dialog",
+        "",
+        "**Capabilities** — watches, schedules, tasks, and goals all run from chat; manage them from the rail surfaces.",
+      ].join("\n"),
     );
     ctx.focusComposer();
     return true;

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -177,7 +177,7 @@ registerSlashCommand({
         "**Shortcuts**",
         "- `Enter` send · `⌘/Ctrl+Enter` newline · `↑` recall input history · `/` command menu",
         "- While the agent is working, `Enter` queues a steer into the running turn",
-        "- `Shift+click` the tab bar's `+` → new incognito chat (also on a tab's right-click menu)",
+        "- `Shift+click` (or focus the `+` and `Shift+Enter`/`Shift+Space`) → new incognito chat (also on a tab's right-click menu)",
         "- `Shift+click` a tab's ✕ → delete the chat without the confirm dialog",
         "",
         "**Capabilities** — watches, schedules, tasks, and goals all run from chat; manage them from the rail surfaces.",

--- a/apps/web/src/ext/slashRegistry.ts
+++ b/apps/web/src/ext/slashRegistry.ts
@@ -28,6 +28,14 @@ export type SlashContext = {
   setDraft: (text: string) => void;
   /** Return focus to the composer textarea. */
   focusComposer: () => void;
+  /** The host's developer-flag predicate (ADR 0068) — the SAME gate that hides/skips
+   *  flag-tagged commands — so a command that enumerates the registry (e.g. `/help`)
+   *  applies the host's visibility rules instead of guessing. Fail-closed when absent. */
+  flagOn?: (id: string) => boolean;
+  /** SERVER slash commands as the host fetched them (`/api/chat/commands` — `/goal`,
+   *  plugin commands…), so a registry-enumerating command reflects what's actually
+   *  installed rather than a hardcoded list. */
+  serverCommands?: { name: string; description: string; usage?: string }[];
 };
 
 export type ClientSlashCommand = {

--- a/docs/adr/0061-frontend-extension-registries.md
+++ b/docs/adr/0061-frontend-extension-registries.md
@@ -53,8 +53,12 @@ registerSlashCommand({
 })                                      // false ⇒ fall through (insert "/name " to edit + send)
 ```
 
-`SlashContext = { rest, sessionId, noteToThread, setDraft, focusComposer }` — the host
-(`ChatSurface`) builds it from local state + the chat store when the command fires.
+`SlashContext = { rest, sessionId, noteToThread, setDraft, focusComposer, flagOn?,
+serverCommands? }` — the host (`ChatSurface`) builds it from local state + the chat store
+when the command fires. The two optional fields carry the host's developer-flag predicate
+(ADR 0068) and its fetched server-command list, so a registry-enumerating command (core's
+`/help`, #1700) reflects the host's own visibility rules and what's actually installed
+instead of a hardcoded copy.
 **Registering a token CLAIMS it** — the frontend twin of `register_chat_command`. Distinct
 from **server** slash commands (`/api/chat/commands`, e.g. `/goal`, plugin `/issue`), which
 fill the draft for the user to send; client commands act locally on pick/submit.

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -107,9 +107,10 @@ summarized into the knowledge store).
   **metadata** (alongside `model` / `reasoning_effort`).
 - **Console** — toggle a chat tab incognito with the `/incognito` slash command
   or the tab's right-click menu ("Turn incognito on/off"; "New incognito chat"
-  starts a thread private). While ON the tab shows an eye-off glyph and the
-  composer an `incognito` chip (click it to turn off), and the console stamps
-  the metadata flag onto **every** message it sends from that tab.
+  starts a thread private — **Shift+click** the tab bar's `+` does the same).
+  While ON the tab shows an eye-off glyph and the composer an `incognito` chip
+  (click it to turn off), and the console stamps the metadata flag onto
+  **every** message it sends from that tab.
 
 The flag is per-message and stamped explicitly on every turn, so a thread is only
 as incognito as its latest message — a raw API caller must send the flag on each


### PR DESCRIPTION
> **UI local-test gate — do not auto-merge; user triages.** Stays a DRAFT until the operator has clicked through it.

Three small chat-UX items in `apps/web`, one PR.

## What / why

### #1697 — Shift+click the tab bar's "+" → new incognito chat
The tab bar already had a Shift-modified capture-phase click handler (Shift+✕ = quick-delete, no confirm). This extends that same handler: Shift+click on the DS TabBar's `.pl-tabbar__add` intercepts in the capture phase (so the DS button's plain `onAdd` never fires) and calls `chatStore.createSession({ incognito: true })` — the **exact** semantics of the tab context menu's "New incognito chat". Plain click is untouched. The + button's hover hint (the DS TabBar renders `addLabel` as the button's native `title`/`aria-label`) now reads **"New chat — Shift+click for incognito"**.

Root-cause note: the issue text says Shift+LMB on existing tabs already opens incognito — it doesn't; on tabs, Shift+click(✕) is quick-*delete*. The existing incognito-creation semantics live in the tab context menu (`createSession({incognito:true})`), and that is what the + now mirrors.

### #1699 — short composer placeholder
`"Message protoAgent  (/ for commands · Enter to send · ↑ history · ⌘/Ctrl+Enter for newline)"` → **`"Message protoAgent…"`** (19 chars). The streaming variant shortens to **`"Steer the agent…"`** (kept prefix — it's the `chat-steer-cancel.spec.ts` e2e anchor). The discoverability the old text carried moves to `/help`.

### #1700 — static client-side `/help`
Registered in `chat/coreSlashCommands.ts` through the ADR 0061 slash seam like every core command — no backend, no agent round-trip; output renders as a local system note. **Nothing hardcoded that can rot**:
- **Commands** are enumerated from the LIVE registry, respecting the host's ADR 0068 flag gate (a `flag:`-tagged command appears only while its flag resolves ON, fail-closed) — via a new optional `SlashContext.flagOn` predicate the host passes down (the same `useFlagPredicate` gating the slash menu).
- **Server commands** (`/goal`, installed plugin commands…) come from the host's fetched `/api/chat/commands` list via a new optional `SlashContext.serverCommands`, deduped against client-claimed tokens.
- Plus a short static **Shortcuts** section (incl. the #1697 Shift+click incognito gesture and the keys the placeholder no longer teaches) and a one-line **Capabilities** pointer.

Both new `SlashContext` fields are optional → additive for forks; ADR 0061's seam description updated (it already tracks seam evolution, cf. #1519).

## Docs
- `docs/guides/knowledge.md` — incognito console paths now mention the Shift+click + gesture.
- `docs/adr/0061-frontend-extension-registries.md` — `SlashContext` field list + the `/help` rationale.

## Test evidence
- `npm run test:unit --workspace @protoagent/web` — **333 passed (333)**, incl. new `/help` coverage in `coreSlashCommands.test.ts`: live registry enumeration, flag gating (fail-closed / off / on), server-command listing + dedupe, shortcut/capabilities content, no-session fall-through.
- New Playwright spec `e2e/chat-incognito-add.spec.ts` — Shift+click + → incognito glyph on the new tab + composer incognito chip; plain click stays regular; + hover hint present. **Passed locally** together with `chat-quick-delete.spec.ts` (no quick-delete regression) against a fresh `vite build` dist.
- Wider local e2e run (`chat.spec`, `chat-quick-delete`, `chat-steer-cancel`, `chat-stop`, `navigation`): 23/24 passed; the 1 failure (`chat.spec.ts:141` tab right-click menu) **also fails on pristine origin/main locally** — it's the known `@protolabsai/ui` version-skew artifact (local install is 0.52.0, lockfile 0.53.1; 0.52 lacks `onTabContextMenu`). Unrelated to this diff.
- `npm run build --workspace @protoagent/web`: `vite build` succeeds; the `tsc` step shows the **same two pre-existing skew errors as pristine origin/main** (verified via stash — `onTabContextMenu` / `onRailBackgroundContextMenu`, both DS-0.53 props missing from the stale local 0.52 install). No new type errors from this diff; CI `npm ci` is authoritative.
- `ruff check .` / `lint-imports` — pass (no Python touched).

Fixes #1697
Fixes #1699
Fixes #1700

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/help` command that shows a live reference of available chat commands and shortcuts.
  * Added incognito support for the chat “+” button via **Shift+click** and **Shift+Enter/Space**.
  * Updated the tab hint to advertise the new incognito shortcut.

* **Bug Fixes**
  * Improved command visibility so built-in and server-provided commands are listed correctly without duplicates.

* **Documentation**
  * Clarified the incognito thread instructions for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->