### PR TITLE
feat(fleet): disable Fleet settings on member instances with a host-pointing tooltip

### DIFF
--- a/apps/web/src/app/FleetSwitcher.tsx
+++ b/apps/web/src/app/FleetSwitcher.tsx
@@ -3,11 +3,13 @@ import { Check, ChevronDown, ExternalLink, Plus, Settings } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Menu, MenuItem, MenuSeparator } from "@protolabsai/ui/menu";
+import { Tooltip } from "@protolabsai/ui/overlays";
 import { Badge } from "@protolabsai/ui/primitives";
 import { StatusDot } from "@protolabsai/ui/data";
 
 import { agentHref, api, currentSlug } from "../lib/api";
 import { queryKeys } from "../lib/queries";
+import { fleetSettingsDisabledReason } from "./fleetSettingsGate";
 
 // The URL slug is the agent's STABLE id, never its (editable) display name — renaming an agent
 // must not change its URL/bookmarks. `host` is the reserved slug for this instance.
@@ -34,6 +36,9 @@ export function FleetSwitcher({
   const agents = fleet.data?.agents ?? [];
   const slug = currentSlug(); // the agent THIS window is on
   const current = agents.find((a) => slugOf(a) === slug);
+  // Fleet settings are hub-only (#1708): non-null in a member window (a hub slug window,
+  // or a spawned workspace member reached directly) — the item disables with this tooltip.
+  const fleetSettingsBlocked = fleetSettingsDisabledReason(agents, slug);
 
   // Only a hard fleet-API error hides the switcher; otherwise it's always available.
   if (fleet.isError) return <>{fallbackName}</>;
@@ -80,9 +85,20 @@ export function FleetSwitcher({
       <MenuItem icon={<Plus size={14} />} onSelect={() => onNewAgent?.()}>
         New agent
       </MenuItem>
-      <MenuItem icon={<Settings size={14} />} onSelect={() => onManageFleet?.()}>
-        Fleet settings
-      </MenuItem>
+      {fleetSettingsBlocked ? (
+        // Disabled, not hidden — discoverable: the tooltip says WHERE fleet settings live.
+        // The DS Tooltip's own wrapper span is the hover target (a disabled Radix menu item
+        // is pointer-events:none, so the item itself can't fire the tooltip).
+        <Tooltip label={fleetSettingsBlocked} side="left">
+          <MenuItem icon={<Settings size={14} />} disabled>
+            Fleet settings
+          </MenuItem>
+        </Tooltip>
+      ) : (
+        <MenuItem icon={<Settings size={14} />} onSelect={() => onManageFleet?.()}>
+          Fleet settings
+        </MenuItem>
+      )}
     </Menu>
   );
 }

--- a/apps/web/src/app/fleetSettingsGate.test.ts
+++ b/apps/web/src/app/fleetSettingsGate.test.ts
@@ -1,0 +1,50 @@
+// "Fleet settings" gate (#1708): the header dropdown item is hub-only — disabled with
+// a point-at-the-host tooltip in member windows, enabled on the host AND on a
+// standalone instance (standalone is where you create your first member).
+import { describe, expect, it } from "vitest";
+
+import type { FleetAgent } from "../lib/types";
+import { FLEET_SETTINGS_MEMBER_TOOLTIP, fleetSettingsDisabledReason } from "./fleetSettingsGate";
+
+const agent = (over: Partial<FleetAgent>): FleetAgent => ({
+  name: "a",
+  id: "a",
+  port: 7871,
+  pid: null,
+  running: true,
+  bundle: "",
+  ...over,
+});
+
+describe("fleetSettingsDisabledReason", () => {
+  it("host instance with a fleet → enabled", () => {
+    const agents = [agent({ name: "main", id: "main", host: true }), agent({ name: "ava", id: "ava-7f3a" })];
+    expect(fleetSettingsDisabledReason(agents, "host")).toBeNull();
+  });
+
+  it("standalone instance (fleet of one, no member flag) → enabled", () => {
+    // A standalone /api/fleet still returns its own host entry — this is the window
+    // where the first fleet member gets CREATED, so it must never be locked out.
+    const agents = [agent({ name: "main", id: "main", host: true })];
+    expect(fleetSettingsDisabledReason(agents, "host")).toBeNull();
+  });
+
+  it("spawned workspace member reached directly (host entry self-reports member) → disabled", () => {
+    const agents = [agent({ name: "ava", id: "ava-7f3a", host: true, member: true })];
+    expect(fleetSettingsDisabledReason(agents, "host")).toBe(FLEET_SETTINGS_MEMBER_TOOLTIP);
+  });
+
+  it("member via the hub's slug window → disabled (slug alone decides)", () => {
+    const agents = [agent({ name: "main", id: "main", host: true }), agent({ name: "ava", id: "ava-7f3a" })];
+    expect(fleetSettingsDisabledReason(agents, "ava-7f3a")).toBe(FLEET_SETTINGS_MEMBER_TOOLTIP);
+    // Even before the fleet poll lands, the slug already marks a member window.
+    expect(fleetSettingsDisabledReason([], "ava-7f3a")).toBe(FLEET_SETTINGS_MEMBER_TOOLTIP);
+  });
+
+  it("remote member reached directly at its own URL → enabled (independent instance)", () => {
+    // A remote's own /api/fleet host entry never carries `member` — registration is
+    // one-sided on the hub, and the remote may legitimately run its OWN fleet.
+    const agents = [agent({ name: "peer", id: "peer", host: true })];
+    expect(fleetSettingsDisabledReason(agents, "host")).toBeNull();
+  });
+});

--- a/apps/web/src/app/fleetSettingsGate.ts
+++ b/apps/web/src/app/fleetSettingsGate.ts
@@ -1,0 +1,38 @@
+// Gate for the header dropdown's "Fleet settings" item (#1708). The fleet is managed
+// from its HOST instance only (ADR 0042) — a member window gets the item DISABLED with
+// a tooltip pointing at the host instead of a broken/irrelevant panel.
+//
+// Host / member / standalone matrix (window = how the console reaches an instance):
+//
+//   host window (hub, or any instance with no slug in the URL and no member flag)
+//     → ENABLED. Covers both a fleet host and a STANDALONE instance — standalone is
+//       where you create your first fleet member, so it must never be locked out.
+//   member via the hub's slug window (/app/agent/<slug>/)
+//     → DISABLED. The Box ▸ Fleet settings group only exists on the host window
+//       (ADR 0047 §7.7): opening it here lands on an unrelated fallback section.
+//       Signal: the URL slug (client-side, no fetch needed).
+//   spawned workspace member reached DIRECTLY (its own port)
+//     → DISABLED. Its own /api/fleet is a fleet-of-one (its workspaces root is empty
+//       by construction) — "managing" it there creates a nested fleet by accident.
+//       Signal: the member self-reports `member: true` on its /api/fleet host entry.
+//   remote member (ADR 0042 §I) reached directly at its own URL
+//     → ENABLED, deliberately. Registration is one-sided on the hub — the remote has
+//       no signal it was registered anywhere, and it is a full independent instance
+//       that may legitimately run its OWN fleet.
+
+import type { FleetAgent } from "../lib/types";
+
+/** Tooltip copy for the disabled item (also the e2e/unit hook). */
+export const FLEET_SETTINGS_MEMBER_TOOLTIP = "Fleet settings are managed from the host instance";
+
+/**
+ * Why "Fleet settings" is unavailable in this window — or `null` when it's allowed.
+ * `agents` is the polled /api/fleet list; `slug` is `currentSlug()` (the window's URL slug,
+ * `"host"` when the console talks to its instance directly).
+ */
+export function fleetSettingsDisabledReason(agents: FleetAgent[], slug: string): string | null {
+  if (slug !== "host") return FLEET_SETTINGS_MEMBER_TOOLTIP; // hub slug window on a member
+  const self = agents.find((a) => a.host);
+  if (self?.member) return FLEET_SETTINGS_MEMBER_TOOLTIP; // spawned member, reached directly
+  return null; // fleet host, or a standalone instance (no fleet configured yet)
+}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -2115,6 +2115,15 @@ textarea {
   color: var(--accent);
 }
 
+/* Tooltip-wrapped menu row (#1708 — the disabled "Fleet settings" item on a fleet
+   member). The DS Tooltip's trigger span is inline-flex, which would shrink the
+   wrapped .pl-menu__item to its content width; make it block so the row spans the
+   menu like its siblings. (DS gap — a disabled-menu-item-with-tooltip pattern
+   belongs in @protolabsai/ui's Menu; drop this once protoContent ships one.) */
+.pl-menu .pl-tip-wrap {
+  display: block;
+}
+
 /* .fleet-host-tag retired (#832) — the "this instance" / "remote" tags in the
    fleet manager + switcher are now DS <Badge status="neutral">. */
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -811,6 +811,10 @@ export type FleetAgent = {
   bundle: string; // "" for a Basic agent
   a2a?: string; // the agent's own A2A endpoint (focus-independent)
   host?: boolean; // the instance serving this console — can't be stopped/removed from itself
+  // Only ever set on the `host` entry, by the instance itself: this instance is a workspace
+  // member SPAWNED by another hub's supervisor (its instance root carries a workspace.yaml).
+  // Consoles reaching a member directly use it to gate hub-only affordances (#1708).
+  member?: boolean;
   remote?: boolean; // a REMOTE member (ADR 0042 §I) — proxied by URL, no start/stop from here
   url?: string; // the remote member's base URL
   // App version (pyproject [project].version). Always set on the host (hub) entry;

--- a/docs/guides/fleet.md
+++ b/docs/guides/fleet.md
@@ -143,6 +143,15 @@ the slug proxy forwards WS upgrades, not just HTTP/SSE ([#883](https://github.co
 (create / start / stop / rename / remove), and **Discover** finds other protoAgents on the
 box, the LAN (mDNS) and your **tailnet** (via the Tailscale CLI).
 
+**Fleet settings are hub-only.** The topbar dropdown's **Fleet settings** item is enabled
+on the host window (and on a standalone instance — that's where you create your first
+member); in a *member* window it renders **disabled** with a tooltip pointing you at the
+host instance. That covers both a member's slug window and a spawned workspace member
+opened directly on its own port — the member self-reports `member: true` on its own
+`GET /api/fleet` host entry (its instance root carries the `workspace.yaml` spawn marker).
+A **remote** member opened at its own URL stays enabled on purpose: it's an independent
+instance that may run its own fleet, and registration is one-sided on the hub.
+
 ## Remote fleet members — the agent there, the UI here
 
 *(ADR 0042 §I.)* A fleet member doesn't have to be local: register any reachable protoAgent

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -288,7 +288,7 @@ def _host_entry() -> dict:
     cfg = getattr(STATE, "graph_config", None)
     name = getattr(cfg, "identity_name", "") or "main"
     port = getattr(STATE, "active_port", None)
-    return {
+    entry = {
         "name": name,
         "id": getattr(cfg, "instance_id", "") or name,
         "port": port,
@@ -302,6 +302,14 @@ def _host_entry() -> dict:
         # release is a real, otherwise-invisible /api/* compat surface.
         "version": package_version(),
     }
+    # This instance is itself a workspace member SPAWNED by another hub's supervisor
+    # (the `workspace.yaml` record at its instance root is the spawn-time marker).
+    # Surfaced read-only on the existing /api/fleet payload so a console reaching the
+    # member DIRECTLY (its own port) can gate hub-only affordances — the header's
+    # "Fleet settings" item disables with a point-at-the-host tooltip (#1708).
+    if manager.is_workspace_member():
+        entry["member"] = True
+    return entry
 
 
 # ── remote fleet members (ADR 0042 §I, the proxy half) ────────────────────────

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -97,6 +97,20 @@ def _read_record(ws: Path) -> dict | None:
         return None
 
 
+def is_workspace_member() -> bool:
+    """True when THIS process runs as a fleet workspace member (ADR 0042): the hub's
+    supervisor spawns members with ``PROTOAGENT_HOME=<ws>``, so a member's instance
+    root IS a workspace dir — and every workspace dir carries its registry record
+    (``workspace.yaml``, written by ``create()``). A hub or standalone instance root
+    never has one, so the record doubles as the read-only "this instance is managed
+    by a host" signal (#1708) with no new state or endpoint. Remote members (ADR
+    0042 §I) are out of scope by design: registration is one-sided on the hub, and a
+    remote is a full independent instance that may legitimately run its own fleet."""
+    from infra.paths import instance_paths
+
+    return _read_record(instance_paths().instance_root) is not None
+
+
 def list_workspaces() -> list[dict]:
     """Every workspace under the root (each dir with a ``workspace.yaml``)."""
     root = workspaces_root()

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -579,3 +579,16 @@ def test_up_reports_boot_death_and_continues(tmp_path, monkeypatch):
     rows = supervisor.up(["brokey"])  # must not raise — the row carries the error
     assert rows[0]["name"] == "brokey" and rows[0]["running"] is False
     assert "exit code 2" in rows[0]["error"]
+
+
+# ── member self-report on the host entry (#1708) ──────────────────────────────
+def test_host_entry_member_flag(fleet, monkeypatch):
+    """A spawned workspace member self-reports ``member: True`` on its own /api/fleet
+    host entry (the console's signal to gate hub-only affordances); a hub/standalone
+    host entry doesn't carry the key at all — the payload shape is unchanged for them."""
+    host = next(a for a in supervisor.status() if a.get("host"))
+    assert "member" not in host  # hub/standalone: no new field
+
+    monkeypatch.setattr(manager, "is_workspace_member", lambda: True)
+    host = next(a for a in supervisor.status() if a.get("host"))
+    assert host["member"] is True

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -261,3 +261,25 @@ def test_run_exec_frozen_argv(root, monkeypatch):
     _, argv = manager.run_exec("gamma", ["--ui", "none"])
     assert argv[0] == sys.executable and "-m" not in argv
     assert argv[1] == "--port" and argv[-2:] == ["--ui", "none"]
+
+
+def test_is_workspace_member_detects_spawned_instance(root, monkeypatch):
+    """#1708: a spawned member runs with ``PROTOAGENT_HOME=<ws>`` (run_exec), and the
+    workspace registry record at that root is the marker — ``is_workspace_member()``
+    is True exactly there, False for a hub/standalone instance root."""
+    import infra.paths as paths
+
+    s = manager.create("ava")
+    ws = root / s["id"]
+
+    # Standalone/hub: instance root without a workspace.yaml → not a member.
+    monkeypatch.setenv("PROTOAGENT_HOME", str(root.parent / "standalone"))
+    paths.reset_instance_paths()
+    assert manager.is_workspace_member() is False
+
+    # The member's own env (what run_exec wires): instance root IS the workspace dir.
+    env, _ = manager.run_exec("ava", [])
+    monkeypatch.setenv("PROTOAGENT_HOME", env["PROTOAGENT_HOME"])
+    paths.reset_instance_paths()
+    assert str(ws) == env["PROTOAGENT_HOME"]
+    assert manager.is_workspace_member() is True


### PR DESCRIPTION
## What / why

The header FleetSwitcher dropdown showed **Fleet settings** enabled on every instance (added in #1556). On a fleet member that item was broken or misleading:

- **Hub slug window** (`/app/agent/<slug>/`): `openGlobalSettings("fleet")` opens the settings overlay, but the Box ▸ Fleet section only exists on the host window (`isHostConsole()`, ADR 0047 §7.7) — the overlay silently fell back to the first Agent section (Identity). Root cause of the "does nothing / irrelevant" report in the issue.
- **Spawned workspace member reached directly on its own port**: its own `GET /api/fleet` is a fleet-of-one (a member's workspaces root is empty by construction, ADR 0042), so the panel showed stale/irrelevant data — and "managing" it there quietly builds a nested fleet.

Now the item renders **disabled** with the DS tooltip **"Fleet settings are managed from the host instance"** in member windows, and stays enabled on the host and on standalone instances.

## Which signal, and why

Predicate: `fleetSettingsDisabledReason(agents, slug)` in `apps/web/src/app/fleetSettingsGate.ts` (unit-tested), fed by the FleetSwitcher's existing 3s `/api/fleet` poll — **no extra request**.

1. **Slug window** → the URL slug alone (`currentSlug() !== "host"`), client-side, no fetch needed. This is the same signal `isHostConsole()` already uses to gate the Box settings group.
2. **Direct access to a spawned member** → the member self-reports `member: true` on the **host entry of its existing `GET /api/fleet` response** (`_host_entry()` in `graph/fleet/supervisor.py`). There was **no** client-reachable signal for this case before, so per the issue guidance this is the smallest possible read-only exposure on an existing fleet-status response — derived server-side from the `workspace.yaml` spawn marker at the instance root (`manager.is_workspace_member()`; the hub's supervisor spawns members with `PROTOAGENT_HOME=<ws>` via `run_exec`, and every workspace dir carries that registry record). No new endpoint, no new state, key absent for non-members so the payload shape is unchanged for hubs/standalone.

ADR 0066's federation token was considered and rejected as the signal: it gates the goal/operator channel, is optional, and doesn't identify *fleet* membership.

## Host / member / standalone matrix

| Window | Fleet settings | Signal |
|---|---|---|
| Host (hub) window | **enabled** | — |
| **Standalone** instance (no fleet configured) | **enabled** — this is where you create your first member; never locked out | no slug + no `member` flag |
| Member via hub slug window `/app/agent/<slug>/` | **disabled + tooltip** | URL slug |
| Spawned workspace member, reached directly on its own port | **disabled + tooltip** | `member: true` on its `/api/fleet` host entry |
| Remote member (ADR 0042 §I) at its own URL | **enabled, deliberately** | none exists: registration is one-sided on the hub, and a remote is a full independent instance that may legitimately run its **own** fleet — disabling would wrongly lock that out |

## UI

DS `MenuItem disabled` + DS `Tooltip` (`@protolabsai/ui/overlays`) wrapping the item — the Tooltip's own trigger span is the hover target, since a disabled Radix menu item is `pointer-events: none` (the DS Tooltip documents exactly this disabled-child anchoring). One scoped CSS override (`.pl-menu .pl-tip-wrap { display: block }`) keeps the wrapped row full-width; flagged in-source as a DS gap (a disabled-menu-item-with-tooltip pattern belongs in `@protolabsai/ui`'s Menu — will file on protoContent per the contribute-back loop).

Adjacent gap observed but left out of scope: "New agent" in a hub slug window has the same fallback-to-Identity behavior (it also opens the fleet section). Happy to follow up if wanted.

## Tests

- `apps/web/src/app/fleetSettingsGate.test.ts` — the predicate across host / member (both paths) / standalone / remote-direct states.
- `tests/test_workspaces.py::test_is_workspace_member_detects_spawned_instance` — marker detection through `run_exec`'s real env.
- `tests/test_fleet_supervisor.py::test_host_entry_member_flag` — `member: True` surfaces on the host entry; key absent otherwise.

Evidence (local):
- `ruff check .` — pass; `lint-imports` — 3 contracts kept
- `python -m pytest tests/ -q` — **2937 passed, 5 skipped**
- `npm run test:unit --workspace @protoagent/web` — **334 passed (34 files)**
- `npx vite build` (production bundle) — pass
- `npm run build --workspace @protoagent/web` — tsc fails **only** on two pre-existing errors in files this PR does not touch (`App.tsx` `onRailBackgroundContextMenu`, `ChatSurface.tsx` `onTabContextMenu`): the known @protolabsai/ui version-skew artifact of the shared local node_modules (installed 0.52.0 vs declared ^0.53.1). CI `npm ci` is authoritative.

Fixes #1708

---
**local-test gate — do not auto-merge; user triages** (console UX change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)