### PR TITLE
fix(memory): inspector tells the truth about what injects + route robustness

### DIFF
--- a/docs/reference/operator-api.md
+++ b/docs/reference/operator-api.md
@@ -79,9 +79,9 @@ injected every turn.
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/memory/sessions` | List session summaries (digest fields: id, timestamp, surface, topic, message count, size) |
+| GET | `/api/memory/sessions` | List session summaries (digest fields: id, timestamp, surface, topic, message count, size, plus `in_digest`: whether the session is in the current `<prior_sessions>` injection window) |
 | GET · DELETE | `/api/memory/sessions/{session_id}` | Full rendered summary (what `recall_session` returns) / delete one |
-| GET | `/api/memory/hot` | List hot-memory chunks (`domain="hot"`) |
+| GET | `/api/memory/hot` | List hot-memory chunks (`domain="hot"`); each row carries `injecting`: whether the chunk is in the current per-turn injection window (omitted on backends without the id-attributed reader) |
 | PUT · DELETE | `/api/memory/hot/{chunk_id}` | Edit (revision stays `hot`) / delete a hot chunk |
 
 ## Activity, inbox & events

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -337,8 +337,16 @@ class KnowledgeMiddleware(AgentMiddleware):
         try:
             from observability.injection_log import injection_log
 
+            session_id = state.get("session_id", "") or ""
+            if not session_id:
+                # session_id is a declared-but-optional state field — an entry
+                # path that omits it would leave the row unattributed. Same
+                # tracing-contextvar fallback _persist_session uses.
+                from observability import tracing
+
+                session_id = tracing.current_session_id() or ""
             injection_log().record(
-                session_id=state.get("session_id", "") or "",
+                session_id=session_id,
                 digest_session_ids=digest_ids,
                 hot_chunk_ids=hot_ids,
                 rag_chunk_ids=rag_ids,

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -52,6 +52,30 @@ def memory_path() -> str:
     return str(instance_paths().store("memory"))
 
 
+def session_filename(session_id: str) -> str:
+    """Filename for *session_id*'s summary, with ``:`` encoded as ``%3A``.
+
+    ``:`` is invalid in NTFS filenames, so ids like ``system:activity`` /
+    ``a2a:...`` silently failed to persist on Windows. ``%`` is outside the
+    :func:`is_safe_session_id` charset, so a crafted id can never collide with
+    an encoded name. Every session_id → filename mapping (the writer below,
+    ``recall_session``, the memory-inspector API) goes through this helper.
+    """
+    return f"{session_id.replace(':', '%3A')}.json"
+
+
+def session_file_candidates(session_id: str, base: str | None = None) -> list[str]:
+    """Paths to try when READING *session_id*'s summary: the encoded name
+    first, then the legacy raw-``:`` name (files a pre-encoding build wrote on
+    POSIX). Writers use the encoded name only — and drop the legacy file after
+    a successful write, so the pair never coexists for long."""
+    if base is None:
+        base = memory_path()
+    encoded = os.path.join(base, session_filename(session_id))
+    legacy = os.path.join(base, f"{session_id}.json")
+    return [encoded] if encoded == legacy else [encoded, legacy]
+
+
 # ---------------------------------------------------------------------------
 # Session persistence
 # ---------------------------------------------------------------------------
@@ -80,11 +104,10 @@ def _persist_session(state: dict, trace_id: str) -> None:
         log.info("[memory] incognito session — skipping session persistence")
         return
 
-    # ``session_id`` is not a declared graph-state field, so LangGraph drops the
-    # key the chat path passes into ``ainvoke`` — ``state.get`` returns "" and
-    # every session would collapse into a single ``unknown.json`` (pooling and
-    # cross-contaminating sessions). Fall back to the tracing contextvar, which
-    # ``trace_session`` always sets, so summaries are keyed per session.
+    # ``session_id`` IS a declared graph-state field (graph/state.py), but it's
+    # optional (NotRequired) — an entry path that omits it leaves ``state.get``
+    # returning "". Fall back to the tracing contextvar, which ``trace_session``
+    # always sets, so summaries stay keyed per session either way.
     session_id: str = state.get("session_id", "") or ""
     if not session_id:
         from observability import tracing
@@ -180,8 +203,7 @@ def _persist_session(state: dict, trace_id: str) -> None:
         return
 
     # --- Atomic write ---
-    filename = f"{session_id}.json"
-    dest = os.path.join(base, filename)
+    dest = os.path.join(base, session_filename(session_id))
     tmp_fd = None
     tmp_path = None
     try:
@@ -192,6 +214,15 @@ def _persist_session(state: dict, trace_id: str) -> None:
         os.rename(tmp_path, dest)
         log.info("[memory] persisted session %s -> %s", session_id, dest)
         tmp_path = None  # rename succeeded — no cleanup needed
+        # A pre-encoding build may have left the raw-':' name on POSIX; drop it
+        # after the encoded write lands so the digest never lists this session
+        # twice. Best-effort — the encoded file is already the source of truth.
+        legacy = os.path.join(base, f"{session_id}.json")
+        if legacy != dest:
+            try:
+                os.remove(legacy)
+            except OSError:
+                pass
     except OSError as exc:
         log.error("[memory] write failed for session %s: %s", session_id, exc)
     finally:
@@ -354,10 +385,11 @@ def load_prior_sessions_digest(
         for fname in os.listdir(memory_dir):
             if not fname.endswith(".json"):
                 continue
-            if fname.startswith("background:"):
+            if fname.startswith(("background:", "background%3A")):
                 # Background worker summaries are disposable (ADR 0070 D3). The
                 # writer no longer produces them; this read-side filter also
-                # keeps LEGACY files already on disk out of the digest.
+                # keeps LEGACY files already on disk out of the digest — under
+                # either the raw or the '%3A'-encoded filename.
                 continue
             fpath = os.path.join(memory_dir, fname)
             try:

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -93,7 +93,7 @@ def _persist_session(state: dict, trace_id: str) -> None:
         final_output     — str | null
         timestamp        — ISO-8601 UTC string
 
-    Writes atomically: temp file → os.rename to avoid partial reads.
+    Writes atomically: temp file → os.replace to avoid partial reads.
     """
     if _PERSISTENCE_DISABLED:
         return
@@ -211,7 +211,10 @@ def _persist_session(state: dict, trace_id: str) -> None:
         with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
             json.dump(summary, fh, indent=2, default=str)
             tmp_fd = None  # fdopen took ownership
-        os.rename(tmp_path, dest)
+        # os.replace, not os.rename: sessions re-persist on every terminal
+        # turn, and on Windows os.rename raises FileExistsError when dest
+        # exists — every summary would freeze at its first write.
+        os.replace(tmp_path, dest)
         log.info("[memory] persisted session %s -> %s", session_id, dest)
         tmp_path = None  # rename succeeded — no cleanup needed
         # A pre-encoding build may have left the raw-':' name on POSIX; drop it
@@ -253,8 +256,9 @@ _SESSION_ID_SAFE_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 
 
 def is_safe_session_id(session_id: str) -> bool:
-    """True when *session_id* maps safely onto ``{memory_path()}/{id}.json`` —
-    non-empty and confined to ``[A-Za-z0-9._:-]`` (no path separators, no NUL)."""
+    """True when *session_id* maps safely onto a :func:`session_filename` under
+    ``memory_path()`` — non-empty and confined to ``[A-Za-z0-9._:-]`` (no path
+    separators, no NUL, and no ``%``, so an id can't spoof an encoded name)."""
     return bool(session_id) and set(session_id) <= _SESSION_ID_SAFE_CHARS
 
 # The always-present framing header (ADR 0069 D1): the digest lists OTHER

--- a/operator_api/memory_routes.py
+++ b/operator_api/memory_routes.py
@@ -1,10 +1,13 @@
 """Memory-inspector routes for the operator console (ADR 0069 D7).
 
 The audit surface for the memory *delivery* layer: which session summaries
-exist on disk (the ``{memory_path()}/{session_id}.json`` files behind the
-``<prior_sessions>`` digest) and which hot-memory chunks ride every turn —
-view/delete for summaries, view/edit/delete for hot chunks. A security control
-first (SpAIware-class memory poisoning gets *detected* here), UX second.
+exist on disk (the ``memory_path()`` files — named via the shared
+``session_filename`` mapper — behind the ``<prior_sessions>`` digest) and
+which hot-memory chunks ride every turn — view/delete for summaries,
+view/edit/delete for hot chunks. A security control first (SpAIware-class
+memory poisoning gets *detected* here), UX second. List rows carry the
+injection truth: ``in_digest`` (session is in the current digest window) and
+``injecting`` (hot chunk is in the current per-turn window).
 
 Generic chunk CRUD already lives in ``knowledge_routes``; these routes add the
 domain-scoped view the inspector needs: a hot edit is pinned to
@@ -36,14 +39,63 @@ log = logging.getLogger("protoagent.server")
 _HOT_LIST_LIMIT = 500
 
 
-def _session_path(session_id: str) -> str | None:
-    """Map *session_id* to its summary file, or None when the id fails the
-    ``[A-Za-z0-9._:-]`` guard (path-traversal safe: no separators survive)."""
-    from graph.middleware.memory import is_safe_session_id, memory_path
+def _session_paths(session_id: str) -> list[str] | None:
+    """Candidate summary files for *session_id* — the '%3A'-encoded name first,
+    then the legacy raw-':' name (``session_file_candidates``, the shared
+    mapper) — or None when the id fails the ``[A-Za-z0-9._:-]`` guard
+    (path-traversal safe: no separators survive)."""
+    from graph.middleware.memory import is_safe_session_id, session_file_candidates
 
     if not is_safe_session_id(session_id):
         return None
-    return os.path.join(memory_path(), f"{session_id}.json")
+    return session_file_candidates(session_id)
+
+
+def _read_summary(paths: list[str]) -> dict:
+    """Load the first candidate file that exists (encoded name, then legacy).
+    Raises FileNotFoundError only when NO candidate exists; a corrupt encoded
+    file propagates its decode error (the caller 422s — it must not fall
+    through to a stale legacy copy)."""
+    for fpath in paths[:-1]:
+        try:
+            with open(fpath, encoding="utf-8") as fh:
+                return json.load(fh)
+        except FileNotFoundError:
+            continue
+    with open(paths[-1], encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _list_sessions() -> list[dict]:
+    """The sessions listing, newest first — sync (dir walk + a ``json.load``
+    per summary + the digest re-derivation); callers run it off the loop."""
+    from graph.middleware.memory import digest_entry, load_prior_sessions_digest, memory_path
+
+    base = memory_path()
+    # The ids the CURRENT digest injection carries — default args match the
+    # middleware's (10 newest, 2000-token cap, background:* excluded), so the
+    # console's "in digest" badge reflects what the model actually sees.
+    digest_ids = set(load_prior_sessions_digest()[1])
+    sessions: list[tuple[float, dict]] = []
+    if os.path.isdir(base):
+        for fname in os.listdir(base):
+            if not fname.endswith(".json"):
+                continue
+            fpath = os.path.join(base, fname)
+            try:
+                size = os.path.getsize(fpath)
+                mtime = os.path.getmtime(fpath)
+                with open(fpath, encoding="utf-8") as fh:
+                    summary = json.load(fh)
+            except (OSError, json.JSONDecodeError, ValueError) as exc:
+                log.warning("[memory] skipping unreadable summary %s: %s", fpath, exc)
+                continue
+            entry = digest_entry(summary)
+            entry["size_bytes"] = size
+            entry["in_digest"] = entry["session_id"] in digest_ids
+            sessions.append((mtime, entry))
+    sessions.sort(key=lambda t: t[0], reverse=True)  # newest first, like the digest
+    return [e for _, e in sessions]
 
 
 def _hot_chunks(store) -> list[dict]:
@@ -75,39 +127,17 @@ def register_memory_routes(app) -> None:
 
     @app.get("/api/memory/sessions")
     async def _api_memory_sessions():
-        from graph.middleware.memory import digest_entry, memory_path
-
-        base = memory_path()
-        sessions: list[tuple[float, dict]] = []
-        if os.path.isdir(base):
-            for fname in os.listdir(base):
-                if not fname.endswith(".json"):
-                    continue
-                fpath = os.path.join(base, fname)
-                try:
-                    size = os.path.getsize(fpath)
-                    mtime = os.path.getmtime(fpath)
-                    with open(fpath, encoding="utf-8") as fh:
-                        summary = json.load(fh)
-                except (OSError, json.JSONDecodeError, ValueError) as exc:
-                    log.warning("[memory] skipping unreadable summary %s: %s", fpath, exc)
-                    continue
-                entry = digest_entry(summary)
-                entry["size_bytes"] = size
-                sessions.append((mtime, entry))
-        sessions.sort(key=lambda t: t[0], reverse=True)  # newest first, like the digest
-        return {"sessions": [e for _, e in sessions]}
+        return {"sessions": await asyncio.to_thread(_list_sessions)}
 
     @app.get("/api/memory/sessions/{session_id}")
     async def _api_memory_session_get(session_id: str):
         from graph.middleware.memory import digest_entry, format_session_summary
 
-        fpath = _session_path(session_id)
-        if fpath is None:
+        paths = _session_paths(session_id)
+        if paths is None:
             return JSONResponse({"detail": "invalid session_id"}, status_code=400)
         try:
-            with open(fpath, encoding="utf-8") as fh:
-                summary = json.load(fh)
+            summary = await asyncio.to_thread(_read_summary, paths)
         except FileNotFoundError:
             return JSONResponse({"detail": "no session summary with that id"}, status_code=404)
         except (OSError, json.JSONDecodeError, ValueError) as exc:
@@ -119,16 +149,29 @@ def register_memory_routes(app) -> None:
 
     @app.delete("/api/memory/sessions/{session_id}")
     async def _api_memory_session_delete(session_id: str):
-        fpath = _session_path(session_id)
-        if fpath is None:
+        paths = _session_paths(session_id)
+        if paths is None:
             return JSONResponse({"detail": "invalid session_id"}, status_code=400)
+
+        def _remove() -> bool:
+            removed = False
+            # Remove EVERY name the summary may live under (encoded + legacy) —
+            # a delete must not leave a legacy copy resurfacing in the digest.
+            for fpath in paths:
+                try:
+                    os.remove(fpath)
+                    removed = True
+                except FileNotFoundError:
+                    continue
+            return removed
+
         try:
-            os.remove(fpath)
-        except FileNotFoundError:
-            return JSONResponse({"detail": "no session summary with that id"}, status_code=404)
+            removed = await asyncio.to_thread(_remove)
         except OSError as exc:
-            log.warning("[memory] delete of summary %s failed: %s", fpath, exc)
+            log.warning("[memory] delete of summary %s failed: %s", session_id, exc)
             return JSONResponse({"detail": f"delete failed: {exc}"}, status_code=500)
+        if not removed:
+            return JSONResponse({"detail": "no session summary with that id"}, status_code=404)
         return {"deleted": True, "session_id": session_id}
 
     # --- Hot memory ----------------------------------------------------------
@@ -136,25 +179,43 @@ def register_memory_routes(app) -> None:
 
     @app.get("/api/memory/hot")
     async def _api_memory_hot():
-        if STATE.knowledge_store is None:
+        store = STATE.knowledge_store
+        if store is None:
             return {"enabled": False, "chunks": []}
         try:
-            chunks = _hot_chunks(STATE.knowledge_store)
+            chunks = await asyncio.to_thread(_hot_chunks, store)
         except Exception:  # noqa: BLE001 — never 500 the console
             log.exception("[memory] hot-memory list failed")
-            chunks = []
+            return {"enabled": True, "chunks": []}
+        # "injecting" = the chunk is in the CURRENT per-turn window: the ids
+        # get_hot_memory_entries returns (newest 100 domain="hot" chunks under
+        # the 6000-char budget) — the same reader the middleware injects from.
+        # On a LayeredKnowledgeStore, __getattr__ delegates it to the PRIVATE
+        # store, whose ids are consistent with the listed rows (commons rows
+        # are already excluded by _hot_chunks). A custom backend without the
+        # reader gets NO field — the console renders a missing flag as unknown.
+        if hasattr(store, "get_hot_memory_entries"):
+            try:
+                window = await asyncio.to_thread(store.get_hot_memory_entries)
+                window_ids = {cid for cid, _ in window}
+            except Exception:  # noqa: BLE001 — the flag is best-effort; the list still serves
+                log.exception("[memory] hot-memory injection window failed")
+            else:
+                for row in chunks:
+                    row["injecting"] = row.get("id") in window_ids
         return {"enabled": True, "chunks": chunks}
 
     @app.put("/api/memory/hot/{chunk_id}")
     async def _api_memory_hot_update(chunk_id: int, body: dict | None = None):
         store = STATE.knowledge_store
         if store is None:
-            return {"enabled": False, "id": None}
+            return {"enabled": False, "id": None, "replaced": False}
         body = body or {}
         content = str(body.get("content", "")).strip()
         if not content:
             return JSONResponse({"detail": "content is required"}, status_code=400)
-        cur = next((c for c in _hot_chunks(store) if c.get("id") == chunk_id), None)
+        rows = await asyncio.to_thread(_hot_chunks, store)
+        cur = next((c for c in rows if c.get("id") == chunk_id), None)
         if cur is None:
             return JSONResponse({"detail": "no hot-memory chunk with that id"}, status_code=404)
         # Same composition as the generic chunk edit (knowledge_routes): add the
@@ -185,7 +246,8 @@ def register_memory_routes(app) -> None:
         store = STATE.knowledge_store
         if store is None:
             return {"enabled": False, "deleted": False}
-        if not any(c.get("id") == chunk_id for c in _hot_chunks(store)):
+        rows = await asyncio.to_thread(_hot_chunks, store)
+        if not any(c.get("id") == chunk_id for c in rows):
             return JSONResponse({"detail": "no hot-memory chunk with that id"}, status_code=404)
         deleted = await asyncio.to_thread(store.delete_by_id, chunk_id)
         return {"enabled": True, "deleted": bool(deleted)}

--- a/operator_api/memory_routes.py
+++ b/operator_api/memory_routes.py
@@ -53,17 +53,16 @@ def _session_paths(session_id: str) -> list[str] | None:
 
 def _read_summary(paths: list[str]) -> dict:
     """Load the first candidate file that exists (encoded name, then legacy).
-    Raises FileNotFoundError only when NO candidate exists; a corrupt encoded
-    file propagates its decode error (the caller 422s — it must not fall
-    through to a stale legacy copy)."""
-    for fpath in paths[:-1]:
+    Raises FileNotFoundError only when NO candidate exists; a corrupt candidate
+    propagates its decode error (the caller 422s — a corrupt encoded file must
+    not fall through to a stale legacy copy)."""
+    for fpath in paths:
         try:
             with open(fpath, encoding="utf-8") as fh:
                 return json.load(fh)
         except FileNotFoundError:
             continue
-    with open(paths[-1], encoding="utf-8") as fh:
-        return json.load(fh)
+    raise FileNotFoundError(paths[0])
 
 
 def _list_sessions() -> list[dict]:

--- a/tests/test_memory_injection_controls.py
+++ b/tests/test_memory_injection_controls.py
@@ -274,6 +274,23 @@ def test_injection_log_records_attributed_ids(tmp_path, monkeypatch):
     assert row["ts"]
 
 
+def test_injection_record_falls_back_to_tracing_session_id(tmp_path):
+    """An entry path that omits the (optional) state session_id still gets an
+    ATTRIBUTED injection row — same tracing-contextvar defense _persist_session
+    has, so forensics never silently lose the session linkage."""
+    from unittest.mock import patch
+
+    from observability.injection_log import injection_log
+
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("deploys go out Fridays", domain="hot")
+    mw = _mw(store)
+    with patch("observability.tracing.current_session_id", return_value="ctx-sid-9"):
+        mw.before_model({"messages": [HumanMessage(content="q")]}, runtime=None)
+    rows = injection_log().recent()
+    assert rows and rows[0]["session_id"] == "ctx-sid-9"
+
+
 def test_incognito_writes_no_injection_row(tmp_path):
     from observability.injection_log import injection_log
 
@@ -327,3 +344,23 @@ def test_injections_route_newest_first_and_filters():
 def test_injections_route_empty_log():
     body = _injections_client().get("/api/memory/injections").json()
     assert body == {"injections": []}
+
+
+def test_injections_route_clamps_limit(monkeypatch):
+    """The route clamps limit into [1, 500] before it reaches the store — an
+    oversized querystring can't turn the read into an unbounded scan."""
+    import observability.injection_log as il
+
+    captured: dict = {}
+
+    class _Stub:
+        def recent(self, session_id=None, limit=50):
+            captured["limit"] = limit
+            return []
+
+    monkeypatch.setattr(il, "injection_log", lambda: _Stub())
+    c = _injections_client()
+    assert c.get("/api/memory/injections", params={"limit": 99999}).json() == {"injections": []}
+    assert captured["limit"] == 500
+    c.get("/api/memory/injections", params={"limit": -5})
+    assert captured["limit"] == 1

--- a/tests/test_memory_load.py
+++ b/tests/test_memory_load.py
@@ -427,6 +427,20 @@ def test_digest_surface_classification(tmp_path):
     assert "background:job-7" not in result
 
 
+def test_digest_excludes_encoded_background_files(tmp_path):
+    """The background:* read-side filter must catch the '%3A'-encoded filename
+    a Windows-safe writer produces, not just the legacy raw-':' name."""
+    _write_session(str(tmp_path), "chat-ok", _sample_session("chat-ok"))
+    with open(os.path.join(str(tmp_path), "background%3Ajob-9.json"), "w", encoding="utf-8") as fh:
+        json.dump(_sample_session("background:job-9"), fh)
+
+    from graph.middleware.memory import load_prior_sessions_digest
+
+    block, ids = load_prior_sessions_digest(str(tmp_path))
+    assert ids == ["chat-ok"]
+    assert "background:job-9" not in block
+
+
 def test_digest_topic_truncated(tmp_path):
     session = _sample_session("sess-long")
     session["messages"] = [{"role": "user", "content": "T" * 300}]
@@ -465,6 +479,24 @@ async def test_recall_session_happy_path(monkeypatch, tmp_path):
 async def test_recall_session_unknown_id(monkeypatch, tmp_path):
     out = await _recall_tool(monkeypatch, tmp_path).ainvoke({"session_id": "no-such-session"})
     assert "No session" in out
+
+
+async def test_recall_session_reads_encoded_filename(monkeypatch, tmp_path):
+    # A ':' id persists under the '%3A'-encoded name (Windows-safe filenames);
+    # recall goes through the same session_filename mapper as the writer.
+    with open(os.path.join(str(tmp_path), "a2a%3Asess-1.json"), "w", encoding="utf-8") as fh:
+        json.dump(_sample_session("a2a:sess-1"), fh)
+    out = await _recall_tool(monkeypatch, tmp_path).ainvoke({"session_id": "a2a:sess-1"})
+    assert 'id="a2a:sess-1"' in out
+    assert "Hello" in out
+
+
+async def test_recall_session_legacy_raw_name_fallback(monkeypatch, tmp_path):
+    # Pre-encoding builds wrote the raw ':' filename on POSIX — reads fall back
+    # to it when the encoded name is absent.
+    _write_session(str(tmp_path), "a2a:legacy", _sample_session("a2a:legacy"))
+    out = await _recall_tool(monkeypatch, tmp_path).ainvoke({"session_id": "a2a:legacy"})
+    assert 'id="a2a:legacy"' in out
 
 
 async def test_recall_session_rejects_traversal(monkeypatch, tmp_path):

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -617,6 +617,25 @@ def test_persist_session_removes_legacy_raw_name(tmp_path):
     assert ids == ["system:activity"]  # once, not twice
 
 
+def test_persist_session_overwrites_existing_summary(tmp_path):
+    """Re-persisting a live session replaces its summary IN PLACE — os.replace,
+    not os.rename: on Windows os.rename raises FileExistsError when dest
+    exists, which would freeze every summary at its first write."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+    mod._persist_session(_make_state("sess-live"), "t-first")
+    mod._persist_session(
+        _make_state(
+            "sess-live",
+            messages=[HumanMessage(content="Later turn"), AIMessage(content="Updated answer, longer now. " * 5)],
+        ),
+        "t-second",
+    )
+    assert [p.name for p in tmp_path.glob("*")] == ["sess-live.json"]  # no .tmp leftovers
+    data = json.loads((tmp_path / "sess-live.json").read_text())
+    assert data["trace_id"] == "t-second"
+    assert data["messages"][0]["content"] == "Later turn"
+
+
 # ---------------------------------------------------------------------------
 # Default path resolution (no MEMORY_PATH override)
 # ---------------------------------------------------------------------------

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -572,6 +572,52 @@ def test_after_agent_does_not_persist_when_last_msg_not_ai(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# 11. Windows-safe filenames — ':' encoded as '%3A' (system:activity, a2a:*)
+# ---------------------------------------------------------------------------
+
+
+def test_session_filename_mapper_roundtrip(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path)})
+    assert mod.session_filename("system:activity") == "system%3Aactivity.json"
+    assert mod.session_filename("plain-id") == "plain-id.json"
+    # Read candidates: encoded name first, legacy raw-':' fallback; ids without
+    # ':' collapse to the single (identical) path.
+    assert mod.session_file_candidates("a2a:x", str(tmp_path)) == [
+        str(tmp_path / "a2a%3Ax.json"),
+        str(tmp_path / "a2a:x.json"),
+    ]
+    assert mod.session_file_candidates("plain", str(tmp_path)) == [str(tmp_path / "plain.json")]
+    # '%' stays outside the safe-id charset — a crafted id can never collide
+    # with an encoded filename.
+    assert not mod.is_safe_session_id("system%3Aactivity")
+
+
+def test_persist_session_encodes_colon_in_filename(tmp_path):
+    """':' is invalid in NTFS filenames — system:activity summaries silently
+    failed to persist on Windows. The writer encodes it as '%3A'."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+    mod._persist_session(_make_state("system:activity"), "t-win")
+    assert (tmp_path / "system%3Aactivity.json").exists()
+    assert not (tmp_path / "system:activity.json").exists()
+    data = json.loads((tmp_path / "system%3Aactivity.json").read_text())
+    assert data["session_id"] == "system:activity"  # only the FILENAME is encoded
+
+
+def test_persist_session_removes_legacy_raw_name(tmp_path):
+    """After a successful encoded write, the pre-encoding raw-':' file for the
+    same id is removed — the digest must never list the session twice."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+    (tmp_path / "system:activity.json").write_text(
+        json.dumps({"session_id": "system:activity", "messages": [], "timestamp": "old"})
+    )
+    mod._persist_session(_make_state("system:activity"), "t-win2")
+    assert (tmp_path / "system%3Aactivity.json").exists()
+    assert not (tmp_path / "system:activity.json").exists()
+    _, ids = mod.load_prior_sessions_digest(str(tmp_path))
+    assert ids == ["system:activity"]  # once, not twice
+
+
+# ---------------------------------------------------------------------------
 # Default path resolution (no MEMORY_PATH override)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -63,6 +63,43 @@ def test_sessions_list_empty_dir(tmp_path, monkeypatch):
     assert c.get("/api/memory/sessions").json() == {"sessions": []}
 
 
+def test_sessions_list_skips_corrupt_file(tmp_path, monkeypatch):
+    (tmp_path / "bad.json").write_text("{not json")
+    _write(tmp_path, "good", [{"role": "user", "content": "ok"}])
+    c = _client(monkeypatch, tmp_path)
+    rows = c.get("/api/memory/sessions").json()["sessions"]
+    assert [r["session_id"] for r in rows] == ["good"]  # corrupt row skipped, not fatal
+
+
+def test_sessions_list_in_digest_flags(tmp_path, monkeypatch):
+    # The inspector lists what EXISTS on disk; in_digest says what the digest
+    # loader actually injects. A legacy background:* file is listed but never
+    # enters the digest (ADR 0070 D3 read-side filter) → in_digest False.
+    _write(tmp_path, "chat-live", [{"role": "user", "content": "hi"}])
+    _write(tmp_path, "background:job1", [{"role": "user", "content": "worker"}])
+    c = _client(monkeypatch, tmp_path)
+    rows = {r["session_id"]: r for r in c.get("/api/memory/sessions").json()["sessions"]}
+    assert rows["chat-live"]["in_digest"] is True
+    assert rows["background:job1"]["in_digest"] is False
+
+
+def test_sessions_list_in_digest_false_beyond_window(tmp_path, monkeypatch):
+    import os
+
+    # 12 sessions with distinct mtimes: the digest carries the 10 newest
+    # (middleware default), so the 2 oldest must report in_digest False.
+    for i in range(12):
+        sid = f"s-{i:02d}"
+        _write(tmp_path, sid, [{"role": "user", "content": sid}])
+        p = tmp_path / f"{sid}.json"
+        os.utime(p, (p.stat().st_atime, p.stat().st_mtime - (12 - i) * 100))
+    c = _client(monkeypatch, tmp_path)
+    rows = c.get("/api/memory/sessions").json()["sessions"]
+    flags = {r["session_id"]: r["in_digest"] for r in rows}
+    assert flags["s-00"] is False and flags["s-01"] is False
+    assert all(flags[f"s-{i:02d}"] for i in range(2, 12))
+
+
 def test_session_get_renders_full_summary(tmp_path, monkeypatch):
     _write(tmp_path, "background:job1", [{"role": "user", "content": "check the feeds"}], final_output="all quiet")
     c = _client(monkeypatch, tmp_path)
@@ -77,6 +114,35 @@ def test_session_get_renders_full_summary(tmp_path, monkeypatch):
 def test_session_get_unknown_404(tmp_path, monkeypatch):
     c = _client(monkeypatch, tmp_path)
     assert c.get("/api/memory/sessions/nope").status_code == 404
+
+
+def test_session_get_corrupt_json_422(tmp_path, monkeypatch):
+    (tmp_path / "bad.json").write_text("{not json")
+    c = _client(monkeypatch, tmp_path)
+    assert c.get("/api/memory/sessions/bad").status_code == 422
+
+
+def test_session_routes_read_encoded_and_legacy_names(tmp_path, monkeypatch):
+    # Windows-safe mapping: the writer encodes ':' as '%3A'; reads try the
+    # encoded name first, then fall back to the legacy raw-':' name (files a
+    # pre-encoding build wrote on POSIX). Deletes remove whichever exists.
+    (tmp_path / "system%3Aactivity.json").write_text(
+        json.dumps(
+            {
+                "session_id": "system:activity",
+                "timestamp": "2026-07-01T00:00:00Z",
+                "messages": [{"role": "user", "content": "encoded-name-body"}],
+            }
+        )
+    )
+    _write(tmp_path, "a2a:legacy", [{"role": "user", "content": "legacy-name-body"}])
+    c = _client(monkeypatch, tmp_path)
+    assert "encoded-name-body" in c.get("/api/memory/sessions/system:activity").json()["session"]["rendered"]
+    assert "legacy-name-body" in c.get("/api/memory/sessions/a2a:legacy").json()["session"]["rendered"]
+    assert c.delete("/api/memory/sessions/system:activity").json()["deleted"] is True
+    assert not (tmp_path / "system%3Aactivity.json").exists()
+    assert c.delete("/api/memory/sessions/a2a:legacy").json()["deleted"] is True
+    assert not (tmp_path / "a2a:legacy.json").exists()
 
 
 def test_session_id_guard_rejects_unsafe_ids(tmp_path, monkeypatch):
@@ -111,6 +177,18 @@ def test_session_delete(tmp_path, monkeypatch):
     assert c.delete("/api/memory/sessions/s1").json() == {"deleted": True, "session_id": "s1"}
     assert not (tmp_path / "s1.json").exists()
     assert c.delete("/api/memory/sessions/s1").status_code == 404  # already gone
+
+
+def test_session_delete_oserror_500(tmp_path, monkeypatch):
+    _write(tmp_path, "s1", [{"role": "user", "content": "x"}])
+    c = _client(monkeypatch, tmp_path)
+    import operator_api.memory_routes as mr
+
+    def _boom(path):
+        raise PermissionError(13, "denied")
+
+    monkeypatch.setattr(mr.os, "remove", _boom)
+    assert c.delete("/api/memory/sessions/s1").status_code == 500
 
 
 # ── hot memory ────────────────────────────────────────────────────────────────
@@ -154,6 +232,76 @@ def test_hot_list(tmp_path, monkeypatch):
     )
 
 
+def test_hot_list_store_error_returns_empty(tmp_path, monkeypatch):
+    ks = _HotKS()
+
+    def _boom(**kwargs):
+        raise RuntimeError("db locked")
+
+    ks.list_chunks = _boom
+    c = _client(monkeypatch, tmp_path, knowledge=ks)
+    assert c.get("/api/memory/hot").json() == {"enabled": True, "chunks": []}  # never 500 the console
+
+
+class _HotKSEntries(_HotKS):
+    """_HotKS plus the id-attributed injection reader the ``injecting`` flag
+    derives from (the same get_hot_memory_entries the middleware injects)."""
+
+    def __init__(self, window_ids):
+        super().__init__()
+        self._window = list(window_ids)
+
+    def get_hot_memory_entries(self, max_chars=6000):
+        return [(cid, "piece") for cid in self._window]
+
+
+def test_hot_list_injecting_flags(tmp_path, monkeypatch):
+    ks = _HotKSEntries(window_ids=[3])
+    ks.rows = [
+        {"id": 3, "content": "in window", "domain": "hot", "created_at": "2026-07-01", "source": "console"},
+        {"id": 5, "content": "out of window", "domain": "hot", "created_at": "2026-06-01", "source": "console"},
+    ]
+    c = _client(monkeypatch, tmp_path, knowledge=ks)
+    flags = {r["id"]: r["injecting"] for r in c.get("/api/memory/hot").json()["chunks"]}
+    assert flags == {3: True, 5: False}
+
+
+def test_hot_list_omits_injecting_without_reader(tmp_path, monkeypatch):
+    # A custom backend without get_hot_memory_entries: the field is OMITTED
+    # entirely (the console renders a missing flag as unknown — no badge).
+    c = _client(monkeypatch, tmp_path, knowledge=_HotKS())
+    rows = c.get("/api/memory/hot").json()["chunks"]
+    assert rows and all("injecting" not in r for r in rows)
+
+
+def test_hot_list_omits_injecting_when_reader_fails(tmp_path, monkeypatch):
+    ks = _HotKSEntries(window_ids=[3])
+
+    def _boom(max_chars=6000):
+        raise RuntimeError("reader broke")
+
+    ks.get_hot_memory_entries = _boom
+    c = _client(monkeypatch, tmp_path, knowledge=ks)
+    rows = c.get("/api/memory/hot").json()["chunks"]
+    assert rows and all("injecting" not in r for r in rows)  # the list still serves
+
+
+def test_hot_budget_break_marks_all_not_injecting(tmp_path, monkeypatch):
+    # get_hot_memory_entries walks newest-first and BREAKS at the first
+    # over-budget piece — one >6000-char newest chunk empties the whole
+    # injection window, so every row (itself included) reports injecting=False.
+    from knowledge.store import KnowledgeStore
+
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("small older fact", domain="hot")
+    store.add_chunk("x" * 6001, domain="hot")  # newest — over budget on its own
+    assert store.get_hot_memory_entries() == []
+    c = _client(monkeypatch, tmp_path, knowledge=store)
+    rows = c.get("/api/memory/hot").json()["chunks"]
+    assert len(rows) == 2
+    assert all(r["injecting"] is False for r in rows)
+
+
 def test_hot_edit_pins_domain_and_adds_before_deleting(tmp_path, monkeypatch):
     ks = _HotKS()
     c = _client(monkeypatch, tmp_path, knowledge=ks)
@@ -178,6 +326,14 @@ def test_hot_edit_unknown_id_404(tmp_path, monkeypatch):
     c = _client(monkeypatch, tmp_path, knowledge=ks)
     assert c.put("/api/memory/hot/99", json={"content": "x"}).status_code == 404
     assert ks.added == [] and ks.deleted == []
+
+
+def test_hot_edit_empty_content_400(tmp_path, monkeypatch):
+    ks = _HotKS()
+    c = _client(monkeypatch, tmp_path, knowledge=ks)
+    for payload in ({}, {"content": ""}, {"content": "   "}):
+        assert c.put("/api/memory/hot/3", json=payload).status_code == 400
+    assert ks.added == [] and ks.deleted == []  # nothing touched the store
 
 
 def test_hot_delete_only_resolves_hot_ids(tmp_path, monkeypatch):
@@ -212,4 +368,8 @@ def test_hot_disabled_without_store(tmp_path, monkeypatch):
     c = _client(monkeypatch, tmp_path)
     assert c.get("/api/memory/hot").json() == {"enabled": False, "chunks": []}
     assert c.delete("/api/memory/hot/1").json() == {"enabled": False, "deleted": False}
-    assert c.put("/api/memory/hot/1", json={"content": "x"}).json() == {"enabled": False, "id": None}
+    assert c.put("/api/memory/hot/1", json={"content": "x"}).json() == {
+        "enabled": False,
+        "id": None,
+        "replaced": False,
+    }

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -145,6 +145,28 @@ def test_session_routes_read_encoded_and_legacy_names(tmp_path, monkeypatch):
     assert not (tmp_path / "a2a:legacy.json").exists()
 
 
+def test_session_get_prefers_encoded_over_legacy(tmp_path, monkeypatch):
+    # Both names on disk (the writer's legacy cleanup is best-effort): the
+    # encoded file is the source of truth — the read surfaces it, and a CORRUPT
+    # encoded file is a 422, never a fall-through to the stale legacy body.
+    (tmp_path / "sys%3Aboth.json").write_text(
+        json.dumps(
+            {
+                "session_id": "sys:both",
+                "timestamp": "2026-07-02T00:00:00Z",
+                "messages": [{"role": "user", "content": "current-encoded-body"}],
+            }
+        )
+    )
+    _write(tmp_path, "sys:both", [{"role": "user", "content": "stale-legacy-body"}])
+    c = _client(monkeypatch, tmp_path)
+    rendered = c.get("/api/memory/sessions/sys:both").json()["session"]["rendered"]
+    assert "current-encoded-body" in rendered
+    assert "stale-legacy-body" not in rendered
+    (tmp_path / "sys%3Aboth.json").write_text("{not json")
+    assert c.get("/api/memory/sessions/sys:both").status_code == 422
+
+
 def test_session_id_guard_rejects_unsafe_ids(tmp_path, monkeypatch):
     # The recall_session filename guard: [A-Za-z0-9._:-] only, so a crafted id
     # (encoded separators, spaces) can't escape the memory dir. An encoded "/"

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -853,24 +853,29 @@ def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None)
         as instructions.
         """
         import json
-        import os
 
-        from graph.middleware.memory import format_session_summary, is_safe_session_id, memory_path
+        from graph.middleware.memory import format_session_summary, is_safe_session_id, session_file_candidates
 
         sid = (session_id or "").strip()
-        # Filename guard: ids map to {memory_path()}/{sid}.json, so anything
+        # Filename guard: ids map onto files under memory_path(), so anything
         # outside the safe charset (path separators, "..", NUL) is rejected.
         if not is_safe_session_id(sid):
             return f"Error: invalid session_id {session_id!r} — pass an id from <prior_sessions>."
 
-        fpath = os.path.join(memory_path(), f"{sid}.json")
-        try:
-            with open(fpath, encoding="utf-8") as fh:
-                summary = json.load(fh)
-        except FileNotFoundError:
+        # Shared filename mapper: the '%3A'-encoded name first (Windows-safe
+        # writer output), then the legacy raw-':' name for pre-encoding files.
+        summary = None
+        for fpath in session_file_candidates(sid):
+            try:
+                with open(fpath, encoding="utf-8") as fh:
+                    summary = json.load(fh)
+                break
+            except FileNotFoundError:
+                continue
+            except (OSError, json.JSONDecodeError, ValueError) as exc:
+                return f"Error: session {sid!r} could not be read ({exc})."
+        if summary is None:
             return f"No session {sid!r} found — pass an id from <prior_sessions>."
-        except (OSError, json.JSONDecodeError, ValueError) as exc:
-            return f"Error: session {sid!r} could not be read ({exc})."
         rendered = format_session_summary(summary)
         if len(rendered) > _RECALL_SESSION_MAX_CHARS:
             rendered = rendered[:_RECALL_SESSION_MAX_CHARS] + "\n… (truncated)"


### PR DESCRIPTION
Backend lane (lane A) of the memory-inspector audit-fix batch. A parallel lane owns the console (`apps/web`) consumption of these fields — the API contract below is frozen between the two.

## Audit findings fixed

1. **Inspector listed hot chunks it does not inject.** `GET /api/memory/hot` lists up to 500 rows, but the per-turn injection window is `get_hot_memory_entries()` (newest 100 `domain="hot"` chunks under the 6000-char budget). Rows now carry `"injecting": boolean` computed from that same reader — the field is **omitted entirely** on custom backends without it (console renders missing as unknown, only `=== false` draws the badge). On a `LayeredKnowledgeStore`, `__getattr__` delegates the reader to the PRIVATE store, whose ids match the listed rows (commons rows are already excluded by `_hot_chunks`).
2. **Inspector listed sessions the digest never injects.** `GET /api/memory/sessions` rows now carry `"in_digest": boolean` — membership in `load_prior_sessions_digest()` with default args (matches the middleware: 10 newest, 2000-token cap, `background:*` excluded). Legacy background files on disk now honestly show `in_digest: false`.
3. **Async handlers did sync I/O on the event loop.** The sessions listing (dir walk + `json.load` per summary) and every `_hot_chunks` call (sync sqlite) in GET/PUT/DELETE hot now go through `asyncio.to_thread`; the single-summary read and delete moved too. Never-500-the-console semantics preserved.
4. **PUT store-off branch under-reported.** Now returns `{"enabled": false, "id": null, "replaced": false}` (the TS type already promised `replaced`).
5. **Injection rows could silently lose attribution.** `_record_injection` now falls back to `tracing.current_session_id()` when state omits the optional `session_id` field — the same defense `_persist_session` has. The stale "not a declared graph-state field" comment in `memory.py` reworded (it IS declared, `NotRequired`, in `graph/state.py`).
6. **Session summaries with `:` ids silently failed to persist on Windows** (`system:activity`, `a2a:*` — and the desktop Windows build just shipped). New shared mapper in `graph/middleware/memory.py`: `session_filename()` encodes `:` as `%3A` for writes; `session_file_candidates()` gives readers the encoded name first with a legacy raw-name fallback; a successful encoded write removes the legacy file so the digest never lists a session twice. `recall_session` (tools/lg_tools.py) and the memory routes are unified on the mapper; the digest's background filter catches both `background:` and `background%3A` prefixes. `is_safe_session_id` still rejects `%`, so a crafted id can't collide with an encoded name.
7. **Re-persisting a session would still fail on Windows even with safe filenames.** The atomic write used `os.rename`, which on Windows raises `FileExistsError` when the destination exists — sessions re-persist on every terminal turn, so every summary would freeze at its first write. Now `os.replace` (POSIX-rename semantics on both platforms).

## Test gaps closed

- `injecting` true/false in/out of window; budget-break case (a >6000-char newest chunk empties the whole window → all rows false); field omitted when the reader is missing or raises.
- `in_digest` false for a legacy `background:*` file and for sessions beyond the 10-newest window.
- Tracing-fallback attribution for injection rows; `replaced: false` on store-off PUT.
- Mapper roundtrip, encoded-name + legacy-name reads (route and tool), legacy cleanup after re-persist (no digest dupes), encoded background filter.
- Preference order when BOTH names exist: the encoded file wins, and a corrupt encoded file is a 422 — never a fall-through to the stale legacy body.
- Re-persist overwrites the summary in place (no `.tmp` leftovers) — the `os.replace` behavior.
- PUT empty/whitespace content → 400; corrupt `.json` → 422 on GET and skipped (not fatal) in the list; session DELETE `OSError` → 500; hot GET store exception → `{"enabled": true, "chunks": []}`; `GET /api/memory/injections` limit clamped to [1, 500].

## Gates

| Gate | Result |
|---|---|
| `ruff check .` | pass |
| `lint-imports` | pass (3 contracts kept) |
| `python -m pytest tests/ -q` | pass — 2957 passed, 5 skipped |
| `python scripts/live_smoke.py` | pass — LIVE SMOKE PASSED |
| Web unit / e2e | not run — no `apps/web` changes in this lane (console half lands in the parallel lane) |

Python-only by design: `apps/web` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
