### PR TITLE
feat(console): memory view tells the truth — injection-window badges, accurate copy, filter + a11y polish

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -764,6 +764,9 @@ export const KNOWLEDGE_CHUNKS = [
 
 // Memory inspector (ADR 0069 D7) — session-summary digest rows, hot-memory chunks,
 // and the per-turn injection record the Memory surface renders.
+// Delivery-truth fields are MIXED on purpose: in_digest/injecting true, false,
+// and ABSENT (a backend predating the fields) — the badge specs assert that only
+// an explicit `false` draws a badge and absent fields degrade gracefully.
 export const MEMORY_SESSIONS = [
   {
     session_id: "chat-1750000000000-abc123",
@@ -772,6 +775,7 @@ export const MEMORY_SESSIONS = [
     topic: "plan the memory hardening rollout",
     message_count: 12,
     size_bytes: 2048,
+    in_digest: true,
   },
   {
     session_id: "sched-hourly-report",
@@ -780,6 +784,15 @@ export const MEMORY_SESSIONS = [
     topic: "compile the hourly ops report",
     message_count: 4,
     size_bytes: 512,
+    in_digest: false,
+  },
+  {
+    // Legacy row: no in_digest / size_bytes — renders with no badge, no size.
+    session_id: "a2a-legacy-noflags",
+    timestamp: "2026-06-29T12:00:00+00:00",
+    surface: "a2a",
+    topic: "row from a backend without delivery flags",
+    message_count: 2,
   },
 ];
 
@@ -796,18 +809,26 @@ export const MEMORY_HOT = [
     id: 31, heading: "Operator timezone", content: "The operator works in US/Pacific.",
     preview: "The operator works in US/Pacific.",
     domain: "hot", source: "chat-1750000000000-abc123", source_type: "extracted", finding_type: null,
-    created_at: "2026-06-29T10:00:00+00:00",
+    created_at: "2026-06-29T10:00:00+00:00", injecting: true,
   },
   {
     id: 32, heading: "", content: "Weekly report goes out Fridays at 9am.",
     preview: "Weekly report goes out Fridays at 9am.",
     domain: "hot", source: "console", source_type: "operator", finding_type: null,
-    created_at: "2026-06-28T09:00:00+00:00",
+    created_at: "2026-06-28T09:00:00+00:00", injecting: false,
+  },
+  {
+    // Legacy row: no `injecting` field — renders with no badge.
+    id: 33, heading: "", content: "Legacy row predating the injection-window field.",
+    preview: "Legacy row predating the injection-window field.",
+    domain: "hot", source: null, source_type: null, finding_type: null,
+    created_at: "2026-06-27T08:00:00+00:00",
   },
 ];
 
 export const MEMORY_INJECTIONS = [
   {
+    id: 7,
     ts: "2026-06-30T18:05:00+00:00",
     session_id: "chat-1750000000000-abc123",
     digest_session_ids: ["sched-hourly-report"],
@@ -816,6 +837,7 @@ export const MEMORY_INJECTIONS = [
     approx_tokens: 420,
   },
   {
+    id: 6,
     ts: "2026-06-30T17:01:00+00:00",
     session_id: "sched-hourly-report",
     digest_session_ids: [],

--- a/apps/web/e2e/memory-inspector.spec.ts
+++ b/apps/web/e2e/memory-inspector.spec.ts
@@ -4,15 +4,31 @@ import { expect, test } from "@playwright/test";
 // layer — session-summary digest rows, hot memory, and the per-turn injection
 // record — with delete flows that confirm + toast.
 
-// The delete tests MUTATE the shared mock (a session row / hot chunk is removed),
-// so run serially and reset the memory fixtures before each test — the same
-// hermeticity guard the knowledge spec uses.
+// The delete tests MUTATE the shared mock (a session row / hot chunk is removed)
+// and several tests flip the mock's degradation mode (500s / store-off / legacy
+// backend), so run serially and reset the memory fixtures + mode before each
+// test — the same hermeticity guard the knowledge spec uses.
 test.describe.configure({ mode: "serial" });
+
+// Fresh page → Memory surface. Tests that pre-set a mock mode re-run this so the
+// first fetch happens under that mode (a page load resets the query cache). The
+// shell PERSISTS the open surface across reloads, so a second visit may restore
+// Memory on its own — clicking the rail button then would TOGGLE it closed; only
+// click when the surface didn't come back by itself.
+async function openMemory(page: import("@playwright/test").Page) {
+  await page.goto("/app/", { waitUntil: "load" });
+  const surface = page.getByTestId("memory-surface");
+  try {
+    await expect(surface).toBeVisible({ timeout: 2000 });
+  } catch {
+    await page.getByRole("button", { name: "Memory" }).click();
+    await expect(surface).toBeVisible();
+  }
+}
+
 test.beforeEach(async ({ page }) => {
   await page.request.post("/api/__test__/memory/reset");
-  await page.goto("/app/", { waitUntil: "load" });
-  await page.getByRole("button", { name: "Memory" }).click();
-  await expect(page.getByTestId("memory-surface")).toBeVisible();
+  await openMemory(page);
 });
 
 test("Sessions panel lists digest rows and opens the full summary in the reader", async ({ page }) => {
@@ -90,8 +106,12 @@ test("Injections panel shows the per-turn record and filters by session id", asy
   await expect(table.getByText("31, 32")).toBeVisible(); // hot chunk ids
   await expect(table.getByText("sched-hourly-report").first()).toBeVisible();
 
-  // Filtering to one session narrows the table.
-  await surface.getByLabel("filter injections by session id").fill("sched-hourly-report");
+  // Filtering to one session narrows the table (the input debounces ~250ms
+  // before the query refires; the assertions auto-wait through it). The
+  // placeholder says the match is EXACT — it's a lookup, not a substring search.
+  const filterInput = surface.getByLabel("filter injections by session id");
+  await expect(filterInput).toHaveAttribute("placeholder", "Exact session id (blank = all sessions)…");
+  await filterInput.fill("sched-hourly-report");
   await expect(table.locator("tbody tr")).toHaveCount(1);
   await expect(table.getByText("chat-1750000000000-abc123")).toHaveCount(0);
 });
@@ -105,4 +125,132 @@ test("a session row's injections jump pre-filters the Injections panel", async (
     "chat-1750000000000-abc123",
   );
   await expect(surface.locator(".memory-injections tbody tr")).toHaveCount(1);
+});
+
+// ── Delivery-truth badges (injection window / digest window) ─────────────────
+
+test("rows outside the digest/injection window are badged; true and legacy rows are not", async ({ page }) => {
+  const surface = page.getByTestId("memory-surface");
+
+  // Sessions: in_digest:false → badge; in_digest:true and absent (legacy) → none.
+  const outRow = surface.locator(".memory-row", { hasText: "sched-hourly-report" });
+  await expect(outRow.getByText("not in digest")).toBeVisible();
+  const inRow = surface.locator(".memory-row", { hasText: "chat-1750000000000-abc123" });
+  await expect(inRow.getByText("not in digest")).toHaveCount(0);
+  const legacyRow = surface.locator(".memory-row", { hasText: "a2a-legacy-noflags" });
+  await expect(legacyRow.getByText("not in digest")).toHaveCount(0);
+
+  // size_bytes renders human-readable in the meta line; the legacy row omits it.
+  await expect(inRow.getByText(/2\.0 KB/)).toBeVisible();
+  await expect(outRow.getByText(/512 B/)).toBeVisible();
+  await expect(legacyRow.getByText(/ B\b|KB/)).toHaveCount(0);
+
+  // Hot memory: injecting:false → badge; injecting:true and absent → none.
+  await surface.getByRole("tab", { name: "Hot memory" }).click();
+  const hotOut = surface.locator(".memory-row", { hasText: "Weekly report goes out" });
+  await expect(hotOut.getByText("not injecting")).toBeVisible();
+  const hotIn = surface.locator(".memory-row", { hasText: "US/Pacific" });
+  await expect(hotIn.getByText("not injecting")).toHaveCount(0);
+  const hotLegacy = surface.locator(".memory-row", { hasText: "Legacy row predating" });
+  await expect(hotLegacy.getByText("not injecting")).toHaveCount(0);
+});
+
+test("a backend without the delivery fields renders exactly as before — no badges, no sizes", async ({ page }) => {
+  // Graceful degradation is a contract: a backend predating injecting/in_digest/
+  // size_bytes (or a custom store) must render the pre-badge view, not crash.
+  await page.request.post("/api/__test__/memory/mode", { data: { legacy: true } });
+  await openMemory(page);
+  const surface = page.getByTestId("memory-surface");
+
+  await expect(surface.getByText("chat-1750000000000-abc123")).toBeVisible();
+  await expect(surface.getByText("not in digest")).toHaveCount(0);
+  await expect(surface.getByText(/KB/)).toHaveCount(0);
+
+  await surface.getByRole("tab", { name: "Hot memory" }).click();
+  await expect(surface.getByText("The operator works in US/Pacific.")).toBeVisible();
+  await expect(surface.getByText("not injecting")).toHaveCount(0);
+});
+
+// ── Error / empty / store-off branches ───────────────────────────────────────
+
+test("each tab shows its contained error alert when the backend read fails", async ({ page }) => {
+  await page.request.post("/api/__test__/memory/mode", { data: { fail: "sessions" } });
+  await openMemory(page);
+  const surface = page.getByTestId("memory-surface");
+  await expect(surface.getByText(/Couldn't list session summaries/)).toBeVisible();
+
+  await page.request.post("/api/__test__/memory/mode", { data: { fail: "hot" } });
+  await surface.getByRole("tab", { name: "Hot memory" }).click();
+  await expect(surface.getByText(/Couldn't list hot memory/)).toBeVisible();
+
+  await page.request.post("/api/__test__/memory/mode", { data: { fail: "injections" } });
+  await surface.getByRole("tab", { name: "Injections" }).click();
+  await expect(surface.getByText(/Couldn't read the injection log/)).toBeVisible();
+});
+
+test("empty stores render the Empty states, not errors", async ({ page }) => {
+  await page.request.post("/api/__test__/memory/mode", { data: { empty: true } });
+  await openMemory(page);
+  const surface = page.getByTestId("memory-surface");
+
+  await expect(surface.getByText("No session summaries")).toBeVisible();
+  await surface.getByRole("tab", { name: "Hot memory" }).click();
+  await expect(surface.getByText("No hot memory")).toBeVisible();
+  await surface.getByRole("tab", { name: "Injections" }).click();
+  await expect(surface.getByText("No injection records")).toBeVisible();
+});
+
+test("a disabled knowledge store shows the store-off notice on the hot tab", async ({ page }) => {
+  await page.request.post("/api/__test__/memory/mode", { data: { enabled: false } });
+  await openMemory(page);
+  const surface = page.getByTestId("memory-surface");
+
+  await surface.getByRole("tab", { name: "Hot memory" }).click();
+  await expect(surface.getByText(/knowledge store is off/)).toBeVisible();
+});
+
+// ── Cancel paths + the replaced:false warning ────────────────────────────────
+
+test("cancel paths leave rows untouched: both delete dialogs dismiss, edit Cancel reverts", async ({ page }) => {
+  const surface = page.getByTestId("memory-surface");
+
+  // Session delete → Cancel: dialog closes, row survives.
+  await surface.getByLabel("delete session sched-hourly-report").click();
+  const dialog = page.getByRole("dialog", { name: "Delete this session summary?" });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(dialog).not.toBeVisible();
+  await expect(surface.getByText("sched-hourly-report")).toBeVisible();
+
+  // Hot edit → Cancel: the draft is discarded, the row shows the original text.
+  await surface.getByRole("tab", { name: "Hot memory" }).click();
+  await surface.getByLabel("edit hot entry 31").click();
+  const field = surface.getByLabel("hot entry 31 content");
+  await field.fill("scribble that must not persist");
+  await surface.getByRole("button", { name: "Cancel", exact: true }).click();
+  await expect(surface.getByText("The operator works in US/Pacific.")).toBeVisible();
+  await expect(surface.getByText("scribble that must not persist")).toHaveCount(0);
+
+  // Hot delete → Cancel: dialog closes, chunk survives.
+  await surface.getByLabel("delete hot entry 32").click();
+  const hotDialog = page.getByRole("dialog", { name: "Delete this hot-memory entry?" });
+  await expect(hotDialog).toBeVisible();
+  await hotDialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(hotDialog).not.toBeVisible();
+  await expect(surface.getByText("Weekly report goes out Fridays at 9am.")).toBeVisible();
+});
+
+test("a hot edit whose old revision couldn't be removed warns via toast", async ({ page }) => {
+  await page.request.post("/api/__test__/memory/mode", { data: { replaced: false } });
+  const surface = page.getByTestId("memory-surface");
+  await surface.getByRole("tab", { name: "Hot memory" }).click();
+
+  await surface.getByLabel("edit hot entry 31").click();
+  await surface.getByLabel("hot entry 31 content").fill("The operator works in US/Eastern.");
+  await surface.getByRole("button", { name: "Save", exact: true }).click();
+
+  // Warning tone, not success — both revisions may inject until one is pruned.
+  await expect(
+    page.locator(".pl-toast.pl-toast--warning", { hasText: "both may inject" }),
+  ).toBeVisible();
 });

--- a/apps/web/e2e/memory-inspector.spec.ts
+++ b/apps/web/e2e/memory-inspector.spec.ts
@@ -232,13 +232,24 @@ test("cancel paths leave rows untouched: both delete dialogs dismiss, edit Cance
   await expect(surface.getByText("The operator works in US/Pacific.")).toBeVisible();
   await expect(surface.getByText("scribble that must not persist")).toHaveCount(0);
 
-  // Hot delete → Cancel: dialog closes, chunk survives.
+  // Hot delete → Cancel: dialog closes, chunk survives. Entry 32 is OUTSIDE the
+  // injection window (badged "not injecting"), so the dialog must not claim the
+  // delete stops anything — that would contradict the badge behind it.
   await surface.getByLabel("delete hot entry 32").click();
   const hotDialog = page.getByRole("dialog", { name: "Delete this hot-memory entry?" });
   await expect(hotDialog).toBeVisible();
+  await expect(hotDialog).toContainText("outside the injection window");
+  await expect(hotDialog).not.toContainText("stops injecting");
   await hotDialog.getByRole("button", { name: "Cancel" }).click();
   await expect(hotDialog).not.toBeVisible();
   await expect(surface.getByText("Weekly report goes out Fridays at 9am.")).toBeVisible();
+
+  // Entry 31 IS in the window — its dialog says the delete stops injection.
+  await surface.getByLabel("delete hot entry 31").click();
+  await expect(hotDialog).toBeVisible();
+  await expect(hotDialog).toContainText("stops injecting into the agent's turns");
+  await hotDialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(hotDialog).not.toBeVisible();
 });
 
 test("a hot edit whose old revision couldn't be removed warns via toast", async ({ page }) => {
@@ -254,4 +265,45 @@ test("a hot edit whose old revision couldn't be removed warns via toast", async 
   await expect(
     page.locator(".pl-toast.pl-toast--warning", { hasText: "both may inject" }),
   ).toBeVisible();
+});
+
+test("a hot edit against a store that went off errors — not the stale-revision warning", async ({ page }) => {
+  const surface = page.getByTestId("memory-surface");
+  await surface.getByRole("tab", { name: "Hot memory" }).click();
+  await expect(surface.getByText("The operator works in US/Pacific.")).toBeVisible();
+
+  // The store goes off AFTER the list rendered (settings hot-reload / restart);
+  // no focus-refetch, so the stale list still shows rows. The PUT now answers the
+  // store-off shape {enabled:false, id:null, replaced:false} — replaced:false is
+  // in that shape, so the store-off branch must win over the "both may inject"
+  // warning, whose every clause would be false here (nothing saved, nothing injects).
+  await page.request.post("/api/__test__/memory/mode", { data: { enabled: false } });
+
+  await surface.getByLabel("edit hot entry 31").click();
+  await surface.getByLabel("hot entry 31 content").fill("The operator works in US/Eastern.");
+  await surface.getByRole("button", { name: "Save", exact: true }).click();
+
+  await expect(
+    page.locator(".pl-toast.pl-toast--error", { hasText: /knowledge store is off — nothing was saved/ }),
+  ).toBeVisible();
+  await expect(page.locator(".pl-toast", { hasText: "both may inject" })).toHaveCount(0);
+  // The refetch lands on the store-off notice — the stale rows are gone.
+  await expect(surface.getByText(/knowledge store is off/)).toBeVisible();
+});
+
+test("a hot delete against a store that went off errors instead of claiming success", async ({ page }) => {
+  const surface = page.getByTestId("memory-surface");
+  await surface.getByRole("tab", { name: "Hot memory" }).click();
+  await expect(surface.getByText("Weekly report goes out Fridays at 9am.")).toBeVisible();
+
+  await page.request.post("/api/__test__/memory/mode", { data: { enabled: false } });
+
+  await surface.getByLabel("delete hot entry 32").click();
+  const dialog = page.getByRole("dialog", { name: "Delete this hot-memory entry?" });
+  await dialog.getByRole("button", { name: "Delete entry" }).click();
+
+  await expect(
+    page.locator(".pl-toast.pl-toast--error", { hasText: /knowledge store is off — nothing was deleted/ }),
+  ).toBeVisible();
+  await expect(page.locator(".pl-toast", { hasText: "Hot-memory entry deleted." })).toHaveCount(0);
 });

--- a/apps/web/e2e/memory-inspector.spec.ts
+++ b/apps/web/e2e/memory-inspector.spec.ts
@@ -12,18 +12,19 @@ test.describe.configure({ mode: "serial" });
 
 // Fresh page → Memory surface. Tests that pre-set a mock mode re-run this so the
 // first fetch happens under that mode (a page load resets the query cache). The
-// shell PERSISTS the open surface across reloads, so a second visit may restore
-// Memory on its own — clicking the rail button then would TOGGLE it closed; only
-// click when the surface didn't come back by itself.
+// shell PERSISTS the open surface across reloads (uiStore hydrates synchronously
+// from localStorage, so a restored surface mounts in the SAME commit that paints
+// the rail) — clicking the rail button then would TOGGLE it closed. Once the rail
+// is visible, one instant check decides restored vs. fresh; no timeout probe.
 async function openMemory(page: import("@playwright/test").Page) {
   await page.goto("/app/", { waitUntil: "load" });
   const surface = page.getByTestId("memory-surface");
-  try {
-    await expect(surface).toBeVisible({ timeout: 2000 });
-  } catch {
-    await page.getByRole("button", { name: "Memory" }).click();
-    await expect(surface).toBeVisible();
-  }
+  // exact: role-name matching is substring by default, and once the surface is
+  // restored a session row whose topic mentions "memory" would also match.
+  const rail = page.getByRole("button", { name: "Memory", exact: true });
+  await expect(rail).toBeVisible();
+  if (!(await surface.isVisible())) await rail.click();
+  await expect(surface).toBeVisible();
 }
 
 test.beforeEach(async ({ page }) => {

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -113,6 +113,24 @@ const cloneMemory = () => ({
 });
 let memory = cloneMemory();
 
+// Degradation switches the memory spec flips via POST /api/__test__/memory/mode
+// (merged; /api/__test__/memory/reset restores the defaults):
+//   fail: "sessions"|"hot"|"injections" → that GET answers 500
+//   enabled: false                      → the hot route reports the store off
+//   empty: true                         → all three lists serve zero rows
+//   replaced: false                     → the hot PUT reports the old revision survived
+//   legacy: true                        → rows are served WITHOUT the delivery-truth
+//                                         fields (in_digest/injecting/size_bytes), like
+//                                         a backend predating them
+const defaultMemoryMode = () => ({ fail: "", enabled: true, empty: false, replaced: true, legacy: false });
+let memoryMode = defaultMemoryMode();
+const stripFields = (rows, keys) =>
+  rows.map((r) => {
+    const copy = { ...r };
+    for (const k of keys) delete copy[k];
+    return copy;
+  });
+
 // Fleet state is the one slice of the mock backend the specs MUTATE (create /
 // stop / rename / add-remote). Isolate it PER SPEC so parallel files and serial-
 // group retries can't observe each other's writes: every `x-e2e-fleet` request
@@ -450,7 +468,12 @@ const server = createServer(async (req, res) => {
       if (/^\/api\/chat\/sessions\/[^/]+\/steer$/.test(pathname)) return sendJson(res, { pending: [] });
       // Memory inspector (ADR 0069 D7) — needs the query string (injections filter),
       // so it's handled here rather than in the pathname-only handleApiGet switch.
-      if (pathname === "/api/memory/sessions") return sendJson(res, { sessions: memory.sessions });
+      if (pathname === "/api/memory/sessions") {
+        if (memoryMode.fail === "sessions") return sendJson(res, { detail: "kaboom (mock)" }, 500);
+        let rows = memoryMode.empty ? [] : memory.sessions;
+        if (memoryMode.legacy) rows = stripFields(rows, ["in_digest", "size_bytes"]);
+        return sendJson(res, { sessions: rows });
+      }
       {
         const m = pathname.match(/^\/api\/memory\/sessions\/([^/]+)$/);
         if (m) {
@@ -460,8 +483,16 @@ const server = createServer(async (req, res) => {
           return sendJson(res, { session: { ...s, trace_id: null, rendered: MEMORY_SESSION_RENDERED } });
         }
       }
-      if (pathname === "/api/memory/hot") return sendJson(res, { enabled: true, chunks: memory.hot });
+      if (pathname === "/api/memory/hot") {
+        if (memoryMode.fail === "hot") return sendJson(res, { detail: "kaboom (mock)" }, 500);
+        if (!memoryMode.enabled) return sendJson(res, { enabled: false, chunks: [] });
+        let rows = memoryMode.empty ? [] : memory.hot;
+        if (memoryMode.legacy) rows = stripFields(rows, ["injecting"]);
+        return sendJson(res, { enabled: true, chunks: rows });
+      }
       if (pathname === "/api/memory/injections") {
+        if (memoryMode.fail === "injections") return sendJson(res, { detail: "kaboom (mock)" }, 500);
+        if (memoryMode.empty) return sendJson(res, { injections: [] });
         const sid = url.searchParams.get("session_id") || "";
         const rows = sid
           ? MEMORY_INJECTIONS.filter((r) => r.session_id === sid)
@@ -533,6 +564,11 @@ const server = createServer(async (req, res) => {
     }
     if (pathname === "/api/__test__/memory/reset" && req.method === "POST") {
       memory = cloneMemory();
+      memoryMode = defaultMemoryMode();
+      return sendJson(res, { ok: true });
+    }
+    if (pathname === "/api/__test__/memory/mode" && req.method === "POST") {
+      memoryMode = { ...memoryMode, ...body };
       return sendJson(res, { ok: true });
     }
     // Memory inspector writes (ADR 0069 D7): delete a session summary / edit + delete
@@ -560,7 +596,9 @@ const server = createServer(async (req, res) => {
         if (!c) return sendJson(res, { detail: "no hot-memory chunk with that id" }, 404);
         c.content = String(body.content || "");
         c.preview = c.content;
-        return sendJson(res, { enabled: true, id: id + 100, replaced: true });
+        // replaced:false = the re-add landed but the old revision couldn't be
+        // deleted (both rows linger) — the console warns via toast.
+        return sendJson(res, { enabled: true, id: id + 100, replaced: memoryMode.replaced });
       }
     }
     if (req.method === "POST" && /^\/api\/knowledge\/\d+\/promote$/.test(pathname)) {

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -116,7 +116,8 @@ let memory = cloneMemory();
 // Degradation switches the memory spec flips via POST /api/__test__/memory/mode
 // (merged; /api/__test__/memory/reset restores the defaults):
 //   fail: "sessions"|"hot"|"injections" → that GET answers 500
-//   enabled: false                      → the hot route reports the store off
+//   enabled: false                      → the hot routes report the store off
+//                                         (GET list; PUT/DELETE drop the write)
 //   empty: true                         → all three lists serve zero rows
 //   replaced: false                     → the hot PUT reports the old revision survived
 //   legacy: true                        → rows are served WITHOUT the delivery-truth
@@ -585,6 +586,8 @@ const server = createServer(async (req, res) => {
       const h = pathname.match(/^\/api\/memory\/hot\/(\d+)$/);
       if (h && req.method === "DELETE") {
         const id = Number(h[1]);
+        // Store off → the write is dropped before any lookup, like the backend.
+        if (!memoryMode.enabled) return sendJson(res, { enabled: false, deleted: false });
         const i = memory.hot.findIndex((x) => x.id === id);
         if (i < 0) return sendJson(res, { detail: "no hot-memory chunk with that id" }, 404);
         memory.hot.splice(i, 1);
@@ -592,6 +595,9 @@ const server = createServer(async (req, res) => {
       }
       if (h && req.method === "PUT") {
         const id = Number(h[1]);
+        // Store off → the edit is dropped; the exact contract shape the console's
+        // store-off toast branch keys on (NOT the replaced:false warning).
+        if (!memoryMode.enabled) return sendJson(res, { enabled: false, id: null, replaced: false });
         const c = memory.hot.find((x) => x.id === id);
         if (!c) return sendJson(res, { detail: "no hot-memory chunk with that id" }, 404);
         c.content = String(body.content || "");

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -25,6 +25,7 @@ import type {
   PluginInstallSummary,
   PluginUpdate,
   KnowledgeChunk,
+  MemoryHotChunk,
   MemoryInjectionRow,
   MemorySessionDigest,
   RuntimeStatus,
@@ -835,9 +836,10 @@ export const api = {
       { method: "DELETE" },
     );
   },
-  // Hot memory: the domain="hot" chunks injected every turn.
+  // Hot memory: the domain="hot" chunks; the newest slice under the budget
+  // injects every turn (rows carry `injecting` when the backend can tell).
   memoryHot() {
-    return request<{ enabled: boolean; chunks: KnowledgeChunk[] }>("/api/memory/hot");
+    return request<{ enabled: boolean; chunks: MemoryHotChunk[] }>("/api/memory/hot");
   },
   updateMemoryHot(chunkId: number, body: { content: string; heading?: string }) {
     return request<{ enabled: boolean; id: number | null; replaced: boolean }>(

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { bytes } from "./format";
+
+describe("bytes", () => {
+  it("renders sub-KB counts raw", () => {
+    expect(bytes(0)).toBe("0 B");
+    expect(bytes(512)).toBe("512 B");
+    expect(bytes(1023)).toBe("1023 B");
+  });
+
+  it("renders KB with one decimal", () => {
+    expect(bytes(1024)).toBe("1.0 KB");
+    expect(bytes(2048)).toBe("2.0 KB");
+    expect(bytes(2150)).toBe("2.1 KB");
+  });
+
+  it("renders MB with one decimal", () => {
+    expect(bytes(1_048_576)).toBe("1.0 MB");
+    expect(bytes(3_565_158)).toBe("3.4 MB");
+  });
+});

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -19,4 +19,14 @@ describe("bytes", () => {
     expect(bytes(1_048_576)).toBe("1.0 MB");
     expect(bytes(3_565_158)).toBe("3.4 MB");
   });
+
+  it("drops the decimal at 10+ in a unit (the store-size convention)", () => {
+    expect(bytes(15_360)).toBe("15 KB");
+    expect(bytes(104_857_600)).toBe("100 MB");
+  });
+
+  it("renders GB and saturates there", () => {
+    expect(bytes(2_147_483_648)).toBe("2.0 GB");
+    expect(bytes(1_099_511_627_776)).toBe("1024 GB");
+  });
 });

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -48,3 +48,10 @@ export function ms(n: number): string {
 export function pct(n: number): string {
   return `${Math.round((n || 0) * 100)}%`;
 }
+
+/** Byte counts — "512 B", "2.0 KB", "3.4 MB". */
+export function bytes(n: number): string {
+  if (n >= 1_048_576) return `${(n / 1_048_576).toFixed(1)} MB`;
+  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${n} B`;
+}

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -49,9 +49,15 @@ export function pct(n: number): string {
   return `${Math.round((n || 0) * 100)}%`;
 }
 
-/** Byte counts — "512 B", "2.0 KB", "3.4 MB". */
+/** Byte counts — "512 B", "2.0 KB", "3.4 MB", "1.2 GB"; ≥10 in a unit drops the decimal ("14 KB"). */
 export function bytes(n: number): string {
-  if (n >= 1_048_576) return `${(n / 1_048_576).toFixed(1)} MB`;
-  if (n >= 1024) return `${(n / 1024).toFixed(1)} KB`;
-  return `${n} B`;
+  if (n < 1024) return `${n} B`;
+  const units = ["KB", "MB", "GB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v.toFixed(v < 10 ? 1 : 0)} ${units[i]}`;
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -728,10 +728,19 @@ export type KnowledgeChunk = {
   source_type: string | null;
   finding_type: string | null;
   created_at: string | null;
+  // BM25/RRF relevance — the backend always sends it (null on plain listings).
+  score?: number | null;
   // Tier (ADR 0041 / bd-2wu): "private" | "commons" — present only when the store is
   // layered (commons ∪ private); null otherwise. Drives the tier badge + promote/unshare.
   tier?: "private" | "commons" | null;
 };
+
+// One hot-memory row (GET /api/memory/hot): a knowledge chunk plus whether it's
+// inside the CURRENT per-turn injection window (the newest ~100 domain="hot"
+// chunks under the character budget). Absent on backends that predate the field
+// (or custom stores without get_hot_memory_entries) → unknown; the console only
+// draws the "not injecting" badge on an explicit `false`.
+export type MemoryHotChunk = KnowledgeChunk & { injecting?: boolean };
 
 // Memory inspector (ADR 0069 D7) — the delivery-layer audit surface.
 // One session-summary digest row (GET /api/memory/sessions) — the same
@@ -744,6 +753,10 @@ export type MemorySessionDigest = {
   topic: string;
   message_count: number;
   size_bytes?: number;
+  // Whether this session is in the CURRENT <prior_sessions> digest window (the
+  // ~10 newest under the token cap, background:* excluded). Absent on older
+  // backends → unknown; only an explicit `false` draws the "not in digest" badge.
+  in_digest?: boolean;
   // Detail-only fields (GET /api/memory/sessions/{id}):
   trace_id?: string | null;
   rendered?: string; // the full render recall_session returns
@@ -752,6 +765,7 @@ export type MemorySessionDigest = {
 // One per-model-call injection record (GET /api/memory/injections, ADR 0069 D6):
 // which memory items entered which turn — the poisoning-forensics trail.
 export type MemoryInjectionRow = {
+  id: number;
   ts: string;
   session_id: string;
   digest_session_ids: string[];

--- a/apps/web/src/memory/MemorySurface.tsx
+++ b/apps/web/src/memory/MemorySurface.tsx
@@ -211,10 +211,22 @@ function HotMemoryPanel() {
   const [draft, setDraft] = useState("");
   const invalidate = () => void qc.invalidateQueries({ queryKey: queryKeys.memoryHot });
 
+  // Both write routes answer 200 with enabled:false when the knowledge store went
+  // off AFTER this list rendered (settings hot-reload / restart; the list has no
+  // focus-refetch so it goes stale silently) — the write was DROPPED, and the
+  // refetch below swaps the panel to the store-off notice.
+  const storeOffToast = (verb: string) =>
+    toast({
+      tone: "error",
+      title: "Memory",
+      message: `The knowledge store is off — nothing was ${verb} (enable middleware.knowledge).`,
+    });
+
   const del = useMutation({
     mutationFn: (id: number) => api.deleteMemoryHot(id),
-    onSuccess: () => {
-      toast({ tone: "success", title: "Memory", message: "Hot-memory entry deleted." });
+    onSuccess: (r) => {
+      if (r.enabled === false) storeOffToast("deleted");
+      else toast({ tone: "success", title: "Memory", message: "Hot-memory entry deleted." });
       invalidate();
     },
     onError: (e) => toast({ tone: "error", title: "Memory", message: errMsg(e) }),
@@ -224,9 +236,14 @@ function HotMemoryPanel() {
     mutationFn: ({ id, content }: { id: number; content: string }) =>
       api.updateMemoryHot(id, { content }),
     onSuccess: (r) => {
-      // The edit is add-new-then-delete-old server-side; replaced:false means the
-      // old revision survived, so BOTH rows sit in the store until one is pruned.
-      if (r.replaced === false) {
+      if (r.enabled === false) {
+        // Store-off branch ({enabled:false, id:null, replaced:false}) — must win
+        // over the replaced check: nothing was updated and nothing injects, so
+        // the stale-revision warning below would be false in every clause.
+        storeOffToast("saved");
+      } else if (r.replaced === false) {
+        // The edit is add-new-then-delete-old server-side; replaced:false means the
+        // old revision survived, so BOTH rows sit in the store until one is pruned.
         toast({
           tone: "warning",
           title: "Memory",
@@ -331,7 +348,7 @@ function HotMemoryPanel() {
                       icon
                       variant="ghost"
                       type="button"
-                      title="Delete this hot-memory entry (stops injecting immediately)"
+                      title="Delete this hot-memory entry outright"
                       aria-label={`delete hot entry ${c.id}`}
                       onClick={() => setPendingDelete(c)}
                     >
@@ -355,8 +372,17 @@ function HotMemoryPanel() {
         }}
         onClose={() => setPendingDelete(null)}
       >
+        {/* Effect copy tracks the row's injection-window state — a backlog row
+            (badged "not injecting") isn't being sent to the agent, so claiming
+            the delete "stops injecting" would contradict its own badge. */}
         {pendingDelete
-          ? `"${(pendingDelete.heading || pendingDelete.content || pendingDelete.preview || "").slice(0, 80)}" stops injecting into every turn. This can't be undone.`
+          ? `"${(pendingDelete.heading || pendingDelete.content || pendingDelete.preview || "").slice(0, 80)}" is removed from hot memory${
+              pendingDelete.injecting === false
+                ? " — it's outside the injection window, so nothing the agent currently sees changes"
+                : pendingDelete.injecting === true
+                  ? " and stops injecting into the agent's turns"
+                  : ""
+            }. This can't be undone.`
           : undefined}
       </ConfirmDialog>
     </>

--- a/apps/web/src/memory/MemorySurface.tsx
+++ b/apps/web/src/memory/MemorySurface.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Alert } from "@protolabsai/ui/data";
 import { Input, Textarea } from "@protolabsai/ui/forms";
 import { PanelHeader, Tabs } from "@protolabsai/ui/navigation";
@@ -10,9 +10,9 @@ import { Flame, History, Pencil, Syringe, Trash2 } from "lucide-react";
 import { RefreshButton } from "../app/ui-kit";
 import { openDocument } from "../docviewer";
 import { api } from "../lib/api";
-import { ago, errMsg } from "../lib/format";
+import { ago, bytes, errMsg } from "../lib/format";
 import { queryKeys } from "../lib/queries";
-import type { KnowledgeChunk, MemorySessionDigest } from "../lib/types";
+import type { MemoryHotChunk, MemorySessionDigest } from "../lib/types";
 
 import "./memory.css";
 
@@ -49,6 +49,7 @@ export function MemorySurface() {
         active={tab}
         onSelect={(t) => setTab(t as MemoryTab)}
         items={TABS.map((t) => ({ id: t.id, label: t.label, icon: t.icon }))}
+        ariaLabel="Memory sections"
       />
       <div className="stage-body">
         {tab === "sessions" ? (
@@ -109,9 +110,10 @@ function SessionsPanel({ onShowInjections }: { onShowInjections: (sid: string) =
     <>
       <div className="memory-panel-head">
         <p className="memory-panel-hint">
-          Persisted session summaries — each is one line of the <code>&lt;prior_sessions&gt;</code>{" "}
-          digest the agent sees every turn. Click a row for the full summary
-          (what <code>recall_session</code> returns); delete to forget a session.
+          Persisted session summaries. The <code>&lt;prior_sessions&gt;</code> digest the agent
+          sees each turn carries only the newest few (token-capped; background sessions
+          excluded) — badged rows are stored but not currently in it. Click a row for the full
+          summary (what <code>recall_session</code> returns); delete to forget a session.
         </p>
         <RefreshButton onClick={() => void refetch()} busy={isFetching} />
       </div>
@@ -134,10 +136,18 @@ function SessionsPanel({ onShowInjections }: { onShowInjections: (sid: string) =
                 <span className="memory-row-title">
                   <Badge status="neutral">{s.surface}</Badge>
                   <code>{s.session_id}</code>
+                  {/* Only an explicit false draws the badge — an older backend omits
+                      the field entirely, and unknown must not read as "excluded". */}
+                  {s.in_digest === false ? (
+                    <span title="Outside the current digest window (the newest summaries under the token cap; background sessions excluded) — stored, but not in the <prior_sessions> digest the agent sees.">
+                      <Badge status="warning">not in digest</Badge>
+                    </span>
+                  ) : null}
                 </span>
                 <span className="memory-row-topic">{s.topic || "(no user message)"}</span>
                 <span className="memory-row-meta">
                   {s.timestamp !== "unknown" ? ago(s.timestamp) : "unknown"} · {s.message_count} msgs
+                  {typeof s.size_bytes === "number" ? <> · {bytes(s.size_bytes)}</> : null}
                 </span>
               </button>
               <span className="knowledge-chunk-actions">
@@ -178,7 +188,7 @@ function SessionsPanel({ onShowInjections }: { onShowInjections: (sid: string) =
         onClose={() => setPendingDelete(null)}
       >
         {pendingDelete
-          ? `"${pendingDelete.session_id}" leaves the <prior_sessions> digest and recall_session — the agent will no longer know of this session. This can't be undone.`
+          ? `"${pendingDelete.session_id}" leaves the <prior_sessions> digest and recall_session — the agent will no longer know of this session. Takes effect within about a minute (the digest is cached per turn loop). This can't be undone.`
           : undefined}
       </ConfirmDialog>
     </>
@@ -196,7 +206,7 @@ function HotMemoryPanel() {
   });
   const enabled = data?.enabled ?? true;
   const chunks = data?.chunks ?? [];
-  const [pendingDelete, setPendingDelete] = useState<KnowledgeChunk | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<MemoryHotChunk | null>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [draft, setDraft] = useState("");
   const invalidate = () => void qc.invalidateQueries({ queryKey: queryKeys.memoryHot });
@@ -213,8 +223,19 @@ function HotMemoryPanel() {
   const save = useMutation({
     mutationFn: ({ id, content }: { id: number; content: string }) =>
       api.updateMemoryHot(id, { content }),
-    onSuccess: () => {
-      toast({ tone: "success", title: "Memory", message: "Hot-memory entry updated." });
+    onSuccess: (r) => {
+      // The edit is add-new-then-delete-old server-side; replaced:false means the
+      // old revision survived, so BOTH rows sit in the store until one is pruned.
+      if (r.replaced === false) {
+        toast({
+          tone: "warning",
+          title: "Memory",
+          message:
+            "Updated, but the old revision couldn't be removed; both may inject — delete the stale row.",
+        });
+      } else {
+        toast({ tone: "success", title: "Memory", message: "Hot-memory entry updated." });
+      }
       setEditingId(null);
       setDraft("");
       invalidate();
@@ -226,8 +247,10 @@ function HotMemoryPanel() {
     <>
       <div className="memory-panel-head">
         <p className="memory-panel-hint">
-          Always-on memory — every entry here is injected into <em>every</em> turn. Keep it
-          small; anything wrong or planted here steers the agent until it's removed.
+          Always-on memory — the <em>newest</em> entries (roughly 100, under a small character
+          budget) are injected into every turn; older rows are backlog that no longer injects.
+          Keep it small; anything wrong or planted in the window steers the agent until it's
+          removed.
         </p>
         <RefreshButton onClick={() => void refetch()} busy={isFetching} />
       </div>
@@ -276,6 +299,14 @@ function HotMemoryPanel() {
                       {c.source ? (
                         <span title="provenance — the session/source that wrote this row">
                           <Badge status="neutral">{c.source}</Badge>
+                        </span>
+                      ) : null}
+                      {/* Only an explicit false draws the badge — an older backend
+                          (or a custom store) omits the field, and unknown must not
+                          read as "outside the window". */}
+                      {c.injecting === false ? (
+                        <span title="Outside the injection window — only the newest hot entries under the character budget ride each turn; this row is kept but not currently sent to the agent.">
+                          <Badge status="warning">not injecting</Badge>
                         </span>
                       ) : null}
                     </span>
@@ -335,9 +366,22 @@ function HotMemoryPanel() {
 // ── Injections — which memory entered which turn (ADR 0069 D6) ───────────────
 
 function InjectionsPanel({ filter, setFilter }: { filter: string; setFilter: (v: string) => void }) {
+  // Local echo of the filter so typing paints instantly; the lifted filter (and
+  // with it the query key) only changes after the debounce, so a fast typist
+  // doesn't fire a request per keystroke. Mount seeds from the lifted value —
+  // the Sessions panel's "injections" jump pre-fills it before switching tabs.
+  const [input, setInput] = useState(filter);
+  useEffect(() => {
+    const t = window.setTimeout(() => setFilter(input), 250);
+    return () => window.clearTimeout(t);
+  }, [input, setFilter]);
+
   const { data, isFetching, error, refetch } = useQuery({
     queryKey: [...queryKeys.memoryInjections, filter] as const,
     queryFn: () => api.memoryInjections(filter, 100),
+    // Keep the last page while the filtered fetch is in flight — otherwise the
+    // table flashes the "no recorded turns" empty state on every filter change.
+    placeholderData: keepPreviousData,
   });
   const rows = data?.injections ?? [];
 
@@ -356,9 +400,9 @@ function InjectionsPanel({ filter, setFilter }: { filter: string; setFilter: (v:
       </div>
       <Input
         type="search"
-        placeholder="Filter by session id (blank = all sessions)…"
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
+        placeholder="Exact session id (blank = all sessions)…"
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
         aria-label="filter injections by session id"
       />
       {error ? <Alert status="error">Couldn't read the injection log — {errMsg(error)}</Alert> : null}
@@ -380,8 +424,8 @@ function InjectionsPanel({ filter, setFilter }: { filter: string; setFilter: (v:
             </tr>
           </thead>
           <tbody>
-            {rows.map((r, i) => (
-              <tr key={`${r.ts}-${i}`}>
+            {rows.map((r) => (
+              <tr key={r.id}>
                 <td title={r.ts}>{ago(r.ts)}</td>
                 <td>
                   <code>{r.session_id}</code>

--- a/apps/web/src/settings/OverviewPanel.tsx
+++ b/apps/web/src/settings/OverviewPanel.tsx
@@ -3,6 +3,7 @@ import { Bot, Database, HardDrive, Settings2, Tag } from "lucide-react";
 import { type ReactNode } from "react";
 
 import { brandName } from "../lib/brand";
+import { bytes } from "../lib/format";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { runtimeStatusQuery } from "../lib/queries";
 import { StagePanel } from "../app/ErrorBoundary";
@@ -11,18 +12,8 @@ import { StagePanel } from "../app/ErrorBoundary";
 // on-disk store sizes). Telemetry is its own tab now. The editable
 // bits (name, persona, middleware, tools) live under the Agent section.
 
-function fmtBytes(n: number | null | undefined): string {
-  if (n == null) return "—";
-  if (n < 1024) return `${n} B`;
-  const units = ["KB", "MB", "GB"];
-  let v = n / 1024;
-  let i = 0;
-  while (v >= 1024 && i < units.length - 1) {
-    v /= 1024;
-    i += 1;
-  }
-  return `${v.toFixed(v < 10 ? 1 : 0)} ${units[i]}`;
-}
+// Store sizes can be null while a store is unbuilt — only this surface needs the dash.
+const fmtBytes = (n: number | null | undefined): string => (n == null ? "—" : bytes(n));
 
 function Metric({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
   return (


### PR DESCRIPTION
Lane B of the memory-inspector audit-fix batch (console half). The Python lane ships the `injecting` / `in_digest` / hot-PUT `replaced:false` fields — frozen contract: the console treats a **missing** field as unknown and renders no badge; only `=== false` draws one. So this PR is safe to land before or after the backend lane.

## Audit findings fixed

1. **Hot tab lied** — hint claimed "every entry here is injected into every turn"; the backend injects only the newest ~100 `domain="hot"` chunks under a character budget and the list includes backlog. Copy fixed; rows with `injecting === false` get a warning `Badge` ("not injecting") with an explanatory title. `undefined` → no badge (older backends / custom stores without `get_hot_memory_entries`).
2. **Sessions tab lied** — hint claimed every row is a digest line; the digest is ~10 newest, token-capped, `background:*` excluded. Copy fixed; `in_digest === false` rows get a "not in digest" badge. Delete-confirm copy now says deletion takes effect within about a minute (the digest is cached per turn loop).
3. **`replaced:false` silently swallowed** — the hot-edit PUT reports whether the old revision was removed; on `replaced === false` the console now warns via DS toast ("Updated, but the old revision couldn't be removed; both may inject — delete the stale row.") instead of claiming success.
4. **Injections filter refetched per keystroke and flashed "no recorded turns"** — the input debounces ~250ms into the lifted filter and the query keeps the previous page while fetching (`placeholderData: keepPreviousData`, the KnowledgeStore pattern). Placeholder copy now says the match is an **exact** session id. Rows keyed on `r.id` (backend `SELECT *` always sends it) instead of `ts+index`.
5. **`size_bytes` fetched but never shown** — rendered human-readable in the session meta line via the shared `bytes()` formatter (`lib/format.ts`).
6. **a11y** — the Memory tablist had no accessible name; `Tabs` gets `ariaLabel="Memory sections"`.
7. **Types drifted from the wire** — added `MemorySessionDigest.in_digest`, `MemoryHotChunk` (`KnowledgeChunk & { injecting?: boolean }`, consumed by `api.memoryHot`), `MemoryInjectionRow.id`, `KnowledgeChunk.score`.

## Consolidation (steelman pass)

- **One byte formatter, not two** — `settings/OverviewPanel.tsx` already hand-rolled `fmtBytes`; adding a second formatter in `lib/format.ts` would have re-created exactly the drift that file exists to kill (see its header). The shared `bytes()` now carries the Overview math verbatim (GB support, decimal drops at ≥10 in a unit) and `fmtBytes` is a one-line null-guard over it — Overview's rendering is byte-identical, and the memory meta line inherits the same convention. Unit tests cover the precision switch and GB saturation.
- **Deterministic e2e open** — the `openMemory` helper originally probed with a 2s try/catch timeout to distinguish "shell restored the surface" from "fresh context" (clicking the rail on a restored surface toggles it *closed*). The persisted UI store hydrates synchronously from localStorage, so a restored surface mounts in the **same commit** that paints the rail — once the rail is visible, one instant `isVisible()` check decides, cutting a flat ~2s per fresh-context test (13 tests in the spec) and removing the timing assumption entirely.

## Tests

- **Unit**: `bytes()` formatter (`src/lib/format.test.ts`) — raw B / one-decimal KB–MB / decimal drop at ≥10 / GB saturation.
- **E2E**: the mock server grew a `POST /api/__test__/memory/mode` degradation switch (per-tab 500s, store-off, empty stores, `replaced:false`, and a `legacy` mode that strips the new fields), reset alongside the fixtures by `/api/__test__/memory/reset`. New specs: badge truth (false → badge; true/absent → none), **graceful degradation** (a backend without the new fields renders exactly the pre-badge view — hard requirement), per-tab error alerts, Empty states, store-off notice, cancel paths (hot-edit Cancel + both ConfirmDialog dismissals), `replaced:false` → `.pl-toast--warning`, exact-id placeholder, size rendering. Fixtures carry mixed `true`/`false`/absent values so every branch is assertable against the real built frontend. (The mock's `memoryMode` is global like the memory rows themselves — safe because only this serial spec touches `/api/memory/*`.)

## Gates

| Gate | Result |
|------|--------|
| `ruff check .` | pass (no Python touched; proves tree clean) |
| `lint-imports` | pass (3 contracts kept) |
| `python -m pytest tests/ -q` | n/a (no Python changes) |
| `python scripts/live_smoke.py` | n/a (no Python changes; CI runs it as a required job) |
| `npm run test:unit --workspace @protoagent/web` | pass (34 files, 334 tests) |
| `npm run test:e2e --workspace @protoagent/web` | pass — full suite green after the steelman pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
