### PR TITLE
feat(plugins): craft — engineering rituals as user-only slash skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ python -m server plugin uninstall your-plugin --purge                # removes c
 
 **Browse the directory → [agent.protolabs.studio/plugins](https://agent.protolabs.studio/plugins)**
 
-First-party plugins ship in `plugins/` — `delegates` is a built-in, `notes`, `docs`, and
-`artifact` are on by default, and the rest are opt-in (enable via `plugins.enabled`):
+First-party plugins ship in `plugins/` — `delegates` is a built-in, `notes`, `docs`,
+`artifact`, and `craft` are on by default, and the rest are opt-in (enable via `plugins.enabled`):
 
 | Plugin | Adds | What it does |
 | --- | --- | --- |
@@ -164,6 +164,7 @@ First-party plugins ship in `plugins/` — `delegates` is a built-in, `notes`, `
 | [`notes`](./plugins/notes/) | tools · view | **On by default** — one shared markdown note the agent and operator both read/write |
 | [`docs`](./plugins/docs/) | tools · view · skill | **On by default** — offline search over protoAgent's own docs |
 | [`artifact`](./plugins/artifact/) | tools · view · skill | **On by default** — generative UI; `show_artifact` renders charts, diagrams, Mermaid, Markdown, or live React into a sandboxed panel ([ADR 0038](./docs/adr/0038-generative-ui-artifacts-two-mode.md)) |
+| [`craft`](./plugins/craft/) | skills · subagent | **On by default** — engineering rituals as user-only slash commands (`/grill`, `/standup`, `/code-review`, `/writing-skills`) + the `skill_writer` subagent; prompt-only |
 | [`plugin-devkit`](./plugins/plugin-devkit/) | tool · subagent · skill · workflow · view | The authoring kit + reference plugin — the agent can scaffold and build its own plugins |
 | [`workflows`](./plugins/workflows/) | tools | Declarative multi-step subagent workflows (DAG recipes) |
 | [`telegram`](./plugins/telegram/) | surface | Run the agent as a Telegram bot — the reference [communication plugin](./docs/guides/communication-plugins.md) |

--- a/plugins/craft/README.md
+++ b/plugins/craft/README.md
@@ -1,0 +1,33 @@
+# Craft
+
+Engineering rituals as **user-only slash commands**, plus a skill-authoring
+delegate. Prompt-only: this plugin registers no tools, routes, surfaces, or
+config — the skills are the product.
+
+| Command | What it does |
+|---------|--------------|
+| `/grill` | Relentless one-question-at-a-time interview that sharpens a plan before anything is built. |
+| `/standup` | Operational status report on everything the agent owns — tasks, goals, schedule, background work, PRs. |
+| `/code-review` | Two-axis review of a diff — Standards vs Spec — in parallel subagents whose findings are never merged. |
+| `/writing-skills` | The house discipline for authoring predictable SKILL.md skills. |
+
+It also registers the **`skill_writer`** subagent: delegate to it ("write a
+skill for X", "tighten this skill") and it returns a complete SKILL.md, its
+placement, and the slash token to collision-check.
+
+All four skills set `user_only: true` — they are withheld from the agent's
+skill retrieval and reachable only by the operator typing the slash command,
+so they cost no context until used.
+
+First-party and enabled by default. Disable per instance with:
+
+```yaml
+plugins:
+  disabled: [craft]
+```
+
+## Attribution
+
+The grilling, two-axis code-review, and skill-authoring discipline are
+adapted from [mattpocock/skills](https://github.com/mattpocock/skills)
+(MIT License, © 2026 Matt Pocock).

--- a/plugins/craft/__init__.py
+++ b/plugins/craft/__init__.py
@@ -1,0 +1,80 @@
+"""Craft — engineering rituals as user-only slash skills, plus a skill-writer subagent.
+
+Prompt-only plugin: four ``user_only`` skills (``/grill``, ``/standup``,
+``/code-review``, ``/writing-skills``) and one delegate (``skill_writer``).
+No tools, routes, surfaces, or config — the skills are the product. The
+grilling / code-review / skill-authoring material is adapted from
+mattpocock/skills (MIT); see README.md for attribution.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger("protoagent.plugins.craft")
+
+
+def _skill_writer():
+    """The skill_writer delegate — drafts SKILL.md skills to the house discipline."""
+    from graph.subagents.config import SubagentConfig
+
+    return SubagentConfig(
+        name="skill_writer",
+        description=(
+            "Drafts and tightens SKILL.md skills to the house authoring discipline. "
+            "Use for: 'write a skill for X', 'tighten/review this skill', "
+            "'turn this workflow into a skill'."
+        ),
+        system_prompt=(
+            "You are skill_writer. You draft and edit protoAgent SKILL.md skills — "
+            "YAML frontmatter (`name` + `description` required, description <= 1024 chars) "
+            "over a markdown body that becomes the agent's working instructions when the "
+            "skill loads.\n\n"
+            "The root virtue is PREDICTABILITY: the same process every run, not the same "
+            "output. Every rule below serves it.\n\n"
+            "Invocation classes — choose deliberately:\n"
+            "- Default (retrievable): indexed in <available_skills>; the agent loads it via "
+            "load_skill. The description is scanned every turn, so it must be TRIGGERS, not "
+            "identity: 'Use when the user ... / mentions ...', one trigger per distinct "
+            "branch, no synonym padding.\n"
+            "- `user_facing: true` + `slash: <token>`: also invokable as /<token> in chat.\n"
+            "- `user_only: true`: withheld from agent retrieval entirely — the slash is the "
+            "only way in. The description becomes human-facing; write one plain sentence.\n"
+            "Slash precedence is goal > plugin command > workflow > subagent > skill: a "
+            "same-token workflow or subagent SHADOWS the skill. Always flag the token for a "
+            "collision check.\n\n"
+            "Body discipline:\n"
+            "- Steps end on a CHECKABLE completion criterion (the agent can tell done from "
+            "not-done); vague criteria invite premature completion.\n"
+            "- Prefer a LEADING WORD — a compact pretrained concept (tracer bullet, tight, "
+            "red) — over a restated triad; it anchors behavior in one token.\n"
+            "- Hunt failure modes: duplication (same meaning twice), sediment (stale layers "
+            "nobody prunes), sprawl (too long even when every line is live), no-ops (lines "
+            "the model already obeys — delete, don't trim).\n"
+            "- Reference material the skill only sometimes needs belongs in repo docs the "
+            "body points at, not inline.\n\n"
+            "Before drafting, load_skill any existing skill you are editing or that "
+            "overlaps, so you extend rather than duplicate.\n\n"
+            "OUTPUT CONTRACT: return (1) the complete SKILL.md — frontmatter + body — in "
+            "one fenced block, (2) where it belongs (operator skills dir ~/.protoagent/"
+            "skills/<slug>/SKILL.md via the console Skills surface; a plugin's skills/ dir; "
+            "or config/skills/ for repo examples), and (3) the slash token to collision-"
+            "check. Do not write files yourself."
+        ),
+        tools=["load_skill"],
+        max_turns=15,
+        # Meta-work: runs that draft skills must not themselves be distilled into skills.
+        allow_skill_emission=False,
+    )
+
+
+def register(registry) -> None:
+    """Entry point — bundled skills + the skill_writer delegate."""
+    try:
+        registry.register_skill_dir("skills")
+    except Exception:
+        log.exception("[craft] failed to register skill dir")
+    try:
+        registry.register_subagent(_skill_writer())
+    except Exception:
+        log.exception("[craft] failed to register skill_writer subagent")

--- a/plugins/craft/protoagent.plugin.yaml
+++ b/plugins/craft/protoagent.plugin.yaml
@@ -1,0 +1,20 @@
+id: craft
+name: Craft
+version: 0.1.0
+# user_only skills (withheld from agent retrieval, slash-only) landed 2026-06;
+# first host release carrying them is 0.85.0.
+min_protoagent_version: "0.85.0"
+description: >-
+  Engineering rituals as user-only slash commands: /grill (relentless plan
+  interview), /standup (operational status report), /code-review (two-axis
+  Standards vs Spec review), /writing-skills (the skill-authoring discipline) —
+  plus a skill_writer subagent that drafts SKILL.md skills to that discipline.
+  Prompt-only: no tools, routes, network, or filesystem access. The grilling,
+  code-review, and skill-authoring material is adapted from mattpocock/skills
+  (MIT).
+# First-party and ON by default, like artifact/notes/docs — pure prompt content,
+# nothing to trust. Turn it off per-instance with `plugins: { disabled: [craft] }`.
+enabled: true
+capabilities:
+  network: []
+  filesystem: none

--- a/plugins/craft/skills/code-review/SKILL.md
+++ b/plugins/craft/skills/code-review/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: code-review
+description: >-
+  /code-review — review a diff along two independent axes, Standards (does it
+  follow the repo's conventions?) and Spec (does it do what was asked?), in
+  parallel subagents whose findings are never merged.
+user_only: true
+slash: code-review
+---
+
+# Code Review — two axes
+
+A change can follow every convention and still build the wrong thing, or do
+exactly what was asked while trashing the codebase's rules. Review both axes
+**separately** so neither masks the other.
+
+## 1. Pin the diff
+
+Get a concrete diff before anything else:
+
+- With shell/git access: `git diff <fixed-point>...HEAD` (three-dot, against
+  the merge-base). Confirm the ref resolves and the diff is non-empty — a bad
+  ref should fail here, not inside two subagents.
+- Without git access: ask the user to paste the diff or point at a PR you can
+  fetch with the tools you have.
+
+## 2. Find the two source documents
+
+- **Spec source** — the originating ask: a tasks-board entry, an active goal,
+  an issue/PRD the user names, or the conversation itself. If none exists,
+  the Spec axis reports "no spec available" instead of inventing one.
+- **Standards sources** — whatever the repo documents about how code should
+  be written (contributor docs, agent instructions, ADRs near the touched
+  code). On top of these, the Standards axis always carries a smell baseline:
+  mysterious names, duplicated logic, data clumps, primitive obsession,
+  shotgun surgery, speculative generality, message chains. Documented repo
+  standards override the baseline; baseline hits are judgement calls, never
+  hard violations; skip anything tooling already enforces.
+
+## 3. Run both axes in parallel
+
+One `task_batch`, two subagents, each given the diff plus only its own source
+documents:
+
+- **Standards brief**: report every documented-standard violation (cite the
+  rule) and any baseline smell (name it, quote the hunk), distinguishing hard
+  violations from judgement calls. Under 400 words.
+- **Spec brief**: report (a) requirements missing or partial, (b) behavior
+  nobody asked for, (c) requirements that look implemented but wrong —
+  quoting the spec line for each. Under 400 words.
+
+## 4. Aggregate without merging
+
+Present the two reports under `## Standards` and `## Spec`, lightly cleaned.
+Do **not** merge or rerank findings across axes — a clean axis must be
+visibly clean, and a noisy one must not bury the other. Close with one line
+per axis: finding count and the worst item within that axis.
+
+*(Adapted from mattpocock/skills `code-review`, MIT.)*

--- a/plugins/craft/skills/code-review/SKILL.md
+++ b/plugins/craft/skills/code-review/SKILL.md
@@ -39,8 +39,9 @@ Get a concrete diff before anything else:
 
 ## 3. Run both axes in parallel
 
-One `task_batch`, two subagents, each given the diff plus only its own source
-documents:
+One `task_batch`, two delegations (`subagent_type: verifier` suits both;
+unknown types are skipped, so use a registered one), each given the diff plus
+only its own source documents:
 
 - **Standards brief**: report every documented-standard violation (cite the
   rule) and any baseline smell (name it, quote the hunk), distinguishing hard

--- a/plugins/craft/skills/grilling/SKILL.md
+++ b/plugins/craft/skills/grilling/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: grilling
+description: >-
+  /grill — a relentless interview that sharpens a plan or design before any of
+  it is built.
+user_only: true
+slash: grill
+---
+
+# Grilling
+
+Interview the user relentlessly about every aspect of the plan or design under
+discussion until you reach a shared understanding. Walk down each branch of
+the decision tree, resolving dependencies between decisions one by one.
+
+Rules:
+
+- Ask questions **one at a time**, waiting for the answer before the next — a
+  battery of questions is bewildering.
+- With every question, give your **recommended answer** and a one-line why.
+- If a question can be answered by the workspace instead of the user — search
+  the knowledge base, recall memory, read the code or docs — go look instead
+  of asking.
+- Do not write code, enact the plan, or produce deliverables until the user
+  confirms the shared understanding is complete.
+
+When the interview converges, restate the agreed plan compactly — decisions,
+not transcript — and ask for the go-ahead. If a decision is durable (a
+constraint or preference that outlives this session), offer to persist it to
+memory.
+
+*(Adapted from mattpocock/skills `grilling`, MIT.)*

--- a/plugins/craft/skills/standup/SKILL.md
+++ b/plugins/craft/skills/standup/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: standup
+description: >-
+  /standup — an operational status report on everything this agent currently
+  owns: tasks, goals, schedules, background work, and what needs the
+  operator's call.
+user_only: true
+slash: standup
+---
+
+# Standup
+
+Produce a status report on the work this agent owns — formatted for a fast
+scan, honest about gaps, ending in decisions rather than chatter.
+
+## 1. Gather
+
+Collect from every surface this instance actually has, in parallel where the
+reads are independent (`task_batch` for anything that needs digging). Skip a
+surface silently only if its tools aren't installed; if a read fails, say so
+in the report rather than omitting it:
+
+- **Tasks** — the tasks board: what's open, in progress, blocked.
+- **Goals & drives** — active goals, their verifier state, recent progress.
+- **Schedule** — scheduler jobs: what fires next, anything failing.
+- **Background work** — recent background reports and running workers.
+- **Session work** — what this conversation has produced or promised.
+- **Code/PRs** — only if git/GitHub tools are available: open PRs, CI state.
+
+## 2. Report
+
+```
+## Owned now
+- 🟡 <in-flight item> (state — what it's waiting on)
+- ⬜ <queued item>
+
+## Done since last standup
+- ✅ <item> (evidence: link/id)
+
+## Gated / blocked
+- 🚨 <item> — <what unblocks it, and whose move it is>
+
+## Schedule
+- <job> — next fire <when> (or "no scheduled jobs")
+
+## Needs your call
+- <decision> — <your recommendation>
+```
+
+Conventions: ✅ done · 🟡 in flight · ⬜ queued · ⬛ deferred (reason inline) ·
+🚨 blocked/escalation (sparingly). Don't oversell — half-done is more honest
+than an inflated status. Name blockers by id, not vibes.
+
+The report is ephemeral: deliver it in chat, don't persist it anywhere.

--- a/plugins/craft/skills/writing-skills/SKILL.md
+++ b/plugins/craft/skills/writing-skills/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: writing-skills
+description: >-
+  /writing-skills — the house discipline for authoring SKILL.md skills that
+  behave predictably. Loads the rules; the skill_writer subagent applies them.
+user_only: true
+slash: writing-skills
+---
+
+# Writing Skills
+
+A skill exists to wrangle determinism out of a stochastic system.
+**Predictability** — the agent taking the same *process* every run, not
+producing the same output — is the root virtue; every rule below serves it.
+
+A protoAgent skill is a folder holding one `SKILL.md`: YAML frontmatter
+(`name` + `description` required, description ≤ 1024 chars) over a markdown
+body that becomes the agent's working instructions when the skill loads.
+Deep docs: `docs/guides/skills.md`, `docs/guides/add-a-skill.md` (ADR 0052,
+ADR 0060).
+
+## Invocation classes — choose deliberately
+
+- **Retrievable (default)** — indexed in the always-on `<available_skills>`
+  list; the agent loads it with `load_skill`. Its description is scanned
+  every turn, so the description is a real cost: write it as **triggers, not
+  identity** — "Use when the user …, mentions …", one trigger per genuinely
+  distinct branch, synonyms collapsed.
+- **`user_facing: true` + `slash: <token>`** — additionally invokable as
+  `/<token>` in chat.
+- **`user_only: true`** — withheld from agent retrieval entirely; the slash
+  is the only way in. Zero context cost; the *user* becomes the index that
+  must remember it exists. The description turns human-facing: one plain
+  sentence for the palette. Use this for rituals only ever fired by hand.
+
+**Token collision check, every time:** slash precedence is goal > plugin
+command > workflow > subagent > skill — a same-token workflow or subagent
+silently shadows the skill (this is why `web-research` isn't `/research`).
+
+## Body discipline
+
+- **Steps end on a checkable completion criterion** — the agent must be able
+  to tell done from not-done ("every modified surface accounted for", not
+  "produce a list"). A fuzzy criterion invites premature completion.
+- **Prefer a leading word** — a compact concept the model already holds
+  (*tracer bullet*, *tight*, *red*) — over a restated triad; it anchors a
+  region of behavior in one token, in the body (execution) and the
+  description (invocation) alike.
+- **Reference the docs, don't inline them.** Material only some runs need
+  belongs in repo docs the body points at; the body carries what every run
+  needs.
+
+## Failure modes (diagnose with these)
+
+- **Premature completion** — a step ends before it's done; sharpen the
+  criterion first, split the sequence only if that fails.
+- **Duplication** — one meaning in two places; costs tokens and maintenance.
+- **Sediment** — stale layers that settle because adding feels safe and
+  removing feels risky; the default fate of an unpruned skill.
+- **Sprawl** — too long even when every line is live; push reference out.
+- **No-op** — a line the model already obeys ("be thorough"); delete the
+  sentence, don't trim it — or replace the weak word with a stronger one
+  (*relentless*).
+
+## Placement & workflow
+
+Operator-authored skills live at `~/.protoagent/skills/<slug>/SKILL.md`
+(create/edit via the console Skills surface — it round-trips the same
+loader). Plugin-bundled skills live in the plugin's `skills/` dir; repo
+examples in `config/skills/`. To draft or tighten one, delegate to the
+**skill_writer** subagent — it returns the complete SKILL.md, its placement,
+and the token to collision-check.
+
+*(Discipline adapted from mattpocock/skills `writing-great-skills`, MIT.)*

--- a/tests/test_craft_plugin.py
+++ b/tests/test_craft_plugin.py
@@ -1,0 +1,79 @@
+"""Craft plugin — bundled user-only skills + the skill_writer subagent.
+
+The plugin is prompt-only, so the tests pin its whole contract: the manifest
+parses, ``register()`` contributes exactly a skill dir + one subagent, every
+bundled SKILL.md is loader-valid and ``user_only`` with the expected slash
+token, and no token is shadowed by a core subagent (slash precedence puts
+subagents above skills).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from graph.plugins.testkit import FakeRegistry, load_plugin
+from graph.skills.loader import parse_skill_md
+
+ROOT = Path("plugins/craft")
+
+EXPECTED_SLASHES = {"grill", "standup", "code-review", "writing-skills"}
+
+
+def _skill_files() -> list[Path]:
+    return sorted(ROOT.glob("skills/*/SKILL.md"))
+
+
+def test_manifest_parses_and_declares_prompt_only():
+    data = yaml.safe_load((ROOT / "protoagent.plugin.yaml").read_text(encoding="utf-8"))
+    assert data["id"] == "craft"
+    assert data["enabled"] is True
+    assert data["version"]
+    assert data["min_protoagent_version"]
+    # Prompt-only contract: no declared network or filesystem reach.
+    assert data["capabilities"] == {"network": [], "filesystem": "none"}
+
+
+def test_register_contributes_skills_and_subagent():
+    pkg = load_plugin(ROOT, "craft")
+    registry = FakeRegistry("craft", plugin_dir=ROOT)
+    pkg.register(registry)
+
+    assert [Path(p).name for p in registry.skill_dirs] == ["skills"]
+    assert len(registry.subagents) == 1
+    sub = registry.subagents[0]
+    assert sub.name == "skill_writer"
+    assert sub.description and sub.system_prompt
+    assert sub.tools == ["load_skill"]
+    # Meta-work must not distill into skills about writing skills.
+    assert sub.allow_skill_emission is False
+    # Prompt-only: nothing else contributed.
+    assert not registry.tools and not registry.routers and not registry.surfaces
+
+
+def test_bundled_skills_are_loader_valid_and_user_only():
+    files = _skill_files()
+    assert len(files) == 4, f"expected 4 bundled skills, found {[str(f) for f in files]}"
+
+    seen = {}
+    for path in files:
+        artifact = parse_skill_md(path)
+        assert artifact is not None, f"{path} failed to parse"
+        assert artifact.user_only, f"{path} must be user_only (slash-only rituals)"
+        assert artifact.user_facing, f"{path}: user_only implies user_facing"
+        assert artifact.slash, f"{path} must pin an explicit slash token"
+        assert artifact.prompt_template, f"{path} has an empty body"
+        seen[artifact.slash] = artifact.name
+
+    assert set(seen) == EXPECTED_SLASHES
+    assert len(seen) == len(files), "slash tokens must be unique"
+
+
+def test_slash_tokens_not_shadowed_by_core_subagents():
+    """Slash precedence is workflow > subagent > skill — a core subagent with the
+    same token would silently shadow the bundled skill (the /research lesson)."""
+    from graph.subagents.config import SUBAGENT_REGISTRY
+
+    collisions = EXPECTED_SLASHES & set(SUBAGENT_REGISTRY)
+    assert not collisions, f"slash tokens shadowed by core subagents: {collisions}"


### PR DESCRIPTION
## What

New first-party, on-by-default, **prompt-only** in-tree plugin `plugins/craft/`:

| Command | What it does |
|---------|--------------|
| `/grill` | Relentless one-question-at-a-time interview that sharpens a plan before building |
| `/standup` | Operational status report: tasks, goals, schedule, background work, PRs |
| `/code-review` | Two-axis review (Standards vs Spec) in parallel subagents, findings never merged |
| `/writing-skills` | The house discipline for authoring predictable SKILL.md skills |

Plus the **`skill_writer`** subagent — drafts SKILL.md skills to that discipline (returns the file, its placement, and the slash token to collision-check; `allow_skill_emission=False`).

## Why user_only

All four skills set `user_only: true` — withheld from agent retrieval, slash-only, zero context cost until invoked. They're operator rituals, not agent-reach skills. Disable per instance with `plugins: { disabled: [craft] }`.

## Tests

`tests/test_craft_plugin.py` pins the contract: prompt-only manifest capabilities, register() contributes exactly a skill dir + one subagent, all four SKILL.md files loader-valid + user_only with unique explicit slash tokens, and a token-shadowing guard against core subagents (slash precedence: the /research lesson).

## Gates

- `ruff check .` + `ruff format --check` — clean
- `lint-imports` — 3 kept, 0 broken
- `pytest tests/ -q` — 2973 passed, 5 skipped

## Attribution

Grilling / two-axis code-review / skill-authoring discipline adapted from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT), credited in the plugin README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)