### PR TITLE
chore(memory): audit-batch follow-up

### DIFF
--- a/docs/reference/operator-api.md
+++ b/docs/reference/operator-api.md
@@ -74,8 +74,9 @@ is a map — `operator_api/*.py` is the source of truth for exact request/respon
 
 The audit surface for the memory delivery layer
 ([ADR 0069](../adr/0069-memory-delivery-layer.md) D7): the persisted session
-summaries behind the `<prior_sessions>` digest, and the hot-memory chunks
-injected every turn.
+summaries behind the `<prior_sessions>` digest, the hot-memory chunks (of which
+the newest ride each turn's injection window), and the per-turn injection
+record.
 
 | Method | Path | Purpose |
 |---|---|---|
@@ -83,6 +84,7 @@ injected every turn.
 | GET · DELETE | `/api/memory/sessions/{session_id}` | Full rendered summary (what `recall_session` returns) / delete one |
 | GET | `/api/memory/hot` | List hot-memory chunks (`domain="hot"`); each row carries `injecting`: whether the chunk is in the current per-turn injection window (omitted on backends without the id-attributed reader) |
 | PUT · DELETE | `/api/memory/hot/{chunk_id}` | Edit (revision stays `hot`) / delete a hot chunk |
+| GET | `/api/memory/injections` | Per-model-call injection records ([ADR 0069](../adr/0069-memory-delivery-layer.md) D6), newest first: which digest sessions / hot chunk ids / RAG chunk ids entered each turn, at what approximate token cost. `?session_id=` filters to one session; `?limit=` clamps to 1–500 (default 50) |
 
 ## Activity, inbox & events
 


### PR DESCRIPTION
Completeness-critic pass over the just-merged memory batch (#1726 backend truth flags, #1727 console badges/copy, #1721 docs rewrite). Everything cross-checked clean — terminology (tab names, badge copy vs docs wording), every numeric claim (hot window 100 chunks / 6 000 chars, digest 10 sessions / 2 000 tokens, `top_k` 10, embeddings default false, injections limit clamp 1–500), the `MemoryInjectionRow.id` wire contract, the e2e mode endpoint, and zero leftover TODO/debug lines — **except two leftovers in `docs/reference/operator-api.md`'s Memory inspector section**:

1. **Missing route row**: the table omitted `GET /api/memory/injections` — the ADR 0069 D6 per-turn injection record behind the console's third Memory tab. Both other docs pages (`docs/explanation/memory-and-knowledge.md`, `docs/guides/knowledge.md`) reference it, and #1726 itself touched the route (limit clamp), yet the reference table listing the memory audit surface never gained the row. Added: newest-first rows of digest/hot/RAG ids per model call, `?session_id=` filter, `?limit=` clamped to 1–500 (default 50).

2. **Contradictory intro copy**: the section intro still said "the hot-memory chunks **injected every turn**" — the exact claim the batch corrected (only the newest chunks under the char budget ride the window), contradicting the `injecting`-field row #1726 added two lines below it. Reworded to window semantics and to name the injection record.

Docs-only. Gate: `npm run docs:build` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)