### PR TITLE
feat(console): banner when the focused fleet member stops mid-session

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@protolabsai/design": "^0.5.1",
     "@protolabsai/ui": "^0.54.1",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
+    "@streamdown/code": "^1.1.1",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.53.1",
+    "@protolabsai/ui": "^0.54.1",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/AgentDownBanner.tsx
+++ b/apps/web/src/app/AgentDownBanner.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Banner, Button } from "@protolabsai/ui/primitives";
+
+import { api, agentHref, currentSlug } from "../lib/api";
+import { brandName } from "../lib/brand";
+import { fleetQuery, queryKeys } from "../lib/queries";
+
+/** Runtime down-detection for the FOCUSED fleet member.
+ *
+ *  The boot gate (App.tsx) only fires while the runtime probe is still failing at
+ *  BOOT; once an agent has loaded, its runtime query stops polling (graph_loaded),
+ *  so a member that stops MID-SESSION left every plugin view to 409 with a raw
+ *  "Could not load: … agent '<slug>' is not running" and gave the operator no
+ *  app-level warning that the agent they were watching had gone down.
+ *
+ *  This hangs off the fleet status the FleetSwitcher already polls (queryKeys.fleet,
+ *  3s — no extra traffic): when the agent THIS window is on has flipped to
+ *  not-running, it renders a slim warning strip with a hub-routed Start. `startAgent`
+ *  is a hub control-plane call (`/api/fleet/<name>/start`, never slug-scoped), so it
+ *  works even though the focused member is down — "going back to the main instance".
+ *  A REMOTE member has no local process to start from here, so it points back to the
+ *  host instead. The host window, or a running agent, renders nothing. */
+export function AgentDownBanner() {
+  const slug = currentSlug();
+  const qc = useQueryClient();
+  const [starting, setStarting] = useState(false);
+  const fleet = useQuery(fleetQuery());
+
+  if (slug === "host") return null;
+  const agent = (fleet.data?.agents ?? []).find((a) => (a.host ? "host" : a.id) === slug);
+  if (!agent || agent.host || agent.running) return null;
+
+  const start = () => {
+    void (async () => {
+      setStarting(true);
+      try {
+        await api.startAgent(agent.name);
+        // On success the next 3s poll reports running:true and this banner self-hides;
+        // invalidate so it flips without waiting out the interval.
+        await qc.invalidateQueries({ queryKey: queryKeys.fleet });
+      } catch {
+        // Leave the banner up — the poll keeps its state honest and the operator can retry.
+      } finally {
+        setStarting(false);
+      }
+    })();
+  };
+
+  return (
+    <Banner
+      tone="warning"
+      title="agent stopped"
+      className="shell-warning-banner agent-down-banner"
+      action={
+        agent.remote ? (
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={() => {
+              window.location.href = agentHref("host");
+            }}
+          >
+            Return to host
+          </Button>
+        ) : (
+          <Button size="sm" variant="primary" loading={starting} onClick={start}>
+            Start
+          </Button>
+        )
+      }
+    >
+      {brandName(agent.name)} has stopped —{" "}
+      {agent.remote
+        ? "it’s unreachable from here; return to the host console."
+        : "start it to reload this view."}
+    </Banner>
+  );
+}

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -75,6 +75,7 @@ import { Button } from "@protolabsai/ui/primitives";
 import { ActivityWidget } from "../activity/ActivityWidget";
 import { ConfirmDialog, Tooltip } from "@protolabsai/ui/overlays";
 import { InboxWidget } from "../inbox/InboxWidget";
+import { AgentDownBanner } from "./AgentDownBanner";
 import { ChatSlot } from "./ChatSlot";
 import { chatStore, useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
@@ -936,6 +937,11 @@ export function App() {
           {w}
         </Alert>
       ))}
+
+      {/* Focused fleet member stopped mid-session (the boot gate only catches boot-time
+          down; a runtime stop otherwise surfaces only as plugin views 409-ing). Slim
+          strip with a hub-routed Start; renders nothing on the host or a running agent. */}
+      <AgentDownBanner />
 
       {/* The dual-rail shell is now the DS AppShell (ADR 0035 + #144): rails (drag-to-reorder +
           cross-rail via dnd-kit), resizable right column, mobile shell, and the utility bar — all

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.53.1",
+        "@protolabsai/ui": "^0.54.1",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
+        "@streamdown/code": "^1.1.1",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -70,9 +71,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.53.1",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.53.1.tgz",
-      "integrity": "sha512-umGTBXinXFZGanESQS8WZKBBA1JBCSaD7a3/YS6YANK2q4f4P3i3jh1cZ1Bn6axlv0ZwZLv5iMwtO4+0WIo9FQ==",
+      "version": "0.54.1",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.54.1.tgz",
+      "integrity": "sha512-dZkxFRmursr3sCQ/KS9HrWg+6lRaDc2JW84cy1H9QYlGo09PEuasw4jo17+hZK63bABtq8aIXVXAwAAoIp9CDg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -3069,7 +3070,6 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -3078,6 +3078,106 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@streamdown/code": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@streamdown/code/-/code-1.1.1.tgz",
+      "integrity": "sha512-i7HTNuDgZWb+VdrNVOam9gQhIc5MSSDXKWXgbUrn/4vSRaSMM+Rtl10MQj4wLWPNpF7p80waJsAqFP8HZfb0Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "shiki": "^3.19.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@streamdown/code/node_modules/@shikijs/core": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.23.0.tgz",
+      "integrity": "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      }
+    },
+    "node_modules/@streamdown/code/node_modules/@shikijs/engine-javascript": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.23.0.tgz",
+      "integrity": "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      }
+    },
+    "node_modules/@streamdown/code/node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@streamdown/code/node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@streamdown/code/node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@streamdown/code/node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@streamdown/code/node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/@streamdown/code/node_modules/shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.23.0.tgz",
+      "integrity": "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "3.23.0",
+        "@shikijs/engine-javascript": "3.23.0",
+        "@shikijs/engine-oniguruma": "3.23.0",
+        "@shikijs/langs": "3.23.0",
+        "@shikijs/themes": "3.23.0",
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.101.1",
@@ -5771,7 +5871,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
       "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -7657,6 +7756,12 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
     "node_modules/oniguruma-to-es": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
@@ -8182,7 +8287,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
       "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -8192,7 +8296,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
       "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -8202,7 +8305,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/rehype-harden": {


### PR DESCRIPTION
## Summary
- The boot gate (App.tsx) only catches a fleet member that's already down at BOOT; once an agent has loaded, its runtime probe stops polling, so a member that stops mid-session left every plugin view 409ing with a raw "agent is not running" error and no app-level signal that the focused agent had gone down.
- `AgentDownBanner` hangs off the fleet status poll `FleetSwitcher` already uses (`queryKeys.fleet`, 3s — no extra traffic): when the agent this window is on flips to not-running, it renders a slim warning strip with a hub-routed Start. `startAgent` is a hub control-plane call (never slug-scoped), so it works even though the focused member is down. A remote member has no local process to start from here, so its banner points back to the host instead.
- Bumps `@protolabsai/ui` to 0.54.1 for the new `Banner` primitive — see the follow-up commit for the lockfile fix this needed (the manifest bump alone doesn't update the lock in this npm workspace, and 0.54.1 adds a new optional peer, `@streamdown/code`, that DS's markdown module imports statically).

## Test plan
- [x] `npm run test:unit --workspace @protoagent/web` — 342 passed
- [x] `npm run build --workspace @protoagent/web` — clean (tsc + vite)
- [x] `npm run test:e2e --workspace @protoagent/web` — 198 passed
- [x] `npm ci` validates the fixed lockfile from a clean install

🤖 Generated with [Claude Code](https://claude.com/claude-code)