### PR TITLE
chore: release v0.88.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.88.0] - 2026-07-03
+
 ### Fixed
 - **The Memory inspector tells the truth about what injects** (#1726). The Hot
   memory and Sessions tabs listed a superset of what actually rides the agent's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.87.0"
+version = "0.88.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "v0.88.0",
+    "date": "2026-07-03",
+    "changes": [
+      "The Memory inspector tells the truth about what injects",
+      "Memory view accuracy and polish"
+    ]
+  },
+  {
     "version": "v0.87.0",
     "date": "2026-07-03",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.88.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.88.0 -m 'Release v0.88.0' && git push origin v0.88.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).