### PR TITLE
fix(plugins): built-in detection requires a manifest, not just a dir (#1731)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the convention the plugin-views guide prescribes. Both the registration-time and
   mount-time checks now accept `/api/plugins/<id>` as canonical (shared predicate),
   reserving the warning for genuinely off-convention prefixes.
+- **A manifest-less ghost dir under `plugins/` no longer blocks install/uninstall**
+  (#1731). Built-in detection treated any directory under `plugins/<id>` as a
+  built-in — so a `__pycache__`-only leftover, orphaned when a plugin is extracted
+  core→standalone (git doesn't track it, so it survives on every machine that ever
+  imported the old plugin), refused installing the standalone successor
+  (`plugin id 'google' is a built-in — cannot install over it`). A directory now
+  counts as built-in only if it actually holds a `protoagent.plugin.yaml` or
+  `protoagent.bundle.yaml`, matching how the loader decides a dir is a plugin.
 
 ## [0.88.0] - 2026-07-03
 

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 from infra.paths import instance_paths
 
-from graph.plugins.manifest import PluginManifest, load_manifest
+from graph.plugins.manifest import MANIFEST_FILENAME, PluginManifest, load_manifest
 
 log = logging.getLogger(__name__)
 
@@ -38,6 +38,19 @@ def bundled_plugins_dir() -> Path:
     """In-tree bundled (built-in) plugins root — ``app_root/plugins``. Resolved at
     call time so the env (PyInstaller _MEIPASS) is honored, never import-time."""
     return instance_paths().app_root / "plugins"
+
+
+def _is_builtin(plugin_id: str) -> bool:
+    """True iff ``plugins/<id>`` is a REAL bundled plugin or bundle — i.e. it holds
+    a manifest (``protoagent.plugin.yaml``) or bundle file (``protoagent.bundle.yaml``),
+    mirroring how the loader (:func:`load_manifest`) decides a directory is a plugin.
+
+    A bare directory is NOT a built-in: a ``__pycache__``-only leftover from a
+    core→standalone extraction (git doesn't track it, so it survives on every
+    machine that ever imported the old plugin) must not block installing or
+    uninstalling the standalone successor of the same id (#1731)."""
+    d = bundled_plugins_dir() / plugin_id
+    return (d / MANIFEST_FILENAME).exists() or (d / BUNDLE_FILENAME).exists()
 
 
 def lock_path() -> Path:
@@ -404,8 +417,9 @@ def install(
             )
         pid = manifest.id
 
-        # No silent shadowing of a built-in (repo) plugin.
-        if (bundled_plugins_dir() / pid).exists():
+        # No silent shadowing of a built-in (repo) plugin. A manifest-less ghost
+        # dir (e.g. a __pycache__ leftover) is not a built-in and must not block.
+        if _is_builtin(pid):
             raise InstallError(f"plugin id {pid!r} is a built-in — cannot install over it.")
 
         # Frozen runtime (desktop): no pip — a plugin can only run if its declared
@@ -621,7 +635,7 @@ def uninstall(plugin_id: str, *, purge: bool = False) -> dict:
     With ``purge=True`` ALSO removes the plugin's config section + its secrets.
     Built-ins are refused; pip deps are NEVER auto-removed (shared venv) — they're
     returned for the operator to remove. Returns a report dict."""
-    if (bundled_plugins_dir() / plugin_id).exists():
+    if _is_builtin(plugin_id):
         raise InstallError(f"{plugin_id!r} is a built-in plugin — not removable via uninstall.")
     target = live_plugins_dir() / plugin_id
     # Read the manifest BEFORE deleting — purge needs the config section + we report

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -129,6 +129,34 @@ def test_refuses_to_shadow_a_builtin(env):
         installer.install(str(repo))
 
 
+def test_ghost_dir_without_manifest_does_not_block_install(env, tmp_path, monkeypatch):
+    # A manifest-less leftover under plugins/<id> (e.g. a __pycache__ dir orphaned
+    # when a plugin was extracted core→standalone, #1731) is NOT a built-in and
+    # must not block installing the standalone successor of the same id.
+    builtins = tmp_path / "builtins"
+    ghost = builtins / "ghost_ext" / "__pycache__"
+    ghost.mkdir(parents=True)
+    (ghost / "loader.cpython-312.pyc").write_bytes(b"\x00")
+    monkeypatch.setattr(installer, "bundled_plugins_dir", lambda: builtins)
+
+    repo = _make_plugin_repo(env, pid="ghost_ext")
+    summary = installer.install(str(repo))  # must not raise "is a built-in"
+    assert summary["id"] == "ghost_ext"
+
+
+def test_manifest_dir_is_treated_as_builtin(env, tmp_path, monkeypatch):
+    # A directory that DOES hold a manifest is a real built-in and still blocks.
+    builtins = tmp_path / "builtins"
+    real = builtins / "real_ext"
+    real.mkdir(parents=True)
+    (real / "protoagent.plugin.yaml").write_text("id: real_ext\nname: R\nversion: 0.1.0\ndescription: x\n")
+    monkeypatch.setattr(installer, "bundled_plugins_dir", lambda: builtins)
+
+    repo = _make_plugin_repo(env, pid="real_ext")
+    with pytest.raises(installer.InstallError, match="built-in"):
+        installer.install(str(repo))
+
+
 def test_repo_without_manifest_is_rejected(env, tmp_path):
     bare = tmp_path / "src-bare"
     bare.mkdir()


### PR DESCRIPTION
Closes #1731.

## Problem
`installer._install`/`uninstall` treated **any** directory under `plugins/<id>` as a built-in. A `__pycache__`-only ghost dir — orphaned when a plugin is extracted core→standalone (#1133 for `google`); git doesn't track `__pycache__`, so it survives on every machine that ever imported the old plugin — made installing the standalone successor fail:

```
$ python -m server plugin install https://github.com/protoLabsAI/google-plugin
✗ plugin id 'google' is a built-in — cannot install over it.
```

## Fix
New `_is_builtin(plugin_id)` helper: a directory is built-in only if it holds a `protoagent.plugin.yaml` **or** `protoagent.bundle.yaml`, mirroring how the loader (`load_manifest`) decides a dir is a plugin. Used at both the install shadow-check (`installer.py:~409`) and the uninstall not-removable check (`~624`).

## Tests
- `test_ghost_dir_without_manifest_does_not_block_install` — a `__pycache__`-only dir under a monkeypatched `bundled_plugins_dir()` no longer blocks install.
- `test_manifest_dir_is_treated_as_builtin` — a dir that DOES hold a manifest still blocks.
- Existing `test_refuses_to_shadow_a_builtin` (real `hello` built-in) stays green.

`ruff check` clean; `tests/test_plugin_installer.py` 32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installing a plugin no longer fails because of leftover empty or cache-only directories from a previous bundled plugin.
  * Plugin removal now correctly blocks only truly bundled plugins, reducing false “built-in” conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->