### PR TITLE
fix(plugins): accept /api/plugins/<id> as a conforming router prefix (#1732)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   smoke test — deleting the wiring left the suite green. The callables are now captured
   in `surface_specs` (keyed by effective name), keeping `surfaces` (names) for existing
   assertions. Mirror of #1637 (`register_chat_command`).
+- **The plugin loader no longer nags about the prescribed `/api/plugins/<id>` data
+  router** (#1732). Every plugin following the documented two-router pattern (public
+  view at `/plugins/<id>`, bearer-gated data at `/api/plugins/<id>` — ADR 0026) drew
+  a `does not start with /plugins/<id>/` WARNING on every boot, including first-party
+  `artifact`/`docs`/`notes` and the `google` plugin — the loader's check contradicted
+  the convention the plugin-views guide prescribes. Both the registration-time and
+  mount-time checks now accept `/api/plugins/<id>` as canonical (shared predicate),
+  reserving the warning for genuinely off-convention prefixes.
 
 ## [0.88.0] - 2026-07-03
 

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -13,6 +13,15 @@ from pathlib import Path
 log = logging.getLogger("protoagent.plugins")
 
 
+def _prefix_conforms(prefix: str, plugin_id: str) -> bool:
+    """True iff a router prefix follows the two-router convention: the public view
+    ``/plugins/<id>`` or the bearer-gated data router ``/api/plugins/<id>`` (docs/
+    guides/plugin-views.md, ADR 0026). Both are canonical — the loader must not nag
+    plugins that follow the prescribed pattern (#1732). Shared by the server-side
+    mount check (server/agent_init.py) so the two never drift."""
+    return prefix.startswith(f"/plugins/{plugin_id}") or prefix.startswith(f"/api/plugins/{plugin_id}")
+
+
 class PluginRegistry:
     """Collects a single plugin's contributions during ``register()``.
 
@@ -314,21 +323,25 @@ class PluginRegistry:
 
         Defaults to the namespaced prefix ``/plugins/<id>`` so a plugin can't
         silently shadow a core route. Pass ``prefix=""`` (or your own) to mount
-        elsewhere — an escape hatch, logged. Plugin routes SHOULD live under
-        ``/plugins/<id>/``; a non-conforming prefix logs a WARNING (#870).
-        The default-deny auth middleware guards all non-public paths regardless
-        of prefix.
+        elsewhere — an escape hatch, logged. The two canonical prefixes are the
+        public view ``/plugins/<id>`` and the bearer-gated data router
+        ``/api/plugins/<id>`` (the documented two-router pattern — docs/guides/
+        plugin-views.md, ADR 0026); a prefix outside both logs a WARNING (#870,
+        #1732). The default-deny auth middleware guards all non-public paths
+        regardless of prefix.
         """
         if router is None or not hasattr(router, "routes"):
             log.warning("[plugins] %s: register_router got a non-router: %r", self.plugin_id, router)
             return
         eff = f"/plugins/{self.plugin_id}" if prefix is None else str(prefix)
-        if eff and not eff.startswith(f"/plugins/{self.plugin_id}"):
+        if eff and not _prefix_conforms(eff, self.plugin_id):
             log.warning(
                 "[plugins] %s: register_router prefix %r does not start with "
-                "/plugins/%s/ — plugin routes SHOULD live under /plugins/<id>/",
+                "/plugins/%s or /api/plugins/%s — plugin routes SHOULD live under "
+                "/plugins/<id>/ (public) or /api/plugins/<id>/ (gated data)",
                 self.plugin_id,
                 eff,
+                self.plugin_id,
                 self.plugin_id,
             )
         self.routers.append({"router": router, "prefix": eff})

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -1183,6 +1183,8 @@ def _mount_plugin_routers(routers: list[dict]) -> None:
     app = STATE.fastapi_app
     if app is None:
         return
+    from graph.plugins.registry import _prefix_conforms
+
     for r in routers:
         plugin_id = r.get("plugin_id", "")
         prefix = r.get("prefix") or ""
@@ -1201,17 +1203,19 @@ def _mount_plugin_routers(routers: list[dict]) -> None:
             )
             continue
         # Warn for non-conforming prefixes (#870 plugin prefix enforcement).
-        # The convention is /plugins/<id>/...; routes under other prefixes are
-        # still mounted (existing plugins use /api/... for data routes) but
-        # the warning surfaces mis-configurations. The default-deny middleware
-        # guards all non-public paths regardless of prefix.
-        if plugin_id and prefix and not prefix.startswith(f"/plugins/{plugin_id}"):
+        # The two canonical prefixes are /plugins/<id>/... (public view) and
+        # /api/plugins/<id>/... (bearer-gated data router) — the documented
+        # two-router pattern (#1732). Routes under any other prefix are still
+        # mounted (mounted as-is; the default-deny middleware guards non-public
+        # paths regardless) but the warning surfaces genuine mis-configurations.
+        if plugin_id and prefix and not _prefix_conforms(prefix, plugin_id):
             log.warning(
-                "[plugins] %s: router prefix %r does not start with /plugins/%s/ "
-                "— plugin routes SHOULD live under /plugins/<id>/ (mounted as-is; "
-                "the default-deny auth middleware guards it)",
+                "[plugins] %s: router prefix %r does not start with /plugins/%s or "
+                "/api/plugins/%s — plugin routes SHOULD live under /plugins/<id>/ "
+                "(public) or /api/plugins/<id>/ (gated data; mounted as-is)",
                 plugin_id,
                 prefix,
+                plugin_id,
                 plugin_id,
             )
         try:

--- a/tests/test_a2a_auth.py
+++ b/tests/test_a2a_auth.py
@@ -355,8 +355,21 @@ def test_ac13_mount_warns_non_conforming_prefix(monkeypatch, caplog):
 
     # The router was still mounted (not rejected).
     assert ("myplugin", "/custom/path") in STATE.plugin_router_keys
-    # A warning was logged.
-    assert any("does not start with /plugins/myplugin/" in m for m in caplog.messages)
+    # A warning was logged for the genuinely off-convention prefix.
+    assert any("does not start with" in m for m in caplog.messages)
+
+    # ...but the prescribed gated-data prefix /api/plugins/<id> is canonical and silent (#1732).
+    caplog.clear()
+    r2 = APIRouter()
+
+    @r2.get("/pong")
+    def _pong():
+        return {"ok": True}
+
+    with caplog.at_level(logging.WARNING, logger="protoagent.server"):
+        _mount_plugin_routers([{"plugin_id": "myplugin", "router": r2, "prefix": "/api/plugins/myplugin"}])
+    assert ("myplugin", "/api/plugins/myplugin") in STATE.plugin_router_keys
+    assert not any("does not start with" in m for m in caplog.messages)
 
 
 # AC14: /api/sse-token endpoint returns a token

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -423,6 +423,31 @@ def register(registry):
 """
 
 
+def test_register_router_prefix_warning_accepts_both_canonical_prefixes(tmp_path, caplog) -> None:
+    # The documented two-router pattern (#1732): a plugin's public view lives under
+    # /plugins/<id> and its bearer-gated data router under /api/plugins/<id>. Neither
+    # should trip the #870 non-conforming-prefix warning; only a genuinely off-
+    # convention prefix should.
+    import logging
+
+    from graph.plugins.registry import PluginRegistry
+
+    class _FakeRouter:
+        routes: list = []
+
+    reg = PluginRegistry("wh", tmp_path)
+    with caplog.at_level(logging.WARNING, logger="protoagent.plugins"):
+        reg.register_router(_FakeRouter())                              # default /plugins/wh
+        reg.register_router(_FakeRouter(), prefix="/api/plugins/wh")    # gated data router
+        reg.register_router(_FakeRouter(), prefix="/api/plugins/wh/data")
+    assert "does not start with" not in caplog.text  # both canonical prefixes are silent
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="protoagent.plugins"):
+        reg.register_router(_FakeRouter(), prefix="/rogue")            # genuinely off-convention
+    assert "does not start with" in caplog.text
+
+
 def test_plugin_contributes_router_surface_subagent(tmp_path, monkeypatch) -> None:
     root = tmp_path / "plugins"
     _make_plugin(root, "ext", enabled=True, body=_EXT_PLUGIN)


### PR DESCRIPTION
Closes #1732.

## Problem
The documented two-router pattern (public view `/plugins/<id>`, bearer-gated data `/api/plugins/<id>` — ADR 0026, `docs/guides/plugin-views.md`) tripped the #870 non-conforming-prefix WARNING on **every boot** for **every conforming plugin**:

```
WARNING protoagent.plugins [plugins] google: register_router prefix
'/api/plugins/google' does not start with /plugins/google/ — plugin routes
SHOULD live under /plugins/<id>/
```

First-party `artifact`, `docs`, `notes` and the `google` plugin all triggered it — the loader's check contradicted the convention the plugin-views guide prescribes.

## Fix
Shared `_prefix_conforms(prefix, plugin_id)` predicate in `graph/plugins/registry.py` accepts **both** canonical prefixes (`/plugins/<id>` and `/api/plugins/<id>`). Used at both the registration-time check (`register_router`) and the mount-time check (`server/agent_init._mount_plugin_routers`) so the two can't drift (`server/` → `graph/` import is layering-legal). The warning now fires only for genuinely off-convention prefixes.

## Tests
- `test_register_router_prefix_warning_accepts_both_canonical_prefixes` — `/plugins/wh`, `/api/plugins/wh`, `/api/plugins/wh/data` are silent; `/rogue` still warns.

`ruff check` clean; `tests/test_plugins.py` 44 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)