### PR TITLE
test(plugins): FakeRegistry.register_surface captures start/stop/reload (#1729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Plugin smoke tests can assert surface lifecycle wiring** (#1729). The testkit's
+  `FakeRegistry.register_surface` kept only the surface *name* and discarded the
+  `start`/`stop`/`reload` callables, so a plugin's surface lifecycle wiring (e.g.
+  arming watch tripwires in `start`) couldn't be exercised from a `register(FakeRegistry)`
+  smoke test — deleting the wiring left the suite green. The callables are now captured
+  in `surface_specs` (keyed by effective name), keeping `surfaces` (names) for existing
+  assertions. Mirror of #1637 (`register_chat_command`).
+
 ## [0.88.0] - 2026-07-03
 
 ### Fixed

--- a/graph/plugins/testkit.py
+++ b/graph/plugins/testkit.py
@@ -198,6 +198,7 @@ class FakeRegistry:
         self.tools: list = []
         self.routers: list = []
         self.surfaces: list = []
+        self.surface_specs: dict = {}  # name -> (start, stop, reload) — assert lifecycle wiring
         self.subagents: list = []
         self.middlewares: list = []
         self.mcp_servers: list = []
@@ -247,7 +248,12 @@ class FakeRegistry:
         self.routers.append((prefix, router))
 
     def register_surface(self, start, stop=None, name: str | None = None, reload=None) -> None:
+        # Keep `surfaces` (names) for existing name-only assertions, AND capture the
+        # start/stop/reload callables so a smoke test can actually exercise a surface's
+        # lifecycle wiring (#1729) — e.g. call `start` and assert it armed its watches.
+        # Keyed by the effective name (name or plugin_id), mirroring the real registry.
         self.surfaces.append(name)
+        self.surface_specs[name or self.plugin_id] = (start, stop, reload)
 
     def register_subagent(self, config) -> None:
         self.subagents.append(config)

--- a/tests/test_plugin_testkit.py
+++ b/tests/test_plugin_testkit.py
@@ -81,6 +81,38 @@ def test_register_runs_host_free_and_fake_registry_captures():
     assert len(reg.late_tool_factories) == 1
 
 
+def test_fake_registry_captures_surface_lifecycle_callables():
+    # #1729: register_surface used to keep only the NAME, so a plugin's surface
+    # lifecycle wiring (arming watches in `start`, etc.) couldn't be exercised from
+    # a register-smoke test. The start/stop/reload callables are now captured and the
+    # smoke can actually CALL them and assert the side effect.
+    reg = testkit.FakeRegistry(plugin_id="demo")
+    armed = []
+
+    def _start():
+        armed.append("armed")
+
+    def _stop():
+        return None
+
+    def _reload(cfg):
+        return None
+
+    reg.register_surface(_start, stop=_stop, name="fleet", reload=_reload)
+
+    assert reg.surfaces == ["fleet"]  # names still captured for existing assertions
+    start, stop, reload = reg.surface_specs["fleet"]
+    assert (start, stop, reload) == (_start, _stop, _reload)
+    start()  # exercisable: mutation-kills a plugin that forgets to wire `start`
+    assert armed == ["armed"]
+
+    # An unnamed surface is keyed by the plugin id (the effective name), so a plugin
+    # that relies on the default name is still reachable.
+    reg2 = testkit.FakeRegistry(plugin_id="solo")
+    reg2.register_surface(_start)
+    assert "solo" in reg2.surface_specs
+
+
 # ── registry parity — the drift guard (#1637) ────────────────────────────────────────
 # FakeRegistry drifted from PluginRegistry (register_chat_command was missing), which made
 # that seam silently untestable: plugins hasattr-guard the call, so the smoke test passed


### PR DESCRIPTION
Closes #1729.

## Gap
`graph/plugins/testkit.py` `FakeRegistry.register_surface` kept only the surface **name**:

```python
def register_surface(self, start, stop=None, name=None, reload=None) -> None:
    self.surfaces.append(name)
```

The `start`/`stop`/`reload` callables were dropped, so a plugin's surface *lifecycle wiring* couldn't be asserted from a `register(FakeRegistry)` smoke test. Concrete case (spacetraders PR #38): the plugin arms its watch tripwires in the fleet surface's `start`; deleting `watches.arm_all()` left the full register-smoke suite green because the smoke could never reach the callable.

## Fix
Capture the callables in `surface_specs` (keyed by effective name = `name or plugin_id`, mirroring the real `PluginRegistry`), keeping `surfaces` (names) for existing assertions. A smoke test can now grab and **call** `start` and assert the side effect. Mirror of #1637 (`register_chat_command`).

## Tests
- `test_fake_registry_captures_surface_lifecycle_callables` — asserts the captured triple and exercises `start()` (mutation-kills a plugin that forgets to wire it); unnamed surface reachable by plugin id.
- Existing signature-parity guard (`test_fake_registry_mirrors_the_full_plugin_registry_surface`) unaffected.

`ruff` clean; `tests/test_plugin_testkit.py` 13 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)