### PR TITLE
fix(checkpointer): retry a locked checkpoint write instead of dying (#1738)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *cleanly* with a clear "provider closed the stream — possible rate limit" log so a
   background scheduler can observe and reschedule, instead of an alarming unhandled-
   exception traceback.
+- **A locked checkpoint write no longer silently kills a background turn** (#1738).
+  WAL + the existing 5s `busy_timeout` absorb almost all contention on
+  `checkpoints.db`, but a writer holding the lock past the timeout (the incremental
+  pruner mid-VACUUM, or two background turns landing at once) surfaced a
+  `sqlite3.OperationalError: database is locked` that bubbled unhandled and lost the
+  whole turn's work — the worst failure class for an autonomous agent. Checkpoint
+  writes (`aput`/`aput_writes`) now retry a locked write a few times with short
+  exponential backoff before failing (a locked write commits nothing, so retry is
+  safe); every other error still propagates unchanged.
 
 ## [0.88.0] - 2026-07-03
 

--- a/graph/checkpointer.py
+++ b/graph/checkpointer.py
@@ -19,9 +19,46 @@ its own lock and ``check_same_thread=False``, which keeps the cross-thread
 from __future__ import annotations
 
 import asyncio
+import logging
 import sqlite3
+import time
 
 from langgraph.checkpoint.sqlite import SqliteSaver
+
+log = logging.getLogger(__name__)
+
+# WAL + a 5s busy_timeout absorb almost all checkpoint-write contention, but a
+# writer that holds the lock *past* the busy_timeout (e.g. the incremental pruner
+# mid-VACUUM, or two background turns landing at once) still surfaces a
+# ``database is locked`` OperationalError. That killed a whole background turn
+# mid-checkpoint (#1738) — the worst class of failure for an autonomous agent, a
+# silent loss of committed work. A locked write commits nothing, so a bounded
+# retry with short exponential backoff is safe and recovers the turn.
+_LOCK_WRITE_RETRIES = 3
+_LOCK_BACKOFF_S = 0.1
+
+
+def _retry_on_locked(fn, *args, **kwargs):
+    """Run a sync checkpointer write, retrying ``database is locked`` a few times
+    before giving up. Only that specific OperationalError is retried; every other
+    error (and the final locked attempt) propagates unchanged."""
+    delay = _LOCK_BACKOFF_S
+    for attempt in range(_LOCK_WRITE_RETRIES):
+        try:
+            return fn(*args, **kwargs)
+        except sqlite3.OperationalError as exc:
+            last = attempt == _LOCK_WRITE_RETRIES - 1
+            if "database is locked" not in str(exc).lower() or last:
+                raise
+            log.warning(
+                "checkpoint %s: database is locked, retry %d/%d in %.2fs",
+                getattr(fn, "__name__", fn),
+                attempt + 1,
+                _LOCK_WRITE_RETRIES - 1,
+                delay,
+            )
+            time.sleep(delay)
+            delay *= 2
 
 
 class ThreadedSqliteSaver(SqliteSaver):
@@ -32,10 +69,10 @@ class ThreadedSqliteSaver(SqliteSaver):
         return await asyncio.to_thread(self.get_tuple, config)
 
     async def aput(self, *args, **kwargs):
-        return await asyncio.to_thread(self.put, *args, **kwargs)
+        return await asyncio.to_thread(_retry_on_locked, self.put, *args, **kwargs)
 
     async def aput_writes(self, *args, **kwargs):
-        return await asyncio.to_thread(self.put_writes, *args, **kwargs)
+        return await asyncio.to_thread(_retry_on_locked, self.put_writes, *args, **kwargs)
 
     async def alist(self, *args, **kwargs):
         # The base `list` is a sync generator; materialize it off-thread, then

--- a/tests/test_checkpointer.py
+++ b/tests/test_checkpointer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
@@ -73,3 +74,52 @@ async def test_threaded_saver_async_methods_work(tmp_path):
     saver = build_sqlite_checkpointer(str(tmp_path / "c.db"))
     # No checkpoint yet for this thread → aget_tuple returns None, doesn't raise.
     assert await saver.aget_tuple({"configurable": {"thread_id": "none"}}) is None
+
+
+# --- #1738: a checkpoint write that hits "database is locked" retries, not dies ---
+
+
+def test_retry_on_locked_recovers_transient_lock(monkeypatch):
+    import graph.checkpointer as ckpt
+
+    monkeypatch.setattr(ckpt.time, "sleep", lambda _s: None)  # no real backoff in tests
+    calls = {"n": 0}
+
+    def flaky(x):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise sqlite3.OperationalError("database is locked")
+        return x
+
+    assert ckpt._retry_on_locked(flaky, "ok") == "ok"
+    assert calls["n"] == 3  # two locked attempts, then success — the turn survives
+
+
+def test_retry_on_locked_gives_up_after_bounded_retries(monkeypatch):
+    import graph.checkpointer as ckpt
+
+    monkeypatch.setattr(ckpt.time, "sleep", lambda _s: None)
+    calls = {"n": 0}
+
+    def always_locked(*_a):
+        calls["n"] += 1
+        raise sqlite3.OperationalError("database is locked")
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        ckpt._retry_on_locked(always_locked)
+    assert calls["n"] == ckpt._LOCK_WRITE_RETRIES  # bounded — no infinite retry loop
+
+
+def test_retry_on_locked_does_not_retry_other_errors(monkeypatch):
+    import graph.checkpointer as ckpt
+
+    monkeypatch.setattr(ckpt.time, "sleep", lambda _s: None)
+    calls = {"n": 0}
+
+    def other(*_a):
+        calls["n"] += 1
+        raise sqlite3.OperationalError("no such table: checkpoints")
+
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        ckpt._retry_on_locked(other)
+    assert calls["n"] == 1  # a non-lock error propagates immediately


### PR DESCRIPTION
Closes #1738.

## Observed (protoTrader, app server 0.87.0)
A background turn died with an unhandled server-level exception:

```
ERROR protoagent.server [a2a-stream] unhandled exception for session=system:activity: database is locked
  graph/checkpointer.py:35 aput → langgraph/checkpoint/sqlite put
sqlite3.OperationalError: database is locked
```

The turn's checkpoint `put` raised, the whole turn died, and its work was lost — same silent-work-loss class as #1728, different root.

## Re-scope note
The issue's first suggestion — *set a `busy_timeout`* — **is already in the code** (`PRAGMA busy_timeout=5000`, added in #322 and present in 0.87.0). So a writer held the lock **past 5s** (the incremental pruner mid-VACUUM, or two background turns landing at once). The actionable delta is the **retry**.

## Fix
Wrap the checkpointer writes (`put` / `put_writes`, via `_retry_on_locked`) in a bounded retry (3 attempts, 0.1s→0.2s backoff) before failing. A locked write commits nothing, so retrying a fresh write is safe. Reads are untouched (WAL doesn't block them). Only `database is locked` is retried — every other `OperationalError` (and the final attempt) propagates unchanged, so genuine problems still surface.

## Tests
- transient lock (locked twice, then succeeds) → recovers, turn survives
- persistent lock → gives up after `_LOCK_WRITE_RETRIES` (bounded, no infinite loop)
- a non-lock `OperationalError` (`no such table`) → propagates immediately, not retried

`ruff` clean; `tests/test_checkpointer.py` 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)