### PR TITLE
fix(chat): reconnect a dropped provider stream instead of killing the turn (#1728)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`plugin id 'google' is a built-in — cannot install over it`). A directory now
   counts as built-in only if it actually holds a `protoagent.plugin.yaml` or
   `protoagent.bundle.yaml`, matching how the loader decides a dir is a plugin.
+- **A dropped provider stream reconnects instead of killing the turn** (#1728). A
+  mid-read `httpcore.ReadError` / `httpx.TransportError` — what a rate-limited or flaky
+  gateway raises when it terminates the SSE response — bubbled unhandled through the
+  A2A stream handler and silently lost a whole background turn's work, despite
+  `model.max_retries` (which only covers request *start*, not a mid-body read). The
+  model stream now reconnects when it drops **before emitting any content** (the
+  rate-limit case), within the configured `max_retries` budget — model-call only, no
+  tool replay, and no reconnect once a token has streamed (which would duplicate it).
+  If reconnects are exhausted (or content already streamed), the turn now fails
+  *cleanly* with a clear "provider closed the stream — possible rate limit" log so a
+  background scheduler can observe and reschedule, instead of an alarming unhandled-
+  exception traceback.
 
 ## [0.88.0] - 2026-07-03
 

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -4,10 +4,13 @@ All models route through the LiteLLM gateway (OpenAI-compatible),
 so we use ChatOpenAI for everything.
 """
 
+import asyncio
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 
+import httpcore
+import httpx
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
 from graph.config import LangGraphConfig
@@ -16,6 +19,59 @@ log = logging.getLogger(__name__)
 
 # Same allowlisted UA the chat client uses (Cloudflare WAF blocks the SDK default).
 _GATEWAY_UA = "protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)"
+
+# A provider stream can drop mid-read — an `httpcore.ReadError` / `httpx.TransportError`
+# (or a read timeout) surfaces while iterating the SSE body. `ChatOpenAI(max_retries=…)`
+# retries the request *start*, never a mid-body read, so a rate-limited or flaky gateway
+# that terminates the response kills the whole turn (#1728). These are the read/transport
+# failures we treat as retryable when the stream produced NOTHING yet.
+RETRYABLE_STREAM_ERRORS: tuple[type[BaseException], ...] = (
+    httpx.TransportError,  # httpx.ReadError / ConnectError / ReadTimeout / …
+    httpcore.NetworkError,  # httpcore.ReadError / WriteError / ConnectError (raw, unwrapped)
+    httpcore.TimeoutException,  # httpcore.ReadTimeout / ConnectTimeout
+)
+_STREAM_RETRY_BACKOFF_S = 0.5
+
+
+async def _stream_with_reconnect(
+    make_stream: Callable[[], AsyncIterator],
+    *,
+    max_retries: int,
+    backoff: float = _STREAM_RETRY_BACKOFF_S,
+    sleep: Callable = asyncio.sleep,
+) -> AsyncIterator:
+    """Yield from a model stream, restarting it on a transport/read error that occurs
+    **before any item is emitted**.
+
+    Retrying is only safe with zero items emitted: each chunk fires its
+    ``on_llm_new_token`` callback as it's yielded, so once one has streamed a fresh
+    stream would duplicate it — there we re-raise. This reconnects the model call only;
+    it never replays tools or restarts the turn. A provider closing the stream at the
+    top (the rate-limit case in #1728) emits nothing, so it reconnects cleanly.
+    """
+    attempts = max(max_retries, 0) + 1
+    delay = backoff
+    for attempt in range(attempts):
+        emitted = 0
+        try:
+            async for item in make_stream():
+                emitted += 1
+                yield item
+            return
+        except RETRYABLE_STREAM_ERRORS as exc:
+            if emitted or attempt == attempts - 1:
+                raise
+            log.warning(
+                "model stream dropped before any content (%s: %s) — reconnecting, "
+                "attempt %d/%d in %.1fs (provider closed stream; possible rate limit)",
+                type(exc).__name__,
+                exc,
+                attempt + 1,
+                attempts - 1,
+                delay,
+            )
+            await sleep(delay)
+            delay *= 2
 
 
 class _ReasoningChatOpenAI(ChatOpenAI):
@@ -36,6 +92,19 @@ class _ReasoningChatOpenAI(ChatOpenAI):
             if reasoning:
                 gen.message.additional_kwargs["reasoning_content"] = reasoning
         return gen
+
+    async def _astream(self, *args, **kwargs):
+        """Reconnect a provider stream that drops before emitting any content (#1728).
+
+        Transparent pass-through on the happy path; on a mid-read transport error with
+        zero chunks yielded it reconnects (within the model's ``max_retries`` budget)
+        instead of letting the error kill the turn — the failure mode a rate-limited
+        gateway produces. Once a chunk has streamed, the error propagates unchanged."""
+        async for chunk in _stream_with_reconnect(
+            lambda: super(_ReasoningChatOpenAI, self)._astream(*args, **kwargs),
+            max_retries=self.max_retries or 0,
+        ):
+            yield chunk
 
 
 def _build_llm_kwargs(config: LangGraphConfig) -> dict:

--- a/server/chat.py
+++ b/server/chat.py
@@ -1309,12 +1309,29 @@ async def _chat_langgraph_stream(
             # tracing.py.
             raise
         except Exception as e:
-            log.exception(
-                "[a2a-stream] unhandled exception for session=%s: %s",
-                session_id,
-                e,
-            )
-            yield ("error", str(e))
+            from graph.llm import RETRYABLE_STREAM_ERRORS
+
+            if isinstance(e, RETRYABLE_STREAM_ERRORS):
+                # The provider dropped the stream and the per-call reconnects
+                # (graph.llm._astream) were exhausted, or content had already
+                # streamed. That's a clean terminal outcome — most likely account
+                # rate limiting — not a code bug, so log it as such (a background
+                # scheduler can observe the failed turn and reschedule). #1728.
+                log.warning(
+                    "[a2a-stream] provider closed the stream for session=%s (%s: %s) — "
+                    "possible rate limit; failing the turn cleanly",
+                    session_id,
+                    type(e).__name__,
+                    e,
+                )
+                yield ("error", "The model provider closed the stream (possibly rate-limited). Please retry.")
+            else:
+                log.exception(
+                    "[a2a-stream] unhandled exception for session=%s: %s",
+                    session_id,
+                    e,
+                )
+                yield ("error", str(e))
         finally:
             tracing.flush()
 
@@ -1599,6 +1616,21 @@ async def _chat_langgraph(
 
             return [{"role": "assistant", "content": response}]
         except Exception as e:
+            from graph.llm import RETRYABLE_STREAM_ERRORS
+
+            if isinstance(e, RETRYABLE_STREAM_ERRORS):
+                log.warning(
+                    "[chat] provider closed the stream for session=%s (%s: %s) — possible rate limit",
+                    session_id,
+                    type(e).__name__,
+                    e,
+                )
+                return [
+                    {
+                        "role": "assistant",
+                        "content": "**Error:** the model provider closed the stream (possibly rate-limited). Please retry.",
+                    }
+                ]
             log.exception(
                 "[chat] unhandled exception for session=%s: %s",
                 session_id,

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,7 +1,10 @@
 """Tests for LLM kwargs assembly — sampling params + extra_body wiring."""
 
+import httpcore
+import pytest
+
 from graph.config import LangGraphConfig
-from graph.llm import _build_llm_kwargs
+from graph.llm import _build_llm_kwargs, _stream_with_reconnect
 
 
 def test_defaults_omit_optional_sampling_params():
@@ -135,3 +138,74 @@ def test_create_llm_routes_acp_model_name_to_acp_aux(monkeypatch):
     monkeypatch.setattr(AR, "make_acp_aux_model", _fake)
     out = create_llm(LangGraphConfig(), model_name="acp:claude")
     assert out is sentinel and captured["agent"] == "claude"
+
+
+# --- #1728: reconnect a provider stream that drops before emitting any content ---
+
+
+async def _nosleep(_delay):
+    return None
+
+
+def _scripted_stream(script):
+    """Build a `make_stream` whose Nth call replays script[N] = (items, exc_or_None):
+    yield each item, then raise `exc` if given. Returns (make_stream, state) so a test
+    can assert how many times the stream was (re)opened."""
+    state = {"opens": 0}
+
+    def make_stream():
+        idx = state["opens"]
+        state["opens"] += 1
+        items, exc = script[idx]
+
+        async def gen():
+            for it in items:
+                yield it
+            if exc is not None:
+                raise exc
+
+        return gen()
+
+    return make_stream, state
+
+
+async def test_stream_reconnect_happy_path_is_transparent():
+    make, state = _scripted_stream([(["a", "b", "c"], None)])
+    out = [x async for x in _stream_with_reconnect(make, max_retries=2, sleep=_nosleep)]
+    assert out == ["a", "b", "c"]
+    assert state["opens"] == 1  # no reconnect on a clean stream
+
+
+async def test_stream_reconnect_recovers_when_nothing_emitted():
+    # Provider closed the stream at the top (rate-limit case) — zero chunks, safe to retry.
+    make, state = _scripted_stream([([], httpcore.ReadError()), (["x", "y"], None)])
+    out = [x async for x in _stream_with_reconnect(make, max_retries=2, sleep=_nosleep)]
+    assert out == ["x", "y"]
+    assert state["opens"] == 2  # reconnected once
+
+
+async def test_stream_reconnect_does_not_retry_after_a_token_streamed():
+    # A drop AFTER a token would duplicate it on a fresh stream — must propagate.
+    make, state = _scripted_stream([(["a"], httpcore.ReadError())])
+    got = []
+    with pytest.raises(httpcore.ReadError):
+        async for x in _stream_with_reconnect(make, max_retries=2, sleep=_nosleep):
+            got.append(x)
+    assert got == ["a"]
+    assert state["opens"] == 1  # no reconnect once content emitted
+
+
+async def test_stream_reconnect_is_bounded_by_max_retries():
+    make, state = _scripted_stream([([], httpcore.ReadError())] * 3)  # attempts = 2 + 1
+    with pytest.raises(httpcore.ReadError):
+        async for _ in _stream_with_reconnect(make, max_retries=2, sleep=_nosleep):
+            pass
+    assert state["opens"] == 3  # bounded — no infinite reconnect loop
+
+
+async def test_stream_reconnect_propagates_non_transport_errors():
+    make, state = _scripted_stream([([], ValueError("boom"))])
+    with pytest.raises(ValueError, match="boom"):
+        async for _ in _stream_with_reconnect(make, max_retries=2, sleep=_nosleep):
+            pass
+    assert state["opens"] == 1  # a non-transport error is never retried


### PR DESCRIPTION
Closes #1728. **Draft — touches the core model-stream path; please review + let the A2A live-smoke run before merge.**

## Problem
A mid-read `httpcore.ReadError` / `httpx.TransportError` (the gateway terminating the SSE response — the issue's comments reattribute it to **account rate limiting**, i.e. a first-class operating condition for an always-on host) bubbled unhandled through `_chat_langgraph_stream` and **silently lost a whole background turn's work**. `model.max_retries` doesn't help: langchain retries request *start*, not a mid-body read. Observed 3× in ~9h on protoTrader.

## Why the fix is at the model-stream layer (not a turn retry)
- Retrying the **whole turn** would replay already-executed tools and risks double-appending the input via checkpoint replay — unsafe.
- Retrying **mid-content** would duplicate tokens (each chunk already fired its `on_llm_new_token` callback).
- The only safe reconnect is **before any chunk is emitted** — which is exactly the rate-limit case (provider closes the stream at the top). That reconnects transparently.

## Change
- `graph/llm.py`: `_stream_with_reconnect(make_stream, max_retries, …)` helper + a thin `_ReasoningChatOpenAI._astream` override that wraps `super()._astream`. Reconnects only with **zero chunks emitted**, within `max_retries`, exponential backoff; re-raises once content has streamed or retries exhaust. `RETRYABLE_STREAM_ERRORS` = httpx transport + raw httpcore network/timeout errors.
- `server/chat.py`: both the a2a-stream and `/api` chat handlers now classify a provider stream-drop — a clear `WARNING` ("provider closed the stream — possible rate limit") + clean terminal turn, instead of `log.exception("unhandled exception")`.

## Tests (control flow, fully isolated from langchain)
`tests/test_llm.py`: happy-path transparent; recovers when nothing emitted; **does not** retry after a token streamed; bounded by `max_retries`; non-transport errors propagate. 17 passed; `ruff` + `lint-imports` clean.

## Reviewer notes
- The happy path is a transparent pass-through; risk is confined to the transport-error branch.
- CI's **A2A live smoke (lean tier)** exercises the real streaming path end-to-end — please confirm it's green before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)