### PR TITLE
feat(coder): solve() can run one forced rung, for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regardless. A plugin pinned to a commit SHA is never auto-updated, and only
   plugins explicitly listed in the policy are ever touched — the default is
   unchanged manual-only updates. See the [plugins guide](docs/guides/plugins.md).
+- **`coder.solve()` can run one forced rung, for testing** (ADR 0064). Verifying
+  fusion (rung 4) actually works required contriving a task hard enough to fail
+  greedy, best-of-k, *and* tree-search first — impractical for a quick check. A new
+  `force_rung` param runs exactly one named rung once — no cascade, no escalation —
+  and reports pass/fail against the real verifier. Deliberately NOT exposed on the
+  agent-facing `coder_solve` tool (it's an operator/testing affordance, same
+  boundary as `board_create_feature` vs. the operator-only `/features/{id}/cancel`
+  route); `projectBoard-plugin` wires it behind a new, non-tool API route.
 
 ### Fixed
 - **Plugin smoke tests can assert surface lifecycle wiring** (#1729). The testkit's

--- a/plugins/coder/protoagent.plugin.yaml
+++ b/plugins/coder/protoagent.plugin.yaml
@@ -1,6 +1,6 @@
 id: coder
 name: Coder (execution-grounded code-solve)
-version: 0.1.0
+version: 0.2.0
 description: >-
   Execution-grounded code-solve (ADR 0064) — the verifier-grounded coder for
   VERIFIABLE coding tasks. Contributes a `coder_solve` tool + a `coder` subagent

--- a/plugins/coder/solve.py
+++ b/plugins/coder/solve.py
@@ -23,6 +23,15 @@ subprocess test runner / worktree) and call this same engine.
 The gate is **test pass/fail**, never an LLM judge — that judge-of-code ceiling
 is exactly what this escapes. With no verifier (no tests), the ladder degrades to
 **greedy** and says so; it never silently falls back to best-of-k-with-a-judge.
+
+``force_rung`` (an operator/testing affordance, not something the ladder ever sets
+itself): run exactly ONE named rung once — no cheaper-rung-first cascade, no
+escalation past it — and report pass/fail. Verifying a specific rung (especially
+fusion, only otherwise reached after three cheaper rungs fail) shouldn't require
+contriving a task hard enough to fail its way there. A forced ``tree-search`` seeds
+one un-refined attempt first (purely to generate the failing-test feedback the
+refine step needs) — that seed itself isn't scored as the rung's result unless it
+happens to pass outright.
 """
 
 from __future__ import annotations
@@ -92,6 +101,9 @@ class Budget:
         return self.remaining >= n
 
 
+FORCEABLE_RUNGS = ("greedy", "best-of-k", "tree-search", "fusion")
+
+
 async def solve(
     task: str,
     *,
@@ -102,12 +114,37 @@ async def solve(
     tree_depth: int = 2,
     fusion_generate: Optional[Generate] = None,
     fusion_k: int = 2,
+    force_rung: Optional[str] = None,
 ) -> SolveResult:
     """Run the execution-grounded ladder. See module docstring.
 
     ``verify=None`` (no oracle) ⇒ greedy 1-shot, returned with ``passed=None`` and
     a scope note — never an un-grounded best-of-k.
+
+    ``force_rung`` bypasses the whole cascade — see the module docstring. Raises
+    ``ValueError`` for an unknown rung name or ``force_rung="fusion"`` with no
+    ``fusion_generate`` configured (a misconfigured test, not a runtime outcome to
+    report as a ``SolveResult``).
     """
+    if force_rung is not None:
+        if force_rung not in FORCEABLE_RUNGS:
+            raise ValueError(f"force_rung must be one of {FORCEABLE_RUNGS}, got {force_rung!r}")
+        if force_rung == "fusion" and fusion_generate is None:
+            raise ValueError("force_rung='fusion' requires fusion_generate to be configured")
+        if verify is None:
+            raise ValueError("force_rung requires a verifier — there's nothing to test a rung against otherwise")
+        return await _solve_forced_rung(
+            force_rung,
+            task,
+            generate=generate,
+            verify=verify,
+            budget=budget,
+            k=k,
+            tree_depth=tree_depth,
+            fusion_generate=fusion_generate,
+            fusion_k=fusion_k,
+        )
+
     tried = 0
 
     # ── No oracle: honest greedy degrade ──────────────────────────────────────
@@ -189,4 +226,104 @@ async def solve(
         tried,
         best_verdict,
         f"no candidate passed within budget; best partial has {best_verdict.failed}/{best_verdict.total} failing",
+    )
+
+
+async def _solve_forced_rung(
+    rung: str,
+    task: str,
+    *,
+    generate: Generate,
+    verify: Verify,
+    budget: Budget,
+    k: int,
+    tree_depth: int,
+    fusion_generate: Optional[Generate],
+    fusion_k: int,
+) -> SolveResult:
+    """Run exactly ONE rung, once, and stop — no cascade, no escalation past it.
+    Reports pass/fail against the real verifier; never used by the real ladder
+    path (``solve()`` only reaches here when the CALLER explicitly asked for one
+    rung, an operator/testing affordance — see the module docstring)."""
+    if rung == "greedy":
+        if not budget.can_afford(1):
+            return SolveResult(None, None, "none", budget.spent, 0, note="budget exhausted before any generation")
+        code = await generate(task, feedback=None)
+        budget.spend(1)
+        v = await verify(code)
+        note = "forced greedy (test) — passed" if v.passed else f"forced greedy (test) — {v.failed}/{v.total} failing"
+        return SolveResult(code, v.passed, "greedy", budget.spent, 1, v, note)
+
+    if rung == "best-of-k":
+        n = min(k, budget.remaining)
+        if n <= 0:
+            return SolveResult(None, None, "none", budget.spent, 0, note="budget exhausted before any generation")
+        cands = await asyncio.gather(*(generate(task, feedback=None) for _ in range(n)))
+        budget.spend(n)
+        verdicts = await asyncio.gather(*(verify(c) for c in cands))
+        best, best_v = cands[0], verdicts[0]
+        for c, v in zip(cands, verdicts):
+            if v.passed:
+                return SolveResult(c, True, "best-of-k", budget.spent, n, v, f"forced best-of-{n} (test) — passed")
+            if v.failed < best_v.failed:
+                best, best_v = c, v
+        return SolveResult(
+            best, False, "best-of-k", budget.spent, n, best_v, f"forced best-of-{n} (test) — no candidate passed"
+        )
+
+    if rung == "tree-search":
+        if not budget.can_afford(1):
+            return SolveResult(None, None, "none", budget.spent, 0, note="budget exhausted before any generation")
+        seed = await generate(task, feedback=None)
+        budget.spend(1)
+        tried = 1
+        best, best_v = seed, await verify(seed)
+        if best_v.passed:
+            return SolveResult(
+                seed,
+                True,
+                "tree-search",
+                budget.spent,
+                tried,
+                best_v,
+                "forced tree-search (test) — seed passed before any refine",
+            )
+        for depth in range(tree_depth):
+            if not budget.can_afford(1):
+                break
+            refined = await generate(task, feedback=best_v.feedback())
+            budget.spend(1)
+            tried += 1
+            v = await verify(refined)
+            if v.passed:
+                return SolveResult(
+                    refined,
+                    True,
+                    "tree-search",
+                    budget.spent,
+                    tried,
+                    v,
+                    f"forced tree-search (test) — solved by refine@{depth + 1}",
+                )
+            if v.failed <= best_v.failed:
+                best, best_v = refined, v
+        return SolveResult(
+            best, False, "tree-search", budget.spent, tried, best_v, "forced tree-search (test) — no refinement passed"
+        )
+
+    # rung == "fusion" (validated by the caller; fusion_generate is guaranteed non-None)
+    fk = min(fusion_k, budget.remaining)
+    if fk <= 0:
+        return SolveResult(None, None, "none", budget.spent, 0, note="budget exhausted before any generation")
+    cands = await asyncio.gather(*(fusion_generate(task, feedback=None) for _ in range(fk)))
+    budget.spend(fk)
+    verdicts = await asyncio.gather(*(verify(c) for c in cands))
+    best, best_v = cands[0], verdicts[0]
+    for c, v in zip(cands, verdicts):
+        if v.passed:
+            return SolveResult(c, True, "fusion", budget.spent, fk, v, f"forced fusion (test, k={fk}) — passed")
+        if v.failed < best_v.failed:
+            best, best_v = c, v
+    return SolveResult(
+        best, False, "fusion", budget.spent, fk, best_v, f"forced fusion (test, k={fk}) — no candidate passed"
     )

--- a/tests/test_coder_plugin.py
+++ b/tests/test_coder_plugin.py
@@ -6,6 +6,8 @@ model, no subprocess), the real subprocess pytest verifier, and code extraction.
 
 from __future__ import annotations
 
+import pytest
+
 from plugins.coder.generate import extract_code
 from plugins.coder.solve import Budget, Verdict, solve
 from plugins.coder.verify import _parse, run_tests
@@ -105,9 +107,94 @@ async def test_fusion_not_invoked_when_cheaper_rung_solves():
         fcalls["n"] += 1
         return "good"
 
-    res = await solve("t", generate=gen, verify=_verify_passes_on("good"), budget=Budget(12), fusion_generate=fusion_gen)
+    res = await solve(
+        "t", generate=gen, verify=_verify_passes_on("good"), budget=Budget(12), fusion_generate=fusion_gen
+    )
     assert res.rung == "greedy"
     assert fcalls["n"] == 0  # fusion never paid for
+
+
+# ── force_rung: an operator/testing affordance, never used by the real ladder ────
+
+
+async def test_force_rung_greedy_reports_pass_without_escalating():
+    gen, calls = _gen_sequence(["good"])
+    res = await solve("t", generate=gen, verify=_verify_passes_on("good"), budget=Budget(6), force_rung="greedy")
+    assert res.passed is True and res.rung == "greedy"
+    assert calls["n"] == 1
+
+
+async def test_force_rung_greedy_reports_fail_without_escalating():
+    """A forced rung STOPS after that one rung — even though best-of-k would have
+    solved it (see test_escalates_to_best_of_k), forcing greedy never gets there."""
+    gen, calls = _gen_sequence(["bad", "good"])
+    res = await solve("t", generate=gen, verify=_verify_passes_on("good"), budget=Budget(6), k=3, force_rung="greedy")
+    assert res.passed is False and res.rung == "greedy"
+    assert calls["n"] == 1  # never escalated to best-of-k, even though gen[1] would pass
+
+
+async def test_force_rung_best_of_k_generates_k_fresh_candidates():
+    gen, calls = _gen_sequence(["bad", "bad", "good"])
+    res = await solve(
+        "t", generate=gen, verify=_verify_passes_on("good"), budget=Budget(6), k=3, force_rung="best-of-k"
+    )
+    assert res.passed is True and res.rung == "best-of-k"
+    assert calls["n"] == 3  # k candidates generated fresh — no greedy pre-spend to reuse
+
+
+async def test_force_rung_tree_search_seeds_then_refines_on_failure():
+    # seed "bad" fails; refine round 1 returns "good".
+    gen, calls = _gen_sequence(["bad", "good"])
+    res = await solve(
+        "t", generate=gen, verify=_verify_passes_on("good"), budget=Budget(6), tree_depth=2, force_rung="tree-search"
+    )
+    assert res.passed is True and res.rung == "tree-search"
+    assert calls["feedbacks"][-1] is not None and "failing" in calls["feedbacks"][-1]
+
+
+async def test_force_rung_tree_search_seed_can_pass_outright():
+    gen, calls = _gen_sequence(["good"])
+    res = await solve("t", generate=gen, verify=_verify_passes_on("good"), budget=Budget(6), force_rung="tree-search")
+    assert res.passed is True and res.rung == "tree-search"
+    assert calls["n"] == 1  # solved on the seed — no refine round needed
+
+
+async def test_force_rung_fusion_generates_fresh_no_prior_feedback():
+    gen, gcalls = _gen_sequence(["irrelevant"])  # the base generator is never touched
+
+    async def fusion_gen(task, *, feedback=None):
+        assert feedback is None  # no prior attempt in an isolated forced-fusion test
+        return "good"
+
+    res = await solve(
+        "t",
+        generate=gen,
+        verify=_verify_passes_on("good"),
+        budget=Budget(6),
+        fusion_generate=fusion_gen,
+        fusion_k=2,
+        force_rung="fusion",
+    )
+    assert res.passed is True and res.rung == "fusion"
+    assert gcalls["n"] == 0  # the ACP generator was never called — fusion only
+
+
+async def test_force_rung_fusion_without_a_fusion_generate_raises():
+    gen, _ = _gen_sequence(["x"])
+    with pytest.raises(ValueError, match="fusion_generate"):
+        await solve("t", generate=gen, verify=_verify_passes_on("good"), budget=Budget(6), force_rung="fusion")
+
+
+async def test_force_rung_unknown_name_raises():
+    gen, _ = _gen_sequence(["x"])
+    with pytest.raises(ValueError, match="force_rung"):
+        await solve("t", generate=gen, verify=_verify_passes_on("good"), budget=Budget(6), force_rung="nonsense")
+
+
+async def test_force_rung_requires_a_verifier():
+    gen, _ = _gen_sequence(["x"])
+    with pytest.raises(ValueError, match="verifier"):
+        await solve("t", generate=gen, verify=None, budget=Budget(6), force_rung="greedy")
 
 
 async def test_no_oracle_degrades_to_greedy():


### PR DESCRIPTION
## Problem

Verifying fusion (rung 4) actually works required contriving a task hard enough to fail greedy, best-of-k, **and** tree-search first before fusion is even reached — impractical for a quick sanity check. Live-caught while dogfooding the board seam (projectBoard-plugin#64): we shipped the fusion rung but had no fast way to confirm it actually fires and works.

## Fix

Add a `force_rung` param to `solve()`: run exactly **one** named rung once — no cheaper-rung-first cascade, no escalation past it — and report pass/fail against the real verifier.

- A forced `tree-search` seeds one un-refined attempt first (purely to generate the failing-test feedback the refine step needs) — that seed isn't scored as the result unless it happens to pass outright.
- Raises `ValueError` for an unknown rung name, or `force_rung="fusion"` with no `fusion_generate` configured — a misconfigured test, not a runtime outcome to silently report.

## Where this does NOT go

Deliberately kept **off** the agent-facing `coder_solve` tool's signature — this is an operator/testing affordance, not something the ladder (or an agent) should reach for on its own. Same boundary this codebase already draws elsewhere: `board_create_feature` is an agent tool; `/features/{id}/cancel` isn't. A companion PR in `projectBoard-plugin` wires `force_rung` behind a new, non-tool API route (`POST /features/{id}/test-rung`) — an operator can trigger it, the board's own lead agent has no tool to.

## Tests

24 passed in `test_coder_plugin.py` (was 15; +9 new — force-greedy pass/fail without escalating, forced best-of-k generates k fresh candidates, forced tree-search seeds-then-refines (and can pass on the seed alone), forced fusion with no prior feedback, and the three `ValueError` guards).

Full suite: **2996 passed, 5 skipped** (pre-existing, unrelated). `lint-imports`: 3 contracts kept.

Coder plugin version bumped 0.1.0 → 0.2.0; `CHANGELOG.md` entry added under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)