### PR TITLE
feat(plugins): required-config gate — plugins degrade gracefully when unconfigured (#1719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Plugins declare required config and degrade gracefully when it's missing**
+  (#1719). A plugin marks a setting `required: true` in its manifest to say it needs
+  that value (an API key, endpoint, …) to function. If an enabled plugin loads while
+  a required field is still blank, it now **stays loaded but is flagged `incomplete`**
+  — a soft gate, unlike `requires_env` which refuses to load. `GET /api/runtime/status`
+  and `/api/plugins/installed` carry `incomplete: true` + `needs_config: [{key, label}]`
+  (so the console can show a ⚠️ "needs setup" cue), and the plugin's **tools are swapped
+  for same-signature stand-ins that return a friendly "needs setup" notice** instead of
+  erroring mid-call — so the agent can point the operator at configuration. Filling the
+  field in and reloading restores the real tools. This is the backend foundation for the
+  guided install wizard (the frontend follow-up); `0`/`false` count as provided, only
+  `null`/empty-string/empty-collection read as unset.
 - **Opt-in plugin auto-update policy** (#1720). Plugins were update-only-on-demand:
   an operator had to click **Update** in the console for each behind plugin. A new
   `plugins.update_policy` config map opts individual plugins into background

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -426,6 +426,22 @@ settings:
       depends_on: { key: ask_enabled, equals: true } }   # also: { key, in: [...] } | bare { key } = truthy
 ```
 
+**Required config & incomplete plugins (#1719):** mark a setting `required: true`
+to declare the plugin needs it to work. If an enabled plugin loads while a required
+field is still blank, it **stays loaded but is flagged `incomplete`** — a soft gate,
+not `requires_env` (which refuses to load). `GET /api/runtime/status` and
+`/api/plugins/installed` then carry `incomplete: true` + `needs_config: [{key, label}]`,
+and the plugin's **tools are swapped for same-signature stand-ins that return a
+friendly "needs setup" notice** instead of erroring mid-call — so the agent can point
+the operator at configuration. Fill the field in; the next config reload restores the
+real tools. (`0` / `false` count as provided — only `null` / empty-string / empty-list
+read as "unset".)
+
+```yaml
+settings:
+  - { key: api_key, label: "API key", type: secret, required: true }
+```
+
 Read the resolved config (manifest defaults ⊕ YAML ⊕ secrets) in `register()`:
 
 ```python
@@ -437,8 +453,9 @@ def register(registry):
 A plugin section colliding with a reserved built-in (`model`, `mcp`, `plugins`,
 …) is ignored. (A plugin section like `discord` is **not** reserved — a plugin,
 bundled or external, claims its own section the same way.)
-The **wizard step** is not yet plugin-contributable (Settings + a docs link
-suffice for now).
+A plugin declares its required config with `required: true` (above) and the console
+surfaces the **incomplete** state so an operator knows to finish setup; a guided
+install **wizard** over those fields is the frontend follow-up (#1719).
 
 **Routes + surfaces are wired once at process init and don't hot-reload** — a
 config reload reuses them, so changing `plugins.enabled` needs a restart

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -307,6 +307,70 @@ def _sweep_plugin_jobs(plugin_id: str) -> None:
         log.info("[plugins] %s is disabled — cancelled %d scheduled job(s) it owned", plugin_id, cancelled)
 
 
+# ── Required-config / incomplete-plugin gate (#1719) ─────────────────────────
+# A plugin marks a setting `required: true` (a `settings[]` field spec) to say "I
+# need this to function". If the resolved config leaves a required field blank, the
+# plugin still LOADS but is flagged `incomplete`, and its tools are swapped for a
+# same-signature stand-in that returns a friendly "needs setup" notice instead of
+# erroring cryptically. Enable/disable stays whole-plugin; this is a soft gate.
+
+
+def _is_blank(value: object) -> bool:
+    """A config value that counts as 'not provided' — ``None``, an empty/whitespace
+    string, or an empty collection. ``0``/``False`` are real values, not blank."""
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    if isinstance(value, (list, tuple, set, dict)):
+        return len(value) == 0
+    return False
+
+
+def _missing_required_config(manifest: PluginManifest, resolved: dict) -> list[dict]:
+    """Required settings (``settings[].required``) left blank in the resolved config.
+    Returns ``[{key, label}]`` — empty ⇒ the plugin has everything it declared it needs.
+    Secrets resolve into ``resolved`` too (unset ⇒ ``""``), so this covers API keys."""
+    out: list[dict] = []
+    for spec in manifest.settings:
+        if not (isinstance(spec, dict) and spec.get("required")):
+            continue
+        key = str(spec.get("key") or "").strip()
+        if not key:
+            continue
+        if _is_blank(resolved.get(key)):
+            out.append({"key": key, "label": str(spec.get("label") or key)})
+    return out
+
+
+def _needs_config_tool(orig, plugin_name: str, needs: list[dict]):
+    """Same-signature stand-in for a tool whose plugin is missing required config —
+    the model sees the same name/description/args but the call returns a friendly
+    'needs setup' notice, so the agent can point the operator at configuration instead
+    of surfacing a cryptic KeyError/None-credential failure (#1719)."""
+    from langchain_core.tools import StructuredTool
+
+    fields = ", ".join(n["label"] for n in needs) or "required config"
+    msg = (
+        f"⚠️ The {plugin_name} plugin needs setup before this tool works — "
+        f"missing: {fields}. Ask the operator to complete it in the plugin's settings."
+    )
+
+    def _blocked(*_args, **_kwargs) -> str:
+        return msg
+
+    async def _ablocked(*_args, **_kwargs) -> str:
+        return msg
+
+    return StructuredTool(
+        name=orig.name,
+        description=orig.description,
+        args_schema=orig.args_schema,
+        func=_blocked,
+        coroutine=_ablocked,
+    )
+
+
 def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLoadResult:
     """Load enabled plugins and collect their contributions.
 
@@ -336,6 +400,11 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
             # aren't optional add-ons) — the flag rides along in /api/runtime/status.
             "builtin": manifest.builtin,
             "loaded": False,
+            # Required-config gate (#1719) — set True + populated below when an enabled
+            # plugin loads but a `required: true` setting is blank. Present on every
+            # entry so consumers can rely on the shape.
+            "incomplete": False,
+            "needs_config": [],
             "tools": [],
             "skills": 0,
             # Console surfaces (ADR 0026) — the rail reads these from /api/runtime/status. Views
@@ -402,13 +471,27 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
             result.meta.append(entry)
             continue
 
+        # Required-config gate (#1719) — the plugin loaded, but if it declared
+        # required settings that are still blank, flag it incomplete and swap its
+        # tools for needs-setup stand-ins (below) so a misconfigured plugin degrades
+        # gracefully instead of erroring mid-call.
+        needs_config = _missing_required_config(manifest, pconf)
+        if needs_config:
+            entry["incomplete"] = True
+            entry["needs_config"] = needs_config
+            log.warning(
+                "[plugins] %s loaded but missing required config (%s) — its tools return a needs-setup notice",
+                manifest.id,
+                ", ".join(n["key"] for n in needs_config),
+            )
+
         kept = []
         for tool in registry.tools:
             if tool.name in seen_tool_names:
                 log.warning("[plugins] %s: tool %s collides with an existing tool — skipped", manifest.id, tool.name)
                 continue
             seen_tool_names.add(tool.name)
-            kept.append(tool)
+            kept.append(_needs_config_tool(tool, manifest.name or manifest.id, needs_config) if needs_config else tool)
 
         result.tools.extend(kept)
         # Attribute each kept tool to this plugin (display name, id fallback) for the Tools tab.

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -106,12 +106,18 @@ def register_plugin_routes(app) -> None:
 
     @app.get("/api/plugins/installed")
     async def _installed():
-        # enabled state comes from the loader's per-plugin meta (id → enabled)
-        enabled = {p["id"]: bool(p.get("enabled")) for p in (STATE.plugin_meta or [])}
+        # enabled + incomplete state come from the loader's per-plugin meta (#1719)
+        meta_by_id = {p["id"]: p for p in (STATE.plugin_meta or [])}
         root = installer.live_plugins_dir()
         out = []
         for e in installer.list_installed():
-            item = {**e, "enabled": enabled.get(e["id"], False)}
+            mt = meta_by_id.get(e["id"], {})
+            item = {
+                **e,
+                "enabled": bool(mt.get("enabled")),
+                "incomplete": bool(mt.get("incomplete")),
+                "needs_config": list(mt.get("needs_config") or []),
+            }
             m = load_manifest(root / e["id"]) if e.get("present") else None
             if m is not None:
                 item["manifest"] = {

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -176,6 +176,73 @@ def test_emits_schemas_flow_to_runtime_status(tmp_path, monkeypatch) -> None:
     assert by_id["evp"]["emits_schemas"] == meta["evp"]["emits_schemas"]
 
 
+# ── Required-config / incomplete-plugin gate (#1719) ─────────────────────────
+
+_REQUIRED_SETTINGS = (
+    "settings:\n"
+    "  - {key: api_key, label: API Key, type: password, required: true}\n"
+    "  - {key: base_url, label: Base URL, type: text}\n"  # optional
+)
+
+
+def test_is_blank_semantics() -> None:
+    from graph.plugins.loader import _is_blank
+
+    assert _is_blank(None) and _is_blank("") and _is_blank("   ") and _is_blank([]) and _is_blank({})
+    # 0 / False are real values, not "unset".
+    assert not _is_blank("x") and not _is_blank(0) and not _is_blank(False) and not _is_blank(["a"])
+
+
+async def test_missing_required_config_flags_incomplete_and_guards_tools(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "plugins"
+    _make_plugin(root, "needy", enabled=True, tool="needy_tool", manifest_extra=_REQUIRED_SETTINGS)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+
+    res = load_plugins(_cfg())  # no plugin_config → api_key blank
+    meta = {m["id"]: m for m in res.meta}
+    # The plugin still loads — this is a soft gate, not requires_env.
+    assert meta["needy"]["loaded"] is True
+    assert meta["needy"]["incomplete"] is True
+    assert [n["key"] for n in meta["needy"]["needs_config"]] == ["api_key"]  # only the REQUIRED one
+
+    # Its tool is swapped for a same-name stand-in that returns a needs-setup notice.
+    tool = next(t for t in res.tools if t.name == "needy_tool")
+    out = await tool.ainvoke({"x": "ignored"})
+    assert "needs setup" in out and "API Key" in out
+
+    # Pass-through to /api/runtime/status (verbatim plugins block).
+    from operator_api.runtime import build_runtime_status
+
+    status = build_runtime_status(config=None, setup_complete=True, graph_loaded=False, plugins=res.meta)
+    by_id = {p["id"]: p for p in status["plugins"]}
+    assert by_id["needy"]["incomplete"] is True and by_id["needy"]["needs_config"][0]["label"] == "API Key"
+
+
+async def test_required_config_present_runs_normally(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "plugins"
+    _make_plugin(root, "ready", enabled=True, tool="ready_tool", manifest_extra=_REQUIRED_SETTINGS)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+
+    res = load_plugins(_cfg(plugin_config={"ready": {"api_key": "sk-live"}}))
+    meta = {m["id"]: m for m in res.meta}
+    assert meta["ready"]["incomplete"] is False
+    assert meta["ready"]["needs_config"] == []
+    # The real tool is registered (echoes its arg), not the stand-in.
+    tool = next(t for t in res.tools if t.name == "ready_tool")
+    assert await tool.ainvoke({"x": "hi"}) == "hi"
+
+
+def test_blank_optional_config_does_not_flag_incomplete(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "plugins"
+    optional_only = "settings:\n  - {key: base_url, label: Base URL, type: text}\n"
+    _make_plugin(root, "opt", enabled=True, tool="opt_tool", manifest_extra=optional_only)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+
+    res = load_plugins(_cfg())  # base_url blank, but it isn't required
+    meta = {m["id"]: m for m in res.meta}
+    assert meta["opt"]["incomplete"] is False and meta["opt"]["needs_config"] == []
+
+
 def test_public_paths_namespace_scoped(tmp_path) -> None:
     # A plugin may declare auth-exempt paths only under its OWN namespace; anything
     # else (a core path, another plugin's path) is dropped by the parser.


### PR DESCRIPTION
Backend foundation for #1719 (archetype setup wizards). Auto-mergeable; the guided wizard UI is a separate frontend follow-up that reuses the #1701 composer-form component.

## Problem

A plugin that needs an API key / endpoint to work has no way to *declare* that. Today it either loads and **fails cryptically mid-call**, or (for env vars only) refuses to load via `requires_env`. There's no soft "loaded but not set up yet" state — the thing the setup wizard needs to hang off.

## What

A plugin marks a setting **`required: true`** in its manifest to declare it needs that value to function:

```yaml
settings:
  - { key: api_key, label: "API key", type: secret, required: true }
```

- **No manifest-parse change** — `settings[]` already passes through verbatim, so `required` just rides along.
- The loader computes `needs_config` from the **resolved** config (manifest defaults ⊕ YAML ⊕ secrets — secrets resolve in too, so API keys are covered). If an enabled plugin loads with a required field blank, it **stays loaded but is flagged `incomplete`** + `needs_config: [{key, label}]`. A *soft* gate — unlike `requires_env`, which refuses to load.
- Its **tools are swapped for same-signature stand-ins** (`_needs_config_tool`) that return a friendly *"⚠️ The X plugin needs setup — missing: API key. Ask the operator to complete it in the plugin's settings."* instead of erroring — so the agent can point the operator at configuration. Fill the field in; the next config reload restores the real tools.
- Surfaced on **`GET /api/runtime/status`** (verbatim meta pass-through) and **`/api/plugins/installed`** (merged from meta) so the console can render a ⚠️ "needs setup" cue and, later, open the wizard.
- `0` / `false` count as provided; only `null` / empty-string / empty-collection read as unset (`_is_blank`).

Whole-plugin enable/disable stays the revocation primitive (consistent with [ADR 0071](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0071-plugin-permissions-trust-model.md)) — this changes tool *behavior* when unconfigured, not tool *availability*.

## Acceptance criteria (from the issue)

- [x] Plugin declares its required config fields (`required: true`)
- [x] Missing required config → plugin marked **incomplete** (not a hard failure)
- [x] Agent tools return a friendly *"needs setup"* error instead of a cryptic one
- [x] `incomplete` + `needs_config` surfaced in the API for the console ⚠️
- [ ] *Wizard UI + ⚠️ badge + "set up" flow* — frontend follow-up (reuses #1701 composer-form)

## Tests

`tests/test_plugins.py`: required-blank → incomplete + guarded tool returns the notice + runtime-status pass-through; required-present → tool runs normally; blank **optional** setting → not flagged; `_is_blank` semantics.

Full gate green locally: `ruff` clean, `lint-imports` clean (3 contracts kept), **3016 passed / 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins with missing required settings now stay loaded but are marked as incomplete.
  * Plugin tools show a clear “needs setup” response until the missing configuration is provided.

* **Bug Fixes**
  * Improved handling of required plugin fields so empty values are detected more consistently.

* **Documentation**
  * Updated plugin setup guidance to explain the new incomplete state, status API details, and guided setup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->