### PR TITLE
feat(web): plugin setup wizard — ⚠️ needs-setup badge + guided config (#1719)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Plugin setup: a "needs setup" cue + guided config for unconfigured plugins**
+  (#1719, console). Building on the required-config gate below, an **incomplete**
+  plugin (loaded but missing a `required: true` setting) now shows a ⚠️ **"needs
+  setup"** badge in the Plugins panel — hovering lists the missing fields — and its
+  row's action becomes a prominent **"Set up"** button instead of the gear icon.
+  "Set up" opens the plugin's config dialog with a **setup banner** naming the
+  fields it still needs; filling them in and saving reloads the plugin, which clears
+  the badge. Skippable — close the dialog and finish later from the same badge.
 - **Plugins declare required config and degrade gracefully when it's missing**
   (#1719). A plugin marks a setting `required: true` in its manifest to say it needs
   that value (an API key, endpoint, …) to function. If an enabled plugin loads while

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -92,6 +92,10 @@ export type RuntimeStatus = {
     tools: string[];
     skills: number;
     error?: string;
+    // Required-config gate (#1719): the plugin loaded but a `required: true` setting
+    // is still blank — its tools return a "needs setup" notice until it's configured.
+    incomplete?: boolean;
+    needs_config?: { key: string; label: string }[];
     // Console surfaces (ADR 0026): rail views the plugin contributes.
     views?: PluginView[];
   }[];
@@ -153,6 +157,10 @@ export type InstalledPlugin = {
   // still listed (and enabled/loaded normally); it just isn't update-tracked.
   tracked?: boolean;
   enabled: boolean;
+  // Required-config gate (#1719) — merged from the loader meta: true when the plugin
+  // loaded but a `required: true` setting is blank, with the fields still needed.
+  incomplete?: boolean;
+  needs_config?: { key: string; label: string }[];
   manifest?: {
     name: string;
     version: string;

--- a/apps/web/src/plugins/PluginSettingsDialog.tsx
+++ b/apps/web/src/plugins/PluginSettingsDialog.tsx
@@ -1,3 +1,4 @@
+import { Alert } from "@protolabsai/ui/data";
 import { Dialog } from "@protolabsai/ui/overlays";
 import { useQueryClient } from "@tanstack/react-query";
 import { Suspense, useEffect } from "react";
@@ -15,11 +16,16 @@ import { pluginSchemaNeedsRefetch } from "./settingsHydration";
 export function PluginSettingsDialog({
   pluginId,
   pluginName,
+  needsConfig,
   open,
   onClose,
 }: {
   pluginId: string;
   pluginName: string;
+  // Required-config gate (#1719) — when the plugin is INCOMPLETE, the fields it's
+  // missing; renders a setup hint above the form so the dialog reads as a wizard.
+  // Saving those fields reloads the plugin, which clears `incomplete` and the badge.
+  needsConfig?: { key: string; label: string }[];
   open: boolean;
   onClose: () => void;
 }) {
@@ -40,6 +46,13 @@ export function PluginSettingsDialog({
   if (!open) return null;
   return (
     <Dialog open onClose={onClose} title={pluginName} width="min(640px, 95vw)" className="plugin-settings-dialog">
+      {needsConfig && needsConfig.length ? (
+        <Alert status="warning" className="settings-banner">
+          <strong>Finish setup to activate this plugin.</strong>{" "}
+          {`Add the required config below — ${needsConfig.map((n) => n.label).join(", ")}. `}
+          Its tools return a “needs setup” notice until then; you can close this and complete it later.
+        </Alert>
+      ) : null}
       <Suspense fallback={<p className="muted">Loading settings…</p>}>
         <SettingsCategory category="Plugins" pluginId={pluginId} title="Configuration" />
       </Suspense>

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -1,6 +1,6 @@
 import "../settings/plugins.css";
 
-import { Button } from "@protolabsai/ui/primitives";
+import { Badge, Button } from "@protolabsai/ui/primitives";
 import { Alert } from "@protolabsai/ui/data";
 import { ConfirmDialog, useToast } from "@protolabsai/ui/overlays";
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
@@ -74,6 +74,17 @@ function PluginRow({
             <strong>{p.name}</strong>
             {p.version ? <span className="plugin-ver">v{p.version}</span> : null}
             <PluginFreshness update={update} />
+            {/* Required-config gate (#1719) — a loaded-but-unconfigured plugin's tools
+                return a needs-setup notice; flag it so the operator can finish setup. */}
+            {p.incomplete ? (
+              <Badge status="warning">
+                <span
+                  title={`Missing required config: ${(p.needs_config ?? []).map((n) => n.label).join(", ") || "setup needed"} — click "Set up"`}
+                >
+                  needs setup
+                </span>
+              </Badge>
+            ) : null}
             {p.error ? <StatusPill label="error" tone="error" /> : null}
           </div>
           <span>{contributionsLabel(p)}</span>
@@ -95,8 +106,20 @@ function PluginRow({
             </Button>
           ) : null}
           {/* Configure opens a per-plugin settings dialog (ADR 0059) rather than expanding
-              the row, so the row stays one line and the form gets room. */}
-          {configurable ? (
+              the row, so the row stays one line and the form gets room. An INCOMPLETE
+              plugin (#1719) gets a prominent labeled "Set up" instead of the gear icon —
+              it's the primary thing to do on that row. */}
+          {p.incomplete ? (
+            <Button
+              type="button"
+              variant="default"
+              size="sm"
+              onClick={() => setConfigOpen(true)}
+              title={`Finish setting up ${p.name}`}
+            >
+              Set up
+            </Button>
+          ) : configurable ? (
             <Button
               type="button"
               icon
@@ -137,10 +160,11 @@ function PluginRow({
           ) : null}
         </div>
       </div>
-      {configurable ? (
+      {configurable || p.incomplete ? (
         <PluginSettingsDialog
           pluginId={p.id}
           pluginName={p.name}
+          needsConfig={p.incomplete ? p.needs_config : undefined}
           open={configOpen}
           onClose={() => setConfigOpen(false)}
         />


### PR DESCRIPTION
The **frontend** half of #1719 (backend #1750 is on main). **DRAFT under the UI local-test gate** — I've wired it into the `formtest` instance for you to try.

## What

An **incomplete** plugin (loaded but missing a `required: true` setting — the `incomplete` / `needs_config` the backend now returns) gets a guided setup path:

- A ⚠️ **"needs setup"** `Badge` in the Plugins panel, tooltip listing the missing fields.
- The row's primary action becomes a labeled **"Set up"** button (instead of the gear icon).
- **"Set up"** opens the plugin's config dialog with a **setup banner** naming the fields it still needs, above the existing config form.
- Reuses `SettingsCategory`, so saving the fields runs the normal save→reload — which clears `incomplete`, and the badge disappears. No new save path.
- **Skippable**: close the dialog and the plugin stays incomplete; the badge is the durable re-entry point.

Deliberately reuses `PluginSettingsDialog` rather than a bespoke multi-step modal — same field renderer, same validation/reload, one place to maintain. (A richer per-archetype wizard could layer on later; this covers the issue's acceptance criteria.)

## Acceptance criteria (#1719)

- [x] Setup surface appears for a plugin missing required config (badge + "Set up")
- [x] Shows required fields with labels/descriptions (setup banner + the config form)
- [x] Skip option (close the dialog; badge persists as re-entry)
- [x] Plugin shows ⚠️ with a "missing required config" hover
- [x] Tools return a friendly needs-setup error (backend #1750)

## Test

`tsc` + `vite build` clean; **web unit tests 355 pass**. Try it live in `formtest` (see the session note) — the `hello` plugin's `api_key` is marked required there so it shows as incomplete; **Set up → fill it → save** clears the badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)