### PR TITLE
fix(watches): honor per-watch interval_s + refresh verifier registry on hot-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collide.
 
 ### Fixed
+- **Watches honor their per-watch `interval_s` cadence** (#1753). `tick_all` evaluated
+  *every* active watch on the global `watch_interval`, so a watch created with
+  `interval_s: 1800` was actually polled every tick — collapsing `stall_after`'s
+  wall-clock meaning (`stall_after × interval_s`) to a few minutes and firing dozens of
+  spurious "stalled" reactions (each a full agent turn) overnight. The cadence tick now
+  **skips a watch until its own `interval_s` has elapsed since `last_checked`** (a floor);
+  watches with no explicit interval still evaluate every tick, and the event-driven
+  `evaluate()`/`evaluate_now()` fast path a plugin calls on state change is unaffected.
+- **Hot-reloading a plugin refreshes its goal/watch verifier + hook registries** (#1752).
+  `POST /api/plugins/{id}/update` (and any settings hot-reload) rebuilt the plugin bundle
+  but never pushed the rebuilt verifiers/hooks into the *live* registry the goal/watch
+  controllers consult — only full startup did. So a plugin update that shipped a **new**
+  watch verifier left it resolving as `unknown plugin verifier` (armed but blind) until a
+  full server restart. The reload commit now re-applies the registries like init does. As
+  a safety net, an unknown plugin verifier now logs a **one-shot WARNING** (deduped per
+  name, re-armed on the next registry change) instead of only being visible by polling
+  `/api/watches`.
 - **Plugin smoke tests can assert surface lifecycle wiring** (#1729). The testkit's
   `FakeRegistry.register_surface` kept only the surface *name* and discarded the
   `start`/`stop`/`reload` callables, so a plugin's surface lifecycle wiring (e.g.

--- a/graph/goals/verifiers.py
+++ b/graph/goals/verifiers.py
@@ -291,6 +291,11 @@ async def _verify_llm(spec: dict, ctx: VerifyContext) -> VerifyResult:
 # with declarative args — no shell, no eval (that's why a ``plugin`` goal is the
 # only verifier type safe to set programmatically; see ADR 0028 D3).
 _PLUGIN_VERIFIERS: dict = {}
+# Plugin-verifier names already warned as unknown — so an armed goal/watch on a missing
+# verifier logs ONCE, not once per tick (a stalled watch re-checks every cadence, 60+×/hour).
+# Cleared whenever the mapping is re-set, so a still-missing name warns again after a reload
+# and a now-present one goes quiet.
+_WARNED_UNKNOWN_VERIFIERS: set[str] = set()
 
 
 def set_plugin_verifiers(mapping: dict | None) -> None:
@@ -306,6 +311,10 @@ def set_plugin_verifiers(mapping: dict | None) -> None:
     so reassigning the global is safe.)"""
     global _PLUGIN_VERIFIERS
     _PLUGIN_VERIFIERS = dict(mapping or {})
+    # A fresh mapping may now resolve names that were unknown before (e.g. a plugin update
+    # that registers new verifiers, #1752) — reset the dedup set so a still-missing name
+    # warns again and a now-present one stops.
+    _WARNED_UNKNOWN_VERIFIERS.clear()
 
 
 def plugin_verifier_names() -> list[str]:
@@ -320,6 +329,19 @@ async def _verify_plugin(spec: dict, ctx: VerifyContext) -> VerifyResult:
     name = (spec or {}).get("check") or ""
     fn = _PLUGIN_VERIFIERS.get(name)
     if fn is None:
+        # An armed goal/watch pointing at a verifier the live registry doesn't know can never
+        # evaluate — it errors every tick, silently, visible only by polling state. Surface it
+        # once (deduped) so an "armed but blind" monitor (e.g. a plugin update that didn't
+        # refresh the registry, #1752) is diagnosable from the logs.
+        if name and name not in _WARNED_UNKNOWN_VERIFIERS:
+            _WARNED_UNKNOWN_VERIFIERS.add(name)
+            log.warning(
+                "[goal] unknown plugin verifier %r — an armed goal/watch on it can never "
+                "evaluate. Is its plugin installed+enabled, and did the last plugin "
+                "update/reload re-register it? Known: %s",
+                name,
+                ", ".join(sorted(_PLUGIN_VERIFIERS)) or "(none)",
+            )
         return VerifyResult(False, f"unknown plugin verifier {name!r}", "")
     try:
         return await fn(spec, ctx)

--- a/graph/watches/controller.py
+++ b/graph/watches/controller.py
@@ -202,10 +202,23 @@ class WatchController:
         return await self.evaluate(watch_id)
 
     async def tick_all(self) -> int:
-        """Evaluate every active watch out-of-band (verifier-only, no agent turn). The server
-        runs this on a cadence. Returns how many reached a terminal state this tick."""
+        """Evaluate the DUE active watches out-of-band (verifier-only, no agent turn).
+
+        The server runs this on the global ``watch_interval`` cadence, but a watch's own
+        ``interval_s`` is a FLOOR: a watch is skipped on ticks where it isn't due yet, so a
+        slow watch (e.g. ``interval_s=1800``) isn't collapsed to the global tick. That keeps
+        ``stall_after``'s wall-clock meaning (``stall_after × interval_s``) intact instead of
+        firing it every few minutes (#1753). Watches with no explicit ``interval_s`` evaluate
+        every tick, as before. The event-driven ``evaluate``/``evaluate_now`` fast path a plugin
+        calls on state change bypasses this gate by design. Returns how many reached a terminal
+        state this tick."""
+        from time import time
+
+        now = time()
         finished = 0
         for watch in self.active_watches():
+            if not self._due(watch, now):
+                continue
             try:
                 status = await self.evaluate(watch.id)
             except Exception:  # noqa: BLE001 — one bad watch must not stop the tick
@@ -214,6 +227,20 @@ class WatchController:
             if status is not None:
                 finished += 1
         return finished
+
+    @staticmethod
+    def _due(watch: Watch, now: float) -> bool:
+        """Whether a watch is due for a CADENCE evaluation at ``now``. A watch with no explicit
+        ``interval_s`` (or a non-positive one) is always due — the global loop cadence is its
+        interval, unchanged behavior. An explicit ``interval_s`` is a floor since
+        ``last_checked``: skip until it elapses, so the per-watch cadence (and ``stall_after``'s
+        wall-clock span) is honored (#1753). A never-checked watch is due immediately."""
+        interval_s = watch.interval_s
+        if interval_s is None or interval_s <= 0:
+            return True
+        if watch.last_checked is None:
+            return True
+        return (now - watch.last_checked) >= interval_s
 
     async def _finish(self, watch: Watch, status: str, reason: str, evidence: str = "") -> str:
         from time import time

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -208,15 +208,10 @@ def _init_langgraph_agent(headless_setup: bool = False):
     # graph compiles below with STATE.knowledge_store). Default built-in store stays
     # the collision-check binding + the degrade-safe fallback.
     STATE.knowledge_store = _apply_plugin_knowledge_backend(STATE.graph_config, STATE.knowledge_store, _plugins)
-    # Register plugin-contributed goal verifiers (ADR 0028) — re-set on each
-    # (re)load so a config change refreshes the available `plugin` verifiers.
-    from graph.goals import hooks as _goal_hooks
-    from graph.goals import verifiers as _goal_verifiers
-    from graph.watches import hooks as _watch_hooks
-
-    _goal_verifiers.set_plugin_verifiers(_plugins.goal_verifiers)
-    _goal_hooks.set_goal_hooks(_plugins.goal_hooks)
-    _watch_hooks.set_watch_hooks(_plugins.watch_hooks)  # ADR 0067
+    # Register plugin-contributed goal verifiers + goal/watch hooks (ADR 0028/0067) into
+    # their live module registries — re-applied on every (re)load via _apply_plugin_registries
+    # so a config/plugin change refreshes the available `plugin` verifiers and hooks.
+    _apply_plugin_registries(_plugins)
     # Surfaces / routes / subagents (ADR 0018). Routers + surfaces are captured
     # here and consumed once by _main (mount) + the startup hook (start) — they
     # don't hot-reload. Subagents register into SUBAGENT_REGISTRY before the graph
@@ -1394,6 +1389,25 @@ def _mount_plugin_routers(routers: list[dict]) -> None:
             log.exception("[plugins] failed to mount router from %s", plugin_id)
 
 
+def _apply_plugin_registries(plugins) -> None:
+    """Push a freshly (re)built plugin bundle's goal verifiers + goal/watch hooks into their
+    LIVE module registries (``graph.goals.verifiers`` / ``graph.goals.hooks`` /
+    ``graph.watches.hooks``). Called at full init AND in the hot-reload commit — without the
+    reload call, a plugin update/enable that adds or changes a verifier or hook leaves the live
+    registry holding the PRE-reload mapping, so a newly-shipped watch/goal verifier resolves as
+    "unknown plugin verifier" (armed but blind) until a full server restart (#1752).
+
+    Not itself serialized: each set_* is a single GIL-atomic global rebind, and the reload
+    caller already holds the config-write lock (init runs once at boot, uncontended)."""
+    from graph.goals import hooks as _goal_hooks
+    from graph.goals import verifiers as _goal_verifiers
+    from graph.watches import hooks as _watch_hooks
+
+    _goal_verifiers.set_plugin_verifiers(plugins.goal_verifiers)  # ADR 0028
+    _goal_hooks.set_goal_hooks(plugins.goal_hooks)
+    _watch_hooks.set_watch_hooks(plugins.watch_hooks)  # ADR 0067
+
+
 @_serialized_config_write
 def _reload_langgraph_agent() -> tuple[bool, str]:
     """Rebuild the compiled graph from the latest config YAML.
@@ -1585,6 +1599,10 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     if is_setup_complete():
         _mount_plugin_routers(new_plugins.routers)
         STATE.plugin_routers = new_plugins.routers
+        # Refresh the live plugin verifier/hook registries too (#1752) — same as full init.
+        # Without this a plugin update/enable that ships a new verifier leaves the watch/goal
+        # controllers resolving it as "unknown" until a full restart.
+        _apply_plugin_registries(new_plugins)
 
     if new_graph is None:
         log.info("[reload] setup not complete — config reloaded, graph not compiled")

--- a/tests/test_goal_verifiers.py
+++ b/tests/test_goal_verifiers.py
@@ -175,6 +175,28 @@ async def test_unknown_plugin_verifier_is_not_met():
 
 
 @pytest.mark.asyncio
+async def test_unknown_plugin_verifier_warns_once_then_again_after_reset(caplog):
+    # #1752 belt-and-braces: an armed goal/watch on a missing verifier logs ONCE (not once per
+    # tick — a stalled watch re-checks 60+×/hour), and re-warns after the mapping is re-set so a
+    # name still missing after a plugin reload is re-surfaced.
+    import logging
+
+    set_plugin_verifiers({})  # empty registry + clears the dedup set
+    spec = {"type": "plugin", "check": "ghost:verifier"}
+    with caplog.at_level(logging.WARNING, logger="graph.goals.verifiers"):
+        await run_verifier(spec, VerifyContext())
+        await run_verifier(spec, VerifyContext())  # tick-after-tick: must NOT re-warn
+        warned = [r for r in caplog.records if "unknown plugin verifier" in r.getMessage()]
+        assert len(warned) == 1
+
+        set_plugin_verifiers({})  # a reload with the name STILL missing → dedup reset
+        await run_verifier(spec, VerifyContext())
+        warned = [r for r in caplog.records if "unknown plugin verifier" in r.getMessage()]
+        assert len(warned) == 2
+    set_plugin_verifiers({})  # cleanup
+
+
+@pytest.mark.asyncio
 async def test_plugin_verifier_error_never_marks_met():
     async def _boom(spec, ctx):
         raise RuntimeError("kaboom")

--- a/tests/test_reload_rebuild_deps.py
+++ b/tests/test_reload_rebuild_deps.py
@@ -88,3 +88,79 @@ def test_reload_threads_surviving_stores_into_the_rebuilt_graph(tmp_path, monkey
     assert captured["background_mgr"] is background_mgr
     # THE regression: the tasks store must ride the rebuild like its siblings.
     assert captured["tasks_store"] is tasks_store
+
+
+def test_reload_refreshes_plugin_verifier_registry(tmp_path, monkeypatch):
+    """#1752: a committed hot-reload must push the rebuilt plugin verifiers into the LIVE
+    registry the watch/goal controllers consult — else a plugin update that ships a new
+    verifier leaves it 'unknown plugin verifier' (armed but blind) until a full restart."""
+    import graph.agent as ga
+    import graph.config_io as cio
+    import server.agent_init as ai
+    from graph.goals import verifiers as gv
+    from runtime.state import STATE
+
+    leaf = tmp_path / "langgraph-config.yaml"
+    leaf.write_text("scheduler:\n  enabled: false\n")
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: leaf)
+    monkeypatch.setattr(cio, "ensure_live_config", lambda: None)
+    monkeypatch.setattr(cio, "is_setup_complete", lambda: True)
+
+    # Heavy builders + commit-side effects stubbed — this test is about the registry refresh.
+    monkeypatch.setattr(ai, "_build_knowledge_store", lambda cfg: None)
+    monkeypatch.setattr(ai, "_build_mcp", lambda *a, **k: ([], [], []))
+    monkeypatch.setattr(ai, "_apply_plugin_knowledge_backend", lambda cfg, store, plugins: store)
+    monkeypatch.setattr(ai, "_register_plugin_subagents", lambda subagents: None)
+    monkeypatch.setattr(ai, "_apply_config_subagents", lambda cfg: None)
+    monkeypatch.setattr(ai, "_resolve_plugin_middleware", lambda cfg, mw: [])
+    monkeypatch.setattr(ai, "_build_skills_index", lambda cfg, extra_skill_dirs=None: None)
+    monkeypatch.setattr(ai, "_build_inbox_store", lambda cfg: None)
+    monkeypatch.setattr(ai, "_mount_plugin_routers", lambda routers: None)
+    monkeypatch.setattr(ai, "_reload_plugin_surfaces", lambda cfg: None)
+    # The commit block also live-reloads egress/callback/bearer globals — no-op them so this
+    # test can't leak allowlist/token state into others.
+    import security.egress as _egress
+    import security.policy as _policy
+
+    monkeypatch.setattr(_egress, "set_allowed_hosts", lambda *a, **k: None)
+    monkeypatch.setattr(_policy, "set_callback_allowlist", lambda *a, **k: None)
+    try:
+        import a2a_impl.auth as _a2a_auth
+
+        monkeypatch.setattr(_a2a_auth, "set_bearer_token", lambda *a, **k: None)
+    except ImportError:
+        pass
+
+    async def _new_verifier(spec, ctx):
+        from graph.goals.types import VerifyResult
+
+        return VerifyResult(True, "ok", "")
+
+    monkeypatch.setattr(
+        ai,
+        "_build_plugins",
+        lambda *a, **k: SimpleNamespace(
+            mcp_servers=[], tools=[], tool_plugins={}, skill_dirs=[], meta=[],
+            chat_commands={}, subagents=[], middleware=[], late_tool_factories=[], routers=[],
+            goal_verifiers={"demo:brand_new": _new_verifier}, goal_hooks=[], watch_hooks=[],
+        ),
+    )
+    # Let the graph rebuild SUCCEED so the commit block (with the registry refresh) runs.
+    monkeypatch.setattr(ga, "create_agent_graph", lambda config, **kwargs: object())
+
+    # Surviving stores + scheduler/graph off.
+    for name in ("checkpointer", "tasks_store", "background_mgr"):
+        monkeypatch.setattr(STATE, name, object(), raising=False)
+    for name in ("scheduler", "graph", "workflow_registry", "workflow_run"):
+        monkeypatch.setattr(STATE, name, None, raising=False)
+
+    # Pre-state: an OLD mapping without the new verifier (mirrors the pre-update registry).
+    gv.set_plugin_verifiers({"demo:old": _new_verifier})
+    assert "demo:brand_new" not in gv.plugin_verifier_names()
+    try:
+        ok, msg = ai._reload_langgraph_agent()
+        assert ok is True, msg
+        # THE regression: the reload pushed the rebuilt verifiers into the live registry.
+        assert "demo:brand_new" in gv.plugin_verifier_names()
+    finally:
+        gv.set_plugin_verifiers({})

--- a/tests/test_watch_controller.py
+++ b/tests/test_watch_controller.py
@@ -272,3 +272,71 @@ async def test_evaluate_passes_watch_invoker_to_plugin_verifier(tmp_path):
     assert second.kind == "watch" and second.id == w2.id and second.id != w1.id
     assert second.session_id == ""  # no target session
     assert second.interval_s == 30.0  # config-default cadence (the server tick fallback)
+
+
+# --- #1753: per-watch interval_s gates the cadence tick -----------------------
+
+
+def test_due_gate_semantics():
+    # _due decides whether a cadence tick should evaluate a watch. An explicit interval_s is a
+    # floor since last_checked; a default-cadence (None) or non-positive interval is always due.
+    from graph.watches.controller import WatchController
+    from graph.watches.types import Watch
+
+    now = 10_000.0
+
+    def w(**kw):
+        return Watch(id="w", condition="c", **kw)
+
+    assert WatchController._due(w(), now) is True  # default cadence → every tick
+    assert WatchController._due(w(interval_s=600), now) is True  # never checked → due now
+    assert WatchController._due(w(interval_s=600, last_checked=now - 60), now) is False  # floor not elapsed
+    assert WatchController._due(w(interval_s=600, last_checked=now - 601), now) is True  # floor elapsed
+    assert WatchController._due(w(interval_s=0, last_checked=now), now) is True  # non-positive → always due
+
+
+@pytest.mark.asyncio
+async def test_tick_all_skips_watch_not_yet_due(tmp_path, monkeypatch):
+    # #1753: a watch with interval_s=600 checked a minute ago must be SKIPPED by the global
+    # tick — not re-evaluated every cadence (which collapsed stall_after to ~minutes).
+    from time import time
+
+    c = _ctrl(tmp_path)
+    _ok, _m, wch = c.create(condition="slow", verifier={"type": "plugin", "check": "p:c"}, interval_s=600)
+    wch.last_checked = time() - 60
+    c.store.set(wch)
+
+    called = []
+
+    async def _spy(watch_id):
+        called.append(watch_id)
+        return None
+
+    monkeypatch.setattr(c, "evaluate", _spy)
+    assert await c.tick_all() == 0
+    assert called == []  # gated out — not due
+
+
+@pytest.mark.asyncio
+async def test_tick_all_evaluates_due_never_checked_and_default(tmp_path, monkeypatch):
+    # A watch past its floor, a never-checked one, and a default-cadence one are all due.
+    from time import time
+
+    c = _ctrl(tmp_path)
+    _ok, _m, due = c.create(
+        condition="due", watch_id="due", verifier={"type": "plugin", "check": "p:c"}, interval_s=600
+    )
+    due.last_checked = time() - 700
+    c.store.set(due)
+    c.create(condition="fresh", watch_id="fresh", verifier={"type": "plugin", "check": "p:c"}, interval_s=600)
+    c.create(condition="default", watch_id="default", verifier={"type": "plugin", "check": "p:c"})  # interval None
+
+    seen = []
+
+    async def _spy(watch_id):
+        seen.append(watch_id)
+        return None
+
+    monkeypatch.setattr(c, "evaluate", _spy)
+    await c.tick_all()
+    assert set(seen) == {"due", "fresh", "default"}


### PR DESCRIPTION
Two watch-reliability bugs surfaced in the same protoTrader (0.87.0) audit — both cheap to fix, both costing real tokens/coverage in production.

## #1753 — per-watch `interval_s` is ignored by the cadence tick
`WatchController.tick_all` evaluated **every** active watch on the global `watch_interval`, so a watch created with `interval_s: 1800` was actually polled every tick. `stall_after` is defined in *checks*, so its wall-clock meaning (`stall_after × interval_s`) collapsed — spacetraders' `st-flatline` (`interval_s=1800, stall_after=3` ⇒ "~90 min of no movement") fired at **~6 min**, producing **39 spurious "fleet flatlined" diagnosis turns in ~16h** (~65k input tokens each) while the fleet actually grew 375k → 1.6M credits.

**Fix:** `tick_all` now skips a watch until its own `interval_s` has elapsed since `last_checked` — the global tick stays the scheduler, per-watch interval becomes a floor (`_due()`). Watches with no explicit `interval_s` evaluate every tick, as before. The event-driven `evaluate()`/`evaluate_now()` fast path a plugin calls on state change bypasses the gate by design.

## #1752 — hot-reload never refreshes the plugin verifier/hook registry
`POST /api/plugins/{id}/update` (and any settings hot-reload) rebuilt the plugin bundle but never pushed the rebuilt verifiers/hooks into the **live** registry the goal/watch controllers consult (`_PLUGIN_VERIFIERS`) — only full startup did. So a plugin update shipping a **new** watch verifier left it resolving as `unknown plugin verifier` (armed but blind, erroring every tick) until a full restart.

**Fix:** extract `_apply_plugin_registries(plugins)` (verifiers + goal hooks + watch hooks) and call it in the `_reload_langgraph_agent` commit block, mirroring init. **Safety net:** an unknown plugin verifier now logs a **one-shot WARNING** (deduped per name, re-armed whenever the mapping is re-set) instead of being visible only by polling `/api/watches`.

> While moving the helper I nearly stole `@_serialized_config_write` from `_reload_langgraph_agent` — caught in self-review; the reload path keeps its config-write serialization and the helper is intentionally undecorated (each `set_*` is a GIL-atomic rebind).

## Tests
- `test_watch_controller`: `_due` gate semantics + `tick_all` skips a not-yet-due watch and evaluates due / never-checked / default-cadence ones.
- `test_reload_rebuild_deps`: a **committed** reload pushes a newly-built plugin verifier into the live registry.
- `test_goal_verifiers`: unknown plugin verifier warns once, then again after a registry re-set.

## Gates
`ruff` ✓ · `lint-imports` ✓ (3 kept) · `pytest tests/ -q` ✓ (3026 passed, 5 skipped) · `live_smoke.py` ✓

Closes #1753
Closes #1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repeated warning spam for unknown plugin verifiers.
  * Plugin verifier updates now take effect after a reload, without requiring a full restart.
  * Watches now run only when they are due, preventing slower watches from being checked too often and improving scheduling consistency.

* **Tests**
  * Added coverage for warning deduplication, reload behavior, and per-watch cadence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->