### PR TITLE
feat(web): browser-style UI zoom — ⌘/Ctrl +/-/0 (#1711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   high-cardinality and would blow up the metric series. (`config_io.soul_revision()` computes
   it; the telemetry-store column is added via a guarded migration, so existing DBs upgrade in
   place.)
+- **Browser-style UI zoom — `⌘/Ctrl` `+` / `-` / `0`** (#1711, console). Scales the whole
+  console up or down (50%–200%, in 10% steps) and persists the choice. The Tauri desktop
+  WebView has no native browser zoom, so this is the only way to size the UI there; in a
+  browser it shadows the native zoom for those combos, like the other shortcuts that override
+  browser defaults. All three are listed and rebindable in **Settings ▸ Keyboard** (group
+  "View"). Applied before first paint, so a saved zoom doesn't flash in at 100%.
 - **Plugin setup: a "needs setup" cue + guided config for unconfigured plugins**
   (#1719, console). Building on the required-config gate below, an **incomplete**
   plugin (loaded but missing a `required: true` setting) now shows a ⚠️ **"needs

--- a/apps/web/src/keybindings/coreKeybindings.ts
+++ b/apps/web/src/keybindings/coreKeybindings.ts
@@ -14,6 +14,7 @@ import { chatStore } from "../chat/chat-store";
 import { toggleLatestToolBlock } from "../chat/toolCollapse";
 import { useUI } from "../state/uiStore";
 import { registerKeybinding } from "../ext/keybindingRegistry";
+import { zoomIn, zoomOut, zoomReset } from "../view/zoom";
 import { useKbIntents } from "./intents";
 
 function switchByOffset(delta: number): void {
@@ -121,6 +122,38 @@ registerKeybinding({
   scope: "chat",
   allowInInput: true,
   run: () => toggleLatestToolBlock(),
+});
+
+// ── View (global) ─────────────────────────────────────────────────────────────────────
+// Browser-style page zoom for the whole console (#1711). The Tauri desktop WebView has no
+// native zoom, so this is the only way to scale the UI there; in a plain browser it shadows
+// the native ⌘/Ctrl +/-/0 for these combos (the host preventDefaults matched binds), like the
+// other bindings above that override browser shortcuts — rebindable in Settings ▸ Keyboard.
+// `mod+=` is the no-shift zoom-in key (same physical key as +); `allowInInput` so it works
+// while the composer is focused (the common case).
+registerKeybinding({
+  id: "view.zoom.in",
+  label: "Zoom in",
+  group: "View",
+  defaultKeys: "mod+=",
+  allowInInput: true,
+  run: () => zoomIn(),
+});
+registerKeybinding({
+  id: "view.zoom.out",
+  label: "Zoom out",
+  group: "View",
+  defaultKeys: "mod+-",
+  allowInInput: true,
+  run: () => zoomOut(),
+});
+registerKeybinding({
+  id: "view.zoom.reset",
+  label: "Reset zoom",
+  group: "View",
+  defaultKeys: "mod+0",
+  allowInInput: true,
+  run: () => zoomReset(),
 });
 
 // ── Panels (global toggles) ──────────────────────────────────────────────────────────

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -20,8 +20,10 @@ import "./app/theme.css";
 import { activateSlugAgent } from "./lib/api";
 import { queryClient } from "./lib/queryClient";
 import { watchThemeChanges } from "./lib/agentTheme";
+import { initZoom } from "./view/zoom";
 
 watchThemeChanges(); // fire `protoagent:theme` on any theme change → plugin iframes repaint live
+initZoom(); // apply the persisted UI zoom (#1711) before first paint — no flash of unscaled UI
 
 // The desktop quick-launcher window (ADR 0057) boots the same bundle but renders ONLY the
 // command palette — no shell, no slug activation. Everything else is the full console.

--- a/apps/web/src/view/zoom.test.ts
+++ b/apps/web/src/view/zoom.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import {
+  clampZoom,
+  readStoredZoom,
+  applyZoom,
+  zoomIn,
+  zoomOut,
+  zoomReset,
+  initZoom,
+  ZOOM_MIN,
+  ZOOM_MAX,
+  ZOOM_DEFAULT,
+} from "./zoom";
+
+const KEY = "pl:ui-zoom";
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.style.removeProperty("zoom");
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("clampZoom", () => {
+  it("clamps to range and rounds to one decimal (no float drift)", () => {
+    expect(clampZoom(0.1)).toBe(ZOOM_MIN);
+    expect(clampZoom(5)).toBe(ZOOM_MAX);
+    expect(clampZoom(1.2345)).toBe(1.2);
+    expect(clampZoom(Number.NaN)).toBe(ZOOM_DEFAULT);
+  });
+});
+
+describe("zoom in / out / reset", () => {
+  it("steps by 0.1 and persists the level", () => {
+    expect(zoomIn()).toBe(1.1);
+    expect(localStorage.getItem(KEY)).toBe("1.1");
+    expect(zoomIn()).toBe(1.2);
+    expect(zoomOut()).toBe(1.1);
+  });
+
+  it("clears storage when back at the default (no leftover zoom:1)", () => {
+    zoomIn();
+    expect(zoomOut()).toBe(ZOOM_DEFAULT);
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it("never exceeds MAX or drops below MIN", () => {
+    for (let i = 0; i < 40; i++) zoomIn();
+    expect(readStoredZoom()).toBe(ZOOM_MAX);
+    for (let i = 0; i < 40; i++) zoomOut();
+    expect(readStoredZoom()).toBe(ZOOM_MIN);
+  });
+
+  it("reset returns to default and clears storage", () => {
+    zoomIn();
+    zoomIn();
+    expect(zoomReset()).toBe(ZOOM_DEFAULT);
+    expect(localStorage.getItem(KEY)).toBeNull();
+  });
+});
+
+describe("applyZoom → document element", () => {
+  it("sets the zoom property, and clears it at the default", () => {
+    const setP = vi.spyOn(document.documentElement.style, "setProperty");
+    const rmP = vi.spyOn(document.documentElement.style, "removeProperty");
+    applyZoom(1.4);
+    expect(setP).toHaveBeenCalledWith("zoom", "1.4");
+    applyZoom(ZOOM_DEFAULT);
+    expect(rmP).toHaveBeenCalledWith("zoom");
+  });
+});
+
+describe("initZoom", () => {
+  it("applies the persisted level on boot", () => {
+    localStorage.setItem(KEY, "1.3");
+    const setP = vi.spyOn(document.documentElement.style, "setProperty");
+    initZoom();
+    expect(setP).toHaveBeenCalledWith("zoom", "1.3");
+  });
+
+  it("tolerates storage being unavailable", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+    expect(() => initZoom()).not.toThrow();
+    expect(readStoredZoom()).toBe(ZOOM_DEFAULT);
+  });
+});

--- a/apps/web/src/view/zoom.ts
+++ b/apps/web/src/view/zoom.ts
@@ -1,0 +1,76 @@
+// UI zoom (#1711) — browser-style Ctrl/Cmd +/-/0 scaling of the whole console, persisted.
+//
+// The Tauri desktop WebView has no built-in browser zoom, so desktop users couldn't scale the
+// UI at all. This applies a page zoom via the CSS `zoom` property on the document element
+// (equivalent to browser zoom — it reflows layout and adjusts scrollbars, unlike a transform),
+// driven by the ADR 0063 keybindings and persisted in localStorage. It behaves the same in a
+// plain browser, shadowing the native Ctrl/⌘ +/-/0 for those combos like the other keybindings
+// that override browser shortcuts (⌘T/⌘O/…) — all rebindable in Settings ▸ Keyboard.
+
+const STORAGE_KEY = "pl:ui-zoom";
+export const ZOOM_MIN = 0.5;
+export const ZOOM_MAX = 2.0;
+export const ZOOM_STEP = 0.1;
+export const ZOOM_DEFAULT = 1.0;
+
+/** Clamp to [MIN, MAX] and round to one decimal, so repeated ±0.1 steps don't drift into
+ *  float noise (0.30000000000000004). A non-finite input falls back to the default. */
+export function clampZoom(level: number): number {
+  const n = Number.isFinite(level) ? level : ZOOM_DEFAULT;
+  return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round(n * 10) / 10));
+}
+
+/** The persisted zoom (default when unset or storage is unavailable — never throws). */
+export function readStoredZoom(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw == null ? ZOOM_DEFAULT : clampZoom(parseFloat(raw));
+  } catch {
+    return ZOOM_DEFAULT; // private-mode / storage-disabled
+  }
+}
+
+function writeStoredZoom(level: number): void {
+  try {
+    if (level === ZOOM_DEFAULT) localStorage.removeItem(STORAGE_KEY);
+    else localStorage.setItem(STORAGE_KEY, String(level));
+  } catch {
+    /* storage disabled — zoom still applies for the session, it just won't persist */
+  }
+}
+
+/** Apply a zoom level to the document (page zoom, like the browser's). Default (1.0) clears
+ *  the property so there's no leftover `zoom: 1` on the html element. */
+export function applyZoom(level: number): void {
+  if (typeof document === "undefined") return;
+  const style = document.documentElement.style;
+  if (level === ZOOM_DEFAULT) style.removeProperty("zoom");
+  else style.setProperty("zoom", String(level));
+}
+
+function setZoom(level: number): number {
+  const next = clampZoom(level);
+  writeStoredZoom(next);
+  applyZoom(next);
+  return next;
+}
+
+/** Step zoom up one increment; returns the new level. */
+export function zoomIn(): number {
+  return setZoom(readStoredZoom() + ZOOM_STEP);
+}
+
+/** Step zoom down one increment; returns the new level. */
+export function zoomOut(): number {
+  return setZoom(readStoredZoom() - ZOOM_STEP);
+}
+
+/** Back to 100%; returns the new level. */
+export function zoomReset(): number {
+  return setZoom(ZOOM_DEFAULT);
+}
+
+/** Apply the persisted zoom on boot — call before first paint to avoid a flash of unscaled UI. */
+export function initZoom(): void {
+  applyZoom(readStoredZoom());
+}


### PR DESCRIPTION
**DRAFT — UI, needs a local test pass** (especially in the desktop app, which is the whole motivation). Ready for review once you've tried it.

## What
The Tauri desktop WebView has no native browser zoom, so desktop users can't scale the console UI at all (#1711). This adds browser-style zoom:

- **⌘/Ctrl `+`** zoom in · **⌘/Ctrl `-`** zoom out · **⌘/Ctrl `0`** reset
- 50% – 200%, 10% steps, **persisted** to `localStorage` and re-applied **before first paint** (no flash of unscaled UI)
- Implemented as a page zoom via the CSS `zoom` property on `<html>` — reflows layout and adjusts scrollbars like real browser zoom (not a `transform` that would break hit-testing/scroll)

## How it's wired
- New `apps/web/src/view/zoom.ts` — pure, storage-backed helpers (`zoomIn/out/reset`, `clampZoom`, `initZoom`), no React context.
- Three ADR-0063 keybindings in `coreKeybindings.ts` (`view.zoom.in/out/reset`), so they show up **rebindable in Settings ▸ Keyboard** under a new "View" group.
- `main.tsx` calls `initZoom()` before render.

## Design notes to confirm
- **It applies everywhere, not just desktop.** In a plain browser it *shadows* the native ⌘/Ctrl +/-/0 for those combos (the keybinding host `preventDefault`s matched binds) — consistent with the existing binds that already override ⌘T/⌘O/⌘B. Browser users who prefer native zoom can rebind. Flag if you'd rather gate this to the desktop app only.
- Bound to `mod+=` (the no-shift zoom-in key). `Ctrl+Shift+=` (the "+" glyph) is not separately bound — same physical key, and it stays rebindable.

## Tests / gates
`vitest` ✓ (363, +8 new in `zoom.test.ts`) · `tsc --noEmit` ✓ · `vite build` ✓. E2E will run in CI when un-drafted.

## Not included
#1744 (swap the add-chat `+` icon to an eye on Shift) — the `+` is the **DS TabBar**'s native add button, so a modifier-reactive icon needs a DS TabBar enhancement (contribute-back to `@protolabsai/ui`), not a local hack. The incognito Shift+click gesture itself already works (#1715) with a descriptive hover label. Left out of this PR.

Closes #1711

🤖 Generated with [Claude Code](https://claude.com/claude-code)