### PR TITLE
feat(config): SOUL.md version history — auto-snapshot + restore API (#1691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **SOUL.md keeps a version history — never lose a persona iteration** (#1691). Every time
+  the agent's persona is saved, the **outgoing** `SOUL.md` is archived to a per-instance
+  `config/soul-history/` directory (deduped against the last snapshot, capped at the most
+  recent 50), so prompt iterations aren't overwritten into oblivion. New read-only + restore
+  API: `GET /api/config/soul/history` (list — id, timestamp, size, preview), `GET
+  /api/config/soul/history/{id}` (full text), and `POST /api/config/soul/history/{id}/restore`
+  to roll back. Restore re-saves through the normal save+reload path, which snapshots the
+  *current* persona first — so rolling back is itself reversible. (Console version-history UI
+  is a follow-up.)
 - **Plugin setup: a "needs setup" cue + guided config for unconfigured plugins**
   (#1719, console). Building on the required-config gate below, an **incomplete**
   plugin (loaded but missing a `required: true` setting) now shows a ⚠️ **"needs

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -23,8 +23,11 @@ Three jobs:
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
+import re
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -790,12 +793,155 @@ def read_soul() -> str:
 def write_soul(text: str) -> list[Path]:
     """Write persona text to the instance's live ``SOUL.md`` (mkdir parents).
 
-    Returns the path(s) written for UI feedback.
+    Before overwriting, the OUTGOING persona is archived to the soul-history dir (#1691) so
+    prompt iterations can be reviewed and rolled back — deduped against the newest snapshot and
+    capped; a history failure never blocks the save. Returns the path(s) written for UI feedback.
     """
     target = instance_paths().soul_path
     target.parent.mkdir(parents=True, exist_ok=True)
+    # Archive the effective outgoing persona — the instance file, or the bundled SEED the agent
+    # was actually running on the very first edit (read_soul falls back to it). Capturing the
+    # seed matters: that first save is exactly the iteration you'd otherwise lose. Best-effort:
+    # reading the old text (or archiving it) must never block the actual save.
+    try:
+        old = read_soul()
+    except (OSError, ValueError):
+        old = ""
+    if old and old != text:
+        snapshot_soul(old)
     target.write_text(text, encoding="utf-8")
     return [target]
+
+
+# ---------------------------------------------------------------------------
+# SOUL.md version history (#1691)
+# ---------------------------------------------------------------------------
+# Every persona save archives the OUTGOING text (see write_soul) into the
+# instance's soul-history dir. Versions are plain .md files named
+# ``<YYYYMMDDThhmmss.ffffffZ>-<8-char content hash>`` — lexical sort ==
+# chronological (microsecond precision), the hash disambiguates same-instant
+# saves. The console surfaces them as a restorable list; restore just re-saves
+# the chosen text (which snapshots the current one first, so rolling back is
+# itself reversible).
+
+_SOUL_VERSION_RE = re.compile(r"^\d{8}T\d{6}\.\d{6}Z-[0-9a-f]{8}$")
+_SOUL_HISTORY_CAP = 50  # keep the most recent N snapshots per instance
+
+
+def _soul_version_id(text: str, when: datetime) -> str:
+    # Microsecond precision so a lexical filename sort stays chronological even for rapid
+    # saves — two saves in the same second would otherwise order by hash, not time.
+    stamp = when.strftime("%Y%m%dT%H%M%S.%fZ")
+    digest = hashlib.sha1(text.encode("utf-8")).hexdigest()[:8]
+    return f"{stamp}-{digest}"
+
+
+def _prune_soul_history(hist: Path, cap: int | None = None) -> None:
+    """Keep only the most-recent ``cap`` snapshots (lexical filename sort == chronological).
+    ``cap`` is resolved at call time (not bound as a default) so it honors a patched module cap."""
+    cap = _SOUL_HISTORY_CAP if cap is None else cap
+    try:
+        files = sorted(hist.glob("*.md"))
+    except OSError:
+        return
+    for stale in files[:-cap] if len(files) > cap else []:
+        try:
+            stale.unlink()
+        except OSError:
+            pass
+
+
+def snapshot_soul(text: str) -> Path | None:
+    """Archive ``text`` (an outgoing persona) into the soul-history dir, unless it's identical
+    to the newest existing snapshot (so repeat no-op saves don't pile up). Returns the snapshot
+    path, or None when skipped/unwritable. Never raises — history is best-effort."""
+    text = text or ""
+    try:
+        hist = instance_paths().soul_history_dir
+        hist.mkdir(parents=True, exist_ok=True)
+        existing = sorted(hist.glob("*.md"))
+        try:
+            if existing and existing[-1].read_text(encoding="utf-8") == text:
+                return None  # already the latest recorded version — dedupe
+        except (OSError, ValueError):
+            pass  # a corrupt/unreadable newest snapshot must not stop us archiving THIS one
+        path = hist / f"{_soul_version_id(text, datetime.now(timezone.utc))}.md"
+        path.write_text(text, encoding="utf-8")
+        _prune_soul_history(hist)
+        return path
+    except (OSError, ValueError) as exc:  # non-utf8/other read error must never block the save
+        log.warning("[soul] history snapshot failed: %s", exc)
+        return None
+
+
+def _soul_history_files() -> list[Path]:
+    try:
+        return sorted(instance_paths().soul_history_dir.glob("*.md"), reverse=True)  # newest first
+    except OSError:
+        return []
+
+
+def _soul_version_saved_at(version_id: str) -> str:
+    """The ISO-8601 UTC timestamp encoded in a version id, or "" if unparseable."""
+    m = re.match(r"^(\d{8}T\d{6}\.\d{6})Z", version_id)
+    if not m:
+        return ""
+    try:
+        return datetime.strptime(m.group(1), "%Y%m%dT%H%M%S.%f").replace(tzinfo=timezone.utc).isoformat()
+    except ValueError:
+        return ""
+
+
+def _soul_preview(text: str, limit: int) -> str:
+    return " ".join((text or "").split())[:limit]
+
+
+def list_soul_versions(preview_chars: int = 140) -> list[dict]:
+    """Recorded SOUL.md snapshots, newest first: ``{id, saved_at, size, preview, is_current}``.
+    ``saved_at`` is ISO-8601 UTC; ``preview`` is the leading text with whitespace collapsed for a
+    one-line UI summary; ``is_current`` marks the snapshot whose text matches the live persona
+    (true right after a restore — so a version panel can flag which one is active without a
+    separate config fetch). Unreadable files are skipped."""
+    try:
+        current = read_soul()
+    except (OSError, ValueError):
+        current = ""
+    out: list[dict] = []
+    for path in _soul_history_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, ValueError):  # a corrupt history file is skipped, never 500s the list
+            continue
+        out.append(
+            {
+                "id": path.stem,
+                "saved_at": _soul_version_saved_at(path.stem),
+                "size": len(text),
+                "preview": _soul_preview(text, preview_chars),
+                "is_current": text == current,
+            }
+        )
+    return out
+
+
+def read_soul_version(version_id: str) -> str | None:
+    """Full text of a recorded snapshot, or None if the id is invalid/missing/unreadable. The id
+    is validated against the generated format so it can never be a caller-controlled path (no
+    traversal), with a resolved-parent check as defense in depth.
+
+    None (absent) is intentionally distinct from "" (a legitimately archived empty persona) —
+    the restore route's 404 relies on that distinction, so don't collapse them to "" for
+    symmetry with read_soul_preset."""
+    if not _SOUL_VERSION_RE.match(version_id or ""):
+        return None
+    hist = instance_paths().soul_history_dir
+    path = hist / f"{version_id}.md"
+    try:
+        if hist.resolve() not in path.resolve().parents:
+            return None
+        return path.read_text(encoding="utf-8")
+    except (OSError, ValueError):  # missing / unreadable / non-utf8 → absent, never raise
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/infra/paths.py
+++ b/infra/paths.py
@@ -583,6 +583,12 @@ class InstancePaths:
         return self.config_dir / "SOUL.md"
 
     @property
+    def soul_history_dir(self) -> Path:
+        """Timestamped snapshots of prior ``SOUL.md`` versions (#1691) — every persona save
+        archives the outgoing text here so prompt iterations can be reviewed and restored."""
+        return self.config_dir / "soul-history"
+
+    @property
     def plugins_dir(self) -> Path:
         raw = os.environ.get("PROTOAGENT_PLUGINS_DIR", "").strip()
         return Path(raw).expanduser() if raw else self.instance_root / "plugins"
@@ -638,6 +644,7 @@ class InstancePaths:
                 "setup_marker": str(self.setup_marker),
                 "theme_json": str(self.theme_json),
                 "soul_path": str(self.soul_path),
+                "soul_history_dir": str(self.soul_history_dir),
                 "plugins_dir": str(self.plugins_dir),
                 "plugins_lock": str(self.plugins_lock),
                 "workspace_dir": str(self.workspace_dir),

--- a/operator_api/config_routes.py
+++ b/operator_api/config_routes.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from fastapi import HTTPException
 from pydantic import BaseModel
 
 from runtime.state import STATE
@@ -103,6 +104,41 @@ def register_config_routes(app) -> None:
         # and would otherwise freeze the server for its duration.
         ok, messages = await asyncio.to_thread(_apply_settings_changes, config=req.config, soul=req.soul)
         return {"ok": ok, "messages": messages}
+
+    # --- SOUL.md version history (#1691) -----------------------------------
+    # Every persona save archives the outgoing SOUL.md (config_io.write_soul); the console
+    # lists these and can roll back to one. Restore re-saves through the same apply path, so
+    # it snapshots the CURRENT persona first — rolling back is itself reversible.
+    @app.get("/api/config/soul/history")
+    async def _api_soul_history():
+        from graph.config_io import list_soul_versions
+
+        return {"versions": list_soul_versions()}
+
+    @app.get("/api/config/soul/history/{version_id}")
+    async def _api_soul_history_one(version_id: str):
+        from graph.config_io import read_soul_version
+
+        content = read_soul_version(version_id)
+        if content is None:
+            raise HTTPException(status_code=404, detail=f"no SOUL version {version_id!r}")
+        return {"id": version_id, "content": content}
+
+    @app.post("/api/config/soul/history/{version_id}/restore")
+    async def _api_soul_history_restore(version_id: str):
+        from graph.config_io import read_soul, read_soul_version
+
+        content = read_soul_version(version_id)
+        if content is None:
+            raise HTTPException(status_code=404, detail=f"no SOUL version {version_id!r}")
+        # Restoring the version that's already live is a no-op — skip the (expensive) graph
+        # recompile a "restore" button on the current row would otherwise trigger.
+        if content == read_soul():
+            return {"ok": True, "messages": ["already the current persona"], "restored": version_id}
+        # Reuse the tested save+reload path: it snapshots the CURRENT persona before overwriting
+        # (so restore is reversible) and recompiles the graph off the event loop (#497).
+        ok, messages = await asyncio.to_thread(_apply_settings_changes, soul=content)
+        return {"ok": ok, "messages": messages, "restored": version_id}
 
     @app.post("/api/config/models")
     async def _api_list_models(req: ModelsProbeRequest | None = None):

--- a/tests/test_config_routes.py
+++ b/tests/test_config_routes.py
@@ -227,3 +227,100 @@ def test_test_model_with_form_key_does_not_clear_breaker(monkeypatch):
     resp = _client().post("/api/config/test-model", json={"api_key": "candidate"}).json()
     assert resp["ok"] is True
     assert store.reset_calls == 0
+
+
+# ── SOUL.md version history (#1691) ───────────────────────────────────────────
+
+
+def test_soul_history_lists_versions(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "graph.config_io",
+        _fake_module(
+            "graph.config_io",
+            list_soul_versions=lambda: [{"id": "v1", "saved_at": "t", "size": 3, "preview": "abc"}],
+        ),
+    )
+    body = _client().get("/api/config/soul/history").json()
+    assert body == {"versions": [{"id": "v1", "saved_at": "t", "size": 3, "preview": "abc"}]}
+
+
+def test_soul_history_get_one_ok(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "graph.config_io",
+        _fake_module("graph.config_io", read_soul_version=lambda vid: "the persona" if vid == "v1" else None),
+    )
+    body = _client().get("/api/config/soul/history/v1").json()
+    assert body == {"id": "v1", "content": "the persona"}
+
+
+def test_soul_history_get_one_404_for_unknown(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "graph.config_io",
+        _fake_module("graph.config_io", read_soul_version=lambda vid: None),
+    )
+    resp = _client().get("/api/config/soul/history/nope")
+    assert resp.status_code == 404
+
+
+def test_soul_history_restore_reapplies_through_the_save_path(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "graph.config_io",
+        _fake_module(
+            "graph.config_io",
+            read_soul_version=lambda vid: "restored persona",
+            read_soul=lambda: "a different current persona",  # not current → really restores
+        ),
+    )
+    calls = {}
+
+    def _fake_apply(config=None, soul=None):
+        calls["soul"] = soul
+        return True, ["SOUL saved (1 path)"]
+
+    import operator_api.config_routes as cr
+
+    monkeypatch.setattr(cr, "_apply_settings_changes", _fake_apply)
+    body = _client().post("/api/config/soul/history/v1/restore").json()
+    assert body["ok"] is True and body["restored"] == "v1"
+    # Restore re-saves the archived text through the tested save+reload path (which snapshots
+    # the current persona first, so a roll-back is itself reversible).
+    assert calls["soul"] == "restored persona"
+
+
+def test_soul_history_restore_current_version_is_a_noop(monkeypatch):
+    # Restoring the version that's already live skips the expensive graph recompile.
+    monkeypatch.setitem(
+        sys.modules,
+        "graph.config_io",
+        _fake_module(
+            "graph.config_io",
+            read_soul_version=lambda vid: "live persona",
+            read_soul=lambda: "live persona",  # already current
+        ),
+    )
+    applied = {"called": False}
+
+    def _fake_apply(config=None, soul=None):
+        applied["called"] = True
+        return True, []
+
+    import operator_api.config_routes as cr
+
+    monkeypatch.setattr(cr, "_apply_settings_changes", _fake_apply)
+    body = _client().post("/api/config/soul/history/v1/restore").json()
+    assert body["ok"] is True and "already the current persona" in body["messages"]
+    assert applied["called"] is False  # no recompile for a no-op restore
+
+
+def test_soul_history_restore_404_for_unknown(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "graph.config_io",
+        _fake_module("graph.config_io", read_soul_version=lambda vid: None, read_soul=lambda: ""),
+    )
+    resp = _client().post("/api/config/soul/history/nope/restore")
+    assert resp.status_code == 404

--- a/tests/test_soul_history.py
+++ b/tests/test_soul_history.py
@@ -1,0 +1,126 @@
+"""SOUL.md version history (#1691) — write_soul archives the OUTGOING persona so prompt
+iterations can be listed and restored. Isolation: PROTOAGENT_HOME → tmp box root (the autouse
+conftest fixture re-resolves instance_paths per test)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graph import config_io
+
+
+def _home(monkeypatch, tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    monkeypatch.setenv("PROTOAGENT_HOME", str(home))
+    # Neutralize the bundled-seed fallback so these tests exercise ONLY the instance SOUL.md
+    # (otherwise the first save would archive the repo's real seed persona). The seed-archival
+    # behavior is covered explicitly by test_first_edit_archives_the_seed_persona.
+    monkeypatch.setattr(config_io, "soul_source_path", lambda: tmp_path / "no-seed.md")
+    return home
+
+
+def _hist(home: Path) -> Path:
+    return home / "config" / "soul-history"
+
+
+def test_first_write_has_nothing_to_archive(monkeypatch, tmp_path: Path) -> None:
+    home = _home(monkeypatch, tmp_path)  # seed neutralized → no prior persona at all
+    config_io.write_soul("v1")
+    assert (home / "config" / "SOUL.md").read_text() == "v1"
+    assert config_io.list_soul_versions() == []  # nothing existed to snapshot
+
+
+def test_first_edit_archives_the_seed_persona(monkeypatch, tmp_path: Path) -> None:
+    # #1691 (steelman): the FIRST save overwrites the bundled seed the agent was actually
+    # running on — that seed must be archived, or the default persona is lost the moment it's
+    # edited. This is the case _home() deliberately neutralizes.
+    home = tmp_path / "home"
+    seed = tmp_path / "seed.md"
+    seed.write_text("bundled default persona", encoding="utf-8")
+    monkeypatch.setenv("PROTOAGENT_HOME", str(home))
+    monkeypatch.setattr(config_io, "soul_source_path", lambda: seed)
+
+    config_io.write_soul("my custom persona")
+    versions = config_io.list_soul_versions()
+    assert len(versions) == 1
+    assert config_io.read_soul_version(versions[0]["id"]) == "bundled default persona"
+
+
+def test_write_snapshots_the_outgoing_version(monkeypatch, tmp_path: Path) -> None:
+    home = _home(monkeypatch, tmp_path)
+    config_io.write_soul("v1")
+    config_io.write_soul("v2")  # archives v1
+    versions = config_io.list_soul_versions()
+    assert len(versions) == 1
+    (only,) = versions
+    assert config_io.read_soul_version(only["id"]) == "v1"  # the archived one is the OLD text
+    assert (home / "config" / "SOUL.md").read_text() == "v2"  # live is the new text
+
+
+def test_identical_consecutive_save_does_not_snapshot(monkeypatch, tmp_path: Path) -> None:
+    _home(monkeypatch, tmp_path)
+    config_io.write_soul("same")
+    config_io.write_soul("same")  # old == new → nothing archived
+    assert config_io.list_soul_versions() == []
+
+
+def test_list_is_newest_first_with_metadata(monkeypatch, tmp_path: Path) -> None:
+    _home(monkeypatch, tmp_path)
+    for text in ("alpha", "beta persona text", "gamma"):
+        config_io.write_soul(text)
+    versions = config_io.list_soul_versions()
+    # Three writes → two archived (alpha, beta); gamma is live.
+    assert [config_io.read_soul_version(v["id"]) for v in versions] == ["beta persona text", "alpha"]
+    newest = versions[0]
+    assert newest["saved_at"].endswith("+00:00")  # ISO-8601 UTC
+    assert newest["size"] == len("beta persona text")
+    assert newest["preview"] == "beta persona text"
+    # The live persona is "gamma" (not archived) → no archived version is flagged current.
+    assert all(v["is_current"] is False for v in versions)
+
+
+def test_is_current_flags_the_live_version_after_restore(monkeypatch, tmp_path: Path) -> None:
+    _home(monkeypatch, tmp_path)
+    config_io.write_soul("one")
+    config_io.write_soul("two")  # archives "one"; live = "two"
+    (v_one,) = config_io.list_soul_versions()
+    assert v_one["is_current"] is False  # "one" is archived, "two" is live
+
+    # Roll back to "one": it becomes live AND is present in history → flagged current.
+    config_io.write_soul(config_io.read_soul_version(v_one["id"]))
+    marked = [v for v in config_io.list_soul_versions() if v["is_current"]]
+    assert [config_io.read_soul_version(v["id"]) for v in marked] == ["one"]
+
+
+def test_restore_roundtrip_is_itself_reversible(monkeypatch, tmp_path: Path) -> None:
+    home = _home(monkeypatch, tmp_path)
+    config_io.write_soul("original")
+    config_io.write_soul("edited")  # archives "original"
+    (orig_v,) = config_io.list_soul_versions()
+
+    # "Roll back" to the archived original by re-saving it (what the restore route does).
+    config_io.write_soul(config_io.read_soul_version(orig_v["id"]))
+    assert (home / "config" / "SOUL.md").read_text() == "original"
+    # Rolling back archived the version it replaced ("edited") — so it's reversible.
+    assert "edited" in [config_io.read_soul_version(v["id"]) for v in config_io.list_soul_versions()]
+
+
+def test_read_version_rejects_traversal_and_unknown(monkeypatch, tmp_path: Path) -> None:
+    _home(monkeypatch, tmp_path)
+    config_io.write_soul("a")
+    config_io.write_soul("b")  # one real version exists
+    assert config_io.read_soul_version("../../etc/passwd") is None
+    assert config_io.read_soul_version("not-a-valid-id") is None
+    assert config_io.read_soul_version("") is None
+
+
+def test_history_is_capped(monkeypatch, tmp_path: Path) -> None:
+    home = _home(monkeypatch, tmp_path)
+    monkeypatch.setattr(config_io, "_SOUL_HISTORY_CAP", 3)
+    for i in range(6):
+        config_io.write_soul(f"rev-{i}")  # each archives the previous → 5 snapshots attempted
+    files = list(_hist(home).glob("*.md"))
+    assert len(files) == 3  # pruned to the cap
+    # The three kept are the most recent (rev-2, rev-3, rev-4 were the outgoing ones last kept).
+    kept = sorted(f.read_text() for f in files)
+    assert kept == ["rev-2", "rev-3", "rev-4"]


### PR DESCRIPTION
**DRAFT while steelman + adversarial review run** — backend only; auto-merges once ready + green.

## Problem
Persona edits overwrite `SOUL.md` in place, so a prior prompt iteration is gone for good (#1691).

## Change
Every persona save archives the **outgoing** `SOUL.md` to a per-instance `config/soul-history/` dir before writing the new text — deduped against the last snapshot, capped at the most recent 50, and a history failure never blocks the save.

- `infra/paths.py` — `soul_history_dir` (`config/soul-history`), in `explain()`.
- `graph/config_io.py` — `write_soul` snapshots the outgoing persona; `snapshot_soul` / `list_soul_versions` / `read_soul_version`. Version ids are `<YYYYMMDDThhmmss.ffffffZ>-<8-char content hash>` so a lexical sort stays chronological even for sub-second saves. `read_soul_version` validates the id against that format (**no path traversal**) with a resolved-parent check.
- `operator_api/config_routes.py` — `GET /api/config/soul/history` (list: id, timestamp, size, preview), `GET /api/config/soul/history/{id}` (full text), `POST /api/config/soul/history/{id}/restore`. **Restore re-saves through the normal `_apply_settings_changes` path, which snapshots the *current* persona first — so rolling back is itself reversible** — and recompiles the graph off the event loop (#497).

## Follow-ups (this batch)
- **Console version-history UI** — the "toggle back" list in Settings ▸ Identity (DRAFT, human visual review).
- **Persona-tagged telemetry** — a short `soul_rev` on the per-turn telemetry row + Langfuse trace metadata, so a run can be correlated with the persona that was live.

## Tests / gates
`tests/test_soul_history.py` (snapshot / dedup / cap / list / restore-roundtrip / traversal-reject) + route tests. `ruff` ✓ · `lint-imports` ✓ (3 kept) · `pytest tests/ -q` ✓ (3038 passed, 5 skipped) · `live_smoke.py` ✓

Closes #1691

🤖 Generated with [Claude Code](https://claude.com/claude-code)