### PR TITLE
feat(observability): tag per-turn telemetry with the active persona revision (#1691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to roll back. Restore re-saves through the normal save+reload path, which snapshots the
   *current* persona first — so rolling back is itself reversible. (Console version-history UI
   is a follow-up.)
+- **Telemetry is tagged with the active persona revision** (#1691). Each per-turn telemetry
+  row now carries `soul_rev` — a short hash of the `SOUL.md` persona that was live for that
+  turn — so a run can be correlated with a specific soul-history version (which persona was
+  the agent running when it did X?). The same tag rides the realtime `turn.usage` bus event
+  and Langfuse trace metadata. Deliberately **not** a Prometheus label: a content hash is
+  high-cardinality and would blow up the metric series. (`config_io.soul_revision()` computes
+  it; the telemetry-store column is added via a guarded migration, so existing DBs upgrade in
+  place.)
 - **Plugin setup: a "needs setup" cue + guided config for unconfigured plugins**
   (#1719, console). Building on the required-config gate below, an **incomplete**
   plugin (loaded but missing a `required: true` setting) now shows a ⚠️ **"needs

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -790,6 +790,15 @@ def read_soul() -> str:
     return ""
 
 
+def soul_revision() -> str:
+    """A short, stable fingerprint (8-char SHA-1) of the CURRENT effective persona (SOUL.md,
+    seed-fallback included) — so a run's telemetry can be tagged with which persona was live
+    (#1691). Empty string when there's no persona text. Matches the content-hash suffix of the
+    soul-history version ids, so a tagged run can be lined up with an archived version."""
+    text = read_soul()
+    return hashlib.sha1(text.encode("utf-8")).hexdigest()[:8] if text else ""
+
+
 def write_soul(text: str) -> list[Path]:
     """Write persona text to the instance's live ``SOUL.md`` (mkdir parents).
 

--- a/observability/telemetry_store.py
+++ b/observability/telemetry_store.py
@@ -41,6 +41,7 @@ _COLUMNS = (
     "tool_calls",
     "created_at",
     "ended_at",
+    "soul_rev",  # short hash of the persona (SOUL.md) live for this turn (#1691)
 )
 
 
@@ -79,17 +80,19 @@ class TelemetryStore:
                     llm_calls                   INTEGER DEFAULT 0,
                     tool_calls                  INTEGER DEFAULT 0,
                     created_at                  TEXT,
-                    ended_at                    TEXT
+                    ended_at                    TEXT,
+                    soul_rev                    TEXT
                 )
                 """
             )
             db.execute("CREATE INDEX IF NOT EXISTS ix_turns_ended ON turns(ended_at)")
-            # Lightweight migration for stores created before `models` existed
-            # (ADR 0006 Slice 4b). ALTER is idempotent-guarded by the try/except.
-            try:
-                db.execute("ALTER TABLE turns ADD COLUMN models TEXT")
-            except sqlite3.OperationalError:
-                pass  # column already present
+            # Lightweight migrations for stores created before a column existed. Each ALTER is
+            # idempotent-guarded by the try/except (fires once on an older DB, no-ops after).
+            for _col, _type in (("models", "TEXT"), ("soul_rev", "TEXT")):  # `models`: ADR 0006 4b; `soul_rev`: #1691
+                try:
+                    db.execute(f"ALTER TABLE turns ADD COLUMN {_col} {_type}")
+                except sqlite3.OperationalError:
+                    pass  # column already present
             db.commit()
         finally:
             db.close()

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -465,6 +465,16 @@ def _record_a2a_telemetry(outcome) -> None:
     except Exception:  # noqa: BLE001 — the Prometheus metric must never break a turn
         pass
 
+    # Which persona (SOUL.md) was live for this turn (#1691), so telemetry can be correlated
+    # with a soul-history version. Deliberately NOT a Prometheus label — a content hash is
+    # high-cardinality and would explode the metric series. Best-effort: never break a turn.
+    try:
+        from graph.config_io import soul_revision
+
+        soul_rev = soul_revision()
+    except Exception:  # noqa: BLE001
+        soul_rev = ""
+
     # Realtime cost/usage on the bus (ADR 0051 Slice 3) — a per-turn HUD can show live
     # spend without polling the telemetry store. Independent of the SQL store.
     try:
@@ -480,6 +490,7 @@ def _record_a2a_telemetry(outcome) -> None:
                 "output_tokens": int(_u.get("output_tokens", 0) or 0),
                 "cost_usd": round(float(getattr(outcome, "cost_usd", 0.0) or 0.0), 6),
                 "duration_ms": int(getattr(outcome, "duration_ms", 0) or 0),
+                "soul_rev": soul_rev,
             },
         )
     except Exception:  # noqa: BLE001 — best-effort
@@ -520,6 +531,7 @@ def _record_a2a_telemetry(outcome) -> None:
                 "tool_calls": int(outcome.tool_calls),
                 "created_at": created.isoformat(),
                 "ended_at": ended.isoformat(),
+                "soul_rev": soul_rev,
             }
         )
     except Exception:  # noqa: BLE001 — telemetry is best-effort

--- a/server/chat.py
+++ b/server/chat.py
@@ -1198,7 +1198,9 @@ async def _chat_langgraph_stream_impl(
 
     from graph.middleware.request_context import request_metadata_scope
 
-    trace_meta: dict = {"message_preview": message[:100]}
+    from graph.config_io import soul_revision
+
+    trace_meta: dict = {"message_preview": message[:100], "soul_rev": soul_revision()}
     if caller_trace:
         if caller_trace.get("traceId"):
             trace_meta["caller_trace_id"] = caller_trace["traceId"]
@@ -1559,10 +1561,12 @@ async def _chat_langgraph_impl(
     _state_extra = {"model": model} if (model or "").strip() else {}
     _state_extra["incognito"] = bool(incognito)
 
+    from graph.config_io import soul_revision
+
     async with tracing.trace_session(
         session_id=session_id,
         name="chat",
-        metadata={"message_preview": message[:100]},
+        metadata={"message_preview": message[:100], "soul_rev": soul_revision()},
     ):
         try:
             # Goal control messages short-circuit (set / status / clear).

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -329,6 +329,28 @@ def test_write_soul_writes_instance_soul(monkeypatch, tmp_path: Path) -> None:
     assert target.read_text() == "hello world"
 
 
+def test_soul_revision_hashes_the_current_persona(monkeypatch, tmp_path: Path) -> None:
+    """soul_revision() is a short SHA-1 of the effective persona — for tagging telemetry."""
+    import hashlib
+
+    from graph import config_io
+
+    home = tmp_path / "home"
+    (home / "config").mkdir(parents=True)
+    (home / "config" / "SOUL.md").write_text("persona text", encoding="utf-8")
+    monkeypatch.setenv("PROTOAGENT_HOME", str(home))
+
+    assert config_io.soul_revision() == hashlib.sha1(b"persona text").hexdigest()[:8]
+
+
+def test_soul_revision_empty_when_no_persona(monkeypatch, tmp_path: Path) -> None:
+    from graph import config_io
+
+    monkeypatch.setenv("PROTOAGENT_HOME", str(tmp_path / "empty"))
+    monkeypatch.setattr(config_io, "soul_source_path", lambda: tmp_path / "no-seed.md")
+    assert config_io.soul_revision() == ""
+
+
 # ── Gateway model listing ────────────────────────────────────────────────────
 
 

--- a/tests/test_telemetry_store.py
+++ b/tests/test_telemetry_store.py
@@ -51,6 +51,34 @@ def test_record_upserts_by_task_id(store):
     assert recent[0]["cost_usd"] == 0.05
 
 
+def test_record_persists_soul_rev(store):
+    # #1691: the persona (SOUL.md) revision live for the turn round-trips.
+    store.record(_row("t1", soul_rev="a1b2c3d4"))
+    assert store.recent()[0]["soul_rev"] == "a1b2c3d4"
+
+
+def test_soul_rev_migrates_onto_an_older_db(tmp_path):
+    # A store created before soul_rev existed gets the column via the guarded ALTER on open,
+    # so a soul_rev row then round-trips (same pattern as the earlier `models` migration).
+    import sqlite3
+
+    path = str(tmp_path / "old.db")
+    cols = (
+        "task_id TEXT PRIMARY KEY, session_id TEXT, state TEXT, success INTEGER, model TEXT, "
+        "models TEXT, input_tokens INTEGER, output_tokens INTEGER, total_tokens INTEGER, "
+        "cache_read_input_tokens INTEGER, cache_creation_input_tokens INTEGER, cost_usd REAL, "
+        "duration_ms INTEGER, llm_calls INTEGER, tool_calls INTEGER, created_at TEXT, ended_at TEXT"
+    )
+    db = sqlite3.connect(path)
+    db.execute(f"CREATE TABLE turns ({cols})")
+    db.commit()
+    db.close()
+
+    store = TelemetryStore(path)  # _init_db runs the guarded ALTER
+    store.record(_row("t1", soul_rev="deadbeef"))
+    assert store.recent()[0]["soul_rev"] == "deadbeef"
+
+
 def test_record_noop_without_task_id(store):
     store.record({"cost_usd": 1.0})  # no task_id
     assert store.recent() == []


### PR DESCRIPTION
**DRAFT — held until #1757 (SOUL.md version history) merges**, since both touch `graph/config_io.py`. Will rebase + mark ready after.

## Why
Once persona edits are versioned (#1757), the natural next question is *which persona was live when the agent did X?* This tags telemetry with a short `soul_rev` so runs can be correlated with a soul-history version.

## Change
- `graph/config_io.py` — `soul_revision()`: short SHA-1 of the current effective persona (same hash scheme as the soul-history version ids, so a tagged run lines up with an archived version).
- `observability/telemetry_store.py` — `soul_rev` column on the per-turn `turns` table, added via a **guarded `ALTER` migration** (same pattern as the earlier `models` column) so existing telemetry DBs upgrade in place.
- `server/a2a.py` — populate `soul_rev` on the SQL telemetry row **and** the realtime `turn.usage` bus event; computed once per turn, best-effort (never breaks a turn).
- `server/chat.py` — `soul_rev` in the Langfuse trace metadata (both trace sites).

**Not a Prometheus label** — a content hash is high-cardinality and would blow up the metric series.

## Tests / gates
telemetry-store column round-trip + old-DB migration; `soul_revision` hashing. `ruff` ✓ · `lint-imports` ✓ · `pytest tests/ -q` ✓ · `live_smoke.py` ✓ (real A2A turn exercises the telemetry path).

Part of #1691

🤖 Generated with [Claude Code](https://claude.com/claude-code)