### PR TITLE
feat(web): SOUL.md version history panel — view + one-click restore (#1691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   API: `GET /api/config/soul/history` (list — id, timestamp, size, preview), `GET
   /api/config/soul/history/{id}` (full text), and `POST /api/config/soul/history/{id}/restore`
   to roll back. Restore re-saves through the normal save+reload path, which snapshots the
-  *current* persona first — so rolling back is itself reversible. (Console version-history UI
-  is a follow-up.)
+  *current* persona first — so rolling back is itself reversible. A **Version history** section
+  under **Agent → Identity** lists every snapshot (with a *current* badge on the live one),
+  expands a row to show its full text, and rolls the persona back in one click behind an inline
+  confirm — the editor re-seeds to the restored persona unless you have an unsaved draft.
 - **Telemetry is tagged with the active persona revision** (#1691). Each per-turn telemetry
   row now carries `soul_rev` — a short hash of the `SOUL.md` persona that was live for that
   turn — so a run can be correlated with a specific soul-history version (which persona was

--- a/apps/web/src/agent/IdentityPanel.tsx
+++ b/apps/web/src/agent/IdentityPanel.tsx
@@ -10,7 +10,7 @@ import { Eye, Pencil, Save } from "lucide-react";
 
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { Markdown } from "../chat/LazyMarkdown";
-import { SoulHistory } from "./SoulHistory";
+import { SoulHistoryButton } from "./SoulHistory";
 import { api } from "../lib/api";
 import { queryKeys } from "../lib/queries";
 
@@ -107,9 +107,12 @@ export function IdentityPanel() {
             <div className="field soul-field">
               <div className="soul-head">
                 <span>SOUL.md — the agent's persona &amp; system identity</span>
-                <Button variant="ghost" type="button" onClick={() => setEditing((e) => !e)} data-testid="identity-soul-toggle">
-                  {editing ? <><Eye size={14} /> Preview</> : <><Pencil size={14} /> Edit</>}
-                </Button>
+                <div className="soul-head-actions">
+                  <SoulHistoryButton onRestored={handleRestored} />
+                  <Button variant="ghost" type="button" onClick={() => setEditing((e) => !e)} data-testid="identity-soul-toggle">
+                    {editing ? <><Eye size={14} /> Preview</> : <><Pencil size={14} /> Edit</>}
+                  </Button>
+                </div>
               </div>
               {editing ? (
                 <Textarea
@@ -127,7 +130,6 @@ export function IdentityPanel() {
                 </div>
               )}
             </div>
-            <SoulHistory onRestored={handleRestored} />
           </>
         )}
       </div>

--- a/apps/web/src/agent/IdentityPanel.tsx
+++ b/apps/web/src/agent/IdentityPanel.tsx
@@ -10,6 +10,7 @@ import { Eye, Pencil, Save } from "lucide-react";
 
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { Markdown } from "../chat/LazyMarkdown";
+import { SoulHistory } from "./SoulHistory";
 import { api } from "../lib/api";
 import { queryKeys } from "../lib/queries";
 
@@ -57,6 +58,19 @@ export function IdentityPanel() {
     },
     onError: () => toast({ tone: "error", title: "Save failed", message: "Check the server log." }),
   });
+
+  // A version restore re-writes SOUL.md out-of-band (through the same cascade a Save uses), so pull
+  // the fresh config and re-seed the editor to the restored persona. Only re-seed when the field is
+  // clean — an unsaved draft in the textarea shouldn't be clobbered by someone hitting Restore.
+  const handleRestored = async () => {
+    const fresh = await qc.fetchQuery({ queryKey: ["config"], queryFn: () => api.config() });
+    if (!dirty) {
+      setName(fresh.config?.identity?.name || "");
+      setSoul(fresh.soul || "");
+      setEditing(false);
+    }
+    qc.invalidateQueries({ queryKey: queryKeys.runtime });
+  };
 
   return (
     <section className="panel stage-panel">
@@ -113,6 +127,7 @@ export function IdentityPanel() {
                 </div>
               )}
             </div>
+            <SoulHistory onRestored={handleRestored} />
           </>
         )}
       </div>

--- a/apps/web/src/agent/SoulHistory.tsx
+++ b/apps/web/src/agent/SoulHistory.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@protolabsai/ui/primitives";
-import { useToast } from "@protolabsai/ui/overlays";
+import { Dialog, useToast } from "@protolabsai/ui/overlays";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { ChevronDown, ChevronRight, History, RotateCcw } from "lucide-react";
@@ -8,9 +8,11 @@ import { api } from "../lib/api";
 import type { SoulVersion } from "../lib/types";
 
 // Version history for the agent's persona (#1691). Every SOUL.md save archives the outgoing
-// text; this lists those snapshots newest-first and lets you roll back to one ("toggle back").
-// Restoring re-saves through the normal path, which snapshots the CURRENT persona first — so a
-// roll-back is itself reversible. `onRestored` lets the parent editor re-seed from the new SOUL.
+// text; this surfaces those snapshots as a restorable list ("toggle back"). It lives behind a
+// trigger button + dialog so it stays out of the way until wanted — the button carries the
+// snapshot count for discoverability. Restoring re-saves through the normal path, which
+// snapshots the CURRENT persona first, so a roll-back is itself reversible; `onRestored` lets
+// the parent editor re-seed from the new SOUL.
 
 function whenLabel(saved_at: string): string {
   if (!saved_at) return "unknown time";
@@ -18,7 +20,43 @@ function whenLabel(saved_at: string): string {
   return Number.isNaN(d.getTime()) ? "unknown time" : d.toLocaleString();
 }
 
-export function SoulHistory({ onRestored }: { onRestored: () => void }) {
+export function SoulHistoryButton({ onRestored }: { onRestored: () => void }) {
+  const [open, setOpen] = useState(false);
+  // Cheap read that also powers the count badge; the dialog's list shares this query key, so
+  // opening it is instant and a restore's invalidation updates both the badge and the list.
+  const { data } = useQuery({ queryKey: ["soul-history"], queryFn: () => api.soulHistory() });
+  const count = data?.versions.length ?? 0;
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        type="button"
+        onClick={() => setOpen(true)}
+        title="View and restore earlier versions of this persona"
+        data-testid="soul-history-open"
+      >
+        <History size={14} /> History{count > 0 ? ` (${count})` : ""}
+      </Button>
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        title="Persona version history"
+        width={620}
+        className="soul-history-dialog"
+      >
+        <SoulHistoryList
+          onRestored={() => {
+            onRestored();
+            setOpen(false); // the editor now shows the restored persona — that's the confirmation
+          }}
+        />
+      </Dialog>
+    </>
+  );
+}
+
+function SoulHistoryList({ onRestored }: { onRestored: () => void }) {
   const qc = useQueryClient();
   const toast = useToast();
   const { data, isLoading, isError } = useQuery({
@@ -44,78 +82,70 @@ export function SoulHistory({ onRestored }: { onRestored: () => void }) {
     onError: () => toast({ tone: "error", title: "Restore failed", message: "Check the server log." }),
   });
 
+  if (isLoading) return <p className="muted soul-history-empty">Loading versions…</p>;
+  if (isError) return <p className="muted soul-history-empty">Couldn't load version history.</p>;
+
   const versions: SoulVersion[] = data?.versions ?? [];
+  if (versions.length === 0) {
+    return (
+      <p className="muted soul-history-empty">
+        No earlier versions yet — each time you save the persona, the previous one is archived here.
+      </p>
+    );
+  }
 
   return (
-    <div className="soul-history" data-testid="soul-history">
-      <div className="soul-history-head">
-        <History size={14} />
-        <span>Version history</span>
-        {versions.length > 0 && <span className="soul-history-count">{versions.length}</span>}
-      </div>
-
-      {isLoading ? (
-        <p className="muted soul-history-empty">Loading versions…</p>
-      ) : isError ? (
-        <p className="muted soul-history-empty">Couldn't load version history.</p>
-      ) : versions.length === 0 ? (
-        <p className="muted soul-history-empty">
-          No earlier versions yet — each time you save the persona, the previous one is archived here.
-        </p>
-      ) : (
-        <ul className="soul-history-list">
-          {versions.map((v) => {
-            const isOpen = expanded === v.id;
-            return (
-              <li key={v.id} className={`soul-history-item${v.is_current ? " is-current" : ""}`}>
-                <div className="soul-history-row">
-                  <button
+    <ul className="soul-history-list" data-testid="soul-history">
+      {versions.map((v) => {
+        const isOpen = expanded === v.id;
+        return (
+          <li key={v.id} className={`soul-history-item${v.is_current ? " is-current" : ""}`}>
+            <div className="soul-history-row">
+              <button
+                type="button"
+                className="soul-history-toggle"
+                aria-expanded={isOpen}
+                onClick={() => setExpanded(isOpen ? null : v.id)}
+                data-testid="soul-history-toggle"
+              >
+                {isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                <span className="soul-history-when">{whenLabel(v.saved_at)}</span>
+                {v.is_current && <span className="soul-history-badge">current</span>}
+                <span className="soul-history-preview">{v.preview || "(empty persona)"}</span>
+              </button>
+              {!v.is_current &&
+                (confirming === v.id ? (
+                  <span className="soul-history-confirm">
+                    <Button
+                      variant="primary"
+                      type="button"
+                      disabled={restore.isPending}
+                      onClick={() => restore.mutate(v.id)}
+                      data-testid="soul-history-confirm"
+                    >
+                      {restore.isPending ? "Restoring…" : "Confirm"}
+                    </Button>
+                    <Button variant="ghost" type="button" onClick={() => setConfirming(null)}>
+                      Cancel
+                    </Button>
+                  </span>
+                ) : (
+                  <Button
+                    variant="ghost"
                     type="button"
-                    className="soul-history-toggle"
-                    aria-expanded={isOpen}
-                    onClick={() => setExpanded(isOpen ? null : v.id)}
-                    data-testid="soul-history-toggle"
+                    onClick={() => setConfirming(v.id)}
+                    title="Roll the persona back to this version"
+                    data-testid="soul-history-restore"
                   >
-                    {isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
-                    <span className="soul-history-when">{whenLabel(v.saved_at)}</span>
-                    {v.is_current && <span className="soul-history-badge">current</span>}
-                    <span className="soul-history-preview">{v.preview || "(empty persona)"}</span>
-                  </button>
-                  {!v.is_current &&
-                    (confirming === v.id ? (
-                      <span className="soul-history-confirm">
-                        <Button
-                          variant="primary"
-                          type="button"
-                          disabled={restore.isPending}
-                          onClick={() => restore.mutate(v.id)}
-                          data-testid="soul-history-confirm"
-                        >
-                          {restore.isPending ? "Restoring…" : "Confirm"}
-                        </Button>
-                        <Button variant="ghost" type="button" onClick={() => setConfirming(null)}>
-                          Cancel
-                        </Button>
-                      </span>
-                    ) : (
-                      <Button
-                        variant="ghost"
-                        type="button"
-                        onClick={() => setConfirming(v.id)}
-                        title="Roll the persona back to this version"
-                        data-testid="soul-history-restore"
-                      >
-                        <RotateCcw size={14} /> Restore
-                      </Button>
-                    ))}
-                </div>
-                {isOpen && <VersionBody id={v.id} />}
-              </li>
-            );
-          })}
-        </ul>
-      )}
-    </div>
+                    <RotateCcw size={14} /> Restore
+                  </Button>
+                ))}
+            </div>
+            {isOpen && <VersionBody id={v.id} />}
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 

--- a/apps/web/src/agent/SoulHistory.tsx
+++ b/apps/web/src/agent/SoulHistory.tsx
@@ -1,0 +1,135 @@
+import { Button } from "@protolabsai/ui/primitives";
+import { useToast } from "@protolabsai/ui/overlays";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { ChevronDown, ChevronRight, History, RotateCcw } from "lucide-react";
+
+import { api } from "../lib/api";
+import type { SoulVersion } from "../lib/types";
+
+// Version history for the agent's persona (#1691). Every SOUL.md save archives the outgoing
+// text; this lists those snapshots newest-first and lets you roll back to one ("toggle back").
+// Restoring re-saves through the normal path, which snapshots the CURRENT persona first — so a
+// roll-back is itself reversible. `onRestored` lets the parent editor re-seed from the new SOUL.
+
+function whenLabel(saved_at: string): string {
+  if (!saved_at) return "unknown time";
+  const d = new Date(saved_at);
+  return Number.isNaN(d.getTime()) ? "unknown time" : d.toLocaleString();
+}
+
+export function SoulHistory({ onRestored }: { onRestored: () => void }) {
+  const qc = useQueryClient();
+  const toast = useToast();
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["soul-history"],
+    queryFn: () => api.soulHistory(),
+  });
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState<string | null>(null);
+
+  const restore = useMutation({
+    mutationFn: (id: string) => api.restoreSoulVersion(id),
+    onSuccess: (res) => {
+      setConfirming(null);
+      qc.invalidateQueries({ queryKey: ["soul-history"] });
+      const noop = res.messages?.some((m) => m.includes("already the current"));
+      toast({
+        tone: "success",
+        title: noop ? "Already current" : "Version restored",
+        message: noop ? "That version is already the live persona." : "Agent reloaded to this persona.",
+      });
+      if (!noop) onRestored();
+    },
+    onError: () => toast({ tone: "error", title: "Restore failed", message: "Check the server log." }),
+  });
+
+  const versions: SoulVersion[] = data?.versions ?? [];
+
+  return (
+    <div className="soul-history" data-testid="soul-history">
+      <div className="soul-history-head">
+        <History size={14} />
+        <span>Version history</span>
+        {versions.length > 0 && <span className="soul-history-count">{versions.length}</span>}
+      </div>
+
+      {isLoading ? (
+        <p className="muted soul-history-empty">Loading versions…</p>
+      ) : isError ? (
+        <p className="muted soul-history-empty">Couldn't load version history.</p>
+      ) : versions.length === 0 ? (
+        <p className="muted soul-history-empty">
+          No earlier versions yet — each time you save the persona, the previous one is archived here.
+        </p>
+      ) : (
+        <ul className="soul-history-list">
+          {versions.map((v) => {
+            const isOpen = expanded === v.id;
+            return (
+              <li key={v.id} className={`soul-history-item${v.is_current ? " is-current" : ""}`}>
+                <div className="soul-history-row">
+                  <button
+                    type="button"
+                    className="soul-history-toggle"
+                    aria-expanded={isOpen}
+                    onClick={() => setExpanded(isOpen ? null : v.id)}
+                    data-testid="soul-history-toggle"
+                  >
+                    {isOpen ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                    <span className="soul-history-when">{whenLabel(v.saved_at)}</span>
+                    {v.is_current && <span className="soul-history-badge">current</span>}
+                    <span className="soul-history-preview">{v.preview || "(empty persona)"}</span>
+                  </button>
+                  {!v.is_current &&
+                    (confirming === v.id ? (
+                      <span className="soul-history-confirm">
+                        <Button
+                          variant="primary"
+                          type="button"
+                          disabled={restore.isPending}
+                          onClick={() => restore.mutate(v.id)}
+                          data-testid="soul-history-confirm"
+                        >
+                          {restore.isPending ? "Restoring…" : "Confirm"}
+                        </Button>
+                        <Button variant="ghost" type="button" onClick={() => setConfirming(null)}>
+                          Cancel
+                        </Button>
+                      </span>
+                    ) : (
+                      <Button
+                        variant="ghost"
+                        type="button"
+                        onClick={() => setConfirming(v.id)}
+                        title="Roll the persona back to this version"
+                        data-testid="soul-history-restore"
+                      >
+                        <RotateCcw size={14} /> Restore
+                      </Button>
+                    ))}
+                </div>
+                {isOpen && <VersionBody id={v.id} />}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// The full text of one version, fetched on demand when a row is expanded.
+function VersionBody({ id }: { id: string }) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["soul-version", id],
+    queryFn: () => api.soulVersion(id),
+  });
+  if (isLoading) return <p className="muted soul-history-body">Loading…</p>;
+  if (isError) return <p className="muted soul-history-body">Couldn't load this version.</p>;
+  return (
+    <pre className="soul-history-body" data-testid="soul-history-body">
+      {data?.content || "(empty persona)"}
+    </pre>
+  );
+}

--- a/apps/web/src/agent/identity.css
+++ b/apps/web/src/agent/identity.css
@@ -46,39 +46,15 @@
   margin: 0;
 }
 
-/* Persona version history (#1691) — sits below the editor. The editor (.soul-field, flex:1)
-   owns the elastic space; the history keeps its natural height and scrolls its own list, so a
-   long list never pushes the editor off-panel. */
-.soul-history {
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding-top: 12px;
-  border-top: 1px solid var(--border);
-}
-.soul-history-head {
+/* Persona version history (#1691) — lives behind the "History" trigger in the SOUL header and
+   opens in a dialog. `.soul-head-actions` groups that trigger with the Edit/Preview toggle. */
+.soul-head-actions {
   display: flex;
   align-items: center;
-  gap: 7px;
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--fg) 62%, transparent);
-}
-.soul-history-count {
-  font-variant-numeric: tabular-nums;
-  min-width: 18px;
-  padding: 0 5px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--fg) 10%, transparent);
-  color: var(--fg);
-  font-size: 11px;
-  text-align: center;
+  gap: 6px;
 }
 .soul-history-empty {
-  font-size: 12px;
+  font-size: 13px;
   margin: 0;
 }
 .soul-history-list {
@@ -88,7 +64,10 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
-  max-height: 210px;
+  /* Grow with the content so the dialog is sized to its list (no dead space under a short list),
+     but cap at most of the viewport so a long history scrolls inside the dialog rather than
+     pushing it past the screen. The DS dialog itself is content-sized (max-height 100vh). */
+  max-height: 68vh;
   overflow-y: auto;
 }
 .soul-history-item {

--- a/apps/web/src/agent/identity.css
+++ b/apps/web/src/agent/identity.css
@@ -45,3 +45,124 @@
   font-size: 12px;
   margin: 0;
 }
+
+/* Persona version history (#1691) — sits below the editor. The editor (.soul-field, flex:1)
+   owns the elastic space; the history keeps its natural height and scrolls its own list, so a
+   long list never pushes the editor off-panel. */
+.soul-history {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.soul-history-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--fg) 62%, transparent);
+}
+.soul-history-count {
+  font-variant-numeric: tabular-nums;
+  min-width: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+  color: var(--fg);
+  font-size: 11px;
+  text-align: center;
+}
+.soul-history-empty {
+  font-size: 12px;
+  margin: 0;
+}
+.soul-history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 210px;
+  overflow-y: auto;
+}
+.soul-history-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--fg) 2%, transparent);
+}
+.soul-history-item.is-current {
+  border-color: color-mix(in srgb, var(--accent, var(--fg)) 45%, var(--border));
+}
+.soul-history-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px 6px 6px;
+}
+.soul-history-toggle {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: 0;
+  padding: 2px;
+  cursor: pointer;
+  color: var(--fg);
+  text-align: left;
+  font: inherit;
+}
+.soul-history-toggle > svg { flex-shrink: 0; opacity: 0.6; }
+.soul-history-when {
+  flex-shrink: 0;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: color-mix(in srgb, var(--fg) 78%, transparent);
+}
+.soul-history-badge {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent, var(--fg)) 18%, transparent);
+  color: color-mix(in srgb, var(--accent, var(--fg)) 90%, var(--fg));
+}
+.soul-history-preview {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: color-mix(in srgb, var(--fg) 52%, transparent);
+}
+.soul-history-confirm {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.soul-history-body {
+  margin: 0 8px 8px;
+  padding: 10px 12px;
+  max-height: 260px;
+  overflow: auto;
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--fg);
+}

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -391,3 +391,39 @@ describe("api.backgroundJob / loadBackgroundReport (ADR 0070 D4)", () => {
     expect(calls).toEqual([`/api/background/${JOB}`]); // never reached the list
   });
 });
+
+// ── SOUL.md version history (#1691) ────────────────────────────────────────────
+// The three routes the version-history panel drives: list, fetch-one, restore.
+describe("api soul version history (#1691)", () => {
+  beforeEach(() => window.history.replaceState({}, "", "/app/")); // host window, no slug prefix
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("soulHistory GETs the history list route", async () => {
+    const calls = stubFetch(() => json({ versions: [] }));
+    await expect(api.soulHistory()).resolves.toEqual({ versions: [] });
+    expect(calls).toEqual(["/api/config/soul/history"]);
+  });
+
+  it("soulVersion GETs one version and URL-encodes the id", async () => {
+    const calls = stubFetch(() => json({ id: "a/b", content: "# persona" }));
+    const res = await api.soulVersion("a/b");
+    expect(res.content).toBe("# persona");
+    expect(calls).toEqual(["/api/config/soul/history/a%2Fb"]); // encodeURIComponent, not a path split
+  });
+
+  it("restoreSoulVersion POSTs to the restore route", async () => {
+    const seen: { path: string; method?: string }[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        seen.push({ path: String(input), method: init?.method });
+        return json({ ok: true, messages: ["reloaded"], restored: "20260101T000000.000000Z-abcd1234" });
+      }),
+    );
+    const res = await api.restoreSoulVersion("20260101T000000.000000Z-abcd1234");
+    expect(res.ok).toBe(true);
+    expect(res.messages).toEqual(["reloaded"]);
+    expect(seen[0].path).toBe("/api/config/soul/history/20260101T000000.000000Z-abcd1234/restore");
+    expect(seen[0].method).toBe("POST");
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -33,6 +33,7 @@ import type {
   SetupStatus,
   SettingsGroup,
   SlashCommand,
+  SoulVersion,
   Playbook,
   Subagent,
   ToolInfo,
@@ -957,6 +958,20 @@ export const api = {
 
   soulPreset(name: string) {
     return request<{ name: string; content: string }>(`/api/config/presets/${encodeURIComponent(name)}`);
+  },
+
+  // SOUL.md version history (#1691): every persona save archives the outgoing text.
+  soulHistory() {
+    return request<{ versions: SoulVersion[] }>("/api/config/soul/history");
+  },
+  soulVersion(id: string) {
+    return request<{ id: string; content: string }>(`/api/config/soul/history/${encodeURIComponent(id)}`);
+  },
+  restoreSoulVersion(id: string) {
+    return request<{ ok: boolean; messages: string[]; restored: string }>(
+      `/api/config/soul/history/${encodeURIComponent(id)}/restore`,
+      { method: "POST" },
+    );
   },
 
   models(apiBase: string, apiKey: string) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -863,3 +863,13 @@ export type FlagInfo = {
   source: "channel" | "env";
 };
 export type FlagsPayload = { channel: FlagChannel; flags: FlagInfo[] };
+
+// A recorded SOUL.md persona snapshot (#1691). `saved_at` is ISO-8601 UTC (or "" if
+// unparseable); `is_current` marks the one whose text matches the live persona.
+export type SoulVersion = {
+  id: string;
+  saved_at: string;
+  size: number;
+  preview: string;
+  is_current: boolean;
+};

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -908,26 +908,32 @@ def _soul_preview(text: str, limit: int) -> str:
 def list_soul_versions(preview_chars: int = 140) -> list[dict]:
     """Recorded SOUL.md snapshots, newest first: ``{id, saved_at, size, preview, is_current}``.
     ``saved_at`` is ISO-8601 UTC; ``preview`` is the leading text with whitespace collapsed for a
-    one-line UI summary; ``is_current`` marks the snapshot whose text matches the live persona
-    (true right after a restore — so a version panel can flag which one is active without a
+    one-line UI summary; ``is_current`` marks the NEWEST snapshot whose text matches the live
+    persona (true right after a restore — so a version panel can flag which one is active without a
     separate config fetch). Unreadable files are skipped."""
     try:
         current = read_soul()
     except (OSError, ValueError):
         current = ""
     out: list[dict] = []
-    for path in _soul_history_files():
+    current_seen = False
+    for path in _soul_history_files():  # newest first
         try:
             text = path.read_text(encoding="utf-8")
         except (OSError, ValueError):  # a corrupt history file is skipped, never 500s the list
             continue
+        # Several archived copies can be byte-identical — dedup only collapses CONSECUTIVE repeats,
+        # so a persona saved, changed, and saved again lands twice. Flag only the FIRST (newest)
+        # match as current, else a restored-to persona lights up every identical row (#1691).
+        is_current = bool(current) and not current_seen and text == current
+        current_seen = current_seen or is_current
         out.append(
             {
                 "id": path.stem,
                 "saved_at": _soul_version_saved_at(path.stem),
                 "size": len(text),
                 "preview": _soul_preview(text, preview_chars),
-                "is_current": text == current,
+                "is_current": is_current,
             }
         )
     return out

--- a/tests/test_soul_history.py
+++ b/tests/test_soul_history.py
@@ -92,6 +92,22 @@ def test_is_current_flags_the_live_version_after_restore(monkeypatch, tmp_path: 
     assert [config_io.read_soul_version(v["id"]) for v in marked] == ["one"]
 
 
+def test_is_current_marks_only_the_newest_of_identical_snapshots(monkeypatch, tmp_path: Path) -> None:
+    # Non-consecutive identical saves BOTH land in history (dedup only collapses adjacent repeats),
+    # so a persona can appear more than once. When the live persona equals them, only the newest
+    # copy may be flagged current — else a restored-to persona lights up every identical row, which
+    # is the "two rows say current" bug reported against #1691.
+    _home(monkeypatch, tmp_path)
+    for text in ("T", "U", "T", "U", "T"):  # archives T, U, T, U → history has T twice; live = "T"
+        config_io.write_soul(text)
+    versions = config_io.list_soul_versions()
+    flagged = [v for v in versions if v["is_current"]]
+    assert len(flagged) == 1, [(v["preview"], v["is_current"]) for v in versions]
+    # ...and it is the NEWEST of the identical "T" snapshots (list is newest-first).
+    t_rows = [v for v in versions if config_io.read_soul_version(v["id"]) == "T"]
+    assert len(t_rows) == 2 and flagged[0]["id"] == t_rows[0]["id"]
+
+
 def test_restore_roundtrip_is_itself_reversible(monkeypatch, tmp_path: Path) -> None:
     home = _home(monkeypatch, tmp_path)
     config_io.write_soul("original")


### PR DESCRIPTION
Closes the console half of #1691. Backend (auto-snapshot + list/get/restore API) shipped in #1757; telemetry tagging in #1758.

## What
A **Version history** section under the persona editor in **Agent → Identity**:
- Every archived `SOUL.md` snapshot, newest-first, with save time + a text preview.
- A **current** badge on the version whose text matches the live persona.
- Expand a row to read that version's full text (fetched on demand).
- **Restore** — rolls the persona back to that version behind an inline confirm ("toggle back"). It routes through the same save+reload path, which snapshots the *current* persona first, so a roll-back is itself reversible.
- After a restore the editor re-seeds to the restored persona — unless there's an unsaved draft in the textarea, which is preserved.
- Loading / empty / error states handled; the list scrolls internally so a long history never pushes the editor off-panel.

## Why draft
Console UX/visual change — CI can't judge layout, spacing, or the restore-confirm flow. Needs a human look before merge (per the UI local-test gate).

## How to test
1. `scripts/dev.sh` + `npm run dev` (dev instance :7871).
2. Agent → Identity → edit the persona → **Save & reload**. Do it 2–3 times.
3. The **Version history** section lists each prior persona; the live one shows a **current** badge.
4. Expand a row → full text. Click **Restore** → **Confirm** → the editor + agent flip to that version; the badge moves.
5. Restore again → confirm the previous persona is itself now in the list (reversible).

## Gates (run in worktree)
- `npm run test:unit` → **355 passed**
- `npx tsc --noEmit` → clean
- `npm run build` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)