### PR TITLE
fix(web): dedupe rail surfaces by id so a fork surface can't render twice (#1755)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -66,6 +66,7 @@ import { ChatResumeWatch } from "./ChatResumeWatch";
 import { BackgroundJobs } from "./BackgroundJobs";
 import { ProtoLabsIcon } from "./ProtoLabsIcon";
 import { bootGatePhase } from "./bootGate";
+import { dedupeRailById } from "./rail";
 import { AuthGate } from "./AuthGate";
 import { authRequired, subscribeAuth } from "../lib/auth";
 import { TenantGuard } from "./TenantGuard";
@@ -530,7 +531,10 @@ export function App() {
       // rather than adding a second rail item.
       .filter((s) => s.id !== "chat")
       .map((s): RailItem => ({ id: s.id, label: s.label, icon: s.icon }));
-    return [...ordered, ...extra, ...ext];
+    // `ext` is appended without a placement check, so a fork surface whose id collides with one
+    // already in `ordered`/`extra` would render a second time — a duplicate rail key that desyncs
+    // the DS sortable rail's index→id mapping. Dedup by id (first occurrence wins). (#1755)
+    return dedupeRailById([...ordered, ...extra, ...ext]);
   }
 
   // Right-click the EMPTY rail background (not an icon) → the "Hidden views" restore menu

--- a/apps/web/src/app/rail.test.ts
+++ b/apps/web/src/app/rail.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+
+import { dedupeRailById } from "./rail";
+
+describe("dedupeRailById (#1755 rail hardening)", () => {
+  it("keeps the first occurrence of each id and drops later duplicates", () => {
+    // A fork-contributed surface whose id collides with a core surface already in the list: the
+    // core one wins (it comes first), the fork dup is dropped — no duplicate rail button/key.
+    const items = [
+      { id: "chat", label: "Chat" },
+      { id: "plugin:github:prs", label: "Pull Requests" },
+      { id: "chat", label: "Chat (fork override)" },
+    ];
+    const out = dedupeRailById(items);
+    expect(out.map((i) => i.id)).toEqual(["chat", "plugin:github:prs"]);
+    expect(out[0].label).toBe("Chat"); // first wins — the fork dup does not replace it
+  });
+
+  it("is a no-op (preserving order) when every id is unique", () => {
+    const items = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    expect(dedupeRailById(items)).toEqual(items);
+  });
+
+  it("collapses several duplicates of the same id to one", () => {
+    const items = [{ id: "x" }, { id: "x" }, { id: "y" }, { id: "x" }];
+    expect(dedupeRailById(items).map((i) => i.id)).toEqual(["x", "y"]);
+  });
+
+  it("handles an empty list", () => {
+    expect(dedupeRailById([])).toEqual([]);
+  });
+});

--- a/apps/web/src/app/rail.ts
+++ b/apps/web/src/app/rail.ts
@@ -1,0 +1,16 @@
+// Rail-surface helpers (ADR 0036). The rail item list is assembled from three sources — the
+// user-ordered `railOrder` surfaces, plugin views not yet reconciled, and fork-contributed
+// (`ext`) surfaces. The first two are mutually exclusive by construction, but `ext` surfaces are
+// appended without a placement check, so a fork id that collides with a core/plugin id already in
+// the list would render twice. A duplicate id is a duplicate React key AND a duplicate dnd-kit
+// sortable id, which desyncs the sortable rail's index→id mapping. Dedup by id before the list
+// reaches the rail. (#1755 hardening — see the issue for the separate DS-side click bug.)
+
+export function dedupeRailById<T extends { id: string }>(items: T[]): T[] {
+  const seen = new Set<string>();
+  return items.filter((it) => {
+    if (seen.has(it.id)) return false;
+    seen.add(it.id);
+    return true;
+  });
+}


### PR DESCRIPTION
Hardening surfaced while investigating #1755 (wrong-item rail clicks).

## The real bug this fixes
`railSurfaces()` (`App.tsx`) assembles rail items from three sources — `ordered` (user's `railOrder`), `extra` (plugin views not yet reconciled), and `ext` (fork-contributed surfaces via the `src/ext` seam). `ordered`/`extra` are mutually exclusive by construction, but **`ext` is appended with no placement check** — only `id === "chat"` is guarded. A fork surface whose id collides with a core/plugin id already in the list rendered **twice**: a duplicate React key *and* a duplicate dnd-kit sortable id, which desyncs the sortable rail's index→id mapping.

Fix: `dedupeRailById([...ordered, ...extra, ...ext])` — first occurrence wins, so a colliding fork surface never adds a second button. No-op in the normal (unique-id) case, so zero visual change.

## Honesty on #1755 — this does NOT close it
The reported case (GitHub *plugin* view, `plugin:github:*`) flows through `ordered`/`extra`, **not** `ext`, and `reconcilePluginViews` keeps `railOrder` duplicate-free — so this dedup can't be the GitHub bug's cause. Both the console click path (`onSelect(side, id) → setSurface(id)`, id-based) and the DS sortable rail (proper `distance: 6` activation constraint; `SortableContext` order == render order) are clean on inspection. The remaining suspect is a **dnd-kit transform/stacking artifact inside `@protolabsai/ui`'s sortable rail** — filed on protoContent. **#1755 stays open pending a live repro.**

## Gates (worktree)
- `npm run test:unit` → **362 passed** (+4, new `src/app/rail.test.ts`)
- `npx tsc --noEmit` → clean
- `npm run build` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate items from appearing in the app’s dock/rail areas.
  * Improved stability of the app shell by keeping rail item ordering consistent when overlaps occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->