### PR TITLE
feat(web): quick-chat with any fleet agent from the command palette (#1733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Quick-chat with any fleet agent from the command palette** (#1733). ⌘K now has an
+  **Agents** section listing every other reachable agent in your fleet (with its reachability
+  inline); pick one and you land straight in that agent's console. Recently-opened agents sort
+  to the top, and a stopped/unreachable agent is shown disabled. Works from the in-app palette
+  and the always-on-top desktop launcher alike, so it's a true from-anywhere agent switcher.
 - **SOUL.md keeps a version history — never lose a persona iteration** (#1691). Every time
   the agent's persona is saved, the **outgoing** `SOUL.md` is archived to a per-instance
   `config/soul-history/` directory (deduped against the last snapshot, capped at the most

--- a/apps/web/src/app/fleetPalette.test.ts
+++ b/apps/web/src/app/fleetPalette.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { fleetPaletteEntries, markAgentOpened, readAgentRecency } from "./fleetPalette";
+import type { FleetAgent } from "../lib/types";
+
+function agent(over: Partial<FleetAgent>): FleetAgent {
+  return { name: "a", id: "a", port: 7870, pid: 1, running: true, bundle: "", ...over };
+}
+
+describe("fleetPaletteEntries (#1733)", () => {
+  it("lists other agents reachable-first then alphabetical, omitting the focused one", () => {
+    const agents = [
+      agent({ name: "zed", id: "zed", running: true }),
+      agent({ name: "ava", id: "ava", running: true }),
+      agent({ name: "down", id: "down", running: false }),
+      agent({ name: "me", id: "me", running: true }),
+    ];
+    const out = fleetPaletteEntries(agents, "me");
+    expect(out.map((e) => e.slug)).toEqual(["ava", "zed", "down"]); // reachable alpha, then the down one
+    expect(out.find((e) => e.slug === "me")).toBeUndefined(); // the focused agent is omitted
+    expect(out.find((e) => e.slug === "down")!.disabled).toBe(true);
+  });
+
+  it("routes the host entry by the literal 'host' slug, not its id", () => {
+    const out = fleetPaletteEntries([agent({ name: "Main", id: "ignored", host: true })], "other");
+    expect(out[0].slug).toBe("host");
+  });
+
+  it("floats a recently-opened agent above alphabetical order", () => {
+    const agents = [agent({ name: "ava", id: "ava" }), agent({ name: "bob", id: "bob" })];
+    expect(fleetPaletteEntries(agents, "me", { bob: 999 }).map((e) => e.slug)).toEqual(["bob", "ava"]);
+  });
+
+  it("shows a down remote as disabled with an 'unreachable' hint", () => {
+    const [only] = fleetPaletteEntries([agent({ name: "r", id: "r", remote: true, running: false })], "me");
+    expect(only.disabled).toBe(true);
+    expect(only.hint).toBe("unreachable");
+  });
+
+  it("labels a reachable remote 'remote · switch'", () => {
+    const [only] = fleetPaletteEntries([agent({ name: "r", id: "r", remote: true, running: true })], "me");
+    expect(only.disabled).toBe(false);
+    expect(only.hint).toBe("remote · switch");
+  });
+});
+
+describe("agent recency store", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("records and reads back last-opened timestamps", () => {
+    markAgentOpened("ava", 100);
+    markAgentOpened("bob", 200);
+    expect(readAgentRecency()).toEqual({ ava: 100, bob: 200 });
+  });
+
+  it("returns an empty map when nothing is stored", () => {
+    expect(readAgentRecency()).toEqual({});
+  });
+});

--- a/apps/web/src/app/fleetPalette.ts
+++ b/apps/web/src/app/fleetPalette.ts
@@ -1,0 +1,70 @@
+// Fleet quick-chat palette entries (#1733). The command palette gets an "Agents" section listing
+// every OTHER fleet agent; picking one navigates to that agent's slug-routed console, where you
+// chat with it immediately. Reachability comes straight from the roster: `running` IS the remote's
+// reachability probe (see FleetManagerPanel), so a down/unreachable agent is shown disabled.
+import type { FleetAgent } from "../lib/types";
+
+export type FleetPaletteEntry = {
+  id: string;
+  slug: string;
+  label: string;
+  hint: string;
+  disabled: boolean;
+  keywords: string[];
+};
+
+const RECENCY_KEY = "protoagent.fleet.recent";
+
+/** Last-opened timestamp per agent slug (localStorage) — powers "recently chatted sorts first". */
+export function readAgentRecency(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(RECENCY_KEY);
+    const parsed = raw ? JSON.parse(raw) : {};
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, number>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Record that an agent was just opened from the palette so it sorts to the top next time. */
+export function markAgentOpened(slug: string, now: number = Date.now()): void {
+  try {
+    const r = readAgentRecency();
+    r[slug] = now;
+    localStorage.setItem(RECENCY_KEY, JSON.stringify(r));
+  } catch {
+    /* localStorage unavailable — recency is a nicety, never let it block the open */
+  }
+}
+
+/** Build the palette's fleet entries from the live roster: every agent EXCEPT the one this window
+ *  is focused on, ordered reachable-first → most-recently-opened → alphabetical. Down agents stay
+ *  in the list but disabled (you can't chat with one that isn't up). The host entry's slug is the
+ *  literal "host" (ADR 0042 routing), not its `id`. */
+export function fleetPaletteEntries(
+  agents: FleetAgent[],
+  currentSlug: string,
+  recency: Record<string, number> = {},
+): FleetPaletteEntry[] {
+  return agents
+    .map((a) => {
+      const slug = a.host ? "host" : a.id;
+      const reachable = a.running;
+      const hint = reachable ? (a.remote ? "remote · switch" : "switch") : a.remote ? "unreachable" : "stopped";
+      return {
+        id: `fleet:${slug}`,
+        slug,
+        label: a.name,
+        hint,
+        disabled: !reachable,
+        keywords: ["fleet", "agent", "chat", "switch", a.name, slug],
+      };
+    })
+    .filter((e) => e.slug !== currentSlug) // you're already on this one — its own "Chat with…" covers it
+    .sort(
+      (a, b) =>
+        Number(a.disabled) - Number(b.disabled) || // reachable before down
+        (recency[b.slug] ?? 0) - (recency[a.slug] ?? 0) || // most-recently-opened next
+        a.label.localeCompare(b.label), // then alphabetical
+    );
+}

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -16,6 +16,10 @@ import { useUI } from "../state/uiStore";
 import type { View } from "../lib/viewRegistry";
 import { registerPaletteCommand, registeredPaletteCommands } from "../ext/paletteRegistry";
 import type { PaletteCommand } from "../ext/paletteRegistry";
+import { useQuery } from "@tanstack/react-query";
+import { agentHref, currentSlug } from "../lib/api";
+import { fleetQuery } from "../lib/queries";
+import { fleetPaletteEntries, markAgentOpened, readAgentRecency } from "./fleetPalette";
 
 /** Optional inline chat with the focused agent (ADR 0057). App builds the native chat
  *  PaletteView (it needs JSX + the focused agent name); the adapter registers it + a
@@ -74,7 +78,8 @@ export function openView(id: string) {
 export type NavIntent =
   | { kind: "view"; id: string }
   | { kind: "plugins"; tab: "local" | "market" }
-  | { kind: "global"; section?: string };
+  | { kind: "global"; section?: string }
+  | { kind: "agent"; slug: string };
 
 /** Apply an intent to THIS window's UI store. The default navigator, and what the main
  *  window calls when it receives a forwarded intent from the launcher. */
@@ -92,6 +97,13 @@ export function applyNavIntent(intent: NavIntent) {
       break;
     case "global":
       ui.openGlobalSettings(intent.section);
+      break;
+    case "agent":
+      // Switch the console to another fleet agent (slug-routed, ADR 0042) — a full navigation,
+      // since that agent's chat, threads, and API surface all key off the URL slug. This runs in
+      // a real console window (the launcher forwards the intent to the main window), so
+      // `window.location` targets the window the operator is actually looking at.
+      window.location.href = agentHref(intent.slug);
       break;
   }
 }
@@ -167,6 +179,11 @@ export function usePaletteRegistry(
   const registry = useMemo(() => createPaletteRegistry(), []);
   const inlineIds = useMemo(() => new Set(inlineViews.map((v) => v.id)), [inlineViews]);
 
+  // The live fleet roster (polled) → a "Quick-chat with any fleet agent" section (#1733). Works
+  // in both the console window and the desktop launcher (both sit under QueryClientProvider).
+  const { data: fleet } = useQuery(fleetQuery());
+  const agents = fleet?.agents ?? [];
+
   // Built-in surfaces (core + fork/ext) live behind `Open ▸`; plugin views are their own
   // root section. A `session` view (none today) would ride with the built-ins.
   const surfaceViews = views.filter((v) => v.kind !== "plugin");
@@ -176,6 +193,9 @@ export function usePaletteRegistry(
   // changes every render; the ids/urls don't).
   const navSig = views.map((v) => `${v.id} ${v.title}`).join("|");
   const inlineSig = inlineViews.map((v) => `${v.id} ${v.url} ${v.title}`).join("|");
+  // Re-register the fleet section only when the roster's identity/status/name actually changes
+  // (React Query's structural sharing keeps `agents` stable when the 3s poll returns equal data).
+  const fleetSig = agents.map((a) => `${a.host ? "host" : a.id}:${a.running}:${a.name}`).join("|");
 
   // Views the palette can morph into: inline plugin iframes, the chat view, and the
   // `Open ▸` submorph (a self-contained command list of the built-in surfaces, so the root
@@ -229,6 +249,25 @@ export function usePaletteRegistry(
           },
         ])
       : undefined;
+    // Fleet quick-chat (#1733): every OTHER agent, in the "Agents" group beneath "Chat with
+    // <this>". Picking one navigates to its slug-routed console via a serializable `agent`
+    // NavIntent (so it also works forwarded from the launcher window). A down agent is listed
+    // but disabled, and opening one records recency so it floats up next time.
+    const recency = readAgentRecency();
+    const fleetCommands: Command[] = fleetPaletteEntries(agents, currentSlug(), recency).map((e) => ({
+      id: e.id,
+      label: e.label,
+      hint: e.hint,
+      group: "Agents",
+      keywords: e.keywords,
+      disabled: e.disabled,
+      run: (c) => {
+        markAgentOpened(e.slug);
+        navigate({ kind: "agent", slug: e.slug });
+        c.close();
+      },
+    }));
+    const offFleet = fleetCommands.length ? registry.registerCommands(fleetCommands) : undefined;
     // Each plugin's views: inline ones morph IN PLACE (also in the launcher window); a
     // rail view navigates — routed through `navigate()` so the launcher hands it off to
     // the main window instead of mutating its own (shell-less) store.
@@ -264,11 +303,12 @@ export function usePaletteRegistry(
     const offCommands = registry.registerCommands([openCommand, ...registeredPaletteCommands().map(toDsCommand)]);
     return () => {
       offChat?.();
+      offFleet?.();
       offPlugins?.();
       offCommands();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [navSig, inlineSig, chat, registry]);
+  }, [navSig, inlineSig, fleetSig, chat, registry]);
 
   return registry;
 }


### PR DESCRIPTION
Closes #1733.

## What
⌘K gains an **Agents** section (beneath "Chat with <this agent>") listing every *other* agent in your fleet. Pick one → you land in that agent's slug-routed console and chat with it immediately.

- **Reachability inline** — each entry's hint shows `switch` / `remote · switch` / `unreachable` / `stopped`; a down agent is listed but **disabled**.
- **Recently-opened floats to the top**, then alphabetical (localStorage-backed recency).
- **Works from the desktop launcher too** — routed through a new serializable `agent` `NavIntent`, so picking an agent in the always-on-top launcher forwards to the main window and navigates there (a raw `window.location` in the launcher's shell-less context would navigate the wrong window). This is what makes it a true *from-anywhere* agent switcher (the global hotkey / launcher already exists).

## How it works
- `src/app/fleetPalette.ts` (new, pure + unit-tested): roster → sorted/filtered entries + a tiny recency store.
- `usePaletteRegistry.ts`: reads the polled `fleetQuery()`, builds the "Agents" commands, adds the `agent` NavIntent + its `applyNavIntent` handler. Both the console and launcher windows sit under `QueryClientProvider`, so the section appears in both.

## Scope note
v1 **navigates** to the agent (full slug route), which is where you chat — matching "start a chat with that agent." True *in-place* chat with a non-focused agent (no navigation) would need new per-target plumbing in `streamChat`/`paletteChatStore` (both key off the URL slug today); deliberately out of scope.

## Gates (worktree)
- `npm run test:unit` → **369 passed** (+7, new `fleetPalette.test.ts`)
- `npx tsc --noEmit` → clean
- `npm run build` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)