### PR TITLE
chore: release v0.89.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.89.0] - 2026-07-04
+
 ### Added
 - **Quick-chat with any fleet agent from the command palette** (#1733). ⌘K now has an
   **Agents** section listing every other reachable agent in your fleet (with its reachability

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.88.0"
+version = "0.89.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,28 @@
 [
   {
+    "version": "v0.89.0",
+    "date": "2026-07-04",
+    "changes": [
+      "Quick-chat with any fleet agent from the command palette",
+      "SOUL.md keeps a version history — never lose a persona iteration",
+      "Telemetry is tagged with the active persona revision",
+      "Browser-style UI zoom — ⌘/Ctrl + / - / 0",
+      "Plugin setup: a \"needs setup\" cue + guided config for unconfigured plugins",
+      "Plugins declare required config and degrade gracefully when it's missing",
+      "Opt-in plugin auto-update policy",
+      "coder.solve() can run one forced rung, for testing",
+      "Plugins can open a form in the chat, not just reply",
+      "/effort opens a picker in the composer",
+      "Watches honor their per-watch interval_s cadence",
+      "Hot-reloading a plugin refreshes its goal/watch verifier + hook registries",
+      "Plugin smoke tests can assert surface lifecycle wiring",
+      "The plugin loader no longer nags about the prescribed /api/plugins/<id> data router",
+      "A manifest-less ghost dir under plugins/ no longer blocks install/uninstall",
+      "A dropped provider stream reconnects instead of killing the turn",
+      "A locked checkpoint write no longer silently kills a background turn"
+    ]
+  },
+  {
     "version": "v0.88.0",
     "date": "2026-07-03",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.89.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.89.0 -m 'Release v0.89.0' && git push origin v0.89.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).