### PR TITLE
feat(plugins): list Career Coach in the plugin catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Career Coach in the plugin catalog** — the new [`careercoach`](https://github.com/protoLabsAI/careercoach-plugin)
+  official plugin (a career coach + job-hunt copilot, and a full-surface showcase: skills, a workflow,
+  a subagent crew, tools + a tunable rubric, a dashboard view, and config) now appears in
+  System → Plugins → Discover for one-click install.
+
 ## [0.89.0] - 2026-07-04
 
 ### Added

--- a/config/plugin-catalog.json
+++ b/config/plugin-catalog.json
@@ -88,6 +88,14 @@
       "official": true,
       "repo": "https://github.com/protoLabsAI/doom-plugin",
       "tagline": "But can it run DOOM? Play shareware DOOM in a console view via WebAssembly (prboom)."
+    },
+    {
+      "id": "careercoach",
+      "name": "Career Coach",
+      "category": "Productivity",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/careercoach-plugin",
+      "tagline": "Your career coach & job-hunt copilot — strategy, mock interviews, honest CV feedback, and offer/negotiation coaching, plus an autonomous evaluate→tailor→apply pipeline. A full-surface plugin showcase."
     }
   ]
 }

--- a/sites/marketing/data/plugins.json
+++ b/sites/marketing/data/plugins.json
@@ -161,5 +161,25 @@
       "source": "https://github.com/protoLabsAI/protoAgent/tree/main/plugins/hello",
       "docs": "/docs/guides/plugins"
     }
+  },
+  {
+    "id": "careercoach",
+    "name": "Career Coach",
+    "category": "Productivity",
+    "official": true,
+    "tagline": "Your career coach & job-hunt copilot — strategy, mock interviews, honest CV feedback, and offer/negotiation coaching, plus an autonomous evaluate→tailor→apply pipeline. A full-surface plugin showcase.",
+    "adds": [
+      "tool",
+      "subagent",
+      "skill",
+      "workflow",
+      "view"
+    ],
+    "bundled": false,
+    "install": "https://github.com/protoLabsAI/careercoach-plugin",
+    "links": {
+      "source": "https://github.com/protoLabsAI/careercoach-plugin",
+      "docs": "https://github.com/protoLabsAI/careercoach-plugin#readme"
+    }
   }
 ]


### PR DESCRIPTION
Adds the new **Career Coach** official plugin to the catalog so it's picked up with the other plugins in **System → Plugins → Discover** (one-click install, ADR 0058/0059).

- **Repo:** https://github.com/protoLabsAI/careercoach-plugin (public, MIT, tagged `v0.1.0`, topic `protoagent-plugin`)
- **What it is:** a career coach + job-hunt copilot — strategy, mock interviews with feedback, honest CV critique, offer/negotiation coaching, plus an autonomous evaluate→tailor→apply pipeline. Built as a **full-surface plugin-system showcase** (skills w/ sub-files, a static-DAG workflow, a 3-subagent crew, tools + a tunable Knobs rubric, a console dashboard, config/secrets/Settings, events). Prompt-engineering IP adapted with credit from [MadsLorentzen/ai-job-search](https://github.com/MadsLorentzen/ai-job-search) (MIT).

### Changes
- `config/plugin-catalog.json` — new `careercoach` entry (category Productivity).
- `sites/marketing/data/plugins.json` — the marketing mirror, kept in sync (per the catalog `_comment`).
- `CHANGELOG.md` — `[Unreleased]` entry.

`tests/test_plugin_catalog_route.py` passes; both JSON files validated.

Related: SDK feedback found while building the plugin filed as #1764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the **Career Coach** plugin to the available plugin catalog.
  * Included its listing details in the marketing plugin directory, with install and documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->