### PR TITLE
docs(plugins): point Career Coach marketing docs link at its Quick start

### DIFF
--- a/sites/marketing/data/plugins.json
+++ b/sites/marketing/data/plugins.json
@@ -179,7 +179,7 @@
     "install": "https://github.com/protoLabsAI/careercoach-plugin",
     "links": {
       "source": "https://github.com/protoLabsAI/careercoach-plugin",
-      "docs": "https://github.com/protoLabsAI/careercoach-plugin#readme"
+      "docs": "https://github.com/protoLabsAI/careercoach-plugin#quick-start"
     }
   }
 ]


### PR DESCRIPTION
Follow-up to #1765. [careercoach-plugin](https://github.com/protoLabsAI/careercoach-plugin) now has a dedicated `## Quick start` section (and its manifest `guide_url` points there for the in-app Settings "Setup guide" link, ADR 0059). This repoints the marketing catalog's `links.docs` from `#readme` → `#quick-start` so the `/plugins` page's docs link lands on the how-to too.

One-line change to `sites/marketing/data/plugins.json`; JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)