### PR TITLE
feat(console): surface server-initiated turns with a typing indicator (#1767)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -63,6 +63,7 @@ import { FleetTurnWatch } from "./FleetTurnWatch";
 import { UpdateNotice } from "./UpdateNotice";
 import { BackgroundWatch } from "./BackgroundWatch";
 import { ChatResumeWatch } from "./ChatResumeWatch";
+import { ServerTurnWatch } from "./ServerTurnWatch";
 import { BackgroundJobs } from "./BackgroundJobs";
 import { ProtoLabsIcon } from "./ProtoLabsIcon";
 import { bootGatePhase } from "./bootGate";
@@ -805,6 +806,11 @@ export function App() {
       {/* wait/scheduled resumes (ADR 0053, bd-k02): a server-fired resume turn lands in
           the chat thread; surface it live in the open tab instead of on next interaction. */}
       <ChatResumeWatch />
+      {/* Server-initiated turns (#1767): background push-resume / scheduled / watch fires
+          hold the connection open for the whole turn but never stream to the browser —
+          drive the chat typing indicator off turn.started/turn.finished so the app doesn't
+          look hung during its longest turns. */}
+      <ServerTurnWatch />
       {/* Tenant guard: if a DIFFERENT backend now owns this origin (the HUB re-keyed —
           a fork booted on the old port), drop the previous tenant's persisted chat view.
           Keyed on the HUB's uid, NOT the focused agent's — switching fleet agents keeps

--- a/apps/web/src/app/ServerTurnWatch.tsx
+++ b/apps/web/src/app/ServerTurnWatch.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+
+import { labelForOrigin, noteTurnFinished, noteTurnStarted } from "../chat/server-turn-store";
+import { onTopic } from "../lib/events";
+
+// Bridges the #1767 `turn.started` / `turn.finished` bus events into the server-turn store,
+// so ChatSurface can show its typing indicator during a server-initiated turn (background
+// push-resume, a scheduled fire, or a watch reaction). These turns run by self-POSTing into
+// a session and hold the connection open for the whole turn — the browser never streams
+// them, so without this the app looks hung during its longest turns.
+//
+// Display-only: it never touches conversation history (the backend owns that; the real
+// answer arrives separately via `chat.resumed`, handled by ChatResumeWatch). Mounted once,
+// app-wide, alongside the other bus watchers.
+
+export function ServerTurnWatch() {
+  useEffect(() => {
+    const offStarted = onTopic("turn.started", (data) => {
+      const session = String(data.session_id ?? "");
+      const origin = String(data.origin ?? "");
+      if (session) noteTurnStarted(session, labelForOrigin(origin));
+    });
+    const offFinished = onTopic("turn.finished", (data) => {
+      const session = String(data.session_id ?? "");
+      if (session) noteTurnFinished(session);
+    });
+    return () => {
+      offStarted();
+      offFinished();
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1,5 +1,6 @@
 import "./chat.css";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
+import { Spinner } from "@protolabsai/ui/data";
 import { Switch } from "@protolabsai/ui/forms";
 import { Conversation, Message, PromptInput } from "@protolabsai/ui/ai";
 import { TabBar } from "@protolabsai/ui/navigation";
@@ -29,6 +30,7 @@ import { useFlagPredicate } from "../flags/flags";
 import { registeredComposerActions } from "../ext/composerRegistry";
 import { ChatMessageView } from "./ChatMessageView";
 import { ComposerModelSelect } from "./ComposerModelSelect";
+import { useServerTurn } from "./server-turn-store";
 import { filesFromTransfer, isLargePaste, pastedTextFile } from "./paste";
 import { inputHistory, pushInputHistory } from "./inputHistory";
 import { finalizeStoppedMessages, resolveStopTarget } from "./stopTurn";
@@ -374,6 +376,10 @@ function ChatSessionSlot({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [composerFocusNonce]);
   const status = chat.sessionStatusMap[sessionId] || "idle";
+  // A server-initiated turn (background push-resume / scheduled / watch fire, #1767) is
+  // running into THIS session — the browser can't stream it, so show a labelled typing
+  // indicator. Suppressed while this tab is itself streaming (its own spinner covers it).
+  const serverTurnLabel = useServerTurn(sessionId);
 
   // Pending file attachments. Each is uploaded to /api/knowledge/attach on pick;
   // the backend tiers it (inline small / index large) and returns a `context`
@@ -1495,6 +1501,17 @@ function ChatSessionSlot({
             <span className="chat-user-text">{q.text}</span>
           </Message>
         ))}
+        {serverTurnLabel && status !== "streaming" ? (
+          // Server-initiated turn in flight (#1767): the same spinner a streaming
+          // assistant shows, plus a label naming the trigger, so a background/scheduled/
+          // watch turn no longer looks like a hung app. Display-only — the real answer
+          // arrives via chat.resumed (ChatResumeWatch).
+          <Message role="assistant">
+            <span className="chat-server-turn">
+              <Spinner size={15} /> {serverTurnLabel}
+            </span>
+          </Message>
+        ) : null}
       </Conversation>
 
       {hitl && (

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -306,6 +306,17 @@
   word-break: break-word;
 }
 
+/* Server-initiated turn indicator (#1767): spinner + a muted, italic label naming the
+   trigger (background report / scheduled task / watch), so a self-POSTed turn the browser
+   can't stream reads as "the agent is working" instead of a hung app. */
+.chat-server-turn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--fg-muted);
+  font-style: italic;
+}
+
 /* An issued slash command rendered as a distinct USER bubble (#1529): a subtle accent
    tint + monospace body + a small "/" badge, so a command sent to the agent reads as a
    command in history — to operator and agent — not as prose. `.chat-slash-msg` sits ON

--- a/apps/web/src/chat/server-turn-store.test.ts
+++ b/apps/web/src/chat/server-turn-store.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  labelForOrigin,
+  noteTurnFinished,
+  noteTurnStarted,
+  resetServerTurns,
+  serverTurnLabel,
+} from "./server-turn-store";
+
+// The server-turn store powers the #1767 typing indicator: `turn.started` arms a labelled
+// indicator for a session, `turn.finished` clears it. It ref-counts so overlapping turns
+// into one session don't clear the indicator early.
+
+describe("labelForOrigin", () => {
+  it("maps the fixed backend origins to human phrasings", () => {
+    expect(labelForOrigin("background-resume")).toMatch(/background report/i);
+    expect(labelForOrigin("scheduler")).toMatch(/scheduled/i);
+  });
+
+  it("recognises a watch reaction from its watch-<id> origin", () => {
+    expect(labelForOrigin("watch-abc123")).toMatch(/watch/i);
+    expect(labelForOrigin("watch")).toMatch(/watch/i);
+  });
+
+  it("falls back to a generic label for an unknown origin", () => {
+    const label = labelForOrigin("something-new");
+    expect(label).toBeTruthy();
+    expect(label).not.toContain("something-new"); // never leaks a raw token to the operator
+  });
+});
+
+describe("server-turn store", () => {
+  beforeEach(() => resetServerTurns());
+
+  it("has no label for a session with no server turn", () => {
+    expect(serverTurnLabel("s1")).toBeNull();
+  });
+
+  it("arms the labelled indicator on turn.started and clears it on turn.finished", () => {
+    noteTurnStarted("s1", labelForOrigin("scheduler"));
+    expect(serverTurnLabel("s1")).toMatch(/scheduled/i);
+    noteTurnFinished("s1");
+    expect(serverTurnLabel("s1")).toBeNull();
+  });
+
+  it("keeps the indicator until the LAST overlapping turn finishes (ref-counted)", () => {
+    noteTurnStarted("s1", labelForOrigin("background-resume"));
+    noteTurnStarted("s1", labelForOrigin("background-resume"));
+    noteTurnFinished("s1");
+    expect(serverTurnLabel("s1")).toMatch(/background report/i); // one still in flight
+    noteTurnFinished("s1");
+    expect(serverTurnLabel("s1")).toBeNull();
+  });
+
+  it("scopes the indicator to its own session", () => {
+    noteTurnStarted("s1", labelForOrigin("scheduler"));
+    expect(serverTurnLabel("s2")).toBeNull();
+    noteTurnFinished("s1");
+  });
+
+  it("ignores an empty session id", () => {
+    noteTurnStarted("", "x");
+    expect(serverTurnLabel("")).toBeNull();
+  });
+
+  it("never underflows when finish arrives without a matching start", () => {
+    noteTurnFinished("s1"); // stray finish (e.g. a replayed frame)
+    expect(serverTurnLabel("s1")).toBeNull();
+    noteTurnStarted("s1", labelForOrigin("scheduler"));
+    expect(serverTurnLabel("s1")).toMatch(/scheduled/i); // start still arms cleanly
+  });
+});

--- a/apps/web/src/chat/server-turn-store.ts
+++ b/apps/web/src/chat/server-turn-store.ts
@@ -1,0 +1,88 @@
+import { useSyncExternalStore } from "react";
+
+// Server-initiated turn indicator (#1767). Background push-resume (ADR 0070), scheduled
+// fires, and watch reactions (ADR 0067) run a turn by self-POSTing into a session — the
+// connection is held open for the WHOLE turn, but the browser only renders turns IT
+// streamed, so during the agent's longest turns the console shows nothing and looks hung.
+//
+// The backend now brackets each such self-POST with `turn.started` / `turn.finished` bus
+// events carrying the target `session_id` and an `origin` (`background-resume` /
+// `scheduler` / `watch-<id>`). This tiny store tracks which sessions currently have a
+// server turn in flight so ChatSurface can render the EXISTING typing indicator, labelled
+// by trigger, without hijacking `sessionStatusMap` (which drives the composer/send loop)
+// or inserting a placeholder message. Additive and self-contained — clears on finish.
+
+/** Human label for the typing indicator, derived from the turn's origin. A watch reaction
+ *  arrives as `watch-<id>` (its scheduler job id); everything else is one of the two fixed
+ *  origins. Unknown origins fall back to a generic phrasing so a new backend trigger still
+ *  reads sensibly instead of showing a raw token. */
+export function labelForOrigin(origin: string): string {
+  if (origin === "background-resume") return "responding to background reports…";
+  if (origin === "scheduler") return "running a scheduled task…";
+  if (origin.startsWith("watch-") || origin === "watch") return "reacting to a triggered watch…";
+  return "responding to a background trigger…";
+}
+
+// Ref-counted per session: two nudges can target one session (the A2A server serializes
+// the turns, but both `turn.started`s can land before either finishes), so a plain
+// last-writer map would clear the indicator while a second turn is still running. Count up
+// on start, down on finish; show while count > 0, using the most-recent label.
+const counts = new Map<string, number>();
+const labels = new Map<string, string>();
+const listeners = new Set<() => void>();
+
+function emit() {
+  listeners.forEach((fn) => fn());
+}
+
+/** A `turn.started` for `sessionId` — arm the indicator with `label`. */
+export function noteTurnStarted(sessionId: string, label: string) {
+  if (!sessionId) return;
+  counts.set(sessionId, (counts.get(sessionId) ?? 0) + 1);
+  labels.set(sessionId, label);
+  emit();
+}
+
+/** A `turn.finished` for `sessionId` — disarm once the last in-flight turn settles. */
+export function noteTurnFinished(sessionId: string) {
+  if (!sessionId) return;
+  const next = (counts.get(sessionId) ?? 0) - 1;
+  if (next <= 0) {
+    counts.delete(sessionId);
+    labels.delete(sessionId);
+  } else {
+    counts.set(sessionId, next);
+  }
+  emit();
+}
+
+/** Test/reset hook — drop all in-flight state. */
+export function resetServerTurns() {
+  counts.clear();
+  labels.clear();
+  emit();
+}
+
+/** The active indicator label for `sessionId`, or null when no server turn is in flight. */
+export function serverTurnLabel(sessionId: string): string | null {
+  return (counts.get(sessionId) ?? 0) > 0 ? (labels.get(sessionId) ?? null) : null;
+}
+
+function subscribe(fn: () => void) {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+/** Subscribe a component to the server-turn label for one session. getSnapshot returns the
+ *  label string (or ""), so a bus event that changed a DIFFERENT session yields the same
+ *  value here (stable by Object.is) and skips this component's re-render. */
+export function useServerTurn(sessionId: string | null | undefined): string | null {
+  const label = useSyncExternalStore(
+    subscribe,
+    () => (sessionId ? (serverTurnLabel(sessionId) ?? "") : ""),
+    () => "",
+  );
+  return label || null;
+}

--- a/background/manager.py
+++ b/background/manager.py
@@ -208,6 +208,23 @@ class BackgroundManager:
         except Exception:  # noqa: BLE001 — the event is best-effort
             log.exception("[background] started-event publish failed for %s", job_id)
 
+    def _publish_turn(
+        self, topic: str, *, session_id: str, origin: str, trigger: str, ok: bool | None = None
+    ) -> None:
+        """Emit a turn-lifecycle event (#1767) around a server-initiated self-POST so an
+        open console can render its typing indicator during an otherwise-invisible turn
+        (the push-resume nudge holds the connection open for the WHOLE origin-session
+        turn). Best-effort — a publish failure never disturbs the fire."""
+        if self._publish is None:
+            return
+        data = {"session_id": session_id, "origin": origin, "trigger": trigger}
+        if ok is not None:
+            data["ok"] = ok
+        try:
+            self._publish(topic, data)
+        except Exception:  # noqa: BLE001 — the event is best-effort
+            log.exception("[background] %s publish failed for %s", topic, trigger)
+
     def _publish_completed(
         self, job_id: str, status: str, kind: str, description: str, origin_session: str, text: str
     ) -> None:
@@ -381,9 +398,17 @@ class BackgroundManager:
             f"[background job {job.id} ({job.description}) {verb} — its report notification "
             "is attached to this turn; review it and brief the operator]"
         )
+        # Turn-lifecycle events (#1767): the nudge holds the connection open for the whole
+        # origin-session turn (the agent briefs the operator against the drained report),
+        # which the console can't otherwise see — no typing indicator, no stream. Emit
+        # `turn.started` before and `turn.finished` after so an open origin-session tab
+        # renders its typing indicator ("responding to background reports…") for the turn.
+        session_id = job.origin_session
+        self._publish_turn("turn.started", session_id=session_id, origin="background-resume", trigger=job.id)
+        ok = False
         try:
             await self._send_a2a_message(
-                context_id=job.origin_session,
+                context_id=session_id,
                 text=text,
                 metadata={
                     # NOT "background": the terminal hook routes origin=="background"
@@ -394,6 +419,7 @@ class BackgroundManager:
                     "background_job_id": job.id,
                 },
             )
+            ok = True
             return True
         except Exception as exc:  # noqa: BLE001 — push-resume is best-effort by contract
             log.warning(
@@ -404,6 +430,10 @@ class BackgroundManager:
                 exc,
             )
             return False
+        finally:
+            self._publish_turn(
+                "turn.finished", session_id=session_id, origin="background-resume", trigger=job.id, ok=ok
+            )
 
 
 def _subagent_fence(subagent_type: str) -> list[str]:

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -596,6 +596,20 @@ class LocalScheduler:
         finally:
             db.close()
 
+    def _publish_turn(self, topic: str, *, session_id: str, origin: str, trigger: str, ok: bool | None = None) -> None:
+        """Emit a turn-lifecycle event (#1767) around the self-POST so an open console
+        can render its typing indicator during an otherwise-invisible server-initiated
+        turn. Best-effort — a publish failure never disturbs the fire."""
+        if self._publish is None:
+            return
+        data: dict[str, Any] = {"session_id": session_id, "origin": origin, "trigger": trigger}
+        if ok is not None:
+            data["ok"] = ok
+        try:
+            self._publish(topic, data)
+        except Exception:  # noqa: BLE001 — the event is best-effort
+            log.exception("[scheduler] %s publish failed for %s", topic, trigger)
+
     async def _fire(self, job: Job) -> bool:
         """Deliver a job by POSTing to the agent's own A2A endpoint.
 
@@ -634,6 +648,19 @@ class LocalScheduler:
             except Exception:  # noqa: BLE001 — the event is best-effort
                 log.exception("[scheduler] fired-event publish failed for %s", job.id)
 
+        # Turn-lifecycle events (#1767): a scheduled/watch fire holds the connection open
+        # for the WHOLE turn (the A2A handler runs it synchronously), so without these the
+        # console shows nothing — no typing indicator, no stream — during the agent's
+        # longest turns. Emit `turn.started` before the POST and `turn.finished` after so
+        # the console renders its typing indicator, labelled by trigger. The session id is
+        # the fire's context (a `wait`/`run_in_session` resume lands in a chat session; a
+        # plain cron lands in the Activity thread); a watch-reaction one-shot carries a
+        # `watch-<id>` job id (graph/watches → sdk.run_in_session), so tag its origin as
+        # such — otherwise it's an ordinary `scheduler` fire.
+        session_id = job.context_id or ACTIVITY_CONTEXT
+        origin = job.id if job.id.startswith("watch-") else "scheduler"
+        self._publish_turn("turn.started", session_id=session_id, origin=origin, trigger=job.id)
+
         message_id = str(uuid.uuid4())
         body = {
             "jsonrpc": "2.0",
@@ -649,7 +676,7 @@ class LocalScheduler:
                     # continues that conversation's thread), else the durable
                     # Activity thread (ADR 0003) so a normal scheduled fire lands
                     # somewhere visible/continuable instead of a throwaway context.
-                    "contextId": job.context_id or ACTIVITY_CONTEXT,
+                    "contextId": session_id,
                     # Scheduler bookkeeping for this fire (origin + job id) —
                     # informational; the handler doesn't require these keys.
                     "metadata": {
@@ -660,6 +687,7 @@ class LocalScheduler:
                 },
             },
         }
+        ok = False
         try:
             async with httpx.AsyncClient(timeout=self._fire_timeout_s) as client:
                 r = await client.post(f"{self._invoke_url}/a2a", headers=headers, json=body)
@@ -672,6 +700,7 @@ class LocalScheduler:
                 )
                 return False
             log.info("[scheduler] fired job %s", job.id)
+            ok = True
             return True
         except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
             # The agent's own HTTP server isn't accepting connections yet — common
@@ -687,6 +716,10 @@ class LocalScheduler:
         except Exception:  # noqa: BLE001
             log.exception("[scheduler] fire exception for job %s", job.id)
             return False
+        finally:
+            # Always clear the indicator, whatever the outcome — a failed fire that left
+            # `turn.started` hanging would spin the console forever.
+            self._publish_turn("turn.finished", session_id=session_id, origin=origin, trigger=job.id, ok=ok)
 
     def _generate_id(self) -> str:
         # Agent-name prefix keeps cross-agent IDs distinct in shared

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -347,6 +347,73 @@ class TestManager:
         assert _manager(tmp_path)._max_concurrency == 3  # default on a bad value
 
 
+# ── #1767: turn-lifecycle events around the push-resume self-POST ─────────────
+
+
+def _resume_job(status: str = "completed") -> "BackgroundJob":  # noqa: F821 — imported at call sites
+    from background.store import BackgroundJob
+
+    return BackgroundJob(
+        id="bg-xyz",
+        agent_name="a",
+        origin_session="sess-1",
+        subagent_type="researcher",
+        description="dig the archives",
+        prompt="p",
+        status=status,
+        result="found it",
+        notified=False,
+        created_at="t1",
+        completed_at="t2",
+    )
+
+
+class TestResumeOriginTurnEvents:
+    """A push-resume nudge (ADR 0070) holds the connection open for the WHOLE
+    origin-session turn; #1767 wraps it in ``turn.started`` / ``turn.finished`` so an
+    open console can render its typing indicator during that otherwise-invisible turn."""
+
+    async def test_resume_origin_emits_started_then_finished(self, tmp_path, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _FakeClient(_FakeResponse(200)))
+        events: list = []
+        mgr = _manager(tmp_path, event_publish=lambda topic, data: events.append((topic, data)))
+
+        ok = await mgr.resume_origin(_resume_job())
+
+        assert ok is True
+        turn_events = [(t, d) for (t, d) in events if t.startswith("turn.")]
+        assert [t for (t, _) in turn_events] == ["turn.started", "turn.finished"]
+        for _t, d in turn_events:
+            assert d["session_id"] == "sess-1"
+            assert d["origin"] == "background-resume"
+            assert d["trigger"] == "bg-xyz"
+        # turn.finished carries the outcome so the console clears an accurate state.
+        assert turn_events[-1][1]["ok"] is True
+
+    async def test_resume_origin_finishes_even_on_delivery_failure(self, tmp_path, monkeypatch):
+        """A failed nudge must still emit ``turn.finished`` — a hanging ``turn.started``
+        would spin the console's indicator forever."""
+        import httpx
+
+        monkeypatch.setattr(
+            httpx,
+            "AsyncClient",
+            lambda **kw: _FakeClient(None, raise_exc=RuntimeError("conn refused")),
+        )
+        events: list = []
+        mgr = _manager(tmp_path, event_publish=lambda topic, data: events.append((topic, data)))
+
+        ok = await mgr.resume_origin(_resume_job(status="failed"))
+
+        assert ok is False  # push-resume is best-effort; the report still drains next turn
+        topics = [t for (t, _) in events if t.startswith("turn.")]
+        assert topics == ["turn.started", "turn.finished"]
+        finished = next(d for (t, d) in events if t == "turn.finished")
+        assert finished["ok"] is False
+
+
 # ── Phase 2: autonomous idle-wake (server/a2a.py) ────────────────────────────
 
 

--- a/tests/test_scheduler_local.py
+++ b/tests/test_scheduler_local.py
@@ -22,14 +22,43 @@ from scheduler.local import LocalScheduler, _compute_next_fire
 # ── helpers ─────────────────────────────────────────────────────────────────
 
 
-def _make_scheduler(tmp_path: Path, agent: str = "gina-test") -> LocalScheduler:
+def _make_scheduler(tmp_path: Path, agent: str = "gina-test", **kw) -> LocalScheduler:
     return LocalScheduler(
         agent_name=agent,
         invoke_url="http://127.0.0.1:7870",
         api_key="k",
         bearer_token="b",
         db_dir=tmp_path,
+        **kw,
     )
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, text: str = ""):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeClient:
+    """Stubs ``httpx.AsyncClient`` so a unit test exercises ``_fire`` without a live A2A."""
+
+    def __init__(self, response, raise_exc=None, **_kw):
+        self._response = response
+        self._raise = raise_exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def post(self, url, headers=None, json=None):
+        if self._raise:
+            raise self._raise
+        return self._response
+
+
+_FUTURE_ISO = "2099-01-01T00:00:00+00:00"
 
 
 # ── interface helpers ──────────────────────────────────────────────────────
@@ -251,6 +280,90 @@ class TestMissedFireRecovery:
         jobs = s.list_jobs()
         assert len(jobs) == 1
         assert jobs[0].next_fire < datetime.now(UTC).isoformat()
+
+
+# ── #1767: turn-lifecycle events around the self-POST ───────────────────────
+
+
+class TestFireTurnEvents:
+    """A scheduled/watch fire holds the connection open for the WHOLE turn, so the
+    console is otherwise blind to it. ``_fire`` brackets the self-POST with
+    ``turn.started`` / ``turn.finished`` (#1767) so the console can render its typing
+    indicator, labelled by trigger, during the agent's longest turns."""
+
+    @pytest.mark.asyncio
+    async def test_scheduler_fire_emits_started_then_finished(self, tmp_path, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _FakeClient(_FakeResponse(200)))
+        events: list = []
+        s = _make_scheduler(tmp_path, event_publish=lambda t, d: events.append((t, d)))
+        job = s.add_job("sweep the inbox", _FUTURE_ISO, job_id="job-1", context_id="chat-42")
+
+        ok = await s._fire(job)
+
+        assert ok is True
+        turn = [(t, d) for (t, d) in events if t.startswith("turn.")]
+        assert [t for (t, _) in turn] == ["turn.started", "turn.finished"]
+        for _t, d in turn:
+            assert d["session_id"] == "chat-42"  # the fire's context (a wait/run_in_session resume)
+            assert d["origin"] == "scheduler"
+            assert d["trigger"] == "job-1"
+        assert turn[-1][1]["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_watch_reaction_fire_tags_watch_origin(self, tmp_path, monkeypatch):
+        """A watch reaction (ADR 0067) enqueues a one-shot with a ``watch-<id>`` job id
+        via sdk.run_in_session — the origin metadata lets the console label the indicator
+        as a watch trigger rather than a plain schedule."""
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _FakeClient(_FakeResponse(200)))
+        events: list = []
+        s = _make_scheduler(tmp_path, event_publish=lambda t, d: events.append((t, d)))
+        job = s.add_job("check on it", _FUTURE_ISO, job_id="watch-abc123", context_id="chat-9")
+
+        await s._fire(job)
+
+        started = next(d for (t, d) in events if t == "turn.started")
+        assert started["origin"] == "watch-abc123"
+        assert started["session_id"] == "chat-9"
+        assert started["trigger"] == "watch-abc123"
+
+    @pytest.mark.asyncio
+    async def test_fire_without_context_defaults_to_activity_thread(self, tmp_path, monkeypatch):
+        import httpx
+
+        from events import ACTIVITY_CONTEXT
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _FakeClient(_FakeResponse(200)))
+        events: list = []
+        s = _make_scheduler(tmp_path, event_publish=lambda t, d: events.append((t, d)))
+        job = s.add_job("daily digest", "0 9 * * *", job_id="cron-1")  # no context_id
+
+        await s._fire(job)
+
+        started = next(d for (t, d) in events if t == "turn.started")
+        assert started["session_id"] == ACTIVITY_CONTEXT
+
+    @pytest.mark.asyncio
+    async def test_fire_finishes_even_on_http_error(self, tmp_path, monkeypatch):
+        """A non-2xx fire must still emit ``turn.finished`` (ok=False) — a hanging
+        ``turn.started`` would spin the console's indicator forever."""
+        import httpx
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _FakeClient(_FakeResponse(500, "boom")))
+        events: list = []
+        s = _make_scheduler(tmp_path, event_publish=lambda t, d: events.append((t, d)))
+        job = s.add_job("sweep", _FUTURE_ISO, job_id="job-err", context_id="chat-1")
+
+        ok = await s._fire(job)
+
+        assert ok is False
+        topics = [t for (t, _) in events if t.startswith("turn.")]
+        assert topics == ["turn.started", "turn.finished"]
+        finished = next(d for (t, d) in events if t == "turn.finished")
+        assert finished["ok"] is False
 
 
 # ── compute_next_fire ───────────────────────────────────────────────────────


### PR DESCRIPTION
Refs #1767 — implements Option 1 (the visibility indicator). Leaves #1767 OPEN for the remainder: suggestion #3 (stamp server-born messages with their trigger; the nudge text still leaks as a pseudo-user message).

## Problem

Server-initiated turns are invisible in the console. Background push-resume (ADR 0070), scheduler/one-shot fires, and watch reactions (ADR 0067) run by **self-POSTing a turn into a session** and hold the connection open for the *whole* turn. The browser only renders turns it streamed itself, so during the agent's longest turns the console shows **nothing** — no typing indicator, no stream — and the app looks hung.

## Approach

This is the issue's **Option 1** (additive, low-risk). It **does not touch the streaming path** (Option 2, the fragile one — #1709/#1713). Instead it adds a lifecycle signal the console already knows how to consume (the #1640 event bridge) and renders the *existing* typing spinner off it.

## What changed

**Backend — emit turn-lifecycle bus events around the self-POST**
- `background/manager.py` `resume_origin` — the push-resume nudge into the origin session.
- `scheduler/local.py` `_fire` — scheduled fires *and* watch-reaction one-shots (a watch reaction enqueues a `watch-<id>` one-shot via `sdk.run_in_session`, so its origin is tagged `watch-<id>`; a plain fire is `scheduler`).
- Each emits `turn.started` before the POST and `turn.finished` after, carrying `{session_id, origin, trigger}` (+ `ok` on finish). Both are best-effort (reuse the existing `event_publish` seam — no new bus wiring) and `turn.finished` **always** fires, even on delivery failure, so a hung `turn.started` can't spin the indicator forever.
- Import-layering clean: `events/`/`background/`/`scheduler/` gain no `server`/`operator_api` imports.

**Frontend — render the existing typing indicator**
- `chat/server-turn-store.ts` — a tiny **ref-counted** store keyed by session id → label (`useServerTurn`). Ref-counting so two overlapping turns into one session don't clear the indicator early.
- `app/ServerTurnWatch.tsx` — subscribes `turn.started`/`turn.finished` via the existing `onTopic` bridge and updates the store. Mounted once app-wide alongside `ChatResumeWatch`.
- `chat/ChatSurface.tsx` — when a server turn is in flight for a session (and it isn't locally streaming), renders the **same `<Spinner>`** a streaming assistant shows, plus a label naming the trigger (e.g. *"responding to background reports…"*). Display-only — it never touches conversation history or `sessionStatusMap`; the real answer still arrives via `chat.resumed` (`ChatResumeWatch`).

## Gates run locally

| Gate | Command | Result |
| --- | --- | --- |
| ruff | `uv run ruff check .` | **PASS** (`All checks passed!`) |
| import-linter | `uv run lint-imports` | **PASS** |
| pytest (full) | `python -m pytest tests/ -q` | **PASS** — `3052 passed, 5 skipped` |

New pytest coverage:
- `tests/test_background.py::TestResumeOriginTurnEvents` — `turn.started`→`turn.finished` with `origin=background-resume`, correct `session_id`/`trigger`, and `turn.finished` still fires (ok=False) on delivery failure.
- `tests/test_scheduler_local.py::TestFireTurnEvents` — scheduler origin, `watch-<id>` origin tagging, Activity-thread session fallback, and `turn.finished` on HTTP error. All stub `httpx.AsyncClient` (no network).

**Frontend gate could NOT be run locally**: `vitest` is not installed in this checkout's `node_modules` (no `vitest`/`tsc` binary resolvable), so `npm run test:unit --workspace @protoagent/web` was **deferred to CI**, which runs the full FE suite on this PR. A vitest spec `apps/web/src/chat/server-turn-store.test.ts` is included (label mapping, arm/clear, ref-count, session scoping, finish-without-start underflow guard).

## How to test

1. Open a chat tab and spawn a background job that reports back (or arm a scheduler one-shot / watch into that session).
2. While the server-initiated turn runs, the tab shows a labelled spinner — *"responding to background reports…"* / *"running a scheduled task…"* / *"reacting to a triggered watch…"* — instead of appearing hung.
3. When the turn finishes, the spinner clears and the answer appears (via the existing `chat.resumed` surfacing).

This PR is human-gated (visual/UX) — it stays a **draft** for review of the indicator's look and copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
