### PR TITLE
feat(chat): swap the add-chat "+" to an incognito eye while Shift is held

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -33,6 +33,7 @@ import { filesFromTransfer, isLargePaste, pastedTextFile } from "./paste";
 import { inputHistory, pushInputHistory } from "./inputHistory";
 import { finalizeStoppedMessages, resolveStopTarget } from "./stopTurn";
 import { addComponent, addToolRef, appendReasoning, appendText, replaceText } from "./parts";
+import { ADD_SELECTOR, isIncognitoAddClick, trackShiftHeld } from "./shiftCue";
 
 function messageId() {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -126,21 +127,12 @@ export function ChatSurface({
     chatStore.deleteSession(id);
   }
 
-  // Quick-delete: Shift+click a tab's ✕ → delete with NO confirm dialog and NO harvest.
-  // While Shift is held the ✕ shows as a red trashcan (the `--del` class → CSS) to signal it.
-  const [shiftDel, setShiftDel] = useState(false);
-  useEffect(() => {
-    const sync = (e: KeyboardEvent) => setShiftDel(e.shiftKey);
-    const clear = () => setShiftDel(false);
-    window.addEventListener("keydown", sync);
-    window.addEventListener("keyup", sync);
-    window.addEventListener("blur", clear);
-    return () => {
-      window.removeEventListener("keydown", sync);
-      window.removeEventListener("keyup", sync);
-      window.removeEventListener("blur", clear);
-    };
-  }, []);
+  // Tab-strip Shift cues. While Shift is held the DS TabBar signals both Shift+click gestures:
+  // the "+" becomes the incognito EyeOff (Shift+click → new incognito chat, #1697/#1744) and the
+  // hovered ✕ becomes a red trashcan (Shift+click → quick-delete, no confirm/harvest, #1373).
+  // One "is Shift held" signal drives both, via the `--incognito`/`--del` wrapper classes → CSS.
+  const [shiftHeld, setShiftHeld] = useState(false);
+  useEffect(() => trackShiftHeld(setShiftHeld), []);
   // The DS TabBar's onClose always opens the confirm dialog, so intercept the close-button
   // click in the CAPTURE phase (before the DS button's own onClick) when Shift is down and
   // delete directly. Maps the clicked ✕ to its session by sibling index (DOM = sessions order).
@@ -150,7 +142,7 @@ export function ChatSurface({
     // tab context menu's "New incognito chat" (same createSession({incognito:true})
     // semantics). Intercepted in the capture phase so the DS button's own onClick (the
     // plain add) never fires; a plain click is untouched.
-    if ((e.target as HTMLElement).closest(".pl-tabbar__add")) {
+    if (isIncognitoAddClick(e.target, e.shiftKey)) {
       e.preventDefault();
       e.stopPropagation();
       chatStore.createSession({ incognito: true });
@@ -175,7 +167,7 @@ export function ChatSurface({
   // stops the synthetic click (and thus the DS onAdd) from ever firing.
   function onTabBarKeyDownCapture(e: ReactKeyboardEvent) {
     if (!e.shiftKey || (e.key !== "Enter" && e.key !== " ")) return;
-    if (!(e.target as HTMLElement).closest(".pl-tabbar__add")) return;
+    if (!(e.target as HTMLElement).closest(ADD_SELECTOR)) return;
     e.preventDefault();
     e.stopPropagation();
     if (e.repeat) return; // held key auto-repeats keydown — only the first press creates a session
@@ -219,7 +211,7 @@ export function ChatSurface({
           (container query). The status dot rides the `icon` slot — wide-strip only:
           the collapsed <option> can't host markup, matching the old behavior. */}
       <div
-        className={`chat-tabbar-wrap${shiftDel ? " chat-tabbar-wrap--del" : ""}`}
+        className={`chat-tabbar-wrap${shiftHeld ? " chat-tabbar-wrap--del chat-tabbar-wrap--incognito" : ""}`}
         onContextMenu={onTabBarBackgroundContextMenu}
         onClickCapture={onTabBarClickCapture}
         onKeyDownCapture={onTabBarKeyDownCapture}

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -278,6 +278,26 @@
   mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M9 3v1H4v2h16V4h-5V3H9zM6 7l1 13h10l1-13H6z'/%3E%3C/svg%3E") center / contain no-repeat;
 }
 
+/* Incognito cue (#1744): while Shift is held, the DS TabBar's add "+" becomes the incognito
+   EyeOff glyph — a Shift+click there opens a new incognito chat (#1697), matching the EyeOff
+   that incognito tabs and the composer chip already wear. Unlike the per-tab delete trash this
+   is NOT :hover-scoped — the "+" is a single button, so it flips the instant Shift goes down.
+   Swap the DS + svg for an EyeOff outline (stroke masked, tinted via currentColor); the
+   Shift+click handler is unchanged, this only adds the visual cue. */
+.chat-tabbar-wrap--incognito .pl-tabbar__add svg {
+  display: none;
+}
+.chat-tabbar-wrap--incognito .pl-tabbar__add::after {
+  content: "";
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  pointer-events: none;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49'/%3E%3Cpath d='M14.084 14.158a3 3 0 0 1-4.242-4.242'/%3E%3Cpath d='M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143'/%3E%3Cpath d='m2 2 20 20'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49'/%3E%3Cpath d='M14.084 14.158a3 3 0 0 1-4.242-4.242'/%3E%3Cpath d='M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143'/%3E%3Cpath d='m2 2 20 20'/%3E%3C/svg%3E") center / contain no-repeat;
+}
+
 /* Incognito tab indicator (ADR 0069 D3b): the EyeOff glyph rides the icon slot
    beside the status dot while the thread's toggle is on. */
 .session-tab-icons {

--- a/apps/web/src/chat/shiftCue.test.ts
+++ b/apps/web/src/chat/shiftCue.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ADD_SELECTOR, isIncognitoAddClick, trackShiftHeld } from "./shiftCue";
+
+function keydown(shiftKey: boolean) {
+  window.dispatchEvent(new KeyboardEvent("keydown", { shiftKey }));
+}
+function keyup(shiftKey: boolean) {
+  window.dispatchEvent(new KeyboardEvent("keyup", { shiftKey }));
+}
+
+describe("trackShiftHeld", () => {
+  let cleanup: (() => void) | undefined;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  it("reports Shift held on keydown and released on keyup", () => {
+    const onChange = vi.fn();
+    cleanup = trackShiftHeld(onChange);
+    keydown(true);
+    expect(onChange).toHaveBeenLastCalledWith(true);
+    keyup(false);
+    expect(onChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("clears on window blur (a blur mid-hold must not strand the cue on)", () => {
+    const onChange = vi.fn();
+    cleanup = trackShiftHeld(onChange);
+    keydown(true);
+    expect(onChange).toHaveBeenLastCalledWith(true);
+    window.dispatchEvent(new Event("blur"));
+    expect(onChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("detaches every listener on cleanup", () => {
+    const onChange = vi.fn();
+    trackShiftHeld(onChange)(); // attach, then immediately clean up
+    keydown(true);
+    keyup(false);
+    window.dispatchEvent(new Event("blur"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+// The + → eye swap is CSS-driven: while Shift is held the tab-strip wrapper carries
+// `chat-tabbar-wrap--incognito`, which swaps the DS "+" for the EyeOff glyph (and drops it to
+// restore the "+"). This mirrors how ChatSurface toggles the class off the trackShiftHeld
+// signal, so it pins the +→eye→+ flip that the issue asks for.
+describe("Shift toggles the add-button eye cue", () => {
+  it("adds --incognito on Shift keydown (+ → eye) and removes it on keyup (eye → +)", () => {
+    const wrap = document.createElement("div");
+    wrap.className = "chat-tabbar-wrap";
+    const cleanup = trackShiftHeld((held) => {
+      wrap.classList.toggle("chat-tabbar-wrap--incognito", held);
+    });
+
+    keydown(true);
+    expect(wrap.classList.contains("chat-tabbar-wrap--incognito")).toBe(true);
+
+    keyup(false);
+    expect(wrap.classList.contains("chat-tabbar-wrap--incognito")).toBe(false);
+
+    cleanup();
+  });
+});
+
+// Guards the existing Shift+click gesture (#1697): swapping the icon must not change WHEN a new
+// incognito chat is created — only Shift + a click on the add "+".
+describe("isIncognitoAddClick (the incognito click path is unchanged)", () => {
+  function addButton() {
+    const btn = document.createElement("button");
+    btn.className = "pl-tabbar__add";
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    btn.appendChild(svg);
+    return { btn, svg };
+  }
+
+  it("is true for a Shift+click on (or inside) the add button", () => {
+    const { btn, svg } = addButton();
+    expect(isIncognitoAddClick(btn, true)).toBe(true);
+    expect(isIncognitoAddClick(svg, true)).toBe(true); // closest() climbs from the inner glyph
+  });
+
+  it("is false without Shift (a plain click still opens a normal chat)", () => {
+    const { btn } = addButton();
+    expect(isIncognitoAddClick(btn, false)).toBe(false);
+  });
+
+  it("is false for a Shift+click that misses the add button", () => {
+    const close = document.createElement("button");
+    close.className = "pl-tabbar__close";
+    expect(isIncognitoAddClick(close, true)).toBe(false);
+    expect(isIncognitoAddClick(null, true)).toBe(false);
+  });
+
+  it("matches on the DS add-button selector", () => {
+    expect(ADD_SELECTOR).toBe(".pl-tabbar__add");
+  });
+});

--- a/apps/web/src/chat/shiftCue.ts
+++ b/apps/web/src/chat/shiftCue.ts
@@ -1,0 +1,36 @@
+// Shared logic for the chat tab-strip's "Shift held" visual cues. While Shift is down the DS
+// TabBar shows two affordances: the add "+" becomes the incognito EyeOff (Shift+click opens a
+// new incognito chat, #1697/#1744) and each tab's ✕ becomes a red trashcan on hover (Shift+click
+// = quick-delete, #1373). Both ride one "is Shift held" signal (trackShiftHeld → the
+// `--incognito`/`--del` wrapper classes → CSS); the incognito gesture itself is decided by
+// isIncognitoAddClick. Kept here as pure functions so the handler and its unit test pin the
+// exact same behavior.
+
+// The DS TabBar's add "+" button (@protolabsai/ui navigation TabBar).
+export const ADD_SELECTOR = ".pl-tabbar__add";
+
+// Shift+click on the add "+" opens a NEW incognito chat (#1697) — the click-path twin of the
+// tab context menu's "New incognito chat". True only when Shift is held AND the click landed on
+// (or inside) the add button.
+export function isIncognitoAddClick(target: EventTarget | null, shiftKey: boolean): boolean {
+  if (!shiftKey) return false;
+  const el = target as (Element & { closest(sel: string): Element | null }) | null;
+  return !!el?.closest?.(ADD_SELECTOR);
+}
+
+// Track whether Shift is currently held, calling `onChange` on every transition. keyup updates
+// from the event's own modifier state, and a window blur clears it (a blur mid-hold would
+// otherwise strand the cue "on" — the keyup fires on a window we no longer have focus for).
+// Returns a cleanup that detaches every listener; call it on unmount.
+export function trackShiftHeld(onChange: (held: boolean) => void): () => void {
+  const sync = (e: KeyboardEvent) => onChange(e.shiftKey);
+  const clear = () => onChange(false);
+  window.addEventListener("keydown", sync);
+  window.addEventListener("keyup", sync);
+  window.addEventListener("blur", clear);
+  return () => {
+    window.removeEventListener("keydown", sync);
+    window.removeEventListener("keyup", sync);
+    window.removeEventListener("blur", clear);
+  };
+}


### PR DESCRIPTION
Closes #1744

## What & why

Shift+click on the chat tab-strip **+** already opens a new **incognito** chat (#1697), but there was **no visual cue** that a plain click and a Shift+click do different things. Now, while Shift is held, the DS TabBar's **+** swaps to the incognito **EyeOff** glyph — the same glyph incognito tabs and the composer chip already wear — and reverts to **+** the instant Shift is released.

## How it works

- The cue rides the **existing "is Shift held" signal** that already drives the per-tab quick-delete trash (#1373). The inline `keydown`/`keyup`/`blur` effect is pulled into a small reusable helper `trackShiftHeld(onChange)` (returns a cleanup, wired via `useEffect(() => trackShiftHeld(setShiftHeld), [])` so listeners are removed on unmount). The state rename `shiftDel → shiftHeld` reflects that it now feeds two cues.
- The tab-strip wrapper carries a new `chat-tabbar-wrap--incognito` modifier alongside `--del`. CSS hides the DS `+` `<svg>` and draws an **EyeOff outline** via a `currentColor`-tinted mask — **mirroring the sibling `--del` trash-mask pattern** already in `chat.css`. No new dependency, no DS prop needed (the DS renders `.pl-tabbar__add > svg` internally). Unlike the per-tab delete trash, this is **not** `:hover`-scoped — the `+` is a single button, so it flips immediately.
- The Shift+click incognito gesture itself is **unchanged**; its predicate is extracted to `isIncognitoAddClick(target, shiftKey)` (in `apps/web/src/chat/shiftCue.ts`) so a unit test can pin it. `onTabBarClickCapture` and the Shift+Enter/Space keyboard twin now call the shared helper/`ADD_SELECTOR`.

## Files

- `apps/web/src/chat/shiftCue.ts` — new: `ADD_SELECTOR`, `isIncognitoAddClick`, `trackShiftHeld`.
- `apps/web/src/chat/ChatSurface.tsx` — use the helpers; `--incognito` class on the wrapper.
- `apps/web/src/chat/chat.css` — `--incognito` add-button EyeOff mask.
- `apps/web/src/chat/shiftCue.test.ts` — new vitest unit tests.

## Gates run locally

This worktree has **no `node_modules`** (the main checkout's are empty too), so the JS/TS gates could **not** be run locally and are **deferred to CI**:

- `npm run test:unit --workspace @protoagent/web` — **NOT run locally** (no vitest installed). CI runs it. New tests added in `shiftCue.test.ts`.
- `npm run test:e2e --workspace @protoagent/web` — **NOT run locally** (no Playwright browsers). CI runs it.

Checks done locally instead:
- **EyeOff mask SVG validated** as well-formed XML (`python3 -c "xml.etree.ElementTree.fromstring(...)"` → OK, 4 paths).
- **CSS-comment `*/` trap** avoided (the `check-css-comments` gate); the new comment has no embedded `*/`.
- Python gates (`ruff`, `lint-imports`, `pytest`) are **unaffected** — this change is frontend-only, touches no Python.

## What the unit tests cover (`shiftCue.test.ts`)

- `trackShiftHeld`: `keydown{shift}` → `true`, `keyup` → `false`, window `blur` → `false`, and **cleanup detaches every listener**.
- The **+ → eye → +** flip: Shift keydown adds `chat-tabbar-wrap--incognito` (the class CSS turns into the eye), keyup removes it (restores the `+`).
- `isIncognitoAddClick`: true only for **Shift + a click on/inside `.pl-tabbar__add`**; false without Shift and false for clicks that miss the add button — pinning that the **incognito click path is unchanged**.

## How to test (visual — human-gated, PR stays DRAFT)

1. `npm run preview --workspace @protoagent/web` (or `scripts/dev.sh` + `npm run dev`), open the console → **Chat**.
2. Hold **Shift**. The **+** at the end of the tab strip changes to a crossed-out **eye** (EyeOff). Release Shift → it reverts to **+**.
3. With Shift held, **click** the eye → a new **incognito** chat opens (tab shows the EyeOff indicator, composer shows the incognito chip). A plain click still opens a normal chat.
4. Shift+Enter / Shift+Space on the focused **+** still opens an incognito chat (keyboard twin unchanged).
