### PR TITLE
feat(background): batch-join fan-out completions into one push-resume (#1766)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Background fan-outs report back in ONE briefing, not N** (#1766). When the agent
+  fans out several background subagents in a single turn (`task_batch(run_in_background=True)`,
+  or several `task(run_in_background=True)`), their completions now coalesce into a single
+  push-resume when the last member finishes — one briefing turn that synthesizes across all
+  the reports, instead of one drip-fed turn per job. Jobs from one turn share a `batch_id`
+  (the emitting turn's id); the coalesced nudge carries a per-status summary
+  (e.g. "completed 6, failed 1"). A straggler safety valve (`BACKGROUND_BATCH_JOIN_TIMEOUT_S`,
+  default 900s) forces a partial briefing if a member hangs so finished reports are never
+  stranded. Lone and plugin-spawned background jobs are unaffected. See ADR 0070 (D5).
 - **Career Coach in the plugin catalog** — the new [`careercoach`](https://github.com/protoLabsAI/careercoach-plugin)
   official plugin (a career coach + job-hunt copilot, and a full-surface showcase: skills, a workflow,
   a subagent crew, tools + a tunable rubric, a dashboard view, and config) now appears in

--- a/background/manager.py
+++ b/background/manager.py
@@ -27,6 +27,10 @@ log = logging.getLogger(__name__)
 
 _DEFAULT_FIRE_TIMEOUT_S = 1800.0  # background turns can run long (research + tools); generous
 _DEFAULT_MAX_CONCURRENCY = 3  # cap on concurrent background turns so a fan-out can't swamp the gateway
+# Straggler safety valve (#1766): if a fan-out batch hasn't fully settled within this many
+# seconds (a member hung), force a PARTIAL push-resume so the finished reports still land.
+_DEFAULT_BATCH_JOIN_TIMEOUT_S = 900.0
+_TERMINAL_STATUSES = ("completed", "failed", "canceled")
 
 
 class BackgroundManager:
@@ -42,6 +46,7 @@ class BackgroundManager:
         bearer_token: str | None = None,
         fire_timeout_s: float | None = None,
         max_concurrency: int | None = None,
+        batch_join_timeout_s: float | None = None,
         event_publish=None,
         on_terminal=None,
     ) -> None:
@@ -82,12 +87,31 @@ class BackgroundManager:
             except ValueError:
                 self._max_concurrency = _DEFAULT_MAX_CONCURRENCY
         self._sem = asyncio.Semaphore(self._max_concurrency)
+        # Straggler-join timeout (#1766). Env ``BACKGROUND_BATCH_JOIN_TIMEOUT_S``.
+        if batch_join_timeout_s is not None:
+            self._batch_join_timeout_s = batch_join_timeout_s
+        else:
+            try:
+                self._batch_join_timeout_s = float(
+                    os.environ.get("BACKGROUND_BATCH_JOIN_TIMEOUT_S", _DEFAULT_BATCH_JOIN_TIMEOUT_S)
+                )
+            except ValueError:
+                self._batch_join_timeout_s = _DEFAULT_BATCH_JOIN_TIMEOUT_S
         # Hold the detached fire tasks so they aren't GC'd mid-flight (the cause of
         # "Task was destroyed but it is pending"); discard on completion.
         self._fire_tasks: set[asyncio.Task] = set()
         # job_id -> the running asyncio.Task for a ``spawn_work`` (deterministic) job, so
         # ``cancel`` can stop the coroutine directly (a work job has no A2A task handle).
         self._work_tasks: dict[str, asyncio.Task] = {}
+        # Fan-out batch-join (#1766). A batch (all jobs sharing a spawning turn id)
+        # push-resumes ONCE, when its last member settles. ``_joined_batches`` is the
+        # single-fire guard — a SYNCHRONOUS check-and-set (``_claim_batch``) so two
+        # concurrent settles, or a settle racing the straggler timeout, can't both fire.
+        # ``_batch_timeouts`` holds the per-batch straggler-timeout task (a hung member
+        # can't strand the finished reports forever); also kept in ``_fire_tasks`` so it
+        # isn't GC'd mid-sleep.
+        self._joined_batches: set[str] = set()
+        self._batch_timeouts: dict[str, asyncio.Task] = {}
 
     async def spawn(
         self,
@@ -97,13 +121,19 @@ class BackgroundManager:
         description: str,
         prompt: str,
         origin_incognito: bool = False,
+        batch_id: str | None = None,
     ) -> str:
         """Register a job and fire it detached. Returns the opaque job id immediately.
 
         ``origin_incognito`` records that the spawning thread was incognito (ADR 0069
         D3b → ADR 0070): the completion then skips the push-resume nudge and the
         knowledge-store indexing — no memory trail — while the report still lives in
-        the jobs DB and drains into the origin session normally."""
+        the jobs DB and drains into the origin session normally.
+
+        ``batch_id`` (#1766) tags the job as a member of a fan-out spawned by one turn
+        (task_batch's specs, or several ``task(run_in_background=True)`` in a turn — all
+        stamp the emitting turn's id), so the completions coalesce into ONE push-resume
+        when the last member settles. ``None`` for a lone spawn (a singleton)."""
         job_id = self.store.create(
             agent_name=self.agent_name,
             origin_session=origin_session or "",
@@ -111,6 +141,7 @@ class BackgroundManager:
             description=description,
             prompt=prompt,
             origin_incognito=origin_incognito,
+            batch_id=batch_id,
         )
         fired_prompt = _build_fired_prompt(subagent_type, description, prompt)
         fence = _subagent_fence(subagent_type)
@@ -133,6 +164,7 @@ class BackgroundManager:
         work,
         detail: str = "",
         origin_incognito: bool = False,
+        batch_id: str | None = None,
     ) -> str:
         """Register and run a deterministic background job — a plain coroutine, NOT an
         LLM subagent turn — through the same durable store + concurrency cap + event
@@ -151,6 +183,7 @@ class BackgroundManager:
             description=description,
             prompt=detail,
             origin_incognito=origin_incognito,
+            batch_id=batch_id,
         )
         t = asyncio.create_task(
             self._run_work(job_id, kind, description, origin_session or "", work),
@@ -433,6 +466,144 @@ class BackgroundManager:
         finally:
             self._publish_turn(
                 "turn.finished", session_id=session_id, origin="background-resume", trigger=job.id, ok=ok
+            )
+
+    # ── fan-out batch-join (#1766) ────────────────────────────────────────────
+
+    def _claim_batch(self, batch_id: str) -> bool:
+        """Atomically claim a batch for its single join nudge. Returns ``True`` if THIS
+        caller won the claim (and must fire the join), ``False`` if the batch was already
+        joined. SYNCHRONOUS — no ``await`` between the membership check and the add — so two
+        concurrent settles (or a settle racing the straggler timeout) can't both win under
+        asyncio's single-threaded scheduling. This is the no-double-fire guarantee."""
+        if batch_id in self._joined_batches:
+            return False
+        self._joined_batches.add(batch_id)
+        return True
+
+    async def resume_for_terminal(self, job) -> bool | None:
+        """Batch-aware terminal delivery (#1766). The server calls this in place of
+        ``resume_origin`` when a background job settles, so a fan-out coalesces into ONE
+        push-resume instead of N drip-fed briefings.
+
+        - **Singleton** (no ``batch_id``, or a batch of one) → delegate to
+          ``resume_origin`` — the UNCHANGED single-job push-resume. Returns its bool.
+        - **Not the last member** to settle → hold: arm the straggler timeout once and
+          return ``None`` (nothing delivered, NOT a failure — the last member delivers).
+        - **Last member** to settle → win the single-fire claim and push-resume the WHOLE
+          fan-out once via ``resume_origin_batch`` (the per-session drain then attaches
+          every sibling report to that one turn). A duplicate last-member — the claim was
+          already taken by a sibling or the straggler timeout — returns ``None``.
+
+        Never raises. Incognito batches never reach here: the server's ``_should_auto_resume``
+        guard skips an incognito job before calling this (all members of one turn share the
+        incognito flag), so no push-resume fires — their reports still drain normally."""
+        batch_id = getattr(job, "batch_id", None)
+        if not batch_id or self.store.batch_size(batch_id) <= 1:
+            return await self.resume_origin(job)
+        if self.store.batch_outstanding(batch_id) > 0:
+            # Siblings still running — hold this completion; the last to settle fires the
+            # single coalesced nudge. Arm the straggler timeout so a hung member can't
+            # strand the finished reports forever.
+            self._ensure_batch_timeout(batch_id, job.origin_session)
+            return None
+        # Last member settled. Win the single-fire claim (or bail if a sibling / the
+        # timeout already fired), then push-resume the whole fan-out exactly once.
+        if not self._claim_batch(batch_id):
+            return None
+        self._cancel_batch_timeout(batch_id)  # settled naturally — no straggler nudge needed
+        return await self.resume_origin_batch(batch_id, job.origin_session)
+
+    def _ensure_batch_timeout(self, batch_id: str, origin_session: str) -> None:
+        """Arm ONE straggler-timeout task for a batch, idempotently. If the batch hasn't
+        joined within ``_batch_join_timeout_s`` (a member hung), force the join so the
+        already-finished reports still land. Best-effort; no-op off-loop or if already
+        armed/joined."""
+        if batch_id in self._batch_timeouts or batch_id in self._joined_batches:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+
+        async def _straggle() -> None:
+            try:
+                await asyncio.sleep(self._batch_join_timeout_s)
+                if not self._claim_batch(batch_id):
+                    return  # the batch joined normally while we slept
+                await self.resume_origin_batch(batch_id, origin_session)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 — the straggler join is best-effort
+                log.exception("[background] batch straggler-join failed for %s", batch_id)
+
+        t = loop.create_task(_straggle(), name=f"background.batch-timeout.{batch_id}")
+        self._batch_timeouts[batch_id] = t
+        self._fire_tasks.add(t)  # hold a ref so the sleep isn't GC'd mid-flight
+        t.add_done_callback(self._fire_tasks.discard)
+        t.add_done_callback(lambda _t, b=batch_id: self._batch_timeouts.pop(b, None))
+
+    def _cancel_batch_timeout(self, batch_id: str) -> None:
+        """Cancel a batch's straggler timeout once the batch joined normally (no straggler
+        nudge needed). No-op when none is armed."""
+        t = self._batch_timeouts.pop(batch_id, None)
+        if t is not None and not t.done():
+            t.cancel()
+
+    async def resume_origin_batch(self, batch_id: str, origin_session: str) -> bool:
+        """Push-resume a whole fan-out ONCE (#1766). Same self-A2A mechanics as
+        ``resume_origin`` (a nudge into ``origin_session`` wrapped in ``turn.started`` /
+        ``turn.finished``), but the text summarizes the batch — the per-session drain
+        (``server/chat.py``) attaches EVERY sibling report to this one turn, so the agent
+        synthesizes a single briefing across all of them. If a straggler forced an early
+        join (members still running), the text says only the settled ones are attached and
+        the rest will notify separately. Never raises; returns whether the nudge landed —
+        on failure ``notified`` is untouched, so the reports still drain next manual turn."""
+        counts = self.store.batch_status_counts(batch_id)
+        total = self.store.batch_size(batch_id)
+        running = counts.get("running", 0)
+        settled_counts = {k: v for k, v in counts.items() if k in _TERMINAL_STATUSES}
+        settled = sum(settled_counts.values())
+        summary = ", ".join(f"{k} {v}" for k, v in sorted(settled_counts.items())) or "no reports"
+        if running > 0:
+            text = (
+                f"[{settled} of {total} background jobs from your fan-out have finished ({summary}); "
+                "their report notifications are attached to this turn — synthesize ONE briefing against "
+                f"them. The remaining {running} are still running and will notify separately.]"
+            )
+        else:
+            text = (
+                f"[all {total} background jobs from your fan-out have finished ({summary}) — their report "
+                "notifications are attached to this turn; synthesize ONE briefing against all of them]"
+            )
+        # Turn-lifecycle events (#1767), keyed on the batch id: the nudge holds the
+        # connection open for the whole origin-session briefing turn.
+        self._publish_turn("turn.started", session_id=origin_session, origin="background-resume", trigger=batch_id)
+        ok = False
+        try:
+            await self._send_a2a_message(
+                context_id=origin_session,
+                text=text,
+                metadata={
+                    "origin": "background-resume",
+                    "trigger": batch_id,
+                    "background_batch_id": batch_id,
+                },
+            )
+            ok = True
+            return True
+        except Exception as exc:  # noqa: BLE001 — push-resume is best-effort by contract
+            log.warning(
+                "[background] batch push-resume for %s into %s failed (%s) — the reports will "
+                "drain on that session's next turn",
+                batch_id,
+                origin_session,
+                exc,
+            )
+            return False
+        finally:
+            self._publish_turn(
+                "turn.finished", session_id=origin_session, origin="background-resume", trigger=batch_id, ok=ok
             )
 
 

--- a/background/store.py
+++ b/background/store.py
@@ -40,6 +40,11 @@ class BackgroundJob:
     # must leave NO memory trail — no push-resume nudge, no knowledge-store indexing.
     # The report still lives here (jobs.db) and drains into the origin session normally.
     origin_incognito: bool = False
+    # The spawning turn's id (#1766): every job a single fan-out turn spawns shares one
+    # ``batch_id`` (task_batch's N specs, or several task(run_in_background=True) in one
+    # turn), so the completions coalesce into ONE push-resume when the last member settles
+    # instead of N drip-fed briefings. ``None`` for a lone / plugin spawn (a singleton).
+    batch_id: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -55,6 +60,7 @@ class BackgroundJob:
             "completed_at": self.completed_at,
             "a2a_task_id": self.a2a_task_id,
             "origin_incognito": self.origin_incognito,
+            "batch_id": self.batch_id,
         }
 
 
@@ -74,6 +80,7 @@ def _row_to_job(row: sqlite3.Row) -> BackgroundJob:
         completed_at=row["completed_at"],
         a2a_task_id=(row["a2a_task_id"] if "a2a_task_id" in keys else "") or "",
         origin_incognito=bool(row["origin_incognito"] if "origin_incognito" in keys else 0),
+        batch_id=(row["batch_id"] if "batch_id" in keys else None) or None,
     )
 
 
@@ -108,7 +115,8 @@ class BackgroundStore:
                     created_at     TEXT NOT NULL,
                     completed_at   TEXT,
                     a2a_task_id    TEXT,
-                    origin_incognito INTEGER NOT NULL DEFAULT 0
+                    origin_incognito INTEGER NOT NULL DEFAULT 0,
+                    batch_id       TEXT
                 )
                 """
             )
@@ -119,10 +127,14 @@ class BackgroundStore:
             # Migrate a pre-ADR-0070 DB: incognito propagation (existing rows default 0).
             if "origin_incognito" not in cols:
                 db.execute("ALTER TABLE background_jobs ADD COLUMN origin_incognito INTEGER NOT NULL DEFAULT 0")
+            # Migrate a pre-#1766 DB: fan-out batch key (existing rows are unbatched → NULL).
+            if "batch_id" not in cols:
+                db.execute("ALTER TABLE background_jobs ADD COLUMN batch_id TEXT")
             db.execute(
                 "CREATE INDEX IF NOT EXISTS ix_bg_session_pending ON background_jobs(origin_session, status, notified)"
             )
             db.execute("CREATE INDEX IF NOT EXISTS ix_bg_status ON background_jobs(status)")
+            db.execute("CREATE INDEX IF NOT EXISTS ix_bg_batch ON background_jobs(batch_id)")
             db.commit()
         finally:
             db.close()
@@ -138,9 +150,14 @@ class BackgroundStore:
         description: str,
         prompt: str,
         origin_incognito: bool = False,
+        batch_id: str | None = None,
         now: datetime | None = None,
     ) -> str:
-        """Insert a ``running`` job and return its opaque id (``bg-<uuid12>``)."""
+        """Insert a ``running`` job and return its opaque id (``bg-<uuid12>``).
+
+        ``batch_id`` (#1766) tags a job as a member of a fan-out spawned by one turn, so
+        the completions coalesce into ONE push-resume; ``None`` (the default) is a
+        singleton spawn."""
         job_id = f"bg-{uuid.uuid4().hex[:12]}"
         created = (now or datetime.now(UTC)).isoformat()
         db = self._connect()
@@ -148,8 +165,8 @@ class BackgroundStore:
             db.execute(
                 "INSERT INTO background_jobs "
                 "(id, agent_name, origin_session, subagent_type, description, prompt, "
-                " status, result, notified, created_at, completed_at, a2a_task_id, origin_incognito) "
-                "VALUES (?, ?, ?, ?, ?, ?, 'running', '', 0, ?, NULL, '', ?)",
+                " status, result, notified, created_at, completed_at, a2a_task_id, origin_incognito, batch_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'running', '', 0, ?, NULL, '', ?, ?)",
                 (
                     job_id,
                     agent_name,
@@ -159,6 +176,7 @@ class BackgroundStore:
                     prompt,
                     created,
                     1 if origin_incognito else 0,
+                    batch_id or None,
                 ),
             )
             db.commit()
@@ -230,6 +248,54 @@ class BackgroundStore:
                 )
                 db.commit()
             return [_row_to_job(r) for r in rows]
+        finally:
+            db.close()
+
+    # ── fan-out batches (#1766) ───────────────────────────────────────────────
+
+    def batch_size(self, batch_id: str) -> int:
+        """Count every job in a fan-out batch. ``0`` for a null/unknown batch — the
+        caller then treats the job as a singleton (the unchanged single-job path)."""
+        if not batch_id:
+            return 0
+        db = self._connect()
+        try:
+            row = db.execute(
+                "SELECT COUNT(*) AS n FROM background_jobs WHERE batch_id = ?", (batch_id,)
+            ).fetchone()
+            return int(row["n"]) if row else 0
+        finally:
+            db.close()
+
+    def batch_outstanding(self, batch_id: str) -> int:
+        """Count still-``running`` members of a batch — the "batch not yet fully settled"
+        check. A queued-at-semaphore job still reads ``running`` (it IS accepted), so this
+        stays >0 until every member reaches a terminal state."""
+        if not batch_id:
+            return 0
+        db = self._connect()
+        try:
+            row = db.execute(
+                "SELECT COUNT(*) AS n FROM background_jobs WHERE batch_id = ? AND status = 'running'",
+                (batch_id,),
+            ).fetchone()
+            return int(row["n"]) if row else 0
+        finally:
+            db.close()
+
+    def batch_status_counts(self, batch_id: str) -> dict[str, int]:
+        """Per-status tallies for a batch, e.g. ``{'completed': 6, 'failed': 1}`` — the
+        summary the join nudge quotes (a still-open batch also carries ``'running'``).
+        Empty for a null/unknown batch."""
+        if not batch_id:
+            return {}
+        db = self._connect()
+        try:
+            rows = db.execute(
+                "SELECT status, COUNT(*) AS n FROM background_jobs WHERE batch_id = ? GROUP BY status",
+                (batch_id,),
+            ).fetchall()
+            return {r["status"]: int(r["n"]) for r in rows}
         finally:
             db.close()
 

--- a/docs/adr/0070-background-results-push-resume.md
+++ b/docs/adr/0070-background-results-push-resume.md
@@ -81,6 +81,27 @@ Cursor:
   excerpt with a bottom fade-out mask, and a primary "Open report" CTA into the
   document viewer. Specificity stacked (`.pl-message--system.chat-report …`) so
   the DS default can't win by load order.
+- **D5 — Fan-out batch-join (#1766).** D1 push-resumes *per job*, so a fan-out of N
+  background subagents (`task_batch(run_in_background=True)`, or several
+  `task(run_in_background=True)` in one turn) fired N separate briefing turns — the
+  real cross-report synthesis only landed on the last. D1 now **coalesces a fan-out
+  into one push-resume**: every job a single turn spawns is tagged with a `batch_id`
+  = **the emitting assistant turn's id** (`graph.agent._turn_id_from`), carried through
+  `spawn`→`store.create` on the new nullable `background_jobs.batch_id` column. On each
+  terminal completion the server calls `manager.resume_for_terminal(job)` instead of
+  `resume_origin`: a singleton (no batch / `batch_size ≤ 1`) push-resumes unchanged; a
+  member that is not the last to settle is **held** (returns `None` — nothing delivered,
+  not a failure); the **last** member (`batch_outstanding == 0`) wins a synchronous
+  single-fire claim (`_joined_batches`) and fires **one** `resume_origin_batch` whose
+  nudge summarizes the fan-out with per-status counts (`batch_status_counts`, e.g.
+  `completed 6, failed 1`) — the drain (already per-session) then attaches *all* sibling
+  reports to that one turn for a single briefing. A failed member counts as settled and
+  appears in the summary. A **straggler timeout** (`BACKGROUND_BATCH_JOIN_TIMEOUT_S`,
+  default 900s) is armed on the first held completion and forces a *partial* join if a
+  member hangs, so finished reports can't be stranded forever; the remaining reports still
+  drain on the session's next turn. Incognito batches never reach the join (the D1
+  `_should_auto_resume` guard skips them before `resume_for_terminal`). The drain and its
+  exactly-once guarantee are unchanged.
 
 ## 4. Consequences
 

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -195,6 +195,28 @@ def _incognito_from(state: Any) -> bool:
     return bool(state.get("incognito")) if isinstance(state, dict) else False
 
 
+def _turn_id_from(state: Any) -> str | None:
+    """The id of the EMITTING assistant turn — the ``AIMessage`` carrying the tool
+    calls (``messages[-1]`` at tool-execution time). Used as the fan-out batch key
+    (#1766): every background job a single turn spawns (task_batch's N specs, or a
+    lone ``task(run_in_background=True)``) shares this id, so their completions
+    coalesce into ONE push-resume when the last member settles. Best-effort — returns
+    ``None`` on any miss, so the job simply falls back to the singleton path (its own
+    push-resume), same as before."""
+    if not isinstance(state, dict):
+        return None
+    try:
+        messages = state.get("messages") or []
+        last = messages[-1] if messages else None
+        # Only the AIMessage carrying tool calls is a valid turn key; a ToolMessage or
+        # a bare AIMessage without tool_calls is not the fan-out's emitter.
+        if last is not None and getattr(last, "tool_calls", None):
+            return getattr(last, "id", None) or None
+    except Exception:  # noqa: BLE001 — batch keying is best-effort; None → singleton path
+        return None
+    return None
+
+
 def _auto_background_seconds() -> float:
     """Time budget (seconds) after which a *foreground* ``task`` delegation transparently
     detaches to the background (ADR 0051). ``BACKGROUND_AUTO_S`` env; 0 (default) = off."""
@@ -527,6 +549,10 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
                 description=description,
                 prompt=prompt,
                 origin_incognito=_incognito_from(state),
+                # Tag the job with the emitting turn's id (#1766) so a fan-out — several
+                # task(run_in_background=True) in one turn — coalesces into one push-resume.
+                # A lone task → batch_size 1 → the unchanged singleton path.
+                batch_id=_turn_id_from(state),
             )
             return job_id
 
@@ -674,6 +700,11 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
         # how many run at once. Degrades to the foreground batch below when no manager exists.
         if run_in_background and background_mgr is not None:
             session_id = _session_id_from(state)
+            # All N specs are spawned by THIS one turn → they share the emitting turn's id
+            # as their batch key (#1766), so their completions coalesce into ONE push-resume
+            # instead of N drip-fed briefings; the real cross-report synthesis happens once.
+            batch_id = _turn_id_from(state)
+            incognito = _incognito_from(state)
             lines: list[str] = []
             started = 0
             for i, spec in enumerate(tasks, start=1):
@@ -694,7 +725,8 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
                     subagent_type=st,
                     description=desc,
                     prompt=prm,
-                    origin_incognito=_incognito_from(state),
+                    origin_incognito=incognito,
+                    batch_id=batch_id,
                 )
                 started += 1
                 lines.append(f"Task {i}: {job_id} ({st}: {desc})")

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -124,10 +124,18 @@ def _spawn_background_wake(job) -> None:
 
 def _spawn_background_resume(mgr, job) -> None:
     """Schedule the push-resume nudge (ADR 0070 D1) fire-and-forget on the running
-    loop. When the nudge can't be delivered, fall back to the ADR 0050 Phase 2
-    Activity wake (when enabled) so the completion still reaches the agent somewhere;
-    either way ``notified`` is untouched — the report itself always drains into the
-    origin session's next turn, exactly once. No-op off-loop."""
+    loop, batch-aware (#1766). Routes through ``mgr.resume_for_terminal(job)``:
+
+    - a SINGLETON (no batch / batch of one) push-resumes exactly as before;
+    - the LAST member of a fan-out fires ONE coalesced batch nudge (siblings' reports
+      ride the same drained turn);
+    - a non-last member returns ``None`` — HELD, nothing delivered — and we do nothing
+      (no wake, no failure); the last member will deliver for the whole batch.
+
+    On a delivered-vs-not bool (singleton or fired batch), a non-delivery falls back to
+    the ADR 0050 Phase 2 Activity wake (when enabled) so the completion still reaches the
+    agent somewhere. Either way ``notified`` is untouched — the report(s) always drain
+    into the origin session, exactly once. No-op off-loop."""
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
@@ -135,10 +143,12 @@ def _spawn_background_resume(mgr, job) -> None:
 
     async def _go() -> None:
         try:
-            delivered = await mgr.resume_origin(job)
-        except Exception:  # noqa: BLE001 — resume_origin is never-raises by contract; belt and braces
+            delivered = await mgr.resume_for_terminal(job)
+        except Exception:  # noqa: BLE001 — resume_for_terminal is never-raises by contract; belt and braces
             log.exception("[background] push-resume failed for %s", getattr(job, "id", "?"))
             delivered = False
+        if delivered is None:
+            return  # held for still-outstanding batch siblings — the last member delivers
         if not delivered and _background_wake_enabled():
             try:
                 await _background_wake(job)

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -135,6 +135,97 @@ class TestStore:
         assert s.get(a) is None
         assert s.get(b) is not None
 
+    # ── fan-out batches (#1766) ───────────────────────────────────────────────
+
+    def test_batch_id_persists_and_defaults_none(self, tmp_path):
+        s = _store(tmp_path)
+        lone = s.create(agent_name="a", origin_session="s1", subagent_type="researcher", description="d", prompt="p")
+        member = s.create(
+            agent_name="a", origin_session="s1", subagent_type="researcher", description="d", prompt="p",
+            batch_id="batch-A",
+        )
+        assert s.get(lone).batch_id is None  # unbatched spawn → NULL
+        assert s.get(member).batch_id == "batch-A"
+
+    def test_batch_size_and_outstanding(self, tmp_path):
+        s = _store(tmp_path)
+        ids = [
+            s.create(
+                agent_name="a", origin_session="s1", subagent_type="researcher", description=f"d{i}", prompt="p",
+                batch_id="batch-A",
+            )
+            for i in range(3)
+        ]
+        # a job in a DIFFERENT batch (and one unbatched) must not leak into the counts
+        s.create(
+            agent_name="a", origin_session="s1", subagent_type="researcher", description="other", prompt="p",
+            batch_id="batch-B",
+        )
+        s.create(agent_name="a", origin_session="s1", subagent_type="researcher", description="lone", prompt="p")
+        assert s.batch_size("batch-A") == 3
+        assert s.batch_outstanding("batch-A") == 3  # all running
+        s.mark_complete(ids[0], "completed", "r0")
+        assert s.batch_outstanding("batch-A") == 2  # a queued/running sibling still counts
+        s.mark_complete(ids[1], "failed", "boom")
+        s.mark_complete(ids[2], "completed", "r2")
+        assert s.batch_outstanding("batch-A") == 0  # fully settled
+        assert s.batch_size("batch-A") == 3  # size never changes
+        # null / unknown batch is empty, never an error
+        assert s.batch_size("") == 0 and s.batch_size("nope") == 0
+        assert s.batch_outstanding("") == 0
+
+    def test_batch_status_counts(self, tmp_path):
+        s = _store(tmp_path)
+        ids = [
+            s.create(
+                agent_name="a", origin_session="s1", subagent_type="researcher", description=f"d{i}", prompt="p",
+                batch_id="batch-A",
+            )
+            for i in range(3)
+        ]
+        s.mark_complete(ids[0], "completed", "r0")
+        s.mark_complete(ids[1], "failed", "boom")  # a failed member is still a settled member
+        # ids[2] left running
+        counts = s.batch_status_counts("batch-A")
+        assert counts == {"completed": 1, "failed": 1, "running": 1}
+        assert s.batch_status_counts("nope") == {}
+
+    def test_batch_id_migrates_in_place(self, tmp_path):
+        """A pre-#1766 DB (no batch_id column) upgrades in place on open — existing rows
+        read batch_id None and new rows can carry one."""
+        import sqlite3
+
+        db_path = tmp_path / "background" / "jobs.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        con = sqlite3.connect(str(db_path))
+        con.execute(
+            """
+            CREATE TABLE background_jobs (
+                id TEXT PRIMARY KEY, agent_name TEXT NOT NULL, origin_session TEXT NOT NULL,
+                subagent_type TEXT NOT NULL, description TEXT NOT NULL, prompt TEXT NOT NULL,
+                status TEXT NOT NULL, result TEXT, notified INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL, completed_at TEXT
+            )
+            """
+        )
+        con.execute(
+            "INSERT INTO background_jobs (id, agent_name, origin_session, subagent_type, description, prompt, "
+            "status, result, notified, created_at, completed_at) "
+            "VALUES ('bg-old', 'a', 's1', 'researcher', 'legacy', 'p', 'completed', 'r', 0, 't1', 't2')"
+        )
+        con.commit()
+        con.close()
+
+        s = BackgroundStore(str(db_path))  # opening runs the guarded migration
+        old = s.get("bg-old")
+        assert old is not None and old.batch_id is None  # legacy row migrated, unbatched
+        new = s.create(
+            agent_name="a", origin_session="s1", subagent_type="researcher", description="d", prompt="p",
+            batch_id="batch-A",
+        )
+        assert s.get(new).batch_id == "batch-A"
+        assert s.batch_size("batch-A") == 1
+
 
 # ── manager ──────────────────────────────────────────────────────────────────
 
@@ -414,6 +505,121 @@ class TestResumeOriginTurnEvents:
         assert finished["ok"] is False
 
 
+# ── #1766: fan-out batch-join (coalesce N completions into one push-resume) ──
+
+
+class TestBatchJoin:
+    """A fan-out of background jobs sharing one ``batch_id`` push-resumes ONCE — held
+    until the last member settles — instead of N drip-fed briefing turns (#1766)."""
+
+    def _member(self, mgr, batch_id, origin="s1", desc="d"):
+        return mgr.store.create(
+            agent_name="a", origin_session=origin, subagent_type="researcher",
+            description=desc, prompt="p", batch_id=batch_id,
+        )
+
+    def _patch_send(self, mgr) -> list:
+        """Replace the network self-A2A send with an in-memory recorder (no network)."""
+        sends: list[dict] = []
+
+        async def _fake_send(*, context_id, text, metadata):
+            sends.append({"context_id": context_id, "text": text, "metadata": metadata})
+
+        mgr._send_a2a_message = _fake_send
+        return sends
+
+    async def _settle(self, mgr, job_id, status="completed", result="r"):
+        """Mirror the server flow: mark the row terminal, then route the fresh row through
+        the batch-aware terminal delivery."""
+        mgr.store.mark_complete(job_id, status, result)
+        return await mgr.resume_for_terminal(mgr.store.get(job_id))
+
+    async def test_batch_of_three_fires_exactly_one_join(self, tmp_path):
+        mgr = _manager(tmp_path, batch_join_timeout_s=1000)
+        sends = self._patch_send(mgr)
+        a = self._member(mgr, "batch-A", desc="topic a")
+        b = self._member(mgr, "batch-A", desc="topic b")
+        c = self._member(mgr, "batch-A", desc="topic c")
+        # the first two settles HOLD — nothing delivered, not a failure
+        assert await self._settle(mgr, a) is None
+        assert await self._settle(mgr, b) is None
+        assert sends == []
+        # the last member fires ONE coalesced batch nudge for the whole fan-out
+        assert await self._settle(mgr, c) is True
+        assert len(sends) == 1
+        nudge = sends[0]
+        assert nudge["context_id"] == "s1"
+        assert nudge["metadata"]["background_batch_id"] == "batch-A"
+        assert nudge["metadata"]["origin"] == "background-resume"
+        assert "synthesize ONE briefing" in nudge["text"]
+        assert "all 3 background jobs" in nudge["text"]
+
+    async def test_already_joined_batch_never_double_fires(self, tmp_path):
+        mgr = _manager(tmp_path, batch_join_timeout_s=1000)
+        sends = self._patch_send(mgr)
+        a = self._member(mgr, "batch-A")
+        b = self._member(mgr, "batch-A")
+        assert await self._settle(mgr, a) is None
+        assert await self._settle(mgr, b) is True  # last → fires exactly once
+        assert len(sends) == 1
+        # a redundant delivery for an already-joined batch delivers nothing (no double-fire)
+        assert await mgr.resume_for_terminal(mgr.store.get(b)) is None
+        assert len(sends) == 1
+
+    async def test_singleton_none_batch_uses_resume_origin(self, tmp_path):
+        mgr = _manager(tmp_path, batch_join_timeout_s=1000)
+        sends = self._patch_send(mgr)
+        jid = mgr.store.create(  # batch_id defaults to None → singleton
+            agent_name="a", origin_session="s1", subagent_type="researcher", description="lone", prompt="p"
+        )
+        assert await self._settle(mgr, jid) is True
+        assert len(sends) == 1
+        # single-job text + single-job metadata (no batch key) — the UNCHANGED path
+        assert "background job bg-" in sends[0]["text"]
+        assert "background_batch_id" not in sends[0]["metadata"]
+        assert sends[0]["metadata"]["background_job_id"] == jid
+
+    async def test_batch_of_one_is_a_singleton(self, tmp_path):
+        mgr = _manager(tmp_path, batch_join_timeout_s=1000)
+        sends = self._patch_send(mgr)
+        jid = self._member(mgr, "batch-solo")
+        assert await self._settle(mgr, jid) is True  # batch_size 1 → singleton path
+        assert len(sends) == 1
+        assert "background_batch_id" not in sends[0]["metadata"]
+
+    async def test_failed_member_counts_as_settled_and_in_summary(self, tmp_path):
+        mgr = _manager(tmp_path, batch_join_timeout_s=1000)
+        sends = self._patch_send(mgr)
+        a = self._member(mgr, "batch-A")
+        b = self._member(mgr, "batch-A")
+        assert await self._settle(mgr, a, status="failed", result="boom") is None
+        assert await self._settle(mgr, b, status="completed", result="ok") is True
+        assert len(sends) == 1
+        text = sends[0]["text"]
+        assert "completed 1" in text and "failed 1" in text
+        assert "all 2 background jobs" in text
+
+    async def test_straggler_timeout_forces_partial_join(self, tmp_path):
+        mgr = _manager(tmp_path, batch_join_timeout_s=0.05)  # tiny straggler window
+        sends = self._patch_send(mgr)
+        a = self._member(mgr, "batch-A")
+        b = self._member(mgr, "batch-A")  # left running — the straggler
+        assert await self._settle(mgr, a) is None  # holds + arms the timeout
+        assert sends == []
+        for _ in range(200):  # let the straggler timeout fire the partial join
+            if sends:
+                break
+            await asyncio.sleep(0.01)
+        assert len(sends) == 1
+        text = sends[0]["text"]
+        assert "1 of 2 background jobs" in text
+        assert "still running" in text
+        assert "batch-A" in mgr._joined_batches
+        # the hung member finishing later must NOT fire a second nudge
+        assert await self._settle(mgr, b) is None
+        assert len(sends) == 1
+
+
 # ── Phase 2: autonomous idle-wake (server/a2a.py) ────────────────────────────
 
 
@@ -681,10 +887,14 @@ class _RecordingBG:
     def __init__(self):
         self.seen_origin = "__unset__"
         self.seen_incognito = None
+        self.seen_batch_id = "__unset__"
 
-    async def spawn(self, *, origin_session, subagent_type, description, prompt, origin_incognito=False):
+    async def spawn(
+        self, *, origin_session, subagent_type, description, prompt, origin_incognito=False, batch_id=None
+    ):
         self.seen_origin = origin_session
         self.seen_incognito = origin_incognito
+        self.seen_batch_id = batch_id
         return "bg-test-1"
 
 
@@ -698,6 +908,7 @@ async def test_background_task_stamps_the_turn_session_as_origin(monkeypatch):
     from graph.config import LangGraphConfig
 
     task_call = AIMessage(
+        id="turn-single-1",  # #1766: the emitting turn's id becomes the job's batch_id
         content="",
         tool_calls=[
             {
@@ -729,6 +940,9 @@ async def test_background_task_stamps_the_turn_session_as_origin(monkeypatch):
         config={"configurable": {"thread_id": "t1"}},
     )
     assert bg.seen_origin == "sess-BG"
+    # A lone task carries the emitting turn's id as its batch_id (#1766) — the store then
+    # sees batch_size 1 → the unchanged singleton push-resume.
+    assert bg.seen_batch_id == "turn-single-1"
 
 
 # ── task_batch(run_in_background=True) stamps the session + spawns every spec ──
@@ -741,8 +955,17 @@ class _RecordingBatchBG:
     def __init__(self):
         self.spawns: list[dict] = []
 
-    async def spawn(self, *, origin_session, subagent_type, description, prompt, origin_incognito=False):
-        self.spawns.append({"origin": origin_session, "subagent_type": subagent_type, "description": description})
+    async def spawn(
+        self, *, origin_session, subagent_type, description, prompt, origin_incognito=False, batch_id=None
+    ):
+        self.spawns.append(
+            {
+                "origin": origin_session,
+                "subagent_type": subagent_type,
+                "description": description,
+                "batch_id": batch_id,
+            }
+        )
         return f"bg-{len(self.spawns)}"
 
 
@@ -756,6 +979,7 @@ async def test_background_batch_stamps_session_and_spawns_all(monkeypatch):
     from graph.config import LangGraphConfig
 
     batch_call = AIMessage(
+        id="turn-batch-1",  # #1766: shared by every spec's job as the fan-out batch key
         content="",
         tool_calls=[
             {
@@ -790,3 +1014,6 @@ async def test_background_batch_stamps_session_and_spawns_all(monkeypatch):
     assert len(bg.spawns) == 2
     assert {s["origin"] for s in bg.spawns} == {"sess-BB"}
     assert {s["description"] for s in bg.spawns} == {"topic a", "topic b"}
+    # Every spec's job shares ONE batch_id — the emitting turn's id (#1766) — so their
+    # completions coalesce into a single push-resume.
+    assert {s["batch_id"] for s in bg.spawns} == {"turn-batch-1"}

--- a/tests/test_task_batch.py
+++ b/tests/test_task_batch.py
@@ -159,13 +159,16 @@ class _RecordingBG:
     def __init__(self):
         self.calls: list[dict] = []
 
-    async def spawn(self, *, origin_session, subagent_type, description, prompt, origin_incognito=False):
+    async def spawn(
+        self, *, origin_session, subagent_type, description, prompt, origin_incognito=False, batch_id=None
+    ):
         self.calls.append(
             {
                 "origin": origin_session,
                 "subagent_type": subagent_type,
                 "description": description,
                 "prompt": prompt,
+                "batch_id": batch_id,
             }
         )
         return f"bg-{len(self.calls)}"


### PR DESCRIPTION
Closes #1766

## Problem
When an agent fans out N background subagents in one turn — `task_batch(run_in_background=True)`, or several `task(run_in_background=True)` — **each** job's completion independently push-resumed the origin session (ADR 0070 D1: `server/a2a.py` → `mgr.resume_origin(job)`), producing **N drip-fed briefing turns** instead of one. The real cross-report synthesis only happened on the last. This coalesces a fan-out into **one** push-resume.

## Design
- **Batch key = the spawning turn's id.** Every job a single turn spawns shares one `batch_id` = the emitting `AIMessage.id` (`graph.agent._turn_id_from`), threaded `spawn` → `store.create` onto a new nullable `background_jobs.batch_id` column. A lone `task` → `batch_size 1` → the unchanged singleton path; a plugin/sdk single-spawn stays unbatched.
- **Hold-until-last.** On each terminal completion the server calls `manager.resume_for_terminal(job)` instead of `resume_origin`:
  - singleton (no batch / `batch_size ≤ 1`) → `resume_origin` (unchanged text + behavior);
  - a member that is **not** the last to settle → **held**: returns `None` (nothing delivered, *not* a failure);
  - the **last** member (`batch_outstanding == 0`) wins a **synchronous** single-fire claim (`_joined_batches` — no `await` between check and set, so two concurrent settles or a settle racing the timeout can't both fire) and fires **one** `resume_origin_batch`. The drain (already per-session, unchanged) then attaches every sibling report to that one turn for a single briefing.
- **Per-status summary.** The batch nudge quotes `batch_status_counts` (e.g. `completed 6, failed 1`); a failed member counts as settled.
- **Straggler timeout.** `BACKGROUND_BATCH_JOIN_TIMEOUT_S` (default 900s) is armed on the first held completion; if a member hangs, it forces a *partial* join so finished reports are never stranded (the rest drain on the next turn).
- **Held → nothing:** a `None` result from `resume_for_terminal` does nothing (no wake, no failure). Singleton/fired-batch keep the non-delivery Activity-wake fallback.
- Incognito batches never reach the join — the D1 `_should_auto_resume` guard skips them upstream (all members of one turn share the incognito flag).

See ADR 0070 (amended, **D5**).

## Files
`background/store.py` (batch_id column + migration + batch_size/outstanding/status_counts) · `background/manager.py` (batch_id on spawn/spawn_work, `resume_for_terminal`, `resume_origin_batch`, straggler timeout, `_claim_batch`) · `graph/agent.py` (`_turn_id_from`, batch_id on task/task_batch) · `server/a2a.py` (route through `resume_for_terminal`) · `docs/adr/0070-…md` (D5) · `CHANGELOG.md` · `tests/test_background.py`, `tests/test_task_batch.py`.

`graph/sdk.py` single-spawn intentionally left unbatched (singleton).

## Gates (run locally in the worktree)
- `uv run ruff check .` → **All checks passed!**
- `uv run --with import-linter==2.11 lint-imports` → **Contracts: 3 kept, 0 broken** (background/graph/server layering intact)
- `uv run python -m pytest tests/ -q` → **3065 passed, 5 skipped** (incl. new batch-join + store-migration tests)
- `uv run python scripts/live_smoke.py` → **LIVE SMOKE PASSED**

## Status
**DRAFT** pending QA — backend-only change; the batch-join and straggler paths warrant a live fan-out sanity check on the dev instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)