### PR TITLE
fix(console): chat/composer errors surface as a toast, not an inline strip

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -6,7 +6,6 @@ import {
   BookOpen,
   Boxes,
   CalendarClock,
-  CircleAlert,
   FileText,
   Gauge,
   Inbox,
@@ -57,7 +56,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { lazy, Suspense, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { ComponentType, LazyExoticComponent, MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { FleetTurnWatch } from "./FleetTurnWatch";
 import { UpdateNotice } from "./UpdateNotice";
@@ -428,16 +427,6 @@ export function App() {
   }, [bootReady]);
   // Which recovery the boot gate shows (pure precedence — tested in bootGate.test.ts).
   const gatePhase = bootGatePhase({ memberAuthFailed, agentDown, unreachable: agentUnreachable, bootFailed, bootStuck });
-  const [error, setError] = useState("");
-
-  // Clear the stale "Load failed" strip once the engine reports ready. The
-  // graph compile (cold start, finishing setup, or a model change) runs inline
-  // on the server loop and freezes it, so concurrent pollers fail and set the
-  // strip — which is otherwise only cleared by a user action. When `graph_loaded`
-  // flips true the connection is healthy again, so that transient error is moot.
-  useEffect(() => {
-    if (engineReady) setError((prev) => (prev ? "" : prev));
-  }, [engineReady]);
 
   // Adopt the server's default project as the fs working dir if none is set (it
   // seeds the setup wizard's allowed-dirs) once runtime resolves.
@@ -459,6 +448,18 @@ export function App() {
   // Goal completions surface as a toast (goal.achieved / goal.failed on the bus, ADR 0039) so a
   // plain operator notices a terminal goal without writing a plugin hook.
   const toast = useToast();
+
+  // Transient chat/composer errors (attach/image/queue/cancel/rewind) surface as a
+  // toast, not an inline strip — the console toast convention. Global, so an error from
+  // a chat docked on the right/bottom shows too (the old strip only rendered on the left);
+  // an empty string is a no-op (the strip's clear-on-success is moot once toasts auto-dismiss).
+  const onChatError = useCallback(
+    (msg: string) => {
+      if (msg) toast({ tone: "error", message: msg });
+    },
+    [toast],
+  );
+
   useEffect(() => {
     const offDone = onServerEvent("goal.achieved", (d) =>
       toast({ tone: "success", title: "Goal achieved", message: String(d.condition || "the goal") }));
@@ -1046,15 +1047,9 @@ export function App() {
         quickBarIds={quickBar}
         leftContent={
           <>
-            {error ? (
-              <div className="error-strip" role="alert">
-                <CircleAlert size={16} />
-                <span>{error}</span>
-              </div>
-            ) : null}
             {chatRail === "left" || isMobile ? (
               <ChatSlot
-                onError={setError}
+                onError={onChatError}
                 active={(isMobile ? mobileActive : leftActive) === "chat"}
                 pluginView={chatSlotView}
                 enabledPluginIds={enabledPluginIds}
@@ -1070,7 +1065,7 @@ export function App() {
           <>
             {chatRail === "right" ? (
               <ChatSlot
-                onError={setError}
+                onError={onChatError}
                 active={rightActive === "chat"}
                 pluginView={chatSlotView}
                 enabledPluginIds={enabledPluginIds}
@@ -1088,7 +1083,7 @@ export function App() {
                 surface — or back — never tears down an in-flight stream (#613). */}
             {chatRail === "bottom" ? (
               <ChatSlot
-                onError={setError}
+                onError={onChatError}
                 active={bottomActive === "chat"}
                 pluginView={chatSlotView}
                 enabledPluginIds={enabledPluginIds}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -606,19 +606,6 @@ select:disabled {
   opacity: 0.55;
 }
 
-.error-strip {
-  min-height: 36px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 10px;
-  border: 1px solid color-mix(in srgb, var(--error) 30%, transparent);
-  border-radius: var(--radius);
-  background: color-mix(in srgb, var(--error) 14%, transparent);
-  color: var(--error);
-  padding: 8px 10px;
-}
-
 .message-list,
 .issue-list,
 .subagent-list,


### PR DESCRIPTION
Moves the red error banner that rendered above the chat to a **DS toast** (`useToast`), per the console toast convention.

## What
- Every `ChatSurface` `onError` source (image-can't-be-seen, attach/read failures, queue/cancel/rewind errors, friendly errors) now routes through one `onChatError` → `toast({ tone: "error", message })`.
- Removed the inline `error-strip` `<div>`, the `error` React state, its engine-ready clear effect, the `.error-strip` CSS, and the now-unused `CircleAlert` import. Net **−34/+16**.

## Bonus fix
The strip only rendered inside the **left** dock's content — an error from a chat docked **right/bottom** set the state but showed nothing. A toast is global, so errors surface regardless of dock.

## Scope decision
The banners that render **above the AppShell** — `shell-warning-banner` (server-driven runtime warnings) and `AgentDownBanner` (persistent status + a Start action) — **intentionally stay banners**. They're ongoing state, not transient notices; a toast (auto-dismiss, no actions) is the wrong surface. Only the transient chat-error strip moved.

## How to test
Attach an image on a non-vision model (no image-describe configured) → expect a red toast (top-right `.pl-toast-stack`), not a banner. Same for a failed attach / rewind. Dock chat on the right rail and repeat → the toast still shows (previously nothing did).

## Gates
Frontend-only. Local `vitest`/`tsc` can't run in the isolated worktree (no `node_modules`); **CI runs the full `test:unit` + `test:e2e` + build (tsc)**. Kept **DRAFT** — visual/UX, human-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat and composer errors now appear as app notifications instead of an inline left-panel error strip.
  * Error handling is now consistent across the left, right, and bottom chat areas.
  * Removed the old inline error display styling for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->