### PR TITLE
fix(soul): seed + heal live SOUL.md so a baked persona isn't shadowed forever

### DIFF
--- a/docs/guides/deploy-docker.md
+++ b/docs/guides/deploy-docker.md
@@ -91,6 +91,28 @@ Console/settings edits write here and survive reboots + image rolls.
 
 **4. Keep secrets in the env, not the seed.** The model key is read from `OPENAI_API_KEY`; the seed (and your image) carry no credentials. In the console the api-key field shows blank (`api_key_configured: false`) — that's expected, the key is env-sourced.
 
+## Baking a persona (SOUL.md)
+
+The persona has the **same** seed/live split as the config — and the same trap. The live `SOUL.md` sits under the config volume (`<instance_root>/config/SOUL.md`), and `read_soul` only falls back to the bundled `config/SOUL.md` when the live file is **absent**. So a placeholder materialised into the live path on an early boot (e.g. by a finished setup wizard) will **silently shadow** any persona you bake into the image later — the agent runs "Replace this file" forever, even after you `COPY` a real `SOUL.md` into the bundle.
+
+`ensure_live_soul` closes that gap on boot, seed-not-force like the config:
+
+- **Absent** live SOUL → seed it (so it's present and console-editable).
+- **Still the shipped starter placeholder** → heal it — replace with your baked persona.
+- **A real, authored SOUL** → never touched.
+
+Two ways to bake the persona, pick one:
+
+```dockerfile
+# a) Overwrite the bundled seed the agent falls back to:
+COPY SOUL.md /opt/protoagent/config/SOUL.md
+# b) Or point at a persona-as-code seed on a plain path (wins over the bundle):
+COPY persona.seed.md /opt/agent/seed/SOUL.md
+ENV PROTOAGENT_SEED_SOUL=/opt/agent/seed/SOUL.md
+```
+
+To **repair a running instance** whose live SOUL is already a stale placeholder without a redeploy, write the live file directly: `POST /api/config {"soul": "<persona text>"}` (writes the live `SOUL.md` and hot-reloads the graph, no restart).
+
 ## Binding & auth
 
 protoAgent refuses to bind `0.0.0.0` with an **open** operator API (`/api/*`, `/v1/*` include plugin-install + config rewrite). Pick one:
@@ -174,6 +196,7 @@ control (Cloudflare Access, an ngrok OAuth policy, or a fronting auth proxy) —
 ## Reference
 
 - `PROTOAGENT_SEED_CONFIG` — file to seed the live config from on first boot (config-as-code).
+- `PROTOAGENT_SEED_SOUL` — file to seed the live `SOUL.md` persona from (persona-as-code); also heals a lingering starter placeholder. Falls back to the bundled `config/SOUL.md`.
 - `PROTOAGENT_CONFIG_DIR` — where the live config + setup marker live (default `/opt/protoagent/config`).
 - `PROTOAGENT_HEADLESS_SETUP` — validate the seed + auto-complete setup (no wizard).
 - `PROTOAGENT_UI` — `console` (default) serves the operator console at `/app`.

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -13,7 +13,10 @@ Three jobs:
 2. **SOUL.md persona.** The live persona lives at the instance's
    ``<instance_root>/config/SOUL.md`` (``instance_paths().soul_path``);
    drawer edits write there and ``read_soul`` falls back to the bundled
-   ``config/SOUL.md`` seed when the instance has none yet.
+   ``config/SOUL.md`` seed when the instance has none yet. ``ensure_live_soul``
+   seeds that live file on first run (seed-not-force, like ``ensure_live_config``)
+   from ``PROTOAGENT_SEED_SOUL`` or the bundle — and heals a lingering starter
+   placeholder so a baked persona isn't shadowed forever.
 
 3. **Gateway introspection.** ``list_gateway_models`` hits
    ``{api_base}/models`` so the drawer's model dropdown reflects
@@ -820,6 +823,70 @@ def write_soul(text: str) -> list[Path]:
         snapshot_soul(old)
     target.write_text(text, encoding="utf-8")
     return [target]
+
+
+# The distinctive sentence in the shipped starter ``config/SOUL.md``. It's the
+# whole point of that file to be replaced, so a live SOUL still carrying this
+# marker was never authored by anyone — it's an un-seeded default we may heal.
+_SOUL_PLACEHOLDER_MARKER = "Replace this file."
+
+
+def _is_placeholder_soul(text: str) -> bool:
+    """True when ``text`` is the shipped starter placeholder (still un-authored)."""
+    return _SOUL_PLACEHOLDER_MARKER in text
+
+
+def ensure_live_soul() -> bool:
+    """Seed the instance's live ``SOUL.md`` on first run — the persona analogue of
+    :func:`ensure_live_config`.
+
+    ``read_soul`` already falls back to the bundled seed when the live SOUL is
+    *absent*, so a fresh agent shows its baked persona. But an older boot (or a
+    finished setup wizard) can materialise the **starter placeholder** into the
+    live path, and that never-absent placeholder then permanently shadows a
+    persona baked into the bundle afterwards — the agent runs "Replace this file"
+    forever. This bridges that gap: it seeds the live SOUL when it is absent
+    **or still the shipped placeholder**, from ``PROTOAGENT_SEED_SOUL`` (a baked
+    persona-as-code file) when set, else the bundled ``soul_source_path()``.
+
+    Seed-not-force, exactly like ``ensure_live_config``: a real (non-placeholder)
+    live SOUL is never touched, and a placeholder is never written *over* another
+    placeholder. Returns ``True`` only when it wrote the file.
+    """
+    live = instance_paths().soul_path
+    if live.exists():
+        try:
+            current = live.read_text(encoding="utf-8")
+        except OSError:
+            return False
+        if not _is_placeholder_soul(current):
+            return False  # a real persona already lives here — never clobber
+
+    seed_override = os.environ.get("PROTOAGENT_SEED_SOUL", "").strip()
+    seed_path = Path(seed_override).expanduser() if seed_override else None
+    if seed_path is not None and seed_path.is_file():
+        source = seed_path
+    else:
+        if seed_override:
+            log.warning(
+                "[soul] PROTOAGENT_SEED_SOUL=%r is not a readable file — falling back to the bundled seed",
+                seed_override,
+            )
+        source = soul_source_path()
+    if not source.exists():
+        return False
+
+    try:
+        source_text = source.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    if _is_placeholder_soul(source_text):
+        return False  # nothing real to seed — don't replace a placeholder with one
+
+    live.parent.mkdir(parents=True, exist_ok=True)
+    live.write_text(source_text, encoding="utf-8")
+    log.info("[soul] seeded live SOUL.md %s from %s", live, source.name)
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -380,11 +380,13 @@ def _main():
         from graph.config_io import (
             config_yaml_path,
             ensure_live_config,
+            ensure_live_soul,
             mark_setup_complete,
             validate_for_headless,
         )
 
         ensure_live_config()
+        ensure_live_soul()
         cfg = LangGraphConfig.from_yaml(config_yaml_path())
         ok, reason = validate_for_headless(cfg)
         if not ok:

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -77,6 +77,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     from graph.config_io import (
         config_yaml_path,
         ensure_live_config,
+        ensure_live_soul,
         is_setup_complete,
         mark_setup_complete,
         validate_for_headless,
@@ -101,6 +102,10 @@ def _init_langgraph_agent(headless_setup: bool = False):
     # config_yaml_path() resolves to <instance_root>/config/langgraph-config.yaml
     # (env-driven via PROTOAGENT_HOME / PROTOAGENT_INSTANCE), so load through it.
     ensure_live_config()
+    # Seed the live SOUL.md the same way (seed-not-force) — and heal a lingering
+    # starter placeholder so a persona baked into the bundle actually takes effect
+    # instead of being shadowed forever by "Replace this file". No-op once authored.
+    ensure_live_soul()
     STATE.graph_config = LangGraphConfig.from_yaml(config_yaml_path())
     # Fork tool denylist (config ``tools.disabled``) — applied before any
     # get_all_tools() call so dropped tools never reach the graph.

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -351,6 +351,94 @@ def test_soul_revision_empty_when_no_persona(monkeypatch, tmp_path: Path) -> Non
     assert config_io.soul_revision() == ""
 
 
+# ── ensure_live_soul (persona seed / placeholder heal) ───────────────────────
+
+# A minimal stand-in for the shipped starter SOUL — its whole job is to be
+# replaced, so the marker is the signal that a live SOUL was never authored.
+_PLACEHOLDER = "# Soul\n\n**Replace this file.** Starter persona doc.\n"
+
+
+def test_ensure_live_soul_seeds_when_absent(monkeypatch, tmp_path: Path) -> None:
+    """No live SOUL → seed the baked persona so it's present + console-editable."""
+    from graph import config_io
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("PROTOAGENT_HOME", str(home))
+    source = tmp_path / "SOUL-source.md"
+    source.write_text("I am Jon, the GTM strategist.", encoding="utf-8")
+    monkeypatch.setattr(config_io, "soul_source_path", lambda: source)
+
+    assert config_io.ensure_live_soul() is True
+    assert (home / "config" / "SOUL.md").read_text(encoding="utf-8") == "I am Jon, the GTM strategist."
+
+
+def test_ensure_live_soul_heals_placeholder(monkeypatch, tmp_path: Path) -> None:
+    """A live SOUL still carrying the starter placeholder is un-authored: replace
+    it with the baked persona (the bug — a placeholder shadowing a baked soul)."""
+    from graph import config_io
+
+    home = tmp_path / "home"
+    (home / "config").mkdir(parents=True)
+    (home / "config" / "SOUL.md").write_text(_PLACEHOLDER, encoding="utf-8")
+    monkeypatch.setenv("PROTOAGENT_HOME", str(home))
+    source = tmp_path / "SOUL-source.md"
+    source.write_text("real persona", encoding="utf-8")
+    monkeypatch.setattr(config_io, "soul_source_path", lambda: source)
+
+    assert config_io.ensure_live_soul() is True
+    assert (home / "config" / "SOUL.md").read_text(encoding="utf-8") == "real persona"
+
+
+def test_ensure_live_soul_does_not_clobber_authored(monkeypatch, tmp_path: Path) -> None:
+    """A real (non-placeholder) live SOUL is never overwritten — seed-not-force."""
+    from graph import config_io
+
+    home = tmp_path / "home"
+    (home / "config").mkdir(parents=True)
+    (home / "config" / "SOUL.md").write_text("operator-authored persona", encoding="utf-8")
+    monkeypatch.setenv("PROTOAGENT_HOME", str(home))
+    source = tmp_path / "SOUL-source.md"
+    source.write_text("baked persona", encoding="utf-8")
+    monkeypatch.setattr(config_io, "soul_source_path", lambda: source)
+
+    assert config_io.ensure_live_soul() is False
+    assert (home / "config" / "SOUL.md").read_text(encoding="utf-8") == "operator-authored persona"
+
+
+def test_ensure_live_soul_seeds_from_seed_soul_env(monkeypatch, tmp_path: Path) -> None:
+    """PROTOAGENT_SEED_SOUL (a baked persona-as-code file) wins over the bundle."""
+    from graph import config_io
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("PROTOAGENT_HOME", str(home))
+    bundle = tmp_path / "SOUL-source.md"
+    bundle.write_text("from bundle", encoding="utf-8")
+    seed = tmp_path / "my-persona.md"
+    seed.write_text("from seed env", encoding="utf-8")
+    monkeypatch.setattr(config_io, "soul_source_path", lambda: bundle)
+    monkeypatch.setenv("PROTOAGENT_SEED_SOUL", str(seed))
+
+    assert config_io.ensure_live_soul() is True
+    assert (home / "config" / "SOUL.md").read_text(encoding="utf-8") == "from seed env"
+
+
+def test_ensure_live_soul_wont_seed_placeholder_over_placeholder(monkeypatch, tmp_path: Path) -> None:
+    """When the bundle itself is still the starter placeholder there's nothing real
+    to seed — leave the live placeholder untouched rather than rewrite it."""
+    from graph import config_io
+
+    home = tmp_path / "home"
+    (home / "config").mkdir(parents=True)
+    (home / "config" / "SOUL.md").write_text(_PLACEHOLDER, encoding="utf-8")
+    monkeypatch.setenv("PROTOAGENT_HOME", str(home))
+    source = tmp_path / "SOUL-source.md"
+    source.write_text(_PLACEHOLDER, encoding="utf-8")
+    monkeypatch.setattr(config_io, "soul_source_path", lambda: source)
+
+    assert config_io.ensure_live_soul() is False
+    assert (home / "config" / "SOUL.md").read_text(encoding="utf-8") == _PLACEHOLDER
+
+
 # ── Gateway model listing ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## The bug

`read_soul()` falls back to the bundled `config/SOUL.md` seed **only when the live persona is absent**. But an early boot can materialise the shipped starter placeholder (`**Replace this file.**`) into the live `<instance_root>/config/SOUL.md` — which lives under the config **volume**. From then on the live file is never absent, so it **permanently shadows** any persona you bake into the bundle afterwards. Re-`COPY`ing a real `SOUL.md` into the image does nothing; the agent keeps introducing itself as the placeholder.

We hit this dogfooding a deployed agent (`jon`): a persona baked into the bundle never took effect because a placeholder seeded on the very first boot was sitting in the sandbox volume, shadowing it. It confabulated an identity until we wrote the live SOUL over the API by hand.

This is the exact persona analogue of the config seed/live-shadow trap already documented in `deploy-docker.md` — the config side has `ensure_live_config` + `PROTOAGENT_SEED_CONFIG`; the persona side had nothing.

## The fix

Add `ensure_live_soul()` in `graph/config_io.py`, wired in beside `ensure_live_config()` at the two boot sites (`server/agent_init.py`, `server/__init__.py --setup`). Seed-not-force:

- **absent** live SOUL → seed it (present + console-editable),
- **shipped starter placeholder** → heal it (replace with the baked persona),
- **real, authored SOUL** → never touched.

Source is `PROTOAGENT_SEED_SOUL` (persona-as-code, mirrors `PROTOAGENT_SEED_CONFIG`) when set, else the bundled `soul_source_path()`. A placeholder is never written over another placeholder (nothing real to seed → no-op).

Placeholder detection keys on the shipped sentinel `**Replace this file.**` — a live SOUL still carrying that line was demonstrably never authored, so healing it is safe; anything else is left alone.

## Repairing an already-running instance

For a deployed agent whose live SOUL is already a stale placeholder, no redeploy is needed — write the live file directly and hot-reload: `POST /api/config {"soul": "<persona text>"}`. (The upstream fix means a fresh volume / next boot heals itself.)

## Tests

`tests/test_config_io.py` — absent→seed, placeholder→heal, authored→no-clobber, `PROTOAGENT_SEED_SOUL` wins over bundle, placeholder-over-placeholder→no-op. Full `test_config_io.py` suite green (54 passed).

## Docs

`docs/guides/deploy-docker.md` gains a **Baking a persona (SOUL.md)** section (same shape as the config seed pattern) + `PROTOAGENT_SEED_SOUL` in the env reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)