### PR TITLE
chore: release v0.90.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.90.0] - 2026-07-04
+
 ### Added
 - **Background fan-outs report back in ONE briefing, not N** (#1766). When the agent
   fans out several background subagents in a single turn (`task_batch(run_in_background=True)`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.89.0"
+version = "0.90.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "v0.90.0",
+    "date": "2026-07-04",
+    "changes": [
+      "Background fan-outs report back in ONE briefing, not N",
+      "Career Coach in the plugin catalog",
+      "Server-initiated turns show a \"responding…\" indicator",
+      "Shift over the add-chat button previews incognito",
+      "Chat errors surface as a toast, not an inline banner",
+      "Browser-style UI zoom (⌘/Ctrl + / - / 0)",
+      "A saved theme survives a reload",
+      "Scaffolded plugins that register a subagent or use Knobs pass their own smoke test"
+    ]
+  },
+  {
     "version": "v0.89.0",
     "date": "2026-07-04",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.90.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.90.0 -m 'Release v0.90.0' && git push origin v0.90.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).