### PR TITLE
feat(fleet): autostart declared members on hub boot (ADR 0072 slice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so existing goals are unaffected. Plumbed through `POST /api/goals` and the operator/programmatic
   set-paths (`set_goal_operator` / `set_goal_safe`); TS types updated for a follow-up
   goal-creation form. `stop_when` v1 is prompt-injected (the agent self-parks via `abandon_goal`).
+- **Fleet members can autostart on boot** (ADR 0072 slice). A container recreate or host
+  restart kills the hub's detached member processes, but `fleet.json` in the volume keeps
+  their now-dead records — so a declared crew stayed down until someone re-activated each
+  by hand. A new **`fleet.autostart`** roster (member ids or display names; env fallback
+  `PROTOAGENT_FLEET_AUTOSTART`, comma-separated) is (re)started by the hub on boot, right
+  after the version reconcile. Idempotent (an already-running member is skipped), best-effort
+  (a missing workspace or a boot-time spawn failure is logged and skipped, never blocking
+  boot or the rest of the roster), and hub-only (a member's own scoped config carries no
+  roster, so it no-ops inside a member). Surfaced in Settings ▸ Host as "Autostart members".
 
 ## [0.90.0] - 2026-07-04
 

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -320,3 +320,5 @@ fleet:
   warm:
     max: 0                  # warm-agent cap (0 = unlimited)
     grace_seconds: 0        # spare agents touched within N seconds from LRU eviction
+  autostart: []             # member ids/names the hub (re)starts on boot (survives container recreate);
+                            # e.g. [cindi, matt]. Env: PROTOAGENT_FLEET_AUTOSTART (comma-separated)

--- a/docs/adr/0047-layered-settings-cascade.md
+++ b/docs/adr/0047-layered-settings-cascade.md
@@ -442,8 +442,9 @@ throughout:
 
 **Status — all three slices SHIPPED.** Slices 1–2 landed with the settings-IA fold
 (PR #925). Slice 3 (this) promotes the box-runtime knobs `network.bind`,
-`fleet.port_base`, `fleet.discovery.port_min/port_max/mdns`, and
-`fleet.warm.max/grace_seconds` into `FIELDS` (`scope="host"`, section "Fleet" →
+`fleet.port_base`, `fleet.discovery.port_min/port_max/mdns`,
+`fleet.warm.max/grace_seconds`, and `fleet.autostart` (the ADR 0072 boot-autostart
+roster, added later) into `FIELDS` (`scope="host"`, section "Fleet" →
 category System, so they surface in Settings ▸ Host / App ▸ Host config). The
 env-fallback bridge lives in `from_dict` as `section.get(key, _env_default(ENV, default))`,
 fixing **Open decision #2 to file > env > default** (operator, 2026-06-11): the file/UI

--- a/docs/adr/0072-fleet-seed-team-via-config.md
+++ b/docs/adr/0072-fleet-seed-team-via-config.md
@@ -1,11 +1,21 @@
 # 0072 — Fleet seed: declare a team in config (team-via-config)
 
-- Status: Proposed
+- Status: Proposed (partially implemented — see below)
 - Date: 2026-07-04
 - Builds on: ADR 0025 (unified delegate registry), 0040 (plugin bundles), 0041
   (workspaces & tiered stores), 0042 (fleet supervisor & unified console).
 - Related: #1778 (hub→member delegation timeout — orthogonal, but a team is only
   as useful as its delegation).
+
+> **Implemented slice — member autostart.** The first, smallest piece of this ADR
+> shipped ahead of the full seed manifest: a `fleet.autostart` roster (member ids/names;
+> env `PROTOAGENT_FLEET_AUTOSTART`) that the hub (re)starts on boot
+> (`graph/fleet/supervisor.start_autostart_members`, wired in `server.__init__`). It
+> reconciles *existing* members (created any way — console, `POST /api/fleet`, or a future
+> seed manifest) against a declared "keep these up" list, so a container recreate no longer
+> drops the crew. The full manifest below (archetype cloning + delegate auto-derivation +
+> commons) is still pending; when it lands, `members[].autostart` folds into this same
+> boot hook rather than adding a second mechanism.
 
 ## Context
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -712,6 +712,11 @@ class LangGraphConfig:
     fleet_warm_grace_seconds: int = (
         0  # spare agents touched within N s from LRU eviction; env: PROTOAGENT_FLEET_WARM_GRACE
     )
+    # Member ids/names (re)started at hub boot (ADR 0072 autostart slice) — a container
+    # recreate/host restart kills the detached member processes, and without this the
+    # declared crew stays down until re-activated by hand. env: PROTOAGENT_FLEET_AUTOSTART
+    # (comma-separated). See graph/fleet/supervisor.start_autostart_members.
+    fleet_autostart: list[str] = field(default_factory=list)
 
     # Operator-console directory allowlist — the extra directories the
     # React console's tasks/notes APIs may read and write. The protoAgent
@@ -1018,6 +1023,13 @@ class LangGraphConfig:
             fleet_max_warm=warm.get("max", _env_default("PROTOAGENT_FLEET_MAX_WARM", cls.fleet_max_warm, int)),
             fleet_warm_grace_seconds=warm.get(
                 "grace_seconds", _env_default("PROTOAGENT_FLEET_WARM_GRACE", cls.fleet_warm_grace_seconds, int)
+            ),
+            fleet_autostart=list(
+                fleet.get(
+                    "autostart",
+                    [s.strip() for s in os.environ.get("PROTOAGENT_FLEET_AUTOSTART", "").split(",") if s.strip()],
+                )
+                or []
             ),
             operator_allowed_dirs=list(operator.get("allowed_dirs", []) or []),
             operator_project_dir=str(operator.get("project_dir", "") or ""),

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -721,6 +721,62 @@ def reconcile_on_boot() -> str:
     return previous
 
 
+def autostart_members() -> list[str]:
+    """The configured ``fleet.autostart`` roster — member ids or display names to keep
+    (re)started at hub boot. Live config first (folds in the ``PROTOAGENT_FLEET_AUTOSTART``
+    comma-separated env fallback, file > env > default), else the env var directly when no
+    config is loaded. Accepts a list or a comma-separated string; blanks are dropped."""
+    raw: object = None
+    cfg = _live_config()
+    if cfg is not None:
+        raw = getattr(cfg, "fleet_autostart", None)
+    if raw is None:
+        raw = os.environ.get("PROTOAGENT_FLEET_AUTOSTART", "")
+    items = raw.split(",") if isinstance(raw, str) else raw
+    try:
+        return [str(x).strip() for x in items if str(x).strip()]
+    except TypeError:  # a non-iterable in config — treat as empty rather than raise at boot
+        return []
+
+
+def start_autostart_members() -> list[str]:
+    """(Re)start every configured autostart member that isn't already alive — the
+    hub-boot half of ADR 0072's ``autostart``.
+
+    A container recreate or host restart kills the detached member processes (fresh pid
+    namespace), but ``fleet.json`` in the volume keeps their now-dead records; without
+    this the declared crew stays down until someone re-activates each by hand. Idempotent:
+    an already-running member is skipped (never double-spawned).
+
+    Hub-only by construction, like :func:`reconcile_on_boot`: a member runs
+    ``PROTOAGENT_INSTANCE``-scoped, so its own config carries no autostart roster and this
+    no-ops inside a member. Best-effort per member — a missing workspace or a boot-time
+    spawn failure is logged and skipped, never blocking the hub or the rest of the roster.
+    Members are started sequentially (each ``start`` briefly boot-watches the child); call
+    off the event loop (the boot hook does via ``asyncio.to_thread``).
+    """
+    roster = autostart_members()
+    if not roster:
+        return []
+    started: list[str] = []
+    for ident in roster:
+        try:
+            if is_running(ident):
+                continue
+            if manager._find(manager._safe(ident)) is None:
+                log.warning("[fleet] autostart: no workspace %r — skipping (create it first)", ident)
+                continue
+            start(ident)
+            started.append(ident)
+        except FleetError as exc:
+            log.error("[fleet] autostart: %r failed to start: %s", ident, exc)
+        except Exception:  # noqa: BLE001 — autostart must never block hub boot
+            log.exception("[fleet] autostart: unexpected error starting %r", ident)
+    if started:
+        log.info("[fleet] autostart: (re)started %d member(s): %s", len(started), ", ".join(started))
+    return started
+
+
 def version_skew_warning() -> str | None:
     """A live warning when running LOCAL members were spawned by a different app
     version than this process runs.

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -791,6 +791,19 @@ FIELDS: list[Field] = [
         scope="host",
     ),
     Field(
+        "fleet.autostart",
+        "fleet_autostart",
+        "Autostart members",
+        "string_list",
+        "Keep-warm",
+        "Fleet members (by id or display name) the hub (re)starts on boot — so a container "
+        "recreate or host restart brings your declared crew back up automatically instead of "
+        "leaving them down until re-activated by hand. One per line. Env fallback: "
+        "PROTOAGENT_FLEET_AUTOSTART (comma-separated).",
+        restart=True,
+        scope="host",
+    ),
+    Field(
         "developer.channel",
         "developer_channel",
         "Developer channel",

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -600,6 +600,10 @@ def _main():
             from graph.fleet import supervisor as _sup
 
             await asyncio.to_thread(_sup.reconcile_on_boot)
+            # Autostart roster (ADR 0072 slice): bring declared members back up after a
+            # container recreate / host restart killed their detached processes. Off the
+            # loop (spawns + per-member boot-watch), best-effort — never blocks hub boot.
+            await asyncio.to_thread(_sup.start_autostart_members)
         except Exception:
             log.exception("[fleet] boot version reconcile failed")
 

--- a/tests/test_config_drift_guard.py
+++ b/tests/test_config_drift_guard.py
@@ -257,6 +257,7 @@ HOST_SCOPED_KEYS = {
     # Egress allowlist (ADR 0008) — a box-wide outbound security policy, so it lives
     # at the Host layer alongside the inbound bind interface.
     "egress.allowed_hosts",
+    "fleet.autostart",
     "fleet.port_base",
     "fleet.discovery.port_min",
     "fleet.discovery.port_max",

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -99,6 +99,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "filesystem_enabled": True,
     "filesystem_projects": [],
     "filesystem_run_requires_approval": True,
+    "fleet_autostart": [],
     "fleet_max_warm": 0,
     "fleet_port_base": 7870,
     "fleet_warm_grace_seconds": 0,

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -505,6 +505,63 @@ def test_version_skew_flags_prestamp_records_as_unknown(tmp_path, monkeypatch):
     assert warn and "version unknown" in warn
 
 
+# ── autostart roster (ADR 0072 slice) ────────────────────────────────────────
+# A container recreate / host restart kills the detached member processes; the hub
+# (re)starts every configured `fleet.autostart` member on boot so the declared crew
+# comes back up instead of staying down until re-activated by hand.
+
+
+class _Cfg:
+    def __init__(self, roster):
+        self.fleet_autostart = roster
+
+
+def test_autostart_members_reads_config_then_env(monkeypatch):
+    # Live config wins.
+    monkeypatch.setattr(supervisor, "_live_config", lambda: _Cfg(["cindi", "matt"]))
+    assert supervisor.autostart_members() == ["cindi", "matt"]
+
+    # A comma-separated string (hand-edited YAML) is normalised, blanks dropped.
+    monkeypatch.setattr(supervisor, "_live_config", lambda: _Cfg(" a , , b "))
+    assert supervisor.autostart_members() == ["a", "b"]
+
+    # No config → the PROTOAGENT_FLEET_AUTOSTART env fallback (comma-separated).
+    monkeypatch.setattr(supervisor, "_live_config", lambda: None)
+    monkeypatch.setenv("PROTOAGENT_FLEET_AUTOSTART", "x, y ,")
+    assert supervisor.autostart_members() == ["x", "y"]
+
+    # Nothing configured → empty (the common case; boot hook no-ops).
+    monkeypatch.delenv("PROTOAGENT_FLEET_AUTOSTART", raising=False)
+    assert supervisor.autostart_members() == []
+
+
+def test_start_autostart_members_starts_declared(fleet, monkeypatch):
+    manager.create("cindi", port=7891)
+    manager.create("matt", port=7892)
+    monkeypatch.setattr(supervisor, "autostart_members", lambda: ["cindi", "matt"])
+
+    started = supervisor.start_autostart_members()
+    assert set(started) == {"cindi", "matt"}
+    assert supervisor.is_running("cindi") and supervisor.is_running("matt")
+
+
+def test_start_autostart_skips_running_and_missing(fleet, monkeypatch):
+    manager.create("cindi", port=7891)
+    manager.create("matt", port=7892)
+    supervisor.start("cindi")  # already up → must be skipped, not double-spawned
+    # "ghost" has no workspace → skipped with a warning, never raises.
+    monkeypatch.setattr(supervisor, "autostart_members", lambda: ["cindi", "ghost", "matt"])
+
+    started = supervisor.start_autostart_members()
+    assert started == ["matt"]  # only the down, existing member is (re)started
+    assert supervisor.is_running("matt")
+
+
+def test_start_autostart_no_roster_is_noop(fleet, monkeypatch):
+    monkeypatch.setattr(supervisor, "autostart_members", lambda: [])
+    assert supervisor.start_autostart_members() == []
+
+
 def test_reconcile_on_boot_stamps_and_returns_previous(tmp_path, monkeypatch):
     import infra.paths as paths_mod
 


### PR DESCRIPTION
## Problem

A container recreate (a Watchtower image roll) or host restart kills the hub's **detached member processes** — but `fleet.json` in the volume keeps their now-dead pid records, and nothing restarts them. So a declared crew silently stays **down** after every roll until an operator re-activates each member by hand (`POST /api/fleet/{name}/activate`).

We hit this dogfooding a content team (a lead + a drafter + a frontend member): every time the lead's image rolled, the two members died and had to be hand-restarted. `reconcile_on_boot` already runs at hub boot but only *stamps the version* — it doesn't bring members back.

## What this adds

The first, smallest slice of **ADR 0072** — a `fleet.autostart` roster the hub (re)starts on boot:

- **`fleet.autostart`** config (member ids or display names) — env fallback `PROTOAGENT_FLEET_AUTOSTART` (comma-separated), file > env > default, host-scoped, surfaced in Settings ▸ Host as *"Autostart members"*.
- **`supervisor.start_autostart_members()`** — starts each declared member that isn't already alive, wired into the `server.__init__` boot hook (via `asyncio.to_thread`, right after `reconcile_on_boot`).
  - **Idempotent** — an already-running member is skipped, never double-spawned.
  - **Best-effort** — a missing workspace or a boot-time spawn failure is logged and skipped; it never blocks boot or the rest of the roster.
  - **Hub-only by construction** — a member runs `PROTOAGENT_INSTANCE`-scoped, so its own config carries no roster and this no-ops inside a member (same posture as `reconcile_on_boot`).

It reconciles **existing** members (created any way — console, `POST /api/fleet`, or a future seed manifest) against a "keep these up" list. When the full ADR 0072 manifest lands, its `members[].autostart` folds into this same boot hook rather than adding a second mechanism (noted in the ADR).

## Config

```yaml
fleet:
  autostart: [cindi, matt]   # or: PROTOAGENT_FLEET_AUTOSTART=cindi,matt
```

## Tests

`tests/test_fleet_supervisor.py` — roster parsing (config list / comma-string / env fallback / empty), starts-declared, skips-running-and-missing (no raise), empty-roster no-op. Drift-guard goldens (host-scoped keys in `test_config_drift_guard`, `from_yaml` example in `test_config_roundtrip`) updated for the new field. Affected suites green — **604 passed**.

## Docs

CHANGELOG (Unreleased), ADR 0072 (implemented-slice note + status), ADR 0047 §2.1 (host-scoped list), example yaml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)