### PR TITLE
feat(goals): goal-creation form — verifier + completion contract via the composer form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (a missing workspace or a boot-time spawn failure is logged and skipped, never blocking
   boot or the rest of the roster), and hub-only (a member's own scoped config carries no
   roster, so it no-ops inside a member). Surfaced in Settings ▸ Host as "Autostart members".
+- **Guided goal-creation form** (ADR 0073, Part 2). A console form for setting a goal with its
+  verifier and completion contract, without hand-writing verifier JSON. It renders through the
+  same `HitlForm` composer-form seam as `/effort`'s picker: pick a verifier type from option
+  cards (`command` · `test` · `ci` · `data` · `llm`, default `llm`), give its one detail (the
+  shell command, the PR #/branch, or `path :: substring`), and fill the optional contract
+  (outcome, constraints/boundaries one-per-line, `stop_when`, max iterations). Two entry points:
+  **`/goal new`** opens it in the chat composer (bare `/goal`, `/goal <text>`, and `/goal clear`
+  still pass through to the server command unchanged), and the **Goals panel's "New goal"** action
+  opens the same form inline. Submits to the operator `POST /api/goals`; a rejected verifier /
+  disabled goal mode surfaces the server's message.
 
 ## [0.90.0] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,15 +32,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   boot or the rest of the roster), and hub-only (a member's own scoped config carries no
   roster, so it no-ops inside a member). Surfaced in Settings ▸ Host as "Autostart members".
 - **Guided goal-creation form** (ADR 0073, Part 2). A console form for setting a goal with its
-  verifier and completion contract, without hand-writing verifier JSON. It renders through the
-  same `HitlForm` composer-form seam as `/effort`'s picker: pick a verifier type from option
-  cards (`command` · `test` · `ci` · `data` · `llm`, default `llm`), give its one detail (the
-  shell command, the PR #/branch, or `path :: substring`), and fill the optional contract
-  (outcome, constraints/boundaries one-per-line, `stop_when`, max iterations). Two entry points:
-  **`/goal new`** opens it in the chat composer (bare `/goal`, `/goal <text>`, and `/goal clear`
-  still pass through to the server command unchanged), and the **Goals panel's "New goal"** action
-  opens the same form inline. Submits to the operator `POST /api/goals`; a rejected verifier /
-  disabled goal mode surfaces the server's message.
+  verifier and completion contract, without hand-writing verifier JSON. It's a **two-step wizard**
+  rendered through the same `HitlForm` composer-form seam as `/effort`'s picker: step 1 is the goal
+  + a verifier type from option cards (`command` · `test` · `ci` · `data` · `llm`, default `llm`)
+  with a **type-aware** verification input — only the field the picked verifier actually needs is
+  shown (a shell command, a PR #/branch, or a file + "must contain" substring); step 2 is the
+  optional contract (outcome, constraints/boundaries one-per-line, `stop_when`, max iterations).
+  Two entry points: **`/goal new`** opens it in the chat composer (bare `/goal`, `/goal <text>`,
+  and `/goal clear` still pass through to the server command unchanged), and the **Goals panel's
+  "New goal"** action opens the same form inline. Submits to the operator `POST /api/goals`; a
+  rejected verifier / disabled goal mode surfaces the server's message.
+- **Composer/HITL forms support conditional fields** (`HitlForm`). A form field can declare
+  `showWhen: { field, equals | in }` and renders (and is required-gated) only when a sibling
+  field's answer matches — mirroring the settings `depends_on` convention. So **any** agent
+  `request_user_input` form, not just the goal form, can show the right inputs for the chosen
+  path (the goal form uses it for the type-aware verifier detail).
+- **`/goal {json}` carries the completion contract** (ADR 0073). The chat/programmatic
+  `/goal {"condition": …, "verifier": …, "constraints": […], "boundaries": […], "stop_when": …}`
+  path now accepts the contract fields too (previously API/form-only), so the full contract is
+  settable from chat and exercisable by the goal evals. It's directive prose (no code-exec), so —
+  unlike the verifier — it's not trust-gated.
 
 ## [0.90.0] - 2026-07-04
 

--- a/apps/web/e2e/commands.spec.ts
+++ b/apps/web/e2e/commands.spec.ts
@@ -7,9 +7,12 @@ import { SLASH_COMMANDS } from "./fixtures.mjs";
 
 // Deterministic client-side commands (ADR 0057) surface FIRST, then the server skills.
 // `/goal` is a client command that claims only `/goal new` (a guided goal form, ADR 0073) —
-// everything else falls through to the SERVER `/goal`, so the token appears in BOTH lists
-// (like `/clear` already does).
+// everything else falls through to the SERVER `/goal`. The menu DEDUPS by token, so a command
+// that's both a client command and a server skill (`/goal`, `/clear`) appears ONCE, client-first
+// — the server duplicate is dropped.
 const CLIENT_SLASH = ["/new", "/clear", "/compact", "/effort", "/incognito", "/help", "/bypass", "/goal"];
+// The server rows the menu shows, with client-token duplicates deduped away.
+const serverRows = () => SLASH_COMMANDS.map((c) => `/${c.name}`).filter((n) => !CLIENT_SLASH.includes(n));
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
@@ -25,9 +28,12 @@ test("slash menu opens and lists the client + server commands", async ({ page })
   // Each command renders as a `.slash-name` row (the description can repeat the
   // name, so scope to the name span to avoid matching twice). Client commands first.
   const names = await menu.locator(".slash-name").allInnerTexts();
-  expect(names).toEqual([...CLIENT_SLASH, ...SLASH_COMMANDS.map((c) => `/${c.name}`)]);
+  expect(names).toEqual([...CLIENT_SLASH, ...serverRows()]);
   // Workflows are listed as slash commands too (ADR 0002).
   expect(names).toContain("/research-and-brief");
+  // Deduped: exactly one `/goal` and one `/clear`, not the client+server pair.
+  expect(names.filter((n) => n === "/goal")).toHaveLength(1);
+  expect(names.filter((n) => n === "/clear")).toHaveLength(1);
 });
 
 test("a flag-gated command (/compact, ADR 0068) vanishes when its flag is forced off", async ({ page }) => {
@@ -40,10 +46,7 @@ test("a flag-gated command (/compact, ADR 0068) vanishes when its flag is forced
   const menu = page.locator(".slash-menu");
   await expect(menu).toBeVisible();
   const names = await menu.locator(".slash-name").allInnerTexts();
-  expect(names).toEqual([
-    ...CLIENT_SLASH.filter((n) => n !== "/compact"),
-    ...SLASH_COMMANDS.map((c) => `/${c.name}`),
-  ]);
+  expect(names).toEqual([...CLIENT_SLASH.filter((n) => n !== "/compact"), ...serverRows()]);
 });
 
 test("filtering narrows the menu and selecting completes the command", async ({ page }) => {
@@ -51,10 +54,9 @@ test("filtering narrows the menu and selecting completes the command", async ({ 
   await composer.fill("/go");
 
   const menu = page.locator(".slash-menu");
-  // Two `/goal` rows now match "/go": the client command (claims `/goal new`) and the
-  // server `/goal` — client first. Both complete the same way (client `/goal` bare falls
-  // through, inserting `/goal ` to edit).
-  await expect(menu.locator(".slash-item")).toHaveCount(2);
+  // "/go" matches a single `/goal` now — the client command and the server `/goal` are
+  // deduped to one row (client wins). Bare `/goal` falls through, inserting `/goal ` to edit.
+  await expect(menu.locator(".slash-item")).toHaveCount(1);
   await expect(menu.getByText("/goal", { exact: true }).first()).toBeVisible();
 
   // Enter completes the highlighted command into the composer.

--- a/apps/web/e2e/commands.spec.ts
+++ b/apps/web/e2e/commands.spec.ts
@@ -6,7 +6,10 @@ import { SLASH_COMMANDS } from "./fixtures.mjs";
 // (GET /api/chat/commands) and autocompletes them as you type "/name".
 
 // Deterministic client-side commands (ADR 0057) surface FIRST, then the server skills.
-const CLIENT_SLASH = ["/new", "/clear", "/compact", "/effort", "/incognito", "/help", "/bypass"];
+// `/goal` is a client command that claims only `/goal new` (a guided goal form, ADR 0073) —
+// everything else falls through to the SERVER `/goal`, so the token appears in BOTH lists
+// (like `/clear` already does).
+const CLIENT_SLASH = ["/new", "/clear", "/compact", "/effort", "/incognito", "/help", "/bypass", "/goal"];
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
@@ -48,8 +51,11 @@ test("filtering narrows the menu and selecting completes the command", async ({ 
   await composer.fill("/go");
 
   const menu = page.locator(".slash-menu");
-  await expect(menu.locator(".slash-item")).toHaveCount(1);
-  await expect(menu.getByText("/goal", { exact: true })).toBeVisible();
+  // Two `/goal` rows now match "/go": the client command (claims `/goal new`) and the
+  // server `/goal` — client first. Both complete the same way (client `/goal` bare falls
+  // through, inserting `/goal ` to edit).
+  await expect(menu.locator(".slash-item")).toHaveCount(2);
+  await expect(menu.getByText("/goal", { exact: true }).first()).toBeVisible();
 
   // Enter completes the highlighted command into the composer.
   await composer.press("Enter");

--- a/apps/web/e2e/work-overview.spec.ts
+++ b/apps/web/e2e/work-overview.spec.ts
@@ -130,10 +130,11 @@ test("an empty card shows the DS Empty with the quick-add as its CTA", async ({ 
   await expect(page.getByTestId("goal-create-submit")).toBeEnabled();
 });
 
-test("the Goals PANEL hosts the same create dialog via its New goal header action", async ({ page }) => {
-  // The other host of the lifted GoalCreateDialog (one form, two hosts): the Goals
-  // panel's header action — the replacement for the old inline <details> form. Tasks/
-  // Schedule panel create flows have their own specs; this covers the Goals panel's.
+test("the Goals PANEL hosts the guided goal form via its New goal header action", async ({ page }) => {
+  // The Goals panel's "New goal" header action opens the guided completion-contract form
+  // (ADR 0073, Part 2) — the SAME goalFormPayload + HitlForm the chat `/goal new` composer
+  // form renders, hosted inline here. (The Work-overview Goals CARD quick-add keeps the
+  // simpler GoalCreateDialog — covered by the "empty card" spec above.)
   let posted: Record<string, unknown> | null = null;
   await page.route("**/api/goals", async (route) => {
     if (route.request().method() === "POST") {
@@ -148,13 +149,17 @@ test("the Goals PANEL hosts the same create dialog via its New goal header actio
   await expect(page.getByRole("heading", { name: "Goals" })).toBeVisible();
 
   await page.getByTestId("goal-new").click();
-  await expect(page.getByTestId("goal-create-dialog")).toBeVisible();
-  await expect(page.getByTestId("goal-create-submit")).toBeDisabled(); // gated on a condition
-  await page.getByTestId("goal-create-condition").fill("All tests pass twice");
-  await page.getByTestId("goal-create-submit").click();
+  const form = page.getByTestId("goal-form");
+  await expect(form).toBeVisible();
+  const submit = form.getByRole("button", { name: "Submit" });
+  await expect(submit).toBeDisabled(); // gated on the required condition (first textbox)
+  await form.getByRole("textbox").first().fill("All tests pass twice");
+  await expect(submit).toBeEnabled();
+  await submit.click();
 
-  // Same payload/endpoint as the old inline form; success closes the dialog + toasts.
-  await expect(page.getByTestId("goal-create-dialog")).toHaveCount(0);
+  // Operator goal-set payload; success closes the inline form + toasts. The verifier
+  // defaults to llm when no card is picked; the contract fields are omitted when empty.
+  await expect(form).toHaveCount(0);
   await expect(page.locator(".pl-toast__title", { hasText: "Goal set" })).toBeVisible();
   expect(posted).toMatchObject({
     session_id: "operator",

--- a/apps/web/e2e/work-overview.spec.ts
+++ b/apps/web/e2e/work-overview.spec.ts
@@ -151,9 +151,14 @@ test("the Goals PANEL hosts the guided goal form via its New goal header action"
   await page.getByTestId("goal-new").click();
   const form = page.getByTestId("goal-form");
   await expect(form).toBeVisible();
-  const submit = form.getByRole("button", { name: "Submit" });
-  await expect(submit).toBeDisabled(); // gated on the required condition (first textbox)
+  // Two-step wizard (ADR 0073): step 1's "Next" is gated on the required condition (the first
+  // textbox); step 2 holds the optional contract, so its "Submit" is enabled straight away.
+  const next = form.getByRole("button", { name: "Next" });
+  await expect(next).toBeDisabled();
   await form.getByRole("textbox").first().fill("All tests pass twice");
+  await expect(next).toBeEnabled();
+  await next.click();
+  const submit = form.getByRole("button", { name: "Submit" });
   await expect(submit).toBeEnabled();
   await submit.click();
 

--- a/apps/web/src/app/GoalsPanel.tsx
+++ b/apps/web/src/app/GoalsPanel.tsx
@@ -14,6 +14,8 @@ import { Plus, Target, Trash2 } from "lucide-react";
 import { Suspense, useEffect, useState } from "react";
 
 import { api } from "../lib/api";
+import { HitlForm } from "../chat/HitlForm";
+import { buildGoalSetBody, goalFormPayload, type GoalSetBody } from "../chat/goalForm";
 import { ago, errMsg } from "../lib/format";
 import { onServerEvent } from "../lib/events";
 import { PanelHeader } from "@protolabsai/ui/navigation";
@@ -211,12 +213,11 @@ export function GoalCreateDialog({
 export function GoalsPanel() {
   const queryClient = useQueryClient();
   const toast = useToast();
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
   const set = useMutation({
-    mutationFn: (body: { session_id: string; condition: string; verifier: unknown }) =>
-      api.setGoal(body),
+    mutationFn: (body: GoalSetBody) => api.setGoal(body),
     onSuccess: (res) => {
-      setDialogOpen(false);
+      setCreating(false);
       toast({ tone: "success", title: "Goal set", message: res.message || "The agent has a new goal." });
     },
     // A rejected verifier / disabled goal mode comes back as HTTP 400 → request() throws here.
@@ -230,17 +231,32 @@ export function GoalsPanel() {
         title="Goals"
         kicker={<>the agent's standing goals · set with <code>/goal</code> in chat</>}
         actions={
-          <Button variant="primary" type="button" onClick={() => setDialogOpen(true)} data-testid="goal-new">
+          <Button variant="primary" type="button" onClick={() => { set.reset(); setCreating(true); }} data-testid="goal-new">
             <Plus size={16} /> New goal
           </Button>
         }
       />
-      <GoalCreateDialog
-        open={dialogOpen}
-        onClose={() => { setDialogOpen(false); set.reset(); }}
-        onCreate={(body) => set.mutate(body)}
-        busy={set.isPending}
-      />
+      {/* Guided goal-creation form (ADR 0073, Part 2) — the SAME `goalFormPayload` +
+          `HitlForm` the chat `/goal new` composer form renders, hosted inline here (the
+          panel isn't a chat tab, so it can't use the `openForm` seam directly). The shared
+          `buildGoalSetBody` mapping assembles the verifier + completion contract. Goals set
+          from the panel target the `operator` session (there's no chat tab to own them). */}
+      {creating && (
+        <div className="goal-form-host" data-testid="goal-form">
+          <HitlForm
+            payload={goalFormPayload()}
+            busy={set.isPending}
+            onSubmit={(answers) => {
+              const body = buildGoalSetBody(
+                "operator",
+                typeof answers === "object" && answers ? (answers as Record<string, unknown>) : {},
+              );
+              if (body) set.mutate(body);
+            }}
+            onCancel={() => { setCreating(false); set.reset(); }}
+          />
+        </div>
+      )}
       <ScrollArea className="goals-list" role="region" aria-label="Goals" tabIndex={0}>
         <QueryErrorResetBoundary>
           {({ reset }: { reset: () => void }) => (

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -503,7 +503,16 @@ function ChatSessionSlot({
         .map((c) => ({ name: c.name, description: c.description, usage: c.usage })),
       ...commands,
     ];
-    return all.filter(
+    // Dedup by token: a command that exists BOTH as a client command and a server skill
+    // (e.g. /goal, /clear) must appear once — the client entry (listed first) wins.
+    const seen = new Set<string>();
+    const unique = all.filter((c) => {
+      const n = c.name.toLowerCase();
+      if (seen.has(n)) return false;
+      seen.add(n);
+      return true;
+    });
+    return unique.filter(
       (c) => !q || c.name.toLowerCase().includes(q) || c.description.toLowerCase().includes(q),
     );
   }, [slashQuery, commands, flagOn]);

--- a/apps/web/src/chat/HitlForm.tsx
+++ b/apps/web/src/chat/HitlForm.tsx
@@ -8,11 +8,11 @@ import type { HitlPayload } from "../lib/types";
 import {
   type FieldSchema,
   anyStepMissing,
-  fieldsOf,
   isCardChoice,
   isMultiChoice,
   missingInStep,
   optionsOf,
+  visibleFieldsOf,
 } from "./hitl-form";
 
 // A lightweight JSON-schema form for HITL requests (request_user_input) and a plain prompt
@@ -253,7 +253,7 @@ export function HitlForm({
       <div className="hitl-step" key={stepIdx}>
         {step.title && <div className="hitl-step-title">{step.title}</div>}
         {step.description && <div className="hitl-prompt">{step.description}</div>}
-        {fieldsOf(step).map(([key, schema, req]) => (
+        {visibleFieldsOf(step, values).map(([key, schema, req]) => (
           <Field
             key={key}
             name={key}

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -7,8 +7,10 @@
 
 import { registeredSlashCommands, registerSlashCommand } from "../ext/slashRegistry";
 import { api } from "../lib/api";
+import { errMsg } from "../lib/format";
 import type { ChatMessage, HitlPayload } from "../lib/types";
 import { chatStore, DEFAULT_REASONING_EFFORT, REASONING_EFFORTS } from "./chat-store";
+import { buildGoalSetBody, goalFormPayload } from "./goalForm";
 
 // Local id for the system notes /compact posts (the command manages messages
 // directly, like /clear, so it needs to own the ids it can later replace).
@@ -265,6 +267,59 @@ registerSlashCommand({
       { tone: next ? "warning" : "info" },
     );
     ctx.focusComposer();
+    return true;
+  },
+});
+
+// `/goal new` opens a guided goal-creation form (ADR 0073 completion contracts, Part 2) in
+// the composer — the SAME `HitlForm` + `openForm` seam as `/effort`'s picker, resolved
+// locally (no agent round-trip): on submit it POSTs the operator goal-set. ONLY the `new`
+// subcommand is claimed client-side; bare `/goal` (status), `/goal <text>` (set), and
+// `/goal clear` all fall through (return false) to the SERVER `/goal` control command
+// (`graph/slash_commands.py`), so none of the existing behavior regresses. A client command
+// registered here CLAIMS the `/goal` token in the menu (like `/clear` already does) — its
+// row surfaces the `/goal new` affordance; picking it inserts `/goal ` to edit as before.
+registerSlashCommand({
+  name: "goal",
+  description: "Set/manage this session's goal — /goal new opens a guided form",
+  usage: "/goal new · /goal <text> · /goal clear",
+  run: (ctx) => {
+    const arg = ctx.rest.trim().toLowerCase();
+    if (arg !== "new") return false; // bare/set/clear → server `/goal` unchanged
+    const sid = ctx.sessionId;
+    if (!sid || !ctx.openForm) {
+      // No tab to own the goal, or a host that never wired the composer-form panel: don't
+      // send "/goal new" on to the server (it would set a goal literally named "new").
+      ctx.noteToThread(
+        "Open a chat tab to set a goal here, or use `/goal <text>` to set one inline.",
+        { tone: "info" },
+      );
+      ctx.focusComposer();
+      return true;
+    }
+    ctx.openForm({
+      payload: goalFormPayload(),
+      onSubmit: (answers) => {
+        const body = buildGoalSetBody(
+          sid,
+          typeof answers === "object" && answers ? (answers as Record<string, unknown>) : {},
+        );
+        if (!body) {
+          ctx.noteToThread("A goal needs a condition — nothing was set.", { tone: "warning" });
+          ctx.focusComposer();
+          return;
+        }
+        void api
+          .setGoal(body)
+          .then((res) =>
+            ctx.noteToThread(`**Goal set.** ${res.message ?? ""}`.trim(), { tone: "success" }),
+          )
+          // A rejected verifier / disabled goal mode comes back as HTTP 400 → request() throws.
+          .catch((e) => ctx.noteToThread(`Couldn't set goal: ${errMsg(e)}`, { tone: "danger" }));
+        ctx.focusComposer();
+      },
+      onCancel: ctx.focusComposer,
+    });
     return true;
   },
 });

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -281,7 +281,9 @@ registerSlashCommand({
 // row surfaces the `/goal new` affordance; picking it inserts `/goal ` to edit as before.
 registerSlashCommand({
   name: "goal",
-  description: "Set/manage this session's goal — /goal new opens a guided form",
+  // Prefix kept as the server /goal's "Set or check goals" so the /help card is unchanged
+  // (this client row shadows the server one in the deduped list) — plus the new affordance.
+  description: "Set or check goals — /goal new opens a guided form",
   usage: "/goal new · /goal <text> · /goal clear",
   run: (ctx) => {
     const arg = ctx.rest.trim().toLowerCase();

--- a/apps/web/src/chat/goalCommand.test.ts
+++ b/apps/web/src/chat/goalCommand.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { findSlashCommand } from "../ext/slashRegistry";
+import "./coreSlashCommands";
+
+// Probe: does the client /goal command intercept `/goal new` and open the form,
+// while letting bare/`<text>`/`clear` fall through to the server (return false)?
+describe("/goal client interception", () => {
+  const goal = findSlashCommand("goal");
+
+  const ctx = (rest: string, extra: Record<string, unknown> = {}) =>
+    ({
+      rest,
+      sessionId: "s1",
+      noteToThread: vi.fn(),
+      setDraft: vi.fn(),
+      focusComposer: vi.fn(),
+      openForm: vi.fn(),
+      flagOn: () => true,
+      serverCommands: [],
+      ...extra,
+    }) as never;
+
+  it("is registered", () => {
+    expect(goal).toBeTruthy();
+  });
+
+  it("/goal new opens the form and handles it (returns true, never sent)", () => {
+    const openForm = vi.fn();
+    const handled = goal!.run(ctx("new", { openForm }));
+    expect(openForm).toHaveBeenCalledTimes(1);
+    expect(handled).toBe(true);
+  });
+
+  it("bare /goal falls through to the server (returns false)", () => {
+    expect(goal!.run(ctx(""))).toBe(false);
+  });
+
+  it("/goal <text> falls through to the server (returns false)", () => {
+    expect(goal!.run(ctx("make the build green"))).toBe(false);
+  });
+});

--- a/apps/web/src/chat/goalForm.test.ts
+++ b/apps/web/src/chat/goalForm.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MAX_ITERATIONS,
+  GOAL_VERIFIER_TYPES,
+  buildGoalSetBody,
+  buildVerifier,
+  goalFormPayload,
+  parseMaxIterations,
+  splitLines,
+} from "./goalForm";
+
+// The form is rendered by HitlForm (not exercised here — jsdom has no renderer and the DS
+// forms are a private-registry dep). These tests pin the PURE pieces: the payload's schema
+// shape + the answers→`POST /api/goals` body mapping (verifier assembly, line-splitting).
+
+describe("goalFormPayload", () => {
+  const payload = goalFormPayload();
+  const step = payload.steps?.[0];
+  const schema = step?.schema as {
+    required?: string[];
+    properties?: Record<string, { type?: string; oneOf?: { const?: unknown }[]; format?: string }>;
+  };
+
+  it("is a single-step form with a title", () => {
+    expect(payload.kind).toBe("form");
+    expect(payload.steps).toHaveLength(1);
+    expect(payload.title).toBeTruthy();
+  });
+
+  it("requires only the condition", () => {
+    expect(schema.required).toEqual(["condition"]);
+  });
+
+  it("declares every contract field", () => {
+    const props = schema.properties ?? {};
+    for (const key of [
+      "condition",
+      "verifier",
+      "verification",
+      "outcome",
+      "constraints",
+      "boundaries",
+      "stop_when",
+      "max_iterations",
+    ]) {
+      expect(props[key], `missing field ${key}`).toBeDefined();
+    }
+  });
+
+  it("renders the verifier field as option cards for every type", () => {
+    const cards = schema.properties?.verifier?.oneOf ?? [];
+    expect(cards.map((c) => c.const)).toEqual(["command", "test", "ci", "data", "llm"]);
+    // The card set mirrors the exported constant (single source of truth).
+    expect(cards.map((c) => c.const)).toEqual(GOAL_VERIFIER_TYPES.map((v) => v.value));
+  });
+
+  it("multi-line contract fields render as textareas", () => {
+    expect(schema.properties?.constraints?.format).toBe("textarea");
+    expect(schema.properties?.boundaries?.format).toBe("textarea");
+  });
+});
+
+describe("buildVerifier", () => {
+  it("command / test carry the detail as the shell command", () => {
+    expect(buildVerifier("command", "pytest -q")).toEqual({ type: "command", command: "pytest -q" });
+    expect(buildVerifier("test", "npm test")).toEqual({ type: "test", command: "npm test" });
+  });
+
+  it("command / test with no detail omit the command", () => {
+    expect(buildVerifier("command", "")).toEqual({ type: "command" });
+  });
+
+  it("ci detects a PR number (with or without #) vs a branch name", () => {
+    expect(buildVerifier("ci", "#123")).toEqual({ type: "ci", pr: 123 });
+    expect(buildVerifier("ci", "123")).toEqual({ type: "ci", pr: 123 });
+    expect(buildVerifier("ci", "feat/my-branch")).toEqual({ type: "ci", branch: "feat/my-branch" });
+    expect(buildVerifier("ci", "")).toEqual({ type: "ci" });
+  });
+
+  it("data parses `path :: substring`, falling back to a bare path", () => {
+    expect(buildVerifier("data", "out.json :: ready")).toEqual({
+      type: "data",
+      path: "out.json",
+      contains: "ready",
+    });
+    expect(buildVerifier("data", "out.json")).toEqual({ type: "data", path: "out.json" });
+  });
+
+  it("llm and unknown types collapse to {type:'llm'}", () => {
+    expect(buildVerifier("llm", "")).toEqual({ type: "llm" });
+    expect(buildVerifier("", "")).toEqual({ type: "llm" });
+    expect(buildVerifier("nonsense", "x")).toEqual({ type: "llm" });
+  });
+});
+
+describe("splitLines", () => {
+  it("trims, drops blanks, and handles CRLF", () => {
+    expect(splitLines("a\nb\r\n\n  c  ")).toEqual(["a", "b", "c"]);
+    expect(splitLines("")).toEqual([]);
+    expect(splitLines(undefined)).toEqual([]);
+  });
+});
+
+describe("parseMaxIterations", () => {
+  it("defaults blank / non-numeric / ≤0 to the default", () => {
+    expect(parseMaxIterations("")).toBe(DEFAULT_MAX_ITERATIONS);
+    expect(parseMaxIterations(undefined)).toBe(DEFAULT_MAX_ITERATIONS);
+    expect(parseMaxIterations(0)).toBe(DEFAULT_MAX_ITERATIONS);
+    expect(parseMaxIterations(-3)).toBe(DEFAULT_MAX_ITERATIONS);
+  });
+  it("floors a positive number", () => {
+    expect(parseMaxIterations(12)).toBe(12);
+    expect(parseMaxIterations("5")).toBe(5);
+    expect(parseMaxIterations(4.9)).toBe(4);
+  });
+});
+
+describe("buildGoalSetBody", () => {
+  it("returns null without a condition", () => {
+    expect(buildGoalSetBody("operator", {})).toBeNull();
+    expect(buildGoalSetBody("operator", { condition: "   " })).toBeNull();
+  });
+
+  it("maps a minimal goal (default llm verifier, default max_iterations)", () => {
+    expect(buildGoalSetBody("s1", { condition: "ship it" })).toEqual({
+      session_id: "s1",
+      condition: "ship it",
+      verifier: { type: "llm" },
+      max_iterations: DEFAULT_MAX_ITERATIONS,
+    });
+  });
+
+  it("assembles the verifier from type + detail and splits the contract lists", () => {
+    const body = buildGoalSetBody("s2", {
+      condition: "suite green",
+      verifier: "command",
+      verification: "pytest -q",
+      outcome: "the suite is green on main",
+      constraints: "no new network calls\npublic API unchanged",
+      boundaries: "graph/goals/\ntests/",
+      stop_when: "a schema migration is needed",
+      max_iterations: 20,
+    });
+    expect(body).toEqual({
+      session_id: "s2",
+      condition: "suite green",
+      verifier: { type: "command", command: "pytest -q" },
+      outcome: "the suite is green on main",
+      constraints: ["no new network calls", "public API unchanged"],
+      boundaries: ["graph/goals/", "tests/"],
+      stop_when: "a schema migration is needed",
+      max_iterations: 20,
+    });
+  });
+
+  it("omits empty contract fields (backward-compatible shape)", () => {
+    const body = buildGoalSetBody("s3", {
+      condition: "done",
+      verifier: "ci",
+      verification: "#42",
+      constraints: "\n  \n",
+    });
+    expect(body).toEqual({
+      session_id: "s3",
+      condition: "done",
+      verifier: { type: "ci", pr: 42 },
+      max_iterations: DEFAULT_MAX_ITERATIONS,
+    });
+    expect(body).not.toHaveProperty("constraints");
+    expect(body).not.toHaveProperty("outcome");
+  });
+});

--- a/apps/web/src/chat/goalForm.test.ts
+++ b/apps/web/src/chat/goalForm.test.ts
@@ -8,56 +8,85 @@ import {
   goalFormPayload,
   parseMaxIterations,
   splitLines,
+  verifierDetail,
 } from "./goalForm";
 
 // The form is rendered by HitlForm (not exercised here — jsdom has no renderer and the DS
-// forms are a private-registry dep). These tests pin the PURE pieces: the payload's schema
-// shape + the answers→`POST /api/goals` body mapping (verifier assembly, line-splitting).
+// forms are a private-registry dep). These tests pin the PURE pieces: the two-step wizard's
+// schema shape (incl. the type-aware `showWhen` verification fields) + the answers→
+// `POST /api/goals` body mapping (verifier assembly, line-splitting).
+
+type Props = Record<string, { type?: string; oneOf?: { const?: unknown }[]; format?: string; showWhen?: unknown }>;
 
 describe("goalFormPayload", () => {
   const payload = goalFormPayload();
-  const step = payload.steps?.[0];
-  const schema = step?.schema as {
-    required?: string[];
-    properties?: Record<string, { type?: string; oneOf?: { const?: unknown }[]; format?: string }>;
-  };
+  const step1 = payload.steps?.[0]?.schema as { required?: string[]; properties?: Props };
+  const step2 = payload.steps?.[1]?.schema as { required?: string[]; properties?: Props };
 
-  it("is a single-step form with a title", () => {
+  it("is a two-step wizard with a title", () => {
     expect(payload.kind).toBe("form");
-    expect(payload.steps).toHaveLength(1);
+    expect(payload.steps).toHaveLength(2);
     expect(payload.title).toBeTruthy();
   });
 
-  it("requires only the condition", () => {
-    expect(schema.required).toEqual(["condition"]);
+  it("step 1 requires only the condition", () => {
+    expect(step1.required).toEqual(["condition"]);
   });
 
-  it("declares every contract field", () => {
-    const props = schema.properties ?? {};
-    for (const key of [
-      "condition",
-      "verifier",
-      "verification",
-      "outcome",
-      "constraints",
-      "boundaries",
-      "stop_when",
-      "max_iterations",
-    ]) {
-      expect(props[key], `missing field ${key}`).toBeDefined();
+  it("step 1 holds the goal, the verifier cards, and the type-aware verification fields", () => {
+    const props = step1.properties ?? {};
+    for (const key of ["condition", "verifier", "verify_command", "verify_ci", "verify_data_path", "verify_data_contains"]) {
+      expect(props[key], `missing step-1 field ${key}`).toBeDefined();
     }
   });
 
-  it("renders the verifier field as option cards for every type", () => {
-    const cards = schema.properties?.verifier?.oneOf ?? [];
-    expect(cards.map((c) => c.const)).toEqual(["command", "test", "ci", "data", "llm"]);
-    // The card set mirrors the exported constant (single source of truth).
+  it("step 2 holds the (optional) completion-contract fields", () => {
+    const props = step2.properties ?? {};
+    for (const key of ["outcome", "constraints", "boundaries", "stop_when", "max_iterations"]) {
+      expect(props[key], `missing step-2 field ${key}`).toBeDefined();
+    }
+    expect(step2.required ?? []).toEqual([]); // the whole contract is optional
+  });
+
+  it("renders the verifier field as option cards for every type (single source of truth)", () => {
+    const cards = step1.properties?.verifier?.oneOf ?? [];
     expect(cards.map((c) => c.const)).toEqual(GOAL_VERIFIER_TYPES.map((v) => v.value));
   });
 
+  it("gates each verification field on the matching verifier (showWhen)", () => {
+    const p = step1.properties ?? {};
+    expect(p.verify_command?.showWhen).toEqual({ field: "verifier", in: ["command", "test"] });
+    expect(p.verify_ci?.showWhen).toEqual({ field: "verifier", equals: "ci" });
+    expect(p.verify_data_path?.showWhen).toEqual({ field: "verifier", equals: "data" });
+    expect(p.verify_data_contains?.showWhen).toEqual({ field: "verifier", equals: "data" });
+  });
+
   it("multi-line contract fields render as textareas", () => {
-    expect(schema.properties?.constraints?.format).toBe("textarea");
-    expect(schema.properties?.boundaries?.format).toBe("textarea");
+    expect(step2.properties?.constraints?.format).toBe("textarea");
+    expect(step2.properties?.boundaries?.format).toBe("textarea");
+  });
+});
+
+describe("verifierDetail — reads the type-aware field(s) for the picked verifier", () => {
+  it("command / test → the shell-command field", () => {
+    expect(verifierDetail({ verifier: "command", verify_command: "pytest -q" })).toBe("pytest -q");
+    expect(verifierDetail({ verifier: "test", verify_command: "npm test" })).toBe("npm test");
+  });
+
+  it("ci → the PR#/branch field", () => {
+    expect(verifierDetail({ verifier: "ci", verify_ci: "#42" })).toBe("#42");
+  });
+
+  it("data → `path :: substring`, or a bare path when the substring is blank", () => {
+    expect(verifierDetail({ verifier: "data", verify_data_path: "out.json", verify_data_contains: "ready" })).toBe(
+      "out.json :: ready",
+    );
+    expect(verifierDetail({ verifier: "data", verify_data_path: "out.json" })).toBe("out.json");
+  });
+
+  it("llm (and anything else) → empty", () => {
+    expect(verifierDetail({ verifier: "llm" })).toBe("");
+    expect(verifierDetail({})).toBe("");
   });
 });
 
@@ -96,22 +125,23 @@ describe("buildVerifier", () => {
 
 describe("splitLines", () => {
   it("trims, drops blanks, and handles CRLF", () => {
-    expect(splitLines("a\nb\r\n\n  c  ")).toEqual(["a", "b", "c"]);
+    expect(splitLines("a\r\n\n  b  \nc\n")).toEqual(["a", "b", "c"]);
     expect(splitLines("")).toEqual([]);
-    expect(splitLines(undefined)).toEqual([]);
+    expect(splitLines(null)).toEqual([]);
   });
 });
 
 describe("parseMaxIterations", () => {
   it("defaults blank / non-numeric / ≤0 to the default", () => {
     expect(parseMaxIterations("")).toBe(DEFAULT_MAX_ITERATIONS);
-    expect(parseMaxIterations(undefined)).toBe(DEFAULT_MAX_ITERATIONS);
+    expect(parseMaxIterations("x")).toBe(DEFAULT_MAX_ITERATIONS);
     expect(parseMaxIterations(0)).toBe(DEFAULT_MAX_ITERATIONS);
     expect(parseMaxIterations(-3)).toBe(DEFAULT_MAX_ITERATIONS);
   });
+
   it("floors a positive number", () => {
     expect(parseMaxIterations(12)).toBe(12);
-    expect(parseMaxIterations("5")).toBe(5);
+    expect(parseMaxIterations("7")).toBe(7);
     expect(parseMaxIterations(4.9)).toBe(4);
   });
 });
@@ -131,11 +161,11 @@ describe("buildGoalSetBody", () => {
     });
   });
 
-  it("assembles the verifier from type + detail and splits the contract lists", () => {
+  it("assembles the verifier from the type-aware field and splits the contract lists", () => {
     const body = buildGoalSetBody("s2", {
       condition: "suite green",
       verifier: "command",
-      verification: "pytest -q",
+      verify_command: "pytest -q",
       outcome: "the suite is green on main",
       constraints: "no new network calls\npublic API unchanged",
       boundaries: "graph/goals/\ntests/",
@@ -154,11 +184,21 @@ describe("buildGoalSetBody", () => {
     });
   });
 
+  it("assembles a data verifier from its two type-aware fields", () => {
+    const body = buildGoalSetBody("sd", {
+      condition: "deployed",
+      verifier: "data",
+      verify_data_path: "status.json",
+      verify_data_contains: "ok",
+    });
+    expect(body?.verifier).toEqual({ type: "data", path: "status.json", contains: "ok" });
+  });
+
   it("omits empty contract fields (backward-compatible shape)", () => {
     const body = buildGoalSetBody("s3", {
       condition: "done",
       verifier: "ci",
-      verification: "#42",
+      verify_ci: "#42",
       constraints: "\n  \n",
     });
     expect(body).toEqual({

--- a/apps/web/src/chat/goalForm.ts
+++ b/apps/web/src/chat/goalForm.ts
@@ -21,10 +21,13 @@ export const GOAL_VERIFIER_TYPES = [
 
 export const DEFAULT_MAX_ITERATIONS = 8;
 
-// A single-step HITL form: the goal + how to verify it, then the OPTIONAL completion
-// contract (outcome/constraints/boundaries/stop_when/max iterations). Single-step (not a
-// wizard) so `condition` — the one required field — gates Submit directly, and both hosts
-// (the chat `/goal new` composer form and the GoalsPanel inline form) render it identically.
+// A two-step wizard (ADR 0073). Step 1 = the goal + how to verify it, with a TYPE-AWARE
+// verification input: the verifier cards drive `showWhen`-conditional fields, so only the
+// input(s) the picked verifier actually needs are shown (a shell command for command/test,
+// a PR#/branch for ci, a file+substring for data, nothing for llm) — no catch-all box.
+// Step 2 = the OPTIONAL completion contract. `condition` (the one required field) lives in
+// step 1 and gates its Next. Both hosts (the `/goal new` composer form and the GoalsPanel
+// inline form) render this identically through `HitlForm`.
 export function goalFormPayload(): HitlPayload {
   return {
     kind: "form",
@@ -32,6 +35,7 @@ export function goalFormPayload(): HitlPayload {
     description: "A testable outcome the agent self-drives toward. The verifier decides DONE.",
     steps: [
       {
+        title: "Goal",
         schema: {
           type: "object",
           required: ["condition"],
@@ -39,11 +43,11 @@ export function goalFormPayload(): HitlPayload {
             condition: {
               type: "string",
               title: "Goal",
-              description: "The outcome the agent should achieve.",
+              description: "The outcome the agent should achieve — in plain English.",
             },
             verifier: {
               type: "string",
-              title: "How to verify",
+              title: "How to verify it's done",
               default: "llm",
               oneOf: GOAL_VERIFIER_TYPES.map((v) => ({
                 const: v.value,
@@ -51,38 +55,64 @@ export function goalFormPayload(): HitlPayload {
                 description: v.description,
               })),
             },
-            verification: {
+            verify_command: {
               type: "string",
-              title: "Verification detail",
-              description:
-                "The verifier's parameter: the shell command (command/test), the PR # or " +
-                "branch (ci), or `path :: substring` (data). Leave blank for llm.",
+              title: "Shell command",
+              description: "Runs on the server; exit 0 = done (e.g. `pytest -q`).",
+              showWhen: { field: "verifier", in: ["command", "test"] },
             },
+            verify_ci: {
+              type: "string",
+              title: "PR # or branch",
+              description: "GitHub checks must be green (e.g. `#1785` or `main`).",
+              showWhen: { field: "verifier", equals: "ci" },
+            },
+            verify_data_path: {
+              type: "string",
+              title: "File to check",
+              description: "Path to a file the goal writes or updates.",
+              showWhen: { field: "verifier", equals: "data" },
+            },
+            verify_data_contains: {
+              type: "string",
+              title: "Must contain (optional)",
+              description: "Done when the file contains this substring — blank just requires the file.",
+              showWhen: { field: "verifier", equals: "data" },
+            },
+          },
+        },
+      },
+      {
+        title: "Completion contract (optional)",
+        description: "Extra guidance the agent re-reads each turn. Everything here is optional.",
+        schema: {
+          type: "object",
+          properties: {
             outcome: {
               type: "string",
-              title: "Outcome (optional)",
+              title: "Outcome",
               description: "The required end-state, in one line. Defaults to the goal.",
             },
             constraints: {
               type: "string",
               format: "textarea",
-              title: "Constraints (optional)",
+              title: "Constraints",
               description: "Invariants the agent must NOT violate — one per line.",
             },
             boundaries: {
               type: "string",
               format: "textarea",
-              title: "Boundaries (optional)",
+              title: "Boundaries",
               description: "Files / dirs / systems in scope — one per line.",
             },
             stop_when: {
               type: "string",
-              title: "Stop and ask when (optional)",
+              title: "Stop and ask when",
               description: "A condition under which the agent pauses and asks you.",
             },
             max_iterations: {
               type: "number",
-              title: "Max iterations (optional)",
+              title: "Max iterations",
               default: DEFAULT_MAX_ITERATIONS,
               description: `Drive-loop budget. Default ${DEFAULT_MAX_ITERATIONS}.`,
             },
@@ -146,6 +176,21 @@ export function buildVerifier(type: unknown, detail: unknown): Record<string, un
   return { type: "llm" };
 }
 
+/** The verifier's free-text detail, read from the TYPE-AWARE field(s) for the picked verifier
+ *  and normalized to the `path :: substring` form `buildVerifier` parses for `data`. Empty for
+ *  llm (and any verifier whose detail field is blank). */
+export function verifierDetail(answers: Record<string, unknown>): string {
+  const t = String(answers.verifier ?? "").trim().toLowerCase();
+  if (t === "command" || t === "test") return String(answers.verify_command ?? "").trim();
+  if (t === "ci") return String(answers.verify_ci ?? "").trim();
+  if (t === "data") {
+    const path = String(answers.verify_data_path ?? "").trim();
+    const contains = String(answers.verify_data_contains ?? "").trim();
+    return contains ? `${path} :: ${contains}` : path;
+  }
+  return "";
+}
+
 /** Coerce the (optional) max-iterations answer to a positive integer, defaulting to
  *  `DEFAULT_MAX_ITERATIONS` when blank / non-numeric / ≤ 0. */
 export function parseMaxIterations(value: unknown): number {
@@ -163,7 +208,7 @@ export function buildGoalSetBody(
   const condition = String(answers.condition ?? "").trim();
   if (!condition) return null;
 
-  const verifier = buildVerifier(answers.verifier, answers.verification);
+  const verifier = buildVerifier(answers.verifier, verifierDetail(answers));
   const outcome = String(answers.outcome ?? "").trim();
   const constraints = splitLines(answers.constraints);
   const boundaries = splitLines(answers.boundaries);

--- a/apps/web/src/chat/goalForm.ts
+++ b/apps/web/src/chat/goalForm.ts
@@ -1,0 +1,182 @@
+// Pure logic for the goal-creation form (ADR 0073 completion contracts, Part 2) — the
+// HitlPayload the composer/panel renders through the SAME `HitlForm` as `/effort`'s picker,
+// plus the answers→`POST /api/goals` body mapping. Kept out of the React/DS layer (no
+// `@protolabsai/ui` imports, only a type-only `HitlPayload`) so the web unit suite
+// (`src/**/*.test.ts`, no renderer) can exercise the schema shape + the verifier/contract
+// mapping directly — mirroring the repo's other pure-helper tests (e.g. shiftCue.ts).
+
+import type { HitlPayload } from "../lib/types";
+
+// The verifier types the operator `/api/goals` surface accepts (ADR 0028/0066). Rendered as
+// option cards (the `oneOf` + descriptions turn the field into cards — hitl-form.isCardChoice).
+// `llm` is the default (applied in the mapping — HitlForm doesn't seed schema defaults, so the
+// field is left OPTIONAL and an unpicked card falls back to llm rather than blocking Submit).
+export const GOAL_VERIFIER_TYPES = [
+  { value: "command", label: "command", description: "A shell command that exits 0" },
+  { value: "test", label: "test", description: "A test command that exits 0" },
+  { value: "ci", label: "ci", description: "GitHub checks are green (PR # or branch)" },
+  { value: "data", label: "data", description: "Assert over a file's contents" },
+  { value: "llm", label: "llm", description: "Fuzzy LLM judgment (the default)" },
+] as const;
+
+export const DEFAULT_MAX_ITERATIONS = 8;
+
+// A single-step HITL form: the goal + how to verify it, then the OPTIONAL completion
+// contract (outcome/constraints/boundaries/stop_when/max iterations). Single-step (not a
+// wizard) so `condition` — the one required field — gates Submit directly, and both hosts
+// (the chat `/goal new` composer form and the GoalsPanel inline form) render it identically.
+export function goalFormPayload(): HitlPayload {
+  return {
+    kind: "form",
+    title: "New goal",
+    description: "A testable outcome the agent self-drives toward. The verifier decides DONE.",
+    steps: [
+      {
+        schema: {
+          type: "object",
+          required: ["condition"],
+          properties: {
+            condition: {
+              type: "string",
+              title: "Goal",
+              description: "The outcome the agent should achieve.",
+            },
+            verifier: {
+              type: "string",
+              title: "How to verify",
+              default: "llm",
+              oneOf: GOAL_VERIFIER_TYPES.map((v) => ({
+                const: v.value,
+                title: v.label,
+                description: v.description,
+              })),
+            },
+            verification: {
+              type: "string",
+              title: "Verification detail",
+              description:
+                "The verifier's parameter: the shell command (command/test), the PR # or " +
+                "branch (ci), or `path :: substring` (data). Leave blank for llm.",
+            },
+            outcome: {
+              type: "string",
+              title: "Outcome (optional)",
+              description: "The required end-state, in one line. Defaults to the goal.",
+            },
+            constraints: {
+              type: "string",
+              format: "textarea",
+              title: "Constraints (optional)",
+              description: "Invariants the agent must NOT violate — one per line.",
+            },
+            boundaries: {
+              type: "string",
+              format: "textarea",
+              title: "Boundaries (optional)",
+              description: "Files / dirs / systems in scope — one per line.",
+            },
+            stop_when: {
+              type: "string",
+              title: "Stop and ask when (optional)",
+              description: "A condition under which the agent pauses and asks you.",
+            },
+            max_iterations: {
+              type: "number",
+              title: "Max iterations (optional)",
+              default: DEFAULT_MAX_ITERATIONS,
+              description: `Drive-loop budget. Default ${DEFAULT_MAX_ITERATIONS}.`,
+            },
+          },
+        },
+      },
+    ],
+  };
+}
+
+// The `POST /api/goals` body (operator goal-set, ADR 0066/0073). `verifier` is an opaque
+// dict the backend validates; the contract fields are omitted when empty so a contract-less
+// goal is byte-for-byte the pre-0073 shape.
+export type GoalSetBody = {
+  session_id: string;
+  condition: string;
+  verifier: Record<string, unknown>;
+  outcome?: string;
+  constraints?: string[];
+  boundaries?: string[];
+  stop_when?: string;
+  max_iterations?: number;
+};
+
+/** Split a textarea value into trimmed, non-empty lines → `string[]` (constraints/boundaries
+ *  are one-per-line). Mirrors the backend's `_as_str_list` coercion (blank entries dropped). */
+export function splitLines(value: unknown): string[] {
+  return String(value ?? "")
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** Assemble the verifier dict from the picked type + its free-text detail (ADR 0028 shapes):
+ *  - command / test → `{type, command: detail}` (detail omitted when blank)
+ *  - ci             → `{type:"ci", pr:<n>}` when detail is `#123`/`123`, else `{type:"ci", branch: detail}`
+ *  - data           → `{type:"data", path, contains}` parsed from `path :: substring`
+ *                     (best-effort; a bare value is taken as the path)
+ *  - llm / unknown  → `{type:"llm"}` (the default) */
+export function buildVerifier(type: unknown, detail: unknown): Record<string, unknown> {
+  const t = String(type ?? "").trim().toLowerCase() || "llm";
+  const d = String(detail ?? "").trim();
+
+  if (t === "command" || t === "test") {
+    return d ? { type: t, command: d } : { type: t };
+  }
+  if (t === "ci") {
+    const pr = /^#?(\d+)$/.exec(d);
+    if (pr) return { type: "ci", pr: Number(pr[1]) };
+    return d ? { type: "ci", branch: d } : { type: "ci" };
+  }
+  if (t === "data") {
+    const sep = d.indexOf("::");
+    const path = (sep >= 0 ? d.slice(0, sep) : d).trim();
+    const contains = sep >= 0 ? d.slice(sep + 2).trim() : "";
+    const spec: Record<string, unknown> = { type: "data" };
+    if (path) spec.path = path;
+    if (contains) spec.contains = contains;
+    return spec;
+  }
+  return { type: "llm" };
+}
+
+/** Coerce the (optional) max-iterations answer to a positive integer, defaulting to
+ *  `DEFAULT_MAX_ITERATIONS` when blank / non-numeric / ≤ 0. */
+export function parseMaxIterations(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : DEFAULT_MAX_ITERATIONS;
+}
+
+/** Map the HitlForm answers → the `POST /api/goals` body for `session_id`. Returns `null`
+ *  when there is no condition (the one required field) so callers can no-op rather than POST
+ *  an unsatisfiable goal. Empty contract fields are omitted (backward-compatible). */
+export function buildGoalSetBody(
+  sessionId: string,
+  answers: Record<string, unknown>,
+): GoalSetBody | null {
+  const condition = String(answers.condition ?? "").trim();
+  if (!condition) return null;
+
+  const verifier = buildVerifier(answers.verifier, answers.verification);
+  const outcome = String(answers.outcome ?? "").trim();
+  const constraints = splitLines(answers.constraints);
+  const boundaries = splitLines(answers.boundaries);
+  const stop_when = String(answers.stop_when ?? "").trim();
+
+  return {
+    session_id: sessionId,
+    condition,
+    verifier,
+    ...(outcome ? { outcome } : {}),
+    ...(constraints.length ? { constraints } : {}),
+    ...(boundaries.length ? { boundaries } : {}),
+    ...(stop_when ? { stop_when } : {}),
+    max_iterations: parseMaxIterations(answers.max_iterations),
+  };
+}

--- a/apps/web/src/chat/hitl-form.test.ts
+++ b/apps/web/src/chat/hitl-form.test.ts
@@ -6,9 +6,11 @@ import {
   fieldsOf,
   hasValue,
   isCardChoice,
+  isFieldVisible,
   isMultiChoice,
   missingInStep,
   optionsOf,
+  visibleFieldsOf,
 } from "./hitl-form";
 
 const step = (schema: Record<string, unknown>): HitlFormStep => ({ schema });
@@ -109,5 +111,57 @@ describe("missingInStep / anyStepMissing", () => {
   it("gates the final submit until every step is satisfied", () => {
     expect(anyStepMissing([s1, s2], { env: "prod" })).toBe(true); // region still missing
     expect(anyStepMissing([s1, s2], { env: "prod", region: ["eu"] })).toBe(false);
+  });
+
+  it("a `showWhen`-HIDDEN required field never gates (it isn't asked)", () => {
+    const conditional = step({
+      properties: {
+        mode: { type: "string" },
+        detail: { type: "string", showWhen: { field: "mode", equals: "custom" } },
+      },
+      required: ["detail"],
+    });
+    // mode≠custom → `detail` is hidden → not missing, so Submit isn't blocked.
+    expect(missingInStep(conditional, { mode: "auto" })).toEqual([]);
+    // mode=custom → `detail` shows → now required-and-empty blocks.
+    expect(missingInStep(conditional, { mode: "custom" })).toEqual(["detail"]);
+    expect(missingInStep(conditional, { mode: "custom", detail: "x" })).toEqual([]);
+  });
+});
+
+describe("isFieldVisible / visibleFieldsOf — conditional fields (showWhen)", () => {
+  it("no showWhen ⇒ always visible", () => {
+    expect(isFieldVisible({ type: "string" }, {})).toBe(true);
+  });
+
+  it("`equals` shows only on a strict match", () => {
+    const f = { type: "string", showWhen: { field: "kind", equals: "ci" } };
+    expect(isFieldVisible(f, { kind: "ci" })).toBe(true);
+    expect(isFieldVisible(f, { kind: "command" })).toBe(false);
+    expect(isFieldVisible(f, {})).toBe(false);
+  });
+
+  it("`in` shows on membership", () => {
+    const f = { type: "string", showWhen: { field: "kind", in: ["command", "test"] } };
+    expect(isFieldVisible(f, { kind: "test" })).toBe(true);
+    expect(isFieldVisible(f, { kind: "data" })).toBe(false);
+  });
+
+  it("showWhen without equals/in ⇒ sibling must be truthy", () => {
+    const f = { type: "string", showWhen: { field: "on" } };
+    expect(isFieldVisible(f, { on: true })).toBe(true);
+    expect(isFieldVisible(f, { on: "" })).toBe(false);
+  });
+
+  it("visibleFieldsOf drops the hidden fields for the current answers", () => {
+    const s = step({
+      properties: {
+        kind: { type: "string" },
+        cmd: { type: "string", showWhen: { field: "kind", equals: "command" } },
+        pr: { type: "string", showWhen: { field: "kind", equals: "ci" } },
+      },
+    });
+    expect(visibleFieldsOf(s, { kind: "command" }).map(([k]) => k)).toEqual(["kind", "cmd"]);
+    expect(visibleFieldsOf(s, { kind: "ci" }).map(([k]) => k)).toEqual(["kind", "pr"]);
   });
 });

--- a/apps/web/src/chat/hitl-form.ts
+++ b/apps/web/src/chat/hitl-form.ts
@@ -18,6 +18,11 @@ export type FieldSchema = {
   default?: unknown;
   // Opt a bare `enum` into card rendering (otherwise an enum stays a dropdown).
   "x-display"?: string;
+  // Conditional visibility (mirrors the settings `depends_on` convention): this field
+  // renders only when a sibling field's answer matches. `equals` = strict equality; `in` =
+  // membership; neither = the sibling is truthy. A hidden field is skipped by required-
+  // gating too, so an optional-when-hidden field never blocks Next/Submit.
+  showWhen?: { field: string; equals?: unknown; in?: unknown[] };
 };
 
 export type FieldEntry = [key: string, schema: FieldSchema, required: boolean];
@@ -79,10 +84,27 @@ export function hasValue(schema: FieldSchema, value: unknown): boolean {
   return value !== undefined && value !== null && value !== "";
 }
 
-/** Required field keys in this step that are still empty — non-empty ⇒ block Next/Submit. */
+/** Should this field render, given the current answers? A field with no `showWhen` always
+ *  shows; otherwise its condition must match the sibling field's value. */
+export function isFieldVisible(schema: FieldSchema, values: Record<string, unknown>): boolean {
+  const cond = schema?.showWhen;
+  if (!cond || !cond.field) return true;
+  const v = values[cond.field];
+  if (Array.isArray(cond.in)) return cond.in.some((x) => x === v);
+  if (cond.equals !== undefined) return v === cond.equals;
+  return Boolean(v); // showWhen with neither equals nor in ⇒ sibling is truthy
+}
+
+/** The step's fields that are visible under the current answers (drops `showWhen`-hidden). */
+export function visibleFieldsOf(step: HitlFormStep | undefined, values: Record<string, unknown>): FieldEntry[] {
+  return fieldsOf(step).filter(([, schema]) => isFieldVisible(schema, values));
+}
+
+/** Required field keys in this step that are still empty — non-empty ⇒ block Next/Submit.
+ *  A `showWhen`-hidden field is never "missing" (it isn't asked, so it can't gate). */
 export function missingInStep(step: HitlFormStep | undefined, values: Record<string, unknown>): string[] {
   return fieldsOf(step)
-    .filter(([key, schema, required]) => required && !hasValue(schema, values[key]))
+    .filter(([key, schema, required]) => required && isFieldVisible(schema, values) && !hasValue(schema, values[key]))
     .map(([key]) => key);
 }
 

--- a/apps/web/src/goals/goals.css
+++ b/apps/web/src/goals/goals.css
@@ -60,3 +60,10 @@
   margin: 0;
   font-size: 11px;
 }
+
+/* Inline guided goal form (ADR 0073, Part 2) — hosts the shared HitlForm in the panel.
+   HitlForm's own .hitl-card carries the border/padding; this wrapper just adds a little
+   top breathing room below the header so the card doesn't butt against it. */
+.goal-form-host {
+  padding-top: 8px;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1112,6 +1112,7 @@ export const api = {
     constraints?: string[];
     boundaries?: string[];
     stop_when?: string;
+    max_iterations?: number;
   }) {
     return request<{ ok: boolean; message?: string; error?: string }>("/api/goals", {
       method: "POST",

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -254,6 +254,26 @@
     "expected_patterns": ["goal achieved"]
   },
   {
+    "id": "goal_llm_verifier",
+    "category": "goal",
+    "kind": "goal",
+    "name": "Fuzzy (llm) verifier resolves an agent-satisfied goal to achieved",
+    "set_goal": {"condition": "the reply clearly names Paris as the capital of France", "verifier": {"type": "llm"}},
+    "prompt": "What is the capital of France? Answer in one word.",
+    "expected_goal_status": "achieved",
+    "expected_patterns": ["goal achieved"]
+  },
+  {
+    "id": "goal_contract_achieved",
+    "category": "goal",
+    "kind": "goal",
+    "name": "A goal carrying an ADR 0073 completion contract resolves via /goal {json}",
+    "set_goal": {"condition": "the readiness check passes", "verifier": {"type": "command", "command": "true"}, "constraints": ["do not touch files outside the target module"], "boundaries": ["the readiness script only"], "stop_when": "a dependency is missing"},
+    "prompt": "Please make progress toward the goal, respecting the contract.",
+    "expected_goal_status": "achieved",
+    "expected_patterns": ["goal achieved"]
+  },
+  {
     "id": "research_delegation",
     "category": "subagent",
     "kind": "ask",

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -91,7 +91,7 @@ class GoalController:
             return "Goal cleared." if existed else "No active goal to clear."
 
         # /goal {json}  or  /goal <free text>  → set
-        spec, condition, max_iters, no_progress, fresh_context = self._parse_set(rest)
+        spec, condition, max_iters, no_progress, fresh_context, contract = self._parse_set(rest)
         if condition is None:
             return (
                 "Could not parse goal. Use `/goal <text>` or "
@@ -118,6 +118,10 @@ class GoalController:
             fresh_context=fresh_context,
             max_iterations=max_iters or getattr(self._config, "goal_max_iterations", 8),
             no_progress_limit=no_progress,  # per-goal patience; None → config
+            outcome=contract.get("outcome", ""),
+            constraints=list(contract.get("constraints") or []),
+            boundaries=list(contract.get("boundaries") or []),
+            stop_when=contract.get("stop_when", ""),
         )
         self._store.set(state)
         return f"Goal set. {state.status_line()}"
@@ -262,22 +266,31 @@ class GoalController:
 
     def _parse_set(self, rest: str):
         """Return (verifier_spec, condition, max_iterations|None, no_progress_limit|None,
-        fresh_context)."""
+        fresh_context, contract) — ``contract`` carries the optional ADR 0073 fields
+        (outcome/constraints/boundaries/stop_when) from a JSON spec; ``{}`` for free text.
+        The contract is directive prose (no code-exec), so it's safe from an untrusted chat
+        set — no trust-gate, unlike the verifier."""
         if rest.lstrip().startswith("{"):
             try:
                 data = json.loads(rest)
             except json.JSONDecodeError:
-                return ({}, None, None, None, False)
+                return ({}, None, None, None, False, {})
             condition = data.get("condition")
             if not condition:
-                return ({}, None, None, None, False)
+                return ({}, None, None, None, False, {})
             verifier = data.get("verifier") or {"type": "llm"}
             if "type" not in verifier:
                 verifier["type"] = "llm"
             fresh_context = bool(data.get("fresh_context", False))
-            return (verifier, condition, data.get("max_iterations"), data.get("no_progress_limit"), fresh_context)
+            contract = {
+                "outcome": data.get("outcome") or "",
+                "constraints": _coerce_str_list(data.get("constraints")),
+                "boundaries": _coerce_str_list(data.get("boundaries")),
+                "stop_when": data.get("stop_when") or "",
+            }
+            return (verifier, condition, data.get("max_iterations"), data.get("no_progress_limit"), fresh_context, contract)
         # plain text → fuzzy goal judged by the llm verifier
-        return ({"type": "llm"}, rest, None, None, False)
+        return ({"type": "llm"}, rest, None, None, False, {})
 
     # --- evaluation --------------------------------------------------------
 

--- a/tests/test_goal_harness.py
+++ b/tests/test_goal_harness.py
@@ -1,0 +1,208 @@
+"""Goal harness (ADR 0028/0067/0073) — drive EVERY goal "version" through the real
+``GoalController.evaluate()`` with made-up, deterministic inputs and assert the lifecycle
+outcome. This is the automated stand-in for hand-testing the goal form: it proves the system
+works end to end for each verifier type + the completion contract.
+
+Hermetic + CI-safe (no model, no network): ``command``/``test``/``data`` run for real (real
+shell + real file); ``ci`` and ``llm`` are faked at their single reach-out point
+(``tools.gh_cli.run_gh`` / ``graph.llm.create_llm``). Matrix per verifier type — MET → the
+goal finishes ``achieved``; NOT-MET → the drive loop ``continue``s — plus the completion
+contract injection, the contract-less backward-compat path, and budget exhaustion.
+
+Run:  ``uv run python -m pytest tests/test_goal_harness.py -v``
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from graph.config import LangGraphConfig
+from graph.goals.controller import GoalController
+from graph.goals.store import GoalStore
+
+
+def _ctrl(tmp_path, **overrides) -> GoalController:
+    return GoalController(LangGraphConfig(**overrides), GoalStore(tmp_path))
+
+
+def _set(c: GoalController, session: str, condition: str, verifier: dict, **kw) -> None:
+    """Set an operator goal and assert it took (surfaces any goal-mode gating)."""
+    ok, msg = c.set_goal_operator(session, condition, verifier, **kw)
+    assert ok, f"set_goal_operator refused the goal: {msg}"
+
+
+# ── fakes for the two non-deterministic verifiers ──────────────────────────
+class _FakeResp:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeLLM:
+    """Stands in for the goal-eval model — returns the judge JSON the llm verifier parses."""
+
+    def __init__(self, met: bool) -> None:
+        self._met = met
+
+    async def ainvoke(self, _messages, config=None):  # noqa: ARG002 — signature parity
+        return _FakeResp(json.dumps({"met": self._met, "reason": "faked judge verdict"}))
+
+
+@pytest.fixture
+def fake_llm(monkeypatch):
+    def _install(met: bool) -> None:
+        monkeypatch.setattr("graph.llm.create_llm", lambda *a, **k: _FakeLLM(met))
+
+    return _install
+
+
+@pytest.fixture
+def fake_ci(monkeypatch):
+    def _install(green: bool) -> None:
+        async def _run_gh(*_a, **_k):
+            return (0 if green else 1, "checks: all green" if green else "checks: failing", "")
+
+        monkeypatch.setattr("tools.gh_cli.run_gh", _run_gh)
+
+    return _install
+
+
+# ── the matrix: each verifier type, MET → achieved / NOT-MET → continue ─────
+@pytest.mark.asyncio
+async def test_command_met_achieves(tmp_path):
+    c = _ctrl(tmp_path)
+    _set(c, "s", "build green", {"type": "command", "command": "exit 0"})
+    d = await c.evaluate("s", last_text="ran the build")
+    assert d.action == "done" and d.state.status == "achieved"
+
+
+@pytest.mark.asyncio
+async def test_command_not_met_continues(tmp_path):
+    c = _ctrl(tmp_path)
+    _set(c, "s", "build green", {"type": "command", "command": "exit 1"})
+    d = await c.evaluate("s", last_text="still broken")
+    assert d.action == "continue"
+
+
+@pytest.mark.asyncio
+async def test_test_verifier_met_achieves(tmp_path):
+    c = _ctrl(tmp_path)
+    _set(c, "s", "tests pass", {"type": "test", "command": "exit 0"})
+    d = await c.evaluate("s", last_text="green")
+    assert d.action == "done" and d.state.status == "achieved"
+
+
+@pytest.mark.asyncio
+async def test_data_met_achieves(tmp_path):
+    f = tmp_path / "out.txt"
+    f.write_text("the DEPLOY succeeded\n")
+    c = _ctrl(tmp_path)
+    _set(c, "s", "deploy done", {"type": "data", "path": str(f), "contains": "DEPLOY"})
+    d = await c.evaluate("s", last_text="wrote the file")
+    assert d.action == "done" and d.state.status == "achieved"
+
+
+@pytest.mark.asyncio
+async def test_data_not_met_continues(tmp_path):
+    f = tmp_path / "out.txt"
+    f.write_text("nothing yet\n")
+    c = _ctrl(tmp_path)
+    _set(c, "s", "deploy done", {"type": "data", "path": str(f), "contains": "DEPLOY"})
+    d = await c.evaluate("s", last_text="not yet")
+    assert d.action == "continue"
+
+
+@pytest.mark.asyncio
+async def test_ci_green_achieves(tmp_path, fake_ci):
+    fake_ci(green=True)
+    c = _ctrl(tmp_path)
+    _set(c, "s", "PR is green", {"type": "ci", "pr": 1785})
+    d = await c.evaluate("s", last_text="pushed the fix")
+    assert d.action == "done" and d.state.status == "achieved"
+
+
+@pytest.mark.asyncio
+async def test_ci_red_continues(tmp_path, fake_ci):
+    fake_ci(green=False)
+    c = _ctrl(tmp_path)
+    _set(c, "s", "PR is green", {"type": "ci", "pr": 1785})
+    d = await c.evaluate("s", last_text="still red")
+    assert d.action == "continue"
+
+
+@pytest.mark.asyncio
+async def test_llm_met_achieves(tmp_path, fake_llm):
+    fake_llm(met=True)
+    c = _ctrl(tmp_path)
+    _set(c, "s", "the doc reads well", {"type": "llm"})
+    d = await c.evaluate("s", last_text="rewrote the doc")
+    assert d.action == "done" and d.state.status == "achieved"
+
+
+@pytest.mark.asyncio
+async def test_llm_not_met_continues(tmp_path, fake_llm):
+    fake_llm(met=False)
+    c = _ctrl(tmp_path)
+    _set(c, "s", "the doc reads well", {"type": "llm"})
+    d = await c.evaluate("s", last_text="first draft")
+    assert d.action == "continue"
+
+
+# ── the completion contract (ADR 0073) flows into the continuation prompt ───
+@pytest.mark.asyncio
+async def test_contract_injected_into_continuation(tmp_path):
+    c = _ctrl(tmp_path)
+    _set(
+        c,
+        "s",
+        "refactor the module",
+        {"type": "command", "command": "exit 1"},
+        outcome="module split cleanly",
+        constraints=["do not change the public API"],
+        boundaries=["graph/goals/ only"],
+        stop_when="a test outside the module fails",
+    )
+    d = await c.evaluate("s", last_text="mid-refactor")
+    assert d.action == "continue"
+    assert "do not change the public API" in d.message
+    assert "graph/goals/ only" in d.message
+    assert "a test outside the module fails" in d.message
+
+
+@pytest.mark.asyncio
+async def test_contractless_goal_has_no_contract_block(tmp_path):
+    c = _ctrl(tmp_path)
+    _set(c, "s", "x", {"type": "command", "command": "exit 1"})
+    d = await c.evaluate("s", last_text="working")
+    assert d.action == "continue"
+    assert "Contract for this goal" not in d.message  # backward-compat: no contract → no block
+
+
+# ── the `/goal {json}` chat/eval path now carries the contract too (not just the API) ──
+@pytest.mark.asyncio
+async def test_goal_json_chat_path_carries_contract(tmp_path):
+    c = _ctrl(tmp_path)
+    spec = {
+        "condition": "ship the fix",
+        "verifier": {"type": "llm"},  # llm is chat-safe (command/test/ci are operator-only)
+        "constraints": ["no breaking changes"],
+        "boundaries": ["graph/ only"],
+        "stop_when": "CI goes red",
+    }
+    reply = await c.parse_control("/goal " + json.dumps(spec), "s")
+    assert reply and "goal set" in reply.lower()
+    g = c.active_goal("s")
+    assert g.constraints == ["no breaking changes"]
+    assert g.boundaries == ["graph/ only"]
+    assert g.stop_when == "CI goes red"
+    assert g.has_contract
+
+
+# ── lifecycle edge: the budget bounds a never-met goal ─────────────────────
+@pytest.mark.asyncio
+async def test_budget_exhaustion_finishes(tmp_path):
+    c = _ctrl(tmp_path)
+    _set(c, "s", "x", {"type": "command", "command": "exit 1"}, max_iterations=1)
+    d = await c.evaluate("s", last_text="try 1")
+    assert d.action == "done" and d.state.status == "exhausted"


### PR DESCRIPTION
## What & why

Part 2 of ADR 0073 **goal completion contracts** (Part 1 / backend + ADR landed in #1785). A console **goal-creation form** so an operator can set a goal with its verifier and completion contract *without hand-writing verifier JSON*.

It reuses the **exact `/effort` composer-form pattern** — a `ClientSlashCommand` that calls `ctx.openForm({ payload, onSubmit })`, rendered through the existing **`HitlForm`** (no new form renderer) via the `openForm` seam (`ext/slashRegistry.ts`). The same payload builder + submit mapping back the panel entry point too.

## The form (`goalFormPayload()`)

A single-step `HitlPayload` (kept simple so the one required field gates Submit directly):

- **Goal / condition** — text, **required**.
- **How to verify** — option **cards**: `command` · `test` · `ci` · `data` · `llm`, each with helper text (`command`/`test` = shell exit 0, `ci` = GitHub checks green, `data` = assert over a file, `llm` = fuzzy judgment). Default `llm`.
- **Verification detail** — one text field (the shell command for command/test, the PR #/branch for ci, `path :: substring` for data, blank for llm). A single field rather than per-type conditional fields, which the HitlForm schema doesn't support.
- **Outcome**, **Constraints** (textarea, one-per-line), **Boundaries** (textarea, one-per-line), **Stop-and-ask when**, **Max iterations** (default 8) — all optional (the completion contract).

**Submit mapping** (pure, extracted + unit-tested): `buildVerifier(type, detail)` assembles the verifier dict — `command`/`test` → `{type, command}`; `ci` → `{type:"ci", pr}` for `#123`/`123` else `{type:"ci", branch}`; `data` → `{type:"data", path, contains}` parsed from `path :: substring`; `llm`/unknown → `{type:"llm"}`. `buildGoalSetBody()` splits constraints/boundaries into `string[]`, omits empty contract fields (backward-compatible), and defaults max_iterations. Then `POST /api/goals` (operator surface, ADR 0066), surfacing the server message on the 400 path (rejected verifier / goal mode disabled).

## Entry points

- **`/goal new`** opens the form in the chat composer. A **client `/goal` command claims ONLY the `new` subcommand** — bare `/goal` (status), `/goal <text>` (set), and `/goal clear` all `return false` and fall through to the **server** `/goal` control command (`graph/slash_commands.py`) **unchanged**. Chosen over intercepting bare `/goal` because bare `/goal` returns the server status line — intercepting it would regress `/goal status`.
- **Goals panel "New goal"** button opens the **same** form inline (the panel isn't a chat tab, so it hosts `HitlForm` directly with the shared `goalFormPayload()` + `buildGoalSetBody()`; panel goals target the `operator` session). The Work-overview Goals *card* quick-add keeps the simpler `GoalCreateDialog` (still used by `WorkPanel`, untouched).

## Files
- `apps/web/src/chat/goalForm.ts` — new: payload builder + verifier/contract mapping (pure).
- `apps/web/src/chat/goalForm.test.ts` — new: vitest unit (17 cases).
- `apps/web/src/chat/coreSlashCommands.ts` — client `/goal` command (`/goal new`).
- `apps/web/src/app/GoalsPanel.tsx` — "New goal" opens the inline guided form.
- `apps/web/src/goals/goals.css` — inline-form host spacing.
- `apps/web/src/lib/api.ts` — `setGoal` body gains `max_iterations`.
- `apps/web/e2e/commands.spec.ts`, `apps/web/e2e/work-overview.spec.ts` — updated for the client `/goal` + inline panel form.
- `CHANGELOG.md` — `[Unreleased] → Added`.

## How to test
1. **Chat:** type `/goal new` and Enter → the guided form opens in the composer. Enter a goal, pick a verifier card, add a detail (e.g. `pytest -q` for command, `#123` for ci, `out.json :: ready` for data), optionally fill the contract, Submit → a success/error note posts to the thread. Confirm bare `/goal`, `/goal <text>`, and `/goal clear` still hit the server command (status / set / clear).
2. **Panel:** open the Goals rail → **New goal** → the same form renders inline → Submit sets an `operator` goal (toast on success).
3. `npm run test:unit --workspace @protoagent/web` (goalForm.test.ts); `npm run test:e2e` (commands + work-overview specs).

## Gates
Frontend-only. Local `vitest`/`tsc`/e2e **can't** run in the worktree (empty `node_modules`, private `@protolabsai/*` registry) — **deferred to CI** (`checks.yml` runs test:unit + test:e2e + build/tsc). The pure `goalForm.test.ts` was run green against a standalone vitest (17/17). **DRAFT** pending visual/UX QA (per the console-layout local-test gate).

## Notes / descoped
- HitlForm doesn't seed schema `default`s into form values, so the verifier field is left **optional** (an unpicked card falls back to `llm` in the mapping) rather than required-and-blocking-Submit.
- Verifier detail is one field, not per-type conditional fields (schema limitation) — noted above.
- Panel goals target `operator` (no per-goal session picker in the form); the Work-overview card quick-add keeps `GoalCreateDialog`. Unifying both hosts onto the guided form is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inline, guided goal-creation flow with step-by-step fields and conditional questions, making it easier to set up goals directly in the app.
  * Added support for richer goal setup details, including completion constraints and iteration limits.

* **Bug Fixes**
  * Improved slash-command handling so duplicate commands no longer appear in autocomplete.
  * Updated goal command behavior so `/goal new` opens the guided form while other `/goal` inputs continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->