### PR TITLE
fix(delegates): a2a SendMessage read budget tracks poll_timeout, not a flat 60s (#1778)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   settable from chat and exercisable by the goal evals. It's directive prose (no code-exec), so —
   unlike the verifier — it's not trust-gated.
 
+### Fixed
+- **`delegate_to` no longer hard-fails on member turns >60s** (#1778). Hub→member A2A
+  dispatch built its client with a flat 60s timeout on every request — but protoAgent's own
+  A2A server answers `SendMessage` **synchronously**, holding the connection open for the whole
+  delegated turn before returning the final Message. So any non-trivial member turn (tool calls +
+  reasoning) blew the 60s read and the lead silently fell back to answering itself; the 300s poll
+  never engaged because a synchronous peer returns a Message, not a Task envelope. The initial
+  read budget now tracks the delegate's **`poll_timeout_s`** (default 300s) instead of the flat
+  60s — connect stays short (10s) so an unreachable peer still fails fast, and an explicit per-call
+  `timeout` still overrides. Raising `poll_timeout_s` now lifts the ceiling for both synchronous
+  and async peers, matching what the setting says it does. This is what made a delegating fleet
+  (a lead + specialist members) actually usable for real work rather than trivial ACKs.
+
 ## [0.90.0] - 2026-07-04
 
 ### Added

--- a/docs/adr/0072-fleet-seed-team-via-config.md
+++ b/docs/adr/0072-fleet-seed-team-via-config.md
@@ -147,9 +147,10 @@ lead config seed + fleet seed + N archetype bundles.
 2. **Per-member secrets** — overrides can reference `*_env` / `credentialsEnv`, but a
    team with distinct per-member credentials needs a story for routing secrets to the
    right member's `secrets.yaml` at seed time.
-3. **Delegation cost** — teams multiply delegate traffic; #1778 (the 60s synchronous
-   `SendMessage` timeout) should land first or the team's delegations silently fall
-   back on any non-trivial member turn.
+3. **Delegation cost** — teams multiply delegate traffic. ✅ **Resolved:** #1778 (the flat
+   60s synchronous `SendMessage` timeout that silently dropped any non-trivial member turn)
+   is fixed — the read budget now tracks `poll_timeout_s`, so a delegating team is usable for
+   real work, not just trivial ACKs. Per-member concurrency/rate limits remain a future concern.
 4. **Remote members** — the manifest assumes local (loopback) members. A `url:` escape
    hatch for a member that lives on another host (ADR 0042 remote members) is a natural
    extension but out of scope here.

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -231,8 +231,10 @@ class A2aAdapter(Adapter):
                 "number",
                 default=300,
                 help="Max seconds to wait for a long-running delegated task to finish before "
-                "giving up locally — the peer keeps working. Raise it for slow agents (e.g. a "
-                "code build); the old fixed 30s cut long tasks off mid-flight.",
+                "giving up locally — the peer keeps working. Also caps the initial synchronous "
+                "SendMessage read, so a peer that answers inline (protoAgent's own server does) "
+                "may legitimately take up to this long to reply — the old flat 60s hard-failed "
+                "every member turn beyond it (#1778). Raise it for slow agents (e.g. a code build).",
             ),
         ]
 
@@ -307,10 +309,17 @@ class A2aAdapter(Adapter):
         poll_timeout = d.poll_timeout_s if d.poll_timeout_s and d.poll_timeout_s > 0 else 300.0
         # A2A 1.0 (a2a-sdk >=1.0): JSON-RPC `SendMessage` / `GetTask`, the ROLE_USER
         # enum, and a `result.task` envelope. (`message/send` + lowercase `user` is
-        # the v0.3 legacy dialect, which 1.0 servers reject with -32601.) The per-request
-        # client timeout caps a single call; the poll DEADLINE caps the overall wait for a
-        # long-running task — so a 2-minute delegated task no longer fails at the old 30s.
-        async with httpx.AsyncClient(timeout=timeout or 60) as client:
+        # the v0.3 legacy dialect, which 1.0 servers reject with -32601.)
+        #
+        # A *synchronous* peer — protoAgent's own A2A server answers SendMessage INLINE,
+        # holding the connection open for the whole delegated turn before returning the final
+        # Message — so the initial SendMessage READ must be allowed to run as long as the task
+        # legitimately might (poll_timeout), NOT the flat 60s that hard-failed every member turn
+        # >60s (#1778: hub→member delegation silently fell back on any non-trivial turn). Connect
+        # stays short so an unreachable peer still fails fast; the same client serves the GetTask
+        # poll loop, which returns quickly regardless. An explicit ``timeout`` still overrides.
+        read_budget = timeout if timeout is not None else poll_timeout
+        async with httpx.AsyncClient(timeout=httpx.Timeout(read_budget, connect=10.0)) as client:
             result = await _rpc(
                 client,
                 "SendMessage",

--- a/tests/test_delegate_a2a_robustness.py
+++ b/tests/test_delegate_a2a_robustness.py
@@ -145,3 +145,43 @@ def test_dispatch_returns_immediate_text(patched):
     _install_client(patched, send_resp=_Resp({"jsonrpc": "2.0", "result": {"text": "pong"}}))
     d = _parse()
     assert asyncio.run(A.dispatch(d, "ping")) == "pong"
+
+
+# ── #1778: the synchronous SendMessage read follows poll_timeout, not a flat 60s ──
+
+
+def _capture_client_timeout(patched, **fake_kw):
+    """Install a fake AsyncClient that records the httpx timeout it was built with."""
+    captured: dict = {}
+
+    def _client(**client_kw):
+        captured["timeout"] = client_kw.get("timeout")
+        return _FakeClient(**fake_kw, **client_kw)
+
+    patched.setattr(httpx, "AsyncClient", _client)
+    return captured
+
+
+def test_sync_read_timeout_tracks_poll_timeout(patched):
+    """A synchronous A2A peer holds the SendMessage connection open for the whole turn,
+    so the read budget must be poll_timeout_s — NOT the old flat 60s that hard-failed
+    every member turn >60s (#1778). Connect stays short so unreachable peers still fail fast."""
+    patched.setattr("tools.a2a_parse._extract_text", lambda result, *a, **k: "ok" if result else "")
+    cap = _capture_client_timeout(patched, send_resp=_Resp({"jsonrpc": "2.0", "result": {"text": "ok"}}))
+    d = _parse(poll_timeout_s=180)
+
+    assert asyncio.run(A.dispatch(d, "hi")) == "ok"
+    t = cap["timeout"]
+    assert isinstance(t, httpx.Timeout)
+    assert t.read == 180.0  # the turn budget, not 60
+    assert t.connect == 10.0  # unreachable peers still fail fast
+
+
+def test_explicit_timeout_overrides_read_budget(patched):
+    """An explicit per-call timeout still wins over poll_timeout_s for the read budget."""
+    patched.setattr("tools.a2a_parse._extract_text", lambda result, *a, **k: "ok" if result else "")
+    cap = _capture_client_timeout(patched, send_resp=_Resp({"jsonrpc": "2.0", "result": {"text": "ok"}}))
+    d = _parse(poll_timeout_s=180)
+
+    assert asyncio.run(A.dispatch(d, "hi", timeout=25)) == "ok"
+    assert cap["timeout"].read == 25.0


### PR DESCRIPTION
Fixes #1778.

## The bug

Hub→member `delegate_to` **hard-failed on any member turn longer than 60s**, so a lead silently fell back to answering itself on all real work — only trivial ACK-style delegations survived.

The a2a adapter built its client as `httpx.AsyncClient(timeout=timeout or 60)` — a flat **60s on every request, including the initial `SendMessage`**. But protoAgent's own A2A server answers `SendMessage` **synchronously**: it runs the entire delegated turn and only then returns the final Message, holding the HTTP connection open the whole time. So a member turn with tool calls + reasoning (routinely >60s) blew the 60s read timeout.

The existing 300s poll deadline never helped — it only engages when the peer returns a **Task envelope** (`result.task` + non-terminal state). A synchronous peer returns a *Message*, not a task, so the poll path is never entered.

## The fix

The initial read budget now tracks the delegate's existing **`poll_timeout_s`** (default 300s) instead of the flat 60s:

```python
read_budget = timeout if timeout is not None else poll_timeout
async with httpx.AsyncClient(timeout=httpx.Timeout(read_budget, connect=10.0)) as client:
```

- **Read** = `poll_timeout_s` — a synchronous peer may legitimately hold the connection for the whole turn.
- **Connect** stays short (10s) — an unreachable peer still fails fast, unchanged.
- An explicit per-call `timeout` still overrides.
- The same client serves the `GetTask` poll loop (returns quickly regardless), so the async path is unaffected.

Net: raising `poll_timeout_s` now lifts the ceiling for **both** synchronous and async peers — matching exactly what the setting says it does ("max seconds to wait for a long-running delegated task"). No new config; no server/executor change.

## Why it matters

This is the gap **ADR 0072 flagged as must-fix** for a delegating team (a lead + specialist members) to be usable for real work rather than trivial ACKs (Open Question #3 — now marked resolved). Dogfooded live on jon's content team (jon → cindi/matt): member turns that previously timed out at 60s now complete.

Scope note: the openai-compat and ACP adapters have their own timeout models and aren't part of this A2A path; left as-is.

## Tests

`tests/test_delegate_a2a_robustness.py` — the read budget tracks `poll_timeout_s` (connect stays 10s); an explicit per-call `timeout` overrides. Full delegates suite green (63 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)