### PR TITLE
docs(fleet): add "Deploying a team — config-as-code" section

### DIFF
--- a/docs/guides/fleet.md
+++ b/docs/guides/fleet.md
@@ -130,6 +130,48 @@ a `fleet.json` registry. Because each agent's chat history is scoped to its own
 checkpoints, a **stopped agent's session resumes** when you restart it — and a **running**
 one keeps its background work (schedules, an in-flight loop) going while you're elsewhere.
 
+## Deploying a team — config-as-code (`fleet.autostart`)
+
+The commands above are **imperative** — you create members and start them by hand. That's
+fine at the console, but a team you *deploy* (a lead plus the specialist members it delegates
+to) should be a **config-as-code artifact**: baked into an image, versioned, and stood up with
+one `docker compose up`. Two pieces make that real.
+
+**1. Declare the crew — `fleet.autostart`.** A container recreate (an image roll) or a host
+restart kills the members' detached processes; `fleet.json` survives in the volume with
+now-dead pids, but nothing restarts them — so a hand-assembled crew silently stays down until
+you re-activate each one. List the members the hub should keep up and it **(re)starts them on
+boot**:
+
+```yaml
+fleet:
+  autostart: [cindi, matt]   # member ids or display names
+```
+
+(or `PROTOAGENT_FLEET_AUTOSTART=cindi,matt` in the environment). It runs right after the boot
+version-reconcile: **idempotent** (an already-running member is skipped), **best-effort** (a
+missing workspace or a failed spawn is logged and skipped — never blocks boot), and **hub-only**
+(a member's own scoped config carries no roster, so it no-ops inside a member).
+
+**2. Bake the lead + personas as seeds.** The lead's own config and persona seed from
+`PROTOAGENT_SEED_CONFIG` and `PROTOAGENT_SEED_SOUL` on first boot (seed-not-force — operator
+edits persist), so the whole team ships in one image with no wizard. See
+[Deploy with Docker](./deploy-docker.md) for the seed pattern and the volume-shadow traps it
+avoids.
+
+Put together, a deployed team is **lead config seed + persona seed + `fleet.autostart` roster +
+[`delegate_to`](./delegates.md) wiring** — `docker compose up` brings up the lead, restarts the
+crew, and hands real work to them (delegation is reliable past 60s as of
+[#1788](https://github.com/protoLabsAI/protoAgent/pull/1788); a member's turn budget is its
+delegate `poll_timeout_s`).
+
+> **Reproducible-from-zero is the next step, not this one.** `fleet.autostart` reconciles members
+> that already **exist** (created via the console, `POST /api/fleet`, or `--from`/`--bundle`) and
+> references them by id/name — so a full volume wipe that must recreate them from scratch is out of
+> scope. Creating members from archetypes, auto-deriving the lead's delegates, and a shared commons
+> — a whole team from a single baked manifest — is [ADR 0072](../adr/0072-fleet-seed-team-via-config.md)'s
+> `PROTOAGENT_SEED_FLEET`; `fleet.autostart` is its first shipped slice.
+
 ## The unified console — every agent in one UI
 
 *(Shipped — ADR 0042 slices 2–5.)* The **hub** (any running agent) serves one console and
@@ -189,6 +231,8 @@ vA.B.C — features may misbehave"). Upgrade the lagging side to clear it.
 
 - ADRs: [0040 bundles](../adr/0040-plugin-bundles.md) ·
   [0041 workspaces & tiered stores](../adr/0041-workspaces-and-tiered-stores.md) ·
-  [0042 fleet supervisor & unified console](../adr/0042-fleet-supervisor-unified-console.md)
-- Guides: [multi-instance scoping](./multi-instance.md) · [plugins](./plugins.md) ·
+  [0042 fleet supervisor & unified console](../adr/0042-fleet-supervisor-unified-console.md) ·
+  [0072 fleet seed / team-via-config](../adr/0072-fleet-seed-team-via-config.md)
+- Guides: [deploy with Docker](./deploy-docker.md) · [delegates](./delegates.md) ·
+  [multi-instance scoping](./multi-instance.md) · [plugins](./plugins.md) ·
   [install & publish plugins](./plugin-registry.md) · [skills](./skills.md)


### PR DESCRIPTION
## Why

`docs/guides/fleet.md` documented only the **imperative** flow — console/CLI `workspace new`, keep-N-warm, remote members. It said nothing about standing up a **team from config**, which is exactly the promise ADR 0072 makes ("A team becomes a config-as-code artifact … and documentable — *stand up a protoAgent team via config*") and what the primitives we just shipped now support. This closes that gap and doubles as the reference for the blog/learning writeup.

## What

A new **"Deploying a team — config-as-code (`fleet.autostart`)"** section that stitches the shipped pieces into one narrative:

- **`fleet.autostart`** — declare the crew (member ids/names, or `PROTOAGENT_FLEET_AUTOSTART`); the hub (re)starts them on boot after a container roll / host restart. Idempotent, best-effort, hub-only.
- **`PROTOAGENT_SEED_CONFIG` + `PROTOAGENT_SEED_SOUL`** — bake the lead's config + persona as first-boot seeds (→ [deploy-docker](./deploy-docker.md)).
- **`delegate_to`** wiring — and a note that delegation is now reliable past 60s (#1788).
- Net: a deployed team = **config seed + persona seed + autostart roster + delegate wiring**, up with one `docker compose up`.

Plus an honest boundary callout: `fleet.autostart` reconciles members that **already exist** (by id/name); reproducible-from-zero (create from archetypes + auto-derive delegates + commons) is ADR 0072's pending `PROTOAGENT_SEED_FLEET` manifest, of which autostart is the first shipped slice. "See also" gains deploy-docker, delegates, and ADR 0072.

Docs-only; `tests/test_docs_plugin.py` green (10 passed), all internal links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)