### PR TITLE
feat(memory): make the Injections view legible — plain-language counts + a detail dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `timeout` still overrides. Raising `poll_timeout_s` now lifts the ceiling for both synchronous
   and async peers, matching what the setting says it does. This is what made a delegating fleet
   (a lead + specialist members) actually usable for real work rather than trivial ACKs.
+### Changed
+- **Memory ▸ Injections is legible to non-developers** (ADR 0069 D6/D7). The per-turn record
+  was a forensics table of comma-joined raw ids (digest sessions · hot chunks · RAG chunks) —
+  meaningless unless you knew the schema. It's now a plain-language table — **when** · **what it
+  used** (e.g. `3 memories · 2 past chats · 4 docs`, derived from the id-array lengths, no backend
+  needed) · **context** (`~N tokens`) — and each row is clickable. A new
+  `GET /api/memory/injections/{id}` resolves that record's ids into their actual content, shown in
+  a detail dialog grouped as **Past conversations** (session titles), **Memories** (heading +
+  snippet), and **Docs** (source + snippet); a chunk that was pruned/deleted renders as
+  "no longer stored" rather than failing. Best-effort throughout — a missing knowledge store or a
+  gone chunk never 500s the dialog.
 
 ## [0.90.0] - 2026-07-04
 

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -847,6 +847,33 @@ export const MEMORY_INJECTIONS = [
   },
 ];
 
+// Resolved detail (GET /api/memory/injections/{id}) keyed by record id — the ids
+// above turned into their referenced content for the click-through dialog. Row 7
+// exercises every group (a pruned doc is marked unavailable).
+export const MEMORY_INJECTION_DETAILS = {
+  7: {
+    ts: "2026-06-30T18:05:00+00:00",
+    session_id: "chat-1750000000000-abc123",
+    approx_tokens: 420,
+    past_sessions: [{ id: "sched-hourly-report", title: "send the hourly report" }],
+    memories: [
+      { id: 31, heading: "Operator timezone", snippet: "The operator works in US/Pacific.", unavailable: false },
+      { id: 32, heading: null, snippet: "Weekly report goes out Fridays at 9am.", unavailable: false },
+    ],
+    docs: [{ id: 11, source: null, snippet: null, unavailable: true }],
+  },
+  6: {
+    ts: "2026-06-30T17:01:00+00:00",
+    session_id: "sched-hourly-report",
+    approx_tokens: 120,
+    past_sessions: [],
+    memories: [
+      { id: 31, heading: "Operator timezone", snippet: "The operator works in US/Pacific.", unavailable: false },
+    ],
+    docs: [],
+  },
+};
+
 // Delegate registry (ADR 0025) — types schema + a sample roster for the panel.
 export const DELEGATE_TYPES = {
   types: [

--- a/apps/web/e2e/memory-inspector.spec.ts
+++ b/apps/web/e2e/memory-inspector.spec.ts
@@ -97,24 +97,47 @@ test("editing a hot-memory entry saves via PUT, toasts, and shows the revision",
   await expect(surface.getByText("The operator works in US/Pacific.")).toHaveCount(0);
 });
 
-test("Injections panel shows the per-turn record and filters by session id", async ({ page }) => {
+test("Injections panel shows a plain-language per-turn record and filters by session id", async ({ page }) => {
   const surface = page.getByTestId("memory-surface");
   await surface.getByRole("tab", { name: "Injections" }).click();
 
-  // Both fixture rows, with their injected ids visible.
+  // Both fixture rows, with a plain-language "what it used" summary (built from
+  // the id-array lengths) instead of raw ids: row 7 = 2 hot chunks · 1 digest
+  // session · 1 RAG chunk.
   const table = surface.locator(".memory-injections");
   await expect(table.locator("tbody tr")).toHaveCount(2);
-  await expect(table.getByText("31, 32")).toBeVisible(); // hot chunk ids
-  await expect(table.getByText("sched-hourly-report").first()).toBeVisible();
+  await expect(table.getByText("2 memories · 1 past chat · 1 doc")).toBeVisible();
+  await expect(table.getByText("~420 tokens")).toBeVisible();
+  await expect(table.getByText("31, 32")).toHaveCount(0); // no raw ids in the table
 
   // Filtering to one session narrows the table (the input debounces ~250ms
   // before the query refires; the assertions auto-wait through it). The
   // placeholder says the match is EXACT — it's a lookup, not a substring search.
   const filterInput = surface.getByLabel("filter injections by session id");
-  await expect(filterInput).toHaveAttribute("placeholder", "Exact session id (blank = all sessions)…");
+  await expect(filterInput).toHaveAttribute("placeholder", "Filter by exact chat/session id (blank = all)…");
   await filterInput.fill("sched-hourly-report");
   await expect(table.locator("tbody tr")).toHaveCount(1);
-  await expect(table.getByText("chat-1750000000000-abc123")).toHaveCount(0);
+  await expect(table.getByText("2 memories · 1 past chat · 1 doc")).toHaveCount(0);
+});
+
+test("clicking an injection row opens the resolved-detail dialog", async ({ page }) => {
+  const surface = page.getByTestId("memory-surface");
+  await surface.getByRole("tab", { name: "Injections" }).click();
+
+  // Open the first row's detail — the resolve endpoint turns its ids into content.
+  await surface.locator(".memory-injections-row").first().click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("What this turn used")).toBeVisible();
+
+  // Grouped, friendly headings + the actual items (not ids).
+  await expect(dialog.getByText("Past conversations (1)")).toBeVisible();
+  await expect(dialog.getByText("send the hourly report")).toBeVisible();
+  await expect(dialog.getByText("Memories (2)")).toBeVisible();
+  await expect(dialog.getByText("Operator timezone")).toBeVisible();
+  await expect(dialog.getByText("The operator works in US/Pacific.")).toBeVisible();
+  // A pruned doc chunk renders gracefully rather than vanishing.
+  await expect(dialog.getByText("Docs (1)")).toBeVisible();
+  await expect(dialog.getByText("no longer stored")).toBeVisible();
 });
 
 test("a session row's injections jump pre-filters the Injections panel", async ({ page }) => {
@@ -186,7 +209,7 @@ test("each tab shows its contained error alert when the backend read fails", asy
 
   await page.request.post("/api/__test__/memory/mode", { data: { fail: "injections" } });
   await surface.getByRole("tab", { name: "Injections" }).click();
-  await expect(surface.getByText(/Couldn't read the injection log/)).toBeVisible();
+  await expect(surface.getByText(/Couldn't read the memory record/)).toBeVisible();
 });
 
 test("empty stores render the Empty states, not errors", async ({ page }) => {
@@ -198,7 +221,7 @@ test("empty stores render the Empty states, not errors", async ({ page }) => {
   await surface.getByRole("tab", { name: "Hot memory" }).click();
   await expect(surface.getByText("No hot memory")).toBeVisible();
   await surface.getByRole("tab", { name: "Injections" }).click();
-  await expect(surface.getByText("No injection records")).toBeVisible();
+  await expect(surface.getByText("Nothing here yet")).toBeVisible();
 });
 
 test("a disabled knowledge store shows the store-off notice on the hot tab", async ({ page }) => {

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -33,6 +33,7 @@ import {
   KNOWLEDGE_CHUNKS,
   MEMORY_HOT,
   MEMORY_INJECTIONS,
+  MEMORY_INJECTION_DETAILS,
   MEMORY_SESSIONS,
   MEMORY_SESSION_RENDERED,
   SUBAGENTS,
@@ -499,6 +500,15 @@ const server = createServer(async (req, res) => {
           ? MEMORY_INJECTIONS.filter((r) => r.session_id === sid)
           : MEMORY_INJECTIONS;
         return sendJson(res, { injections: rows });
+      }
+      {
+        // Resolved detail for the click-through dialog (ids → content, grouped).
+        const m = pathname.match(/^\/api\/memory\/injections\/([^/]+)$/);
+        if (m) {
+          const detail = MEMORY_INJECTION_DETAILS[m[1]];
+          if (!detail) return sendJson(res, { detail: "no injection record with that id" }, 404);
+          return sendJson(res, detail);
+        }
       }
       const payload = handleApiGet(pathname, fleetFor(req));
       if (payload !== null) return sendJson(res, payload);

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -26,6 +26,7 @@ import type {
   PluginUpdate,
   KnowledgeChunk,
   MemoryHotChunk,
+  MemoryInjectionDetail,
   MemoryInjectionRow,
   MemorySessionDigest,
   RuntimeStatus,
@@ -868,6 +869,12 @@ export const api = {
     if (sessionId) q.set("session_id", sessionId);
     q.set("limit", String(limit));
     return request<{ injections: MemoryInjectionRow[] }>(`/api/memory/injections?${q}`);
+  },
+  // One record's ids RESOLVED to their content, grouped for the detail dialog
+  // (past conversations · memories · docs). Chunks that no longer resolve come
+  // back marked `unavailable`.
+  memoryInjectionDetail(id: number) {
+    return request<MemoryInjectionDetail>(`/api/memory/injections/${id}`);
   },
 
   // Chat attachment — extract + TIER a dropped file (FormData: `file` + `session_id`).

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -32,6 +32,7 @@ export const queryKeys = {
   memorySessions: ["memory", "sessions"] as const,
   memoryHot: ["memory", "hot"] as const,
   memoryInjections: ["memory", "injections"] as const,
+  memoryInjectionDetail: (id: number) => ["memory", "injections", "detail", id] as const,
 };
 
 // The fleet of workspace agents (ADR 0042). `running` is a live-pid probe, so poll

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -794,6 +794,32 @@ export type MemoryInjectionRow = {
   approx_tokens: number;
 };
 
+// The RESOLVED detail for one injection record (GET /api/memory/injections/{id}):
+// the id arrays turned into their referenced content, grouped for the detail
+// dialog. An item whose underlying chunk was pruned/deleted comes back
+// `unavailable` (the dialog shows "no longer stored") rather than dropping it.
+export type InjectionPastSession = { id: string; title: string | null };
+export type InjectionMemoryItem = {
+  id: number;
+  heading: string | null;
+  snippet: string | null;
+  unavailable: boolean;
+};
+export type InjectionDocItem = {
+  id: number;
+  source: string | null;
+  snippet: string | null;
+  unavailable: boolean;
+};
+export type MemoryInjectionDetail = {
+  ts: string;
+  session_id: string;
+  past_sessions: InjectionPastSession[];
+  memories: InjectionMemoryItem[];
+  docs: InjectionDocItem[];
+  approx_tokens: number;
+};
+
 // Delegate registry (ADR 0025) — the agents & endpoints the agent can talk to.
 export type DelegateFieldSpec = {
   key: string;

--- a/apps/web/src/memory/MemorySurface.tsx
+++ b/apps/web/src/memory/MemorySurface.tsx
@@ -3,7 +3,7 @@ import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tansta
 import { Alert } from "@protolabsai/ui/data";
 import { Input, Textarea } from "@protolabsai/ui/forms";
 import { PanelHeader, Tabs } from "@protolabsai/ui/navigation";
-import { ConfirmDialog, useToast } from "@protolabsai/ui/overlays";
+import { ConfirmDialog, Dialog, Tooltip, useToast } from "@protolabsai/ui/overlays";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { Flame, History, Pencil, Syringe, Trash2 } from "lucide-react";
 
@@ -12,8 +12,14 @@ import { openDocument } from "../docviewer";
 import { api } from "../lib/api";
 import { ago, bytes, errMsg } from "../lib/format";
 import { queryKeys } from "../lib/queries";
-import type { MemoryHotChunk, MemorySessionDigest } from "../lib/types";
+import type {
+  MemoryHotChunk,
+  MemoryInjectionDetail,
+  MemoryInjectionRow,
+  MemorySessionDigest,
+} from "../lib/types";
 
+import { injectionSummary } from "./injectionSummary";
 import "./memory.css";
 
 // Memory inspector (ADR 0069 D7) — the audit surface over the memory DELIVERY
@@ -411,60 +417,166 @@ function InjectionsPanel({ filter, setFilter }: { filter: string; setFilter: (v:
   });
   const rows = data?.injections ?? [];
 
-  const idList = (ids: Array<string | number>) =>
-    ids.length ? <code>{ids.join(", ")}</code> : <span className="memory-none">—</span>;
+  // The record whose detail dialog is open (null = closed). The dialog resolves
+  // this record's ids → their actual content on open.
+  const [openRow, setOpenRow] = useState<MemoryInjectionRow | null>(null);
 
   return (
     <>
       <div className="memory-panel-head">
         <p className="memory-panel-hint">
-          The per-turn injection record — which digest sessions, hot chunks, and RAG chunks
-          entered each model call. This is the "why did it say that?" / poisoning-forensics
-          trail.
+          What the agent pulled into memory for each turn — click a row to see exactly what.
         </p>
         <RefreshButton onClick={() => void refetch()} busy={isFetching} />
       </div>
       <Input
         type="search"
-        placeholder="Exact session id (blank = all sessions)…"
+        placeholder="Filter by exact chat/session id (blank = all)…"
         value={input}
         onChange={(e) => setInput(e.target.value)}
         aria-label="filter injections by session id"
       />
-      {error ? <Alert status="error">Couldn't read the injection log — {errMsg(error)}</Alert> : null}
+      {error ? <Alert status="error">Couldn't read the memory record — {errMsg(error)}</Alert> : null}
       {!error && rows.length === 0 ? (
         <Empty
-          title="No injection records"
-          description={filter ? "no recorded turns for that session id." : "records appear as turns run."}
+          title="Nothing here yet"
+          description={
+            filter ? "no turns recorded for that id." : "each turn the agent takes shows up here."
+          }
         />
       ) : (
         <table className="memory-injections">
           <thead>
             <tr>
               <th>when</th>
-              <th>session</th>
-              <th>digest sessions</th>
-              <th>hot chunks</th>
-              <th>RAG chunks</th>
-              <th>~tokens</th>
+              <th>what it used</th>
+              <th>context</th>
             </tr>
           </thead>
           <tbody>
             {rows.map((r) => (
-              <tr key={r.id}>
-                <td title={r.ts}>{ago(r.ts)}</td>
+              <tr
+                key={r.id}
+                className="memory-injections-row"
+                role="button"
+                tabIndex={0}
+                aria-label={`${ago(r.ts)} — used ${injectionSummary(r)}; open details`}
+                onClick={() => setOpenRow(r)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setOpenRow(r);
+                  }
+                }}
+              >
                 <td>
-                  <code>{r.session_id}</code>
+                  {/* DS Tooltip (never HTML title=) surfaces the exact timestamp. */}
+                  <Tooltip label={r.ts}>
+                    <span>{ago(r.ts)}</span>
+                  </Tooltip>
                 </td>
-                <td>{idList(r.digest_session_ids)}</td>
-                <td>{idList(r.hot_chunk_ids)}</td>
-                <td>{idList(r.rag_chunk_ids)}</td>
-                <td>{r.approx_tokens}</td>
+                <td className="memory-injections-what">{injectionSummary(r)}</td>
+                <td className="memory-injections-context">~{r.approx_tokens} tokens</td>
               </tr>
             ))}
           </tbody>
         </table>
       )}
+      {openRow ? <InjectionDetailDialog row={openRow} onClose={() => setOpenRow(null)} /> : null}
     </>
+  );
+}
+
+// The click-through detail: resolves ONE injection record's ids into the actual
+// items the turn used, grouped (past conversations · memories · docs). Fetches
+// on open (the table itself needs no resolve — its counts are the id arrays).
+function InjectionDetailDialog({
+  row,
+  onClose,
+}: {
+  row: MemoryInjectionRow;
+  onClose: () => void;
+}) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: queryKeys.memoryInjectionDetail(row.id),
+    queryFn: () => api.memoryInjectionDetail(row.id),
+  });
+
+  return (
+    <Dialog open onClose={onClose} title="What this turn used" width="min(560px, 94vw)">
+      {/* Time + cost render immediately from the row we already have. */}
+      <p className="memory-detail-meta">
+        {ago(row.ts)} · ~{row.approx_tokens} tokens
+      </p>
+      {isLoading ? (
+        <p className="memory-panel-hint">Loading the details…</p>
+      ) : error ? (
+        <Alert status="error">Couldn't load the details — {errMsg(error)}</Alert>
+      ) : data ? (
+        <InjectionDetailBody detail={data} />
+      ) : null}
+    </Dialog>
+  );
+}
+
+function InjectionDetailBody({ detail }: { detail: MemoryInjectionDetail }) {
+  const isEmpty =
+    detail.past_sessions.length === 0 && detail.memories.length === 0 && detail.docs.length === 0;
+  if (isEmpty) {
+    return <p className="memory-panel-hint">This turn didn't pull in any stored memory.</p>;
+  }
+  return (
+    <div className="memory-detail">
+      {detail.past_sessions.length ? (
+        <section className="memory-detail-group">
+          <h4>Past conversations ({detail.past_sessions.length})</h4>
+          <ul>
+            {detail.past_sessions.map((s) => (
+              <li key={s.id}>
+                <span className="memory-detail-line">{s.title || s.id}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      {detail.memories.length ? (
+        <section className="memory-detail-group">
+          <h4>Memories ({detail.memories.length})</h4>
+          <ul>
+            {detail.memories.map((m) => (
+              <li key={m.id}>
+                {m.unavailable ? (
+                  <span className="memory-detail-gone">no longer stored</span>
+                ) : (
+                  <>
+                    {m.heading ? <strong className="memory-detail-heading">{m.heading}</strong> : null}
+                    {m.snippet ? <span className="memory-detail-snippet">{m.snippet}</span> : null}
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      {detail.docs.length ? (
+        <section className="memory-detail-group">
+          <h4>Docs ({detail.docs.length})</h4>
+          <ul>
+            {detail.docs.map((d) => (
+              <li key={d.id}>
+                {d.unavailable ? (
+                  <span className="memory-detail-gone">no longer stored</span>
+                ) : (
+                  <>
+                    {d.source ? <span className="memory-detail-source">{d.source}</span> : null}
+                    {d.snippet ? <span className="memory-detail-snippet">{d.snippet}</span> : null}
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/memory/injectionSummary.test.ts
+++ b/apps/web/src/memory/injectionSummary.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { NOTHING_USED, injectionSummary } from "./injectionSummary";
+
+// Build a counts-shaped row with arrays of the given lengths (contents are
+// irrelevant — the summary reads only lengths).
+function row(hot: number, digest: number, rag: number) {
+  const fill = (n: number) => Array.from({ length: n }, (_, i) => i);
+  return { hot_chunk_ids: fill(hot), digest_session_ids: fill(digest), rag_chunk_ids: fill(rag) };
+}
+
+describe("injectionSummary", () => {
+  it("joins all three groups in memories → past chats → docs order", () => {
+    expect(injectionSummary(row(3, 2, 4))).toBe("3 memories · 2 past chats · 4 docs");
+  });
+
+  it("uses singular labels for a single item in each group", () => {
+    expect(injectionSummary(row(1, 1, 1))).toBe("1 memory · 1 past chat · 1 doc");
+  });
+
+  it("drops empty groups rather than showing a zero", () => {
+    expect(injectionSummary(row(2, 0, 0))).toBe("2 memories");
+    expect(injectionSummary(row(0, 0, 5))).toBe("5 docs");
+    expect(injectionSummary(row(0, 1, 3))).toBe("1 past chat · 3 docs");
+  });
+
+  it("shows a dash when the turn injected nothing extra", () => {
+    expect(injectionSummary(row(0, 0, 0))).toBe(NOTHING_USED);
+  });
+});

--- a/apps/web/src/memory/injectionSummary.ts
+++ b/apps/web/src/memory/injectionSummary.ts
@@ -1,0 +1,36 @@
+// Plain-language "what it used" summary for one injection record — the legible
+// replacement for the old forensics columns of comma-joined raw ids. Built
+// purely from the id-array LENGTHS the list route already returns, so the table
+// needs no backend resolve; the detail dialog fetches the actual items on click.
+//
+// The forensic id groups map to friendly names (ADR 0069 D6):
+//   hot_chunk_ids      → "memories"     (always-on hot memory)
+//   digest_session_ids → "past chats"   (prior-session digest)
+//   rag_chunk_ids      → "docs"         (knowledge retrieval)
+// Empty groups are dropped; when the turn injected nothing extra we show a dash.
+
+// Only the length of each id group matters here, so accept the widest shape.
+type InjectionCounts = {
+  digest_session_ids: readonly unknown[];
+  hot_chunk_ids: readonly unknown[];
+  rag_chunk_ids: readonly unknown[];
+};
+
+// The em dash the console uses elsewhere for an empty memory cell (.memory-none).
+export const NOTHING_USED = "—";
+
+function count(n: number, singular: string, plural: string): string {
+  return `${n} ${n === 1 ? singular : plural}`;
+}
+
+// e.g. `3 memories · 2 past chats · 4 docs`. Groups appear memories → past chats
+// → docs, matching the detail dialog's order; a group with zero items is omitted.
+// All three empty → `NOTHING_USED`.
+export function injectionSummary(row: InjectionCounts): string {
+  const parts: string[] = [];
+  if (row.hot_chunk_ids.length) parts.push(count(row.hot_chunk_ids.length, "memory", "memories"));
+  if (row.digest_session_ids.length)
+    parts.push(count(row.digest_session_ids.length, "past chat", "past chats"));
+  if (row.rag_chunk_ids.length) parts.push(count(row.rag_chunk_ids.length, "doc", "docs"));
+  return parts.length ? parts.join(" · ") : NOTHING_USED;
+}

--- a/apps/web/src/memory/memory.css
+++ b/apps/web/src/memory/memory.css
@@ -89,33 +89,104 @@
   line-height: 1.5;
 }
 
-/* Injection-record table — a forensics readout, clarity over polish. */
+/* Injection-record table — legible per-turn "what did it use?" readout. Each
+   row is a clickable affordance opening the resolved-detail dialog. */
 .memory-injections {
   width: 100%;
   margin-top: 0.6rem;
   border-collapse: collapse;
-  font-size: 0.8rem;
+  font-size: 0.85rem;
 }
 
 .memory-injections th,
 .memory-injections td {
   text-align: left;
   vertical-align: top;
-  padding: 0.35rem 0.5rem;
+  padding: 0.45rem 0.5rem;
   border-bottom: 1px solid var(--pl-color-border, rgba(128, 128, 128, 0.25));
 }
 
 .memory-injections th {
   font-weight: 600;
+  font-size: 0.75rem;
   color: var(--pl-color-text-muted, #8a8f98);
 }
 
-.memory-injections code {
-  font-size: 0.75rem;
-  overflow-wrap: anywhere;
+.memory-injections-row {
+  cursor: pointer;
+}
+
+.memory-injections-row:hover,
+.memory-injections-row:focus-visible {
+  background: var(--pl-color-surface-2, rgba(128, 128, 128, 0.08));
+  outline: none;
+}
+
+.memory-injections-what {
+  font-weight: 500;
+}
+
+.memory-injections-context {
+  color: var(--pl-color-text-muted, #8a8f98);
+  white-space: nowrap;
 }
 
 .memory-none {
+  color: var(--pl-color-text-muted, #8a8f98);
+}
+
+/* Injection detail dialog — the resolved items, grouped + scannable. */
+.memory-detail-meta {
+  margin: 0 0 0.75rem;
+  font-size: 0.78rem;
+  color: var(--pl-color-text-muted, #8a8f98);
+}
+
+.memory-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.memory-detail-group h4 {
+  margin: 0 0 0.4rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--pl-color-text-muted, #8a8f98);
+}
+
+.memory-detail-group ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.memory-detail-group li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.85rem;
+  overflow-wrap: anywhere;
+}
+
+.memory-detail-heading {
+  font-weight: 600;
+}
+
+.memory-detail-source {
+  font-size: 0.78rem;
+  color: var(--pl-color-text-muted, #8a8f98);
+}
+
+.memory-detail-snippet {
+  color: var(--pl-color-text, inherit);
+}
+
+.memory-detail-gone {
+  font-style: italic;
   color: var(--pl-color-text-muted, #8a8f98);
 }
 

--- a/observability/injection_log.py
+++ b/observability/injection_log.py
@@ -100,6 +100,17 @@ class InjectionLog:
         finally:
             db.close()
 
+    @staticmethod
+    def _decode(row: sqlite3.Row) -> dict:
+        """One row → dict with the JSON id-columns decoded to Python lists."""
+        d = dict(row)
+        for col in _JSON_COLUMNS:
+            try:
+                d[col] = json.loads(d.get(col) or "[]")
+            except (json.JSONDecodeError, TypeError):
+                d[col] = []
+        return d
+
     def recent(self, session_id: str | None = None, limit: int = 50) -> list[dict]:
         """Injection rows, newest first, id-list columns decoded to Python lists.
 
@@ -120,16 +131,24 @@ class InjectionLog:
             return []
         finally:
             db.close()
-        out: list[dict] = []
-        for r in rows:
-            d = dict(r)
-            for col in _JSON_COLUMNS:
-                try:
-                    d[col] = json.loads(d.get(col) or "[]")
-                except (json.JSONDecodeError, TypeError):
-                    d[col] = []
-            out.append(d)
-        return out
+        return [self._decode(r) for r in rows]
+
+    def get(self, record_id: int) -> dict | None:
+        """One injection row by id (JSON id-columns decoded), or None if there is
+        no row with that id. The detail read behind
+        ``GET /api/memory/injections/{record_id}`` — the resolver turns the ids
+        this returns into their referenced content."""
+        db = self._connect()
+        try:
+            row = db.execute(
+                "SELECT * FROM injections WHERE id = ?", (int(record_id),)
+            ).fetchone()
+        except sqlite3.DatabaseError as exc:
+            log.warning("[injection-log] get failed: %s", exc)
+            return None
+        finally:
+            db.close()
+        return self._decode(row) if row is not None else None
 
 
 # ---------------------------------------------------------------------------

--- a/operator_api/injection_routes.py
+++ b/operator_api/injection_routes.py
@@ -12,6 +12,94 @@ other's files.
 
 from __future__ import annotations
 
+import logging
+
+log = logging.getLogger("protoagent.server")
+
+# Snippet cap for a resolved chunk's body in the detail dialog — enough to
+# recognize the item, short enough to keep the grouped lists scannable.
+_SNIPPET_MAX = 200
+
+
+def _clip(text: str, limit: int = _SNIPPET_MAX) -> str:
+    """Collapse whitespace and clip to ``limit`` chars (ellipsis when cut)."""
+    text = " ".join((text or "").split())
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _resolve_chunk(store, chunk_id) -> dict | None:
+    """One knowledge-store chunk row by id, best-effort. Returns None when the
+    store is off, the chunk was pruned/deleted, or the backend errors — the
+    caller renders that as an 'unavailable' item, never a 500."""
+    if store is None:
+        return None
+    try:
+        return store.get_chunk(int(chunk_id))
+    except Exception:  # noqa: BLE001 — a broken/backend-less store must not 500 the dialog
+        log.exception("[injection-detail] get_chunk(%s) failed", chunk_id)
+        return None
+
+
+def _memory_item(store, chunk_id) -> dict:
+    """A hot-memory chunk → ``{id, heading, snippet, unavailable}``."""
+    row = _resolve_chunk(store, chunk_id)
+    if row is None:
+        return {"id": chunk_id, "heading": None, "snippet": None, "unavailable": True}
+    return {
+        "id": chunk_id,
+        "heading": row.get("heading") or None,
+        "snippet": _clip(row.get("content") or ""),
+        "unavailable": False,
+    }
+
+
+def _doc_item(store, chunk_id) -> dict:
+    """A RAG (knowledge) chunk → ``{id, source, snippet, unavailable}``."""
+    row = _resolve_chunk(store, chunk_id)
+    if row is None:
+        return {"id": chunk_id, "source": None, "snippet": None, "unavailable": True}
+    return {
+        "id": chunk_id,
+        "source": row.get("source") or row.get("source_type") or None,
+        "snippet": _clip(row.get("content") or ""),
+        "unavailable": False,
+    }
+
+
+def _session_item(session_id: str) -> dict:
+    """A digest session id → ``{id, title}`` where title is the session's topic
+    (first user message, via the SAME ``digest_entry`` derivation the Sessions
+    tab shows). Best-effort: an invalid/missing/corrupt summary falls back to a
+    null title, and the console renders the id."""
+    from graph.middleware.memory import digest_entry
+    from operator_api.memory_routes import _read_summary, _session_paths
+
+    try:
+        paths = _session_paths(session_id)
+        if paths:
+            entry = digest_entry(_read_summary(paths))
+            return {"id": session_id, "title": entry.get("topic") or None}
+    except Exception:  # noqa: BLE001 — an unresolvable summary falls back to the id
+        log.exception("[injection-detail] session summary %s unresolvable", session_id)
+    return {"id": session_id, "title": None}
+
+
+def _resolve_injection(row: dict) -> dict:
+    """Turn one injection record's id arrays into the grouped, resolved content
+    the detail dialog renders. Every group is best-effort — a missing knowledge
+    store or a pruned chunk yields an 'unavailable' item, never an error."""
+    from runtime.state import STATE
+
+    store = STATE.knowledge_store
+    return {
+        "ts": row.get("ts"),
+        "session_id": row.get("session_id") or "",
+        "past_sessions": [_session_item(str(s)) for s in row.get("digest_session_ids") or []],
+        "memories": [_memory_item(store, c) for c in row.get("hot_chunk_ids") or []],
+        "docs": [_doc_item(store, c) for c in row.get("rag_chunk_ids") or []],
+        "approx_tokens": int(row.get("approx_tokens") or 0),
+    }
+
 
 def register_injection_routes(app) -> None:
     """Register the ``/api/memory/injections`` read-only route on ``app``."""
@@ -35,3 +123,22 @@ def register_injection_routes(app) -> None:
             limit=min(max(1, limit), 500),
         )
         return {"injections": rows}
+
+    @app.get("/api/memory/injections/{record_id}")
+    async def _api_memory_injection_detail(record_id: int):
+        """One injection record's ids resolved to their content, grouped for the
+        console's detail dialog: ``past_sessions`` (digest-session titles),
+        ``memories`` (hot chunks), ``docs`` (RAG chunks), plus ``ts`` /
+        ``session_id`` / ``approx_tokens``. 404 when no record has that id;
+        individual items that no longer resolve are marked ``unavailable`` rather
+        than failing the request."""
+        import asyncio
+
+        from fastapi.responses import JSONResponse
+
+        from observability.injection_log import injection_log
+
+        row = await asyncio.to_thread(injection_log().get, record_id)
+        if row is None:
+            return JSONResponse({"detail": "no injection record with that id"}, status_code=404)
+        return await asyncio.to_thread(_resolve_injection, row)

--- a/tests/test_memory_injection_controls.py
+++ b/tests/test_memory_injection_controls.py
@@ -364,3 +364,128 @@ def test_injections_route_clamps_limit(monkeypatch):
     assert captured["limit"] == 500
     c.get("/api/memory/injections", params={"limit": -5})
     assert captured["limit"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 3b) The detail route (GET /api/memory/injections/{id}) — ids → resolved,
+#     grouped content for the console's "what did this turn use?" dialog.
+# ---------------------------------------------------------------------------
+
+
+class _FakeKnowledgeStore:
+    """Minimal store exposing only the reader the resolver uses. Unknown ids
+    return None — the pruned/deleted-chunk path."""
+
+    def __init__(self, chunks: dict[int, dict]):
+        self._chunks = chunks
+
+    def get_chunk(self, chunk_id: int) -> dict | None:
+        return self._chunks.get(int(chunk_id))
+
+
+def _detail_client(monkeypatch, tmp_path, *, knowledge=None):
+    import runtime.state as rs
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from operator_api.injection_routes import register_injection_routes
+
+    # Session-summary resolution reads memory_path(); point it at tmp_path so the
+    # digest-session title comes from a summary we control (not the real store).
+    monkeypatch.setenv("MEMORY_PATH", str(tmp_path))
+    monkeypatch.setattr(rs.STATE, "knowledge_store", knowledge, raising=False)
+    app = FastAPI()
+    register_injection_routes(app)
+    return TestClient(app)
+
+
+def _last_record_id() -> int:
+    from observability.injection_log import injection_log
+
+    return injection_log().recent()[0]["id"]
+
+
+def test_injection_detail_resolves_all_groups(tmp_path, monkeypatch):
+    from observability.injection_log import injection_log
+
+    # A real summary file so the digest-session id resolves to a human title
+    # (its topic = the first user message, via digest_entry).
+    (tmp_path / "sess-prev.json").write_text(
+        json.dumps(
+            {
+                "session_id": "sess-prev",
+                "timestamp": "2026-07-01T00:00:00+00:00",
+                "messages": [{"role": "user", "content": "earlier launch topic"}],
+            }
+        )
+    )
+    store = _FakeKnowledgeStore(
+        {
+            7: {"id": 7, "heading": "Deploy cadence", "content": "deploys go out Fridays", "source": "chat-x"},
+            3: {"id": 3, "content": "gravity pulls apples", "source": "physics.pdf", "source_type": "pdf"},
+        }
+    )
+    injection_log().record(
+        session_id="sess-now",
+        digest_session_ids=["sess-prev"],
+        hot_chunk_ids=[7],
+        rag_chunk_ids=[3],
+        approx_tokens=42,
+    )
+
+    c = _detail_client(monkeypatch, tmp_path, knowledge=store)
+    body = c.get(f"/api/memory/injections/{_last_record_id()}").json()
+
+    assert body["session_id"] == "sess-now"
+    assert body["approx_tokens"] == 42
+    assert body["ts"]
+    assert body["past_sessions"] == [{"id": "sess-prev", "title": "earlier launch topic"}]
+    assert body["memories"] == [
+        {"id": 7, "heading": "Deploy cadence", "snippet": "deploys go out Fridays", "unavailable": False}
+    ]
+    assert body["docs"] == [
+        {"id": 3, "source": "physics.pdf", "snippet": "gravity pulls apples", "unavailable": False}
+    ]
+
+
+def test_injection_detail_pruned_chunk_marked_unavailable(tmp_path, monkeypatch):
+    """A hot/RAG id whose chunk was pruned (get_chunk → None) still renders — as
+    an 'unavailable' item — instead of failing the request."""
+    from observability.injection_log import injection_log
+
+    store = _FakeKnowledgeStore({})  # every id resolves to None
+    injection_log().record(session_id="s", hot_chunk_ids=[999], rag_chunk_ids=[888], approx_tokens=3)
+
+    c = _detail_client(monkeypatch, tmp_path, knowledge=store)
+    body = c.get(f"/api/memory/injections/{_last_record_id()}").json()
+
+    assert body["memories"] == [{"id": 999, "heading": None, "snippet": None, "unavailable": True}]
+    assert body["docs"] == [{"id": 888, "source": None, "snippet": None, "unavailable": True}]
+
+
+def test_injection_detail_no_knowledge_store_is_best_effort(tmp_path, monkeypatch):
+    """A missing knowledge store (middleware.knowledge off) must not 500 — every
+    chunk item comes back marked unavailable."""
+    from observability.injection_log import injection_log
+
+    injection_log().record(session_id="s", hot_chunk_ids=[1], rag_chunk_ids=[2], approx_tokens=1)
+    c = _detail_client(monkeypatch, tmp_path, knowledge=None)
+    body = c.get(f"/api/memory/injections/{_last_record_id()}").json()
+    assert body["memories"][0]["unavailable"] is True
+    assert body["docs"][0]["unavailable"] is True
+
+
+def test_injection_detail_unresolvable_session_falls_back_to_id(tmp_path, monkeypatch):
+    """A digest-session id with no summary file on disk falls back to a null
+    title (the console renders the id) rather than erroring."""
+    from observability.injection_log import injection_log
+
+    injection_log().record(session_id="s", digest_session_ids=["ghost-sess"], approx_tokens=1)
+    c = _detail_client(monkeypatch, tmp_path, knowledge=_FakeKnowledgeStore({}))
+    body = c.get(f"/api/memory/injections/{_last_record_id()}").json()
+    assert body["past_sessions"] == [{"id": "ghost-sess", "title": None}]
+
+
+def test_injection_detail_404_for_unknown_id(tmp_path, monkeypatch):
+    c = _detail_client(monkeypatch, tmp_path, knowledge=_FakeKnowledgeStore({}))
+    assert c.get("/api/memory/injections/424242").status_code == 404


### PR DESCRIPTION
## The problem

**Memory ▸ Injections** was a forensics table for developers: columns `when · session · digest sessions · hot chunks · RAG chunks · ~tokens`, where the middle three were **comma-joined raw ids** (`31, 32`, `sched-hourly-report`, …). It's the "why did it say that?" / poisoning trail (ADR 0069 D6), but a non-developer couldn't tell what any of it meant.

## The design (relabel the table + a detail dialog on click)

**Table — legible, no raw ids.** Columns are now **when** (`ago(ts)`, exact time on hover) · **what it used** · **context** (`~N tokens`). "What it used" is a plain-language summary built purely from the id-array **lengths** — `3 memories · 2 past chats · 4 docs` — mapping the forensic groups to friendly names (`hot_chunk_ids` → memories, `digest_session_ids` → past chats, `rag_chunk_ids` → docs); empty groups drop out, an all-empty turn shows a dash. **No backend needed** for the table — the counts are the id arrays the list route already returns. The session-id filter, empty/error/refresh states are kept; the hint is rewritten in plain language.

**Detail dialog — the actual items, on click.** Each row is a clickable affordance opening a DS `Dialog` that fetches the *resolved* content for that record, grouped and omitting empty groups:
- **Past conversations (N)** — each session's title (its summary's first user message).
- **Memories (M)** — heading + a short snippet.
- **Docs (K)** — source + a short snippet.

Plus the turn's time + `~tokens`. A chunk whose row was pruned/deleted renders as **"no longer stored"** rather than vanishing or erroring.

**DS `Tooltip`** (not the HTML `title=` attribute, per request) surfaces the exact timestamp on the `when` cell.

## The new detail endpoint

- `observability/injection_log.py`: `get(record_id)` — one row by id, JSON id-columns decoded (shares a new `_decode` helper with `recent()`).
- `operator_api/injection_routes.py`: `GET /api/memory/injections/{record_id}` resolves the row's ids →
  - `hot_chunk_ids` / `rag_chunk_ids` → `STATE.knowledge_store.get_chunk(id)` → `{id, heading|source, snippet}` (content clipped to ~200 chars; hot = memories, rag = docs, kept separate).
  - `digest_session_ids` → each session's human title via the Sessions-tab summary path (`_session_paths` + `_read_summary` + `graph.middleware.memory.digest_entry`), falling back to the id.
  - Returns `{ ts, session_id, past_sessions, memories, docs, approx_tokens }`.
- **Best-effort throughout**: a missing knowledge store or a gone chunk yields an item marked `unavailable`, never a 500. Import layering unchanged (operator_api may import knowledge/graph; `lint-imports` green).
- FE: `api.memoryInjectionDetail(id)` + the detail type in `types.ts`.

## How to test

- **Backend unit** (`tests/test_memory_injection_controls.py`): fake knowledge store + a recorded injection row → asserts the grouped resolved shape; a pruned chunk → `unavailable` marker; a missing store → all items unavailable; an unresolvable digest session → id fallback; unknown record id → 404.
- **FE unit** (`apps/web/src/memory/injectionSummary.test.ts`): the pure `injectionSummary(row)` helper — singular/plural, dropped empty groups, all-empty dash.
- **e2e** (`apps/web/e2e/memory-inspector.spec.ts`): relabeled table shows `2 memories · 1 past chat · 1 doc` (no raw ids); clicking a row opens the dialog with the grouped, resolved content incl. a "no longer stored" pruned doc; empty/error copy updated. Mock server serves `GET /api/memory/injections/{id}`.
- **Manual**: Memory ▸ Injections → read a row's "what it used" → click it → the dialog lists the actual past chats / memories / docs.

## Gates

- `uv run ruff check .` (changed files) ✅ · `uv run lint-imports` ✅ (3 kept, 0 broken) · `uv run python -m pytest tests/ -q` ✅ **3102 passed, 5 skipped**
- `npm run test:unit --workspace @protoagent/web` ✅ **445 passed** · `tsc -p tsconfig.json` + `tsconfig.node.json` ✅
- **e2e run on CI.** Opening as **DRAFT** — this is a console UX change, so it wants a human's visual QA before merge (per the UI layout local-test gate). Nothing auto-merges on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)