### PR TITLE
chore: release v0.91.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `timeout` still overrides. Raising `poll_timeout_s` now lifts the ceiling for both synchronous
   and async peers, matching what the setting says it does. This is what made a delegating fleet
   (a lead + specialist members) actually usable for real work rather than trivial ACKs.
+- **A baked persona is no longer shadowed forever by a stale live `SOUL.md`** (#1782). A member
+  seeded from an archetype bundle bakes its persona into the image, but a leftover live `SOUL.md`
+  in the instance volume shadowed it permanently. Boot now seeds the live SOUL from the baked
+  default when it's absent and heals a shadowing copy, so a declared persona actually takes effect.
 ### Changed
 - **Memory ▸ Injections is legible to non-developers** (ADR 0069 D6/D7). The per-turn record
   was a forensics table of comma-joined raw ids (digest sessions · hot chunks · RAG chunks) —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.91.0] - 2026-07-04
+
 ### Added
 - **Goal completion contracts** (ADR 0073). A goal can now carry an optional, structured
   *completion contract* — `outcome` (the single required end-state), `constraints` (invariants

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.90.0"
+version = "0.91.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "v0.91.0",
+    "date": "2026-07-04",
+    "changes": [
+      "Goal completion contracts",
+      "Fleet members can autostart on boot",
+      "Guided goal-creation form",
+      "Composer/HITL forms support conditional fields",
+      "/goal {json} carries the completion contract",
+      "delegate_to no longer hard-fails on member turns >60s",
+      "Memory ▸ Injections is legible to non-developers"
+    ]
+  },
+  {
     "version": "v0.90.0",
     "date": "2026-07-04",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.91.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.91.0 -m 'Release v0.91.0' && git push origin v0.91.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).