### PR TITLE
fix(marketing): fold scraped plugin cards onto their overrides (#1772)

### DIFF
--- a/sites/marketing/src/pages/plugins.astro
+++ b/sites/marketing/src/pages/plugins.astro
@@ -102,7 +102,10 @@ async function ecosystemPlugins() {
           (t: string) => !['protoagent', 'protoagent-plugin', 'protoagent-bundle'].includes(t),
         );
         return {
-          id: r.name,
+          // The ecosystem repo convention is `<id>-plugin`, but editorial overrides in
+          // plugins.json are keyed by the bare plugin id. Strip the suffix so a scraped
+          // card folds onto its override instead of rendering a duplicate (#1772).
+          id: r.name.replace(/-plugin$/, ''),
           name: r.name,
           tagline: String(r.description || (isBundle ? 'A protoAgent plugin bundle.' : 'A protoAgent plugin.')).trim(),
           // Bundles are kept in their OWN group; plugins auto-group by domain topic.


### PR DESCRIPTION
## Problem

The marketing plugins page renders **two cards for the same plugin** whenever its `data/plugins.json` override id differs from its GitHub repo name — currently **careercoach**, **spacetraders**, and **github**.

**Root cause:** the page merges bundled manifests ∪ ecosystem tag-scrape ∪ editorial overrides. Scraped entries are keyed by repo name (`id: r.name` → `"careercoach-plugin"`) but overrides are keyed by the bare plugin id (`"careercoach"`). When they differ, the override never merges onto the scraped card, and the override-only fallback loop appends it as a second card (mis-categorised "Framework" via the `langgraph` topic).

## Fix

One line — strip a trailing `-plugin` from the scraped id (repo convention is `<id>-plugin`):

```ts
id: r.name.replace(/-plugin$/, ''),   // "careercoach-plugin" -> "careercoach"
```

The scraped card then folds onto its override (category / tagline / name win as intended) instead of duplicating.

## Verification

No test runner on the marketing site, and a full repro needs a deploy-time `GITHUB_TOKEN` + astro build — so I replicated the exact merge logic (plugins.astro:121-138) against fixtures modelling all three sources, and asserted before/after:

```
PASS  bug reproduces before (careercoach = 2 cards)
PASS  fixed: careercoach = 1 card
PASS  fixed: override wins (name=Career Coach, cat=Productivity)
PASS  fixed: spacetraders = 1 card
PASS  override-less google still renders exactly once
PASS  prototrader-finance (no suffix) unaffected, 1 card
PASS  two dups before (careercoach+spacetraders): 6 → 4 after
```

Confirms both dups collapse, overrides win, and override-less / no-suffix plugins are untouched.

Closes #1772

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin cards now use the expected plugin ID format, improving consistency with existing override entries and reducing mismatches in displayed plugin data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->