### PR TITLE
feat(knowledge): bulk delete-by-source in the Knowledge view (reversible soft delete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Bulk delete-by-source in the Knowledge view** (#1770). Ingesting an article,
+  transcript, or batch of docs can leave dozens or hundreds of chunks that used to be
+  removable only one at a time. A source with several loaded chunks now collapses into a
+  group whose trash button deletes the **whole ingest** in one action — a counted
+  confirmation dialog ("Delete all N chunks from …?"), then an **Undo** toast. The delete
+  is a *reversible soft delete*: `POST /api/knowledge/delete-by-source` stamps
+  `invalidated_at` on every matching chunk (`invalidate_by_source`) so they leave recall
+  immediately but survive a grace window; `POST /api/knowledge/restore-by-source`
+  (`restore_by_source`, the Undo) brings them back verbatim. Past the recovery window they
+  are hard-swept by a new `purge_invalidated(older_than_seconds)` grace sweep (run
+  opportunistically on the next bulk delete; the hybrid store drops the side-table vectors
+  too). Per-chunk delete is unchanged. On a layered store the lifecycle targets the
+  **private** tier only, like `purge_domain`.
+
 ## [0.91.0] - 2026-07-04
 
 ### Added

--- a/apps/web/e2e/knowledge.spec.ts
+++ b/apps/web/e2e/knowledge.spec.ts
@@ -82,7 +82,9 @@ test("groups a multi-chunk source into a collapsible section (#1575)", async ({ 
   await expect(surface).toBeVisible();
 
   // The 3-chunk YouTube source collapses under one header (title + count), closed by default.
-  const header = surface.getByRole("button", { name: /Hiking with Kevin/ });
+  // Anchor to the start so the group's toggle (name begins with the source) is picked, not the
+  // sibling bulk-delete button (name begins "delete all chunks from …", #1770).
+  const header = surface.getByRole("button", { name: /^Hiking with Kevin/ });
   await expect(header).toBeVisible();
   await expect(header).toContainText("3 chunks");
   await expect(header).toHaveAttribute("aria-expanded", "false");
@@ -98,4 +100,40 @@ test("groups a multi-chunk source into a collapsible section (#1575)", async ({ 
   await expect(surface.getByText("The summit view pays off the climb.")).toBeVisible();
   await header.click();
   await expect(surface.getByText("Switchbacks keep the grade walkable.")).toHaveCount(0);
+});
+
+test("bulk-deletes a whole source with a counted confirm, and Undo restores it (#1770)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Knowledge" }).click();
+  const surface = page.getByTestId("knowledge-store");
+  await expect(surface).toBeVisible();
+
+  // The 3-chunk YouTube source renders as one group with a bulk-delete button.
+  // Anchor to the start so this matches the toggle, not the "delete all chunks from …" button.
+  const groupHeader = () => surface.getByRole("button", { name: /^Hiking with Kevin/ });
+  await expect(groupHeader()).toContainText("3 chunks");
+  const bulkDel = surface.getByLabel("delete all chunks from Hiking with Kevin — Christina Mariani", {
+    exact: true,
+  });
+  await expect(bulkDel).toBeVisible();
+  await bulkDel.click();
+
+  // AC3: a confirmation dialog warns with the count of chunks to be deleted.
+  const dialog = page.getByRole("dialog", { name: "Delete all chunks from this source?" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText("Delete all 3 chunks");
+  await dialog.getByRole("button", { name: "Delete chunks", exact: true }).click();
+
+  // The whole group leaves the list in one operation (AC1/AC2).
+  await expect(groupHeader()).toHaveCount(0);
+
+  // AC4: deletion is reversible — Undo from the toast restores every chunk.
+  const toast = page.locator(".pl-toast").filter({ hasText: "Deleted 3 chunks" });
+  await expect(toast).toBeVisible();
+  await toast.getByRole("button", { name: "Undo", exact: true }).click();
+  await expect(groupHeader()).toBeVisible();
+  await expect(groupHeader()).toContainText("3 chunks");
+
+  // AC5: single-chunk delete is untouched — the loose chunk still has its own control.
+  await expect(surface.getByLabel("delete entry 12", { exact: true })).toBeVisible();
 });

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -104,6 +104,10 @@ let playbooks = clonePlaybooks();
 // knowledge test resets via POST /api/__test__/knowledge/reset.
 const cloneKnowledge = () => JSON.parse(JSON.stringify(KNOWLEDGE_CHUNKS));
 let knowledgeChunks = cloneKnowledge();
+// Bulk delete-by-source (#1770) is a reversible SOFT delete: matching chunks move
+// to this staging area (out of the search response) so an Undo / restore-by-source
+// can move them back. Reset with the knowledge fixture.
+let knowledgeInvalidated = [];
 
 // Memory inspector (ADR 0069 D7) — sessions + hot chunks are MUTATED by the delete
 // specs, so serve working copies each memory test resets via
@@ -571,6 +575,7 @@ const server = createServer(async (req, res) => {
     }
     if (pathname === "/api/__test__/knowledge/reset" && req.method === "POST") {
       knowledgeChunks = cloneKnowledge();
+      knowledgeInvalidated = [];
       return sendJson(res, { ok: true });
     }
     if (pathname === "/api/__test__/memory/reset" && req.method === "POST") {
@@ -637,6 +642,24 @@ const server = createServer(async (req, res) => {
       const i = knowledgeChunks.findIndex((x) => x.id === id);
       if (i >= 0) knowledgeChunks.splice(i, 1);
       return sendJson(res, { enabled: true, deleted: i >= 0 });
+    }
+    if (pathname === "/api/knowledge/delete-by-source" && req.method === "POST") {
+      // Bulk soft delete (#1770): move every chunk of this source to the staging
+      // area so it leaves the list, but restore-by-source can bring it back.
+      const source = String(body.source || "").trim();
+      if (!source) return sendJson(res, { detail: "source is required" }, 400);
+      const moved = knowledgeChunks.filter((c) => c.source === source);
+      knowledgeChunks = knowledgeChunks.filter((c) => c.source !== source);
+      knowledgeInvalidated.push(...moved);
+      return sendJson(res, { enabled: true, deleted: moved.length });
+    }
+    if (pathname === "/api/knowledge/restore-by-source" && req.method === "POST") {
+      const source = String(body.source || "").trim();
+      if (!source) return sendJson(res, { detail: "source is required" }, 400);
+      const back = knowledgeInvalidated.filter((c) => c.source === source);
+      knowledgeInvalidated = knowledgeInvalidated.filter((c) => c.source !== source);
+      knowledgeChunks.push(...back);
+      return sendJson(res, { enabled: true, restored: back.length });
     }
     if (pathname === "/api/settings") {
       // ADR 0047: a layer-aware save — "agent" (per-agent leaf, default) or "host"

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1870,12 +1870,17 @@ textarea {
 /* Collapsible source groups in the Knowledge Base (#1575). A group is a plain
    list item holding a full-width header button + (when open) a nested card list. */
 .kb-group { list-style: none; display: flex; flex-direction: column; gap: 8px; }
+/* Toggle + a bulk delete-by-source button sit side by side (#1770); the toggle
+   flexes to fill, the trash button is a fixed sibling at the end. */
+.kb-group-header-row { display: flex; align-items: center; gap: 4px; }
 .kb-group-header {
+  flex: 1; min-width: 0;
   display: flex; align-items: center; gap: 8px; width: 100%;
   padding: 8px 12px; border: 1px solid var(--border); border-radius: var(--radius);
   background: var(--bg-raised); color: var(--fg); cursor: pointer; text-align: left;
 }
 .kb-group-header:hover { border-color: var(--border-strong); }
+.kb-group-delete { flex: none; }
 .kb-group-caret { flex: none; color: var(--fg-muted); transition: transform 0.12s ease; }
 .kb-group-title {
   flex: 1; min-width: 0; font-size: 13px; font-weight: 600;

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -15,6 +15,10 @@ import { knowledgeQuery, queryKeys } from "../lib/queries";
 import { QuickSetting } from "../settings/QuickSetting";
 import type { KnowledgeChunk } from "../lib/types";
 
+// The shape every knowledge list/search query caches — reused for optimistic
+// bulk-delete cache surgery (#1770) without re-declaring the response fields.
+type KnowledgeSearchData = Awaited<ReturnType<typeof api.knowledgeSearch>>;
+
 // Knowledge → Store (ADR 0020) — a searchable window onto the agent's knowledge
 // base (knowledge/store.py, FTS5): findings, daily-log entries, harvested
 // sessions, operator notes. The same store KnowledgeMiddleware queries before
@@ -235,6 +239,8 @@ export function KnowledgeStore() {
   const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
   const [pendingDelete, setPendingDelete] = useState<KnowledgeChunk | null>(null);
   const [forgetPending, setForgetPending] = useState<KnowledgeChunk | null>(null);
+  // Bulk delete-by-source (#1770): the group awaiting a confirm (source + count).
+  const [pendingSourceDelete, setPendingSourceDelete] = useState<{ source: string; count: number } | null>(null);
 
   const save = useMutation({
     mutationFn: () => (editingId !== null ? api.updateKnowledgeChunk(editingId, draft) : api.addKnowledgeChunk(draft)),
@@ -251,6 +257,58 @@ export function KnowledgeStore() {
     mutationFn: (id: number) => api.deleteKnowledgeChunk(id),
     onSuccess: () => invalidate(),
     onError: (e) => onError(errMsg(e)),
+  });
+
+  // Bulk delete-by-source (#1770) — remove a whole ingest at once. It's a reversible
+  // SOFT delete, so restore just re-validates the same rows. The restore mutation is
+  // declared first because the delete's success toast embeds an Undo that calls it.
+  const restoreBySource = useMutation({
+    mutationFn: (source: string) => api.restoreKnowledgeBySource(source),
+    onSuccess: (r) => {
+      if (r.error) { onError(r.error); return; }
+      invalidate();
+    },
+    onError: (e) => onError(errMsg(e)),
+  });
+
+  const delBySource = useMutation({
+    mutationFn: ({ source }: { source: string; count: number }) => api.deleteKnowledgeBySource(source),
+    // Optimistically drop the group from every knowledge list cache so it vanishes
+    // instantly; snapshot for rollback if the server rejects it.
+    onMutate: async ({ source }) => {
+      await qc.cancelQueries({ queryKey: queryKeys.knowledge });
+      const prev = qc.getQueriesData<KnowledgeSearchData>({ queryKey: queryKeys.knowledge });
+      qc.setQueriesData<KnowledgeSearchData>({ queryKey: queryKeys.knowledge }, (old) =>
+        old ? { ...old, results: old.results.filter((c) => c.source !== source) } : old,
+      );
+      return { prev };
+    },
+    onSuccess: (r, { source, count }, ctx) => {
+      if (r.error) {
+        for (const [key, data] of ctx?.prev ?? []) qc.setQueryData(key, data); // rollback
+        onError(r.error);
+        return;
+      }
+      invalidate();
+      const n = r.deleted || count;
+      toast({
+        tone: "success",
+        title: "Knowledge",
+        duration: 10000, // long enough to catch the Undo
+        message: (
+          <span>
+            Deleted {n} chunk{n === 1 ? "" : "s"} from “{source}”.{" "}
+            <Button variant="ghost" size="sm" onClick={() => restoreBySource.mutate(source)}>
+              Undo
+            </Button>
+          </span>
+        ),
+      });
+    },
+    onError: (e, _vars, ctx) => {
+      for (const [key, data] of ctx?.prev ?? []) qc.setQueryData(key, data); // rollback
+      onError(errMsg(e));
+    },
   });
 
   // Share a private chunk into the shared commons (ADR 0041 / bd-2wu).
@@ -559,21 +617,44 @@ export function KnowledgeStore() {
                 const st = members.find((m) => m.source_type)?.source_type;
                 return (
                   <li key={`grp:${src}`} className="kb-group">
-                    <button
-                      type="button"
-                      className="kb-group-header"
-                      aria-expanded={open}
-                      onClick={() => toggleGroup(src)}
-                    >
-                      <ChevronRight
-                        size={14}
-                        className="kb-group-caret"
-                        style={{ transform: open ? "rotate(90deg)" : undefined }}
-                      />
-                      <span className="kb-group-title" title={src}>{src}</span>
-                      {st ? <Badge status="neutral">{st}</Badge> : null}
-                      <Badge status="neutral">{members.length} chunks</Badge>
-                    </button>
+                    {/* Toggle + a bulk-delete button are SIBLINGS (a button can't nest
+                        inside the header button). Bulk delete a whole ingest at once
+                        (#1770): Shift+click skips the confirm, like the per-chunk path. */}
+                    <div className="kb-group-header-row">
+                      <button
+                        type="button"
+                        className="kb-group-header"
+                        aria-expanded={open}
+                        onClick={() => toggleGroup(src)}
+                      >
+                        <ChevronRight
+                          size={14}
+                          className="kb-group-caret"
+                          style={{ transform: open ? "rotate(90deg)" : undefined }}
+                        />
+                        <span className="kb-group-title" title={src}>{src}</span>
+                        {st ? <Badge status="neutral">{st}</Badge> : null}
+                        <Badge status="neutral">{members.length} chunks</Badge>
+                      </button>
+                      <Button
+                        icon
+                        variant="ghost"
+                        type="button"
+                        className={`kb-group-delete${shiftDel ? " knowledge-del-armed" : ""}`}
+                        title={
+                          shiftDel
+                            ? `Delete all ${members.length} chunks now — Shift skips the confirmation`
+                            : `Delete all ${members.length} chunks from this source`
+                        }
+                        aria-label={`delete all chunks from ${src}`}
+                        onClick={(e) => {
+                          if (e.shiftKey) delBySource.mutate({ source: src, count: members.length });
+                          else setPendingSourceDelete({ source: src, count: members.length });
+                        }}
+                      >
+                        <Trash2 size={14} />
+                      </Button>
+                    </div>
                     {open ? (
                       <ul className="playbook-list kb-group-body">{members.map(renderCard)}</ul>
                     ) : null}
@@ -598,6 +679,22 @@ export function KnowledgeStore() {
       >
         {pendingDelete
           ? `"${pendingDelete.heading || pendingDelete.preview.slice(0, 80)}" will be removed from the knowledge base — the agent will no longer recall it. This can't be undone.`
+          : undefined}
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        open={pendingSourceDelete !== null}
+        title="Delete all chunks from this source?"
+        confirmLabel="Delete chunks"
+        destructive
+        onConfirm={() => {
+          if (pendingSourceDelete) delBySource.mutate(pendingSourceDelete);
+          setPendingSourceDelete(null);
+        }}
+        onClose={() => setPendingSourceDelete(null)}
+      >
+        {pendingSourceDelete
+          ? `Delete all ${pendingSourceDelete.count} chunk${pendingSourceDelete.count === 1 ? "" : "s"} from “${pendingSourceDelete.source}”? The agent will stop recalling them. You can undo this from the toast.`
           : undefined}
       </ConfirmDialog>
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -818,6 +818,22 @@ export const api = {
       { method: "POST" },
     );
   },
+  // Bulk delete-by-source (#1770) — remove a whole ingest (all chunks sharing one
+  // `source`) in one call. It's a reversible SOFT delete: the chunks leave recall
+  // immediately but survive a grace window, so `restoreKnowledgeBySource` (the Undo
+  // toast) can bring them back. `deleted` is the count invalidated.
+  deleteKnowledgeBySource(source: string) {
+    return request<{ enabled: boolean; deleted: number; error?: string }>(
+      "/api/knowledge/delete-by-source",
+      { method: "POST", body: { source } },
+    );
+  },
+  restoreKnowledgeBySource(source: string) {
+    return request<{ enabled: boolean; restored: number; error?: string }>(
+      "/api/knowledge/restore-by-source",
+      { method: "POST", body: { source } },
+    );
+  },
   // Document ingestion engine — extract a file/URL/YouTube into the KB (chunked,
   // enriched, embedded). FormData carries `file` OR `url` OR `text`, plus `domain`.
   ingestKnowledge(form: FormData) {

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -223,7 +223,10 @@ D9) instead of judging it with a model at write time:
   window** — `restore_by_source` (the Undo) brings them back verbatim. Past the
   window they're hard-swept by `purge_invalidated`, run opportunistically on the next
   bulk delete. This is the one operator delete that's *not* immediately permanent —
-  by design, so a mistaken cleanup is recoverable.
+  by design, so a mistaken cleanup is recoverable. The soft delete carries an
+  `invalidation_reason` marker so the sweep reaps **only** these bulk delete-by-source
+  rows — auto-supersession audit history (above), which stamps `invalidated_at` with
+  no reason, is never touched and stays reachable via `include_invalidated`.
 
 ### Plugin knowledge lifecycle
 

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -215,6 +215,15 @@ D9) instead of judging it with a model at write time:
 - **Operator deletes stay hard deletes.** `forget_memory` and the memory
   inspector's DELETE routes remove rows outright — explicit operator intent
   beats history-keeping. Supersession is only for the *automatic* write paths.
+- **Bulk delete-by-source is a *reversible* soft delete** (#1770). In the console's
+  Knowledge view, a source with several loaded chunks collapses into a group; its
+  trash button deletes the **whole ingest** at once (a counted confirm, then an Undo
+  toast). Under the hood this stamps `invalidated_at` on every chunk of that source
+  (`invalidate_by_source`), so they leave recall immediately but survive a **grace
+  window** — `restore_by_source` (the Undo) brings them back verbatim. Past the
+  window they're hard-swept by `purge_invalidated`, run opportunistically on the next
+  bulk delete. This is the one operator delete that's *not* immediately permanent —
+  by design, so a mistaken cleanup is recoverable.
 
 ### Plugin knowledge lifecycle
 

--- a/docs/reference/operator-api.md
+++ b/docs/reference/operator-api.md
@@ -66,6 +66,7 @@ is a map — `operator_api/*.py` is the source of truth for exact request/respon
 | POST | `/api/knowledge/ingest` | [Ingest](/guides/ingestion) a file / URL / text |
 | POST | `/api/knowledge/attach` | Attach a chat upload (tiered inline-vs-index) |
 | POST · PUT · DELETE | `/api/knowledge/chunks[/{id}]` | Add / edit / delete a chunk |
+| POST | `/api/knowledge/delete-by-source` · `/api/knowledge/restore-by-source` | Bulk soft-delete / restore every chunk from one ingest (reversible, grace-swept) |
 | GET | `/api/playbooks` · `/api/playbooks/{id}` | List / fetch skills ("playbooks") |
 | POST · PUT · DELETE | `/api/playbooks[/{id}]` | Create / edit / delete a skill |
 | POST | `/api/playbooks/{id}/promote` | Promote a private skill into the commons |

--- a/knowledge/hybrid_store.py
+++ b/knowledge/hybrid_store.py
@@ -30,7 +30,7 @@ import sqlite3
 import time
 from collections.abc import Callable
 
-from knowledge.store import KnowledgeStore, _namespace_clause, _normalize_before
+from knowledge.store import _BULK_DELETE_REASON, KnowledgeStore, _namespace_clause, _normalize_before
 
 log = logging.getLogger(__name__)
 
@@ -323,18 +323,22 @@ class HybridKnowledgeStore(KnowledgeStore):
         return super().purge_domain(domain, before=cutoff)
 
     def purge_invalidated(self, older_than_seconds: int = 0, *, _cutoff: str | None = None) -> int:
-        """Sweep past-grace soft-deleted chunks AND their vectors (#1770) — the
+        """Sweep past-grace bulk-soft-deleted chunks AND their vectors (#1770) — the
         :meth:`delete_by_namespace` / :meth:`purge_domain` pattern: no FK cascade
         on the side table, so the vectors go first under the SAME cutoff (shared
-        via ``_cutoff`` so a swept chunk can't linger as a vector-only hit)."""
+        via ``_cutoff`` so a swept chunk can't linger as a vector-only hit).
+
+        Mirrors the base's ``invalidation_reason`` filter so only bulk delete-by-source
+        vectors are dropped — auto-supersession audit rows (ADR 0069 D9) keep theirs."""
         cutoff = _cutoff if _cutoff is not None else self._invalidated_cutoff(older_than_seconds)
         db = self._get_db()
         if db is not None:
             try:
                 db.execute(
                     "DELETE FROM chunk_vectors WHERE chunk_id IN "
-                    "(SELECT id FROM chunks WHERE invalidated_at IS NOT NULL AND invalidated_at <= ?)",
-                    (cutoff,),
+                    "(SELECT id FROM chunks WHERE invalidated_at IS NOT NULL "
+                    "AND invalidated_at <= ? AND invalidation_reason = ?)",
+                    (cutoff, _BULK_DELETE_REASON),
                 )
                 db.commit()
             except sqlite3.DatabaseError as exc:

--- a/knowledge/hybrid_store.py
+++ b/knowledge/hybrid_store.py
@@ -322,6 +322,27 @@ class HybridKnowledgeStore(KnowledgeStore):
                 db.close()
         return super().purge_domain(domain, before=cutoff)
 
+    def purge_invalidated(self, older_than_seconds: int = 0, *, _cutoff: str | None = None) -> int:
+        """Sweep past-grace soft-deleted chunks AND their vectors (#1770) — the
+        :meth:`delete_by_namespace` / :meth:`purge_domain` pattern: no FK cascade
+        on the side table, so the vectors go first under the SAME cutoff (shared
+        via ``_cutoff`` so a swept chunk can't linger as a vector-only hit)."""
+        cutoff = _cutoff if _cutoff is not None else self._invalidated_cutoff(older_than_seconds)
+        db = self._get_db()
+        if db is not None:
+            try:
+                db.execute(
+                    "DELETE FROM chunk_vectors WHERE chunk_id IN "
+                    "(SELECT id FROM chunks WHERE invalidated_at IS NOT NULL AND invalidated_at <= ?)",
+                    (cutoff,),
+                )
+                db.commit()
+            except sqlite3.DatabaseError as exc:
+                log.warning("[knowledge] purge_invalidated vectors failed: %s", exc)
+            finally:
+                db.close()
+        return super().purge_invalidated(older_than_seconds, _cutoff=cutoff)
+
     def _vector_search(
         self,
         query_vec: list[float],

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -36,7 +36,7 @@ import re
 import sqlite3
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -271,6 +271,7 @@ CREATE TABLE IF NOT EXISTS chunks (
 
 CREATE INDEX IF NOT EXISTS idx_chunks_domain     ON chunks(domain);
 CREATE INDEX IF NOT EXISTS idx_chunks_created_at ON chunks(created_at);
+CREATE INDEX IF NOT EXISTS idx_chunks_source     ON chunks(source);
 
 CREATE TABLE IF NOT EXISTS _kb_meta (
     key   TEXT PRIMARY KEY,
@@ -1087,6 +1088,101 @@ class KnowledgeStore:
             return int(cur.rowcount)
         except sqlite3.DatabaseError as exc:
             log.warning("[knowledge] purge_domain failed: %s", exc)
+            return 0
+        finally:
+            db.close()
+
+    # ── bulk delete-by-source lifecycle (#1770) ─────────────────────────────
+    # Deleting a whole ingest one chunk at a time is impractical, so the console
+    # groups chunks by source and bulk-deletes them. It's a SOFT delete: the rows
+    # are invalidated (drop out of search/list/hot-memory at once, ADR 0069 D9) but
+    # survive a grace window so an Undo — restore_by_source — can bring them back.
+    # purge_invalidated is the sweep that eventually makes the removal permanent.
+
+    def invalidate_by_source(self, source: str) -> int:
+        """SOFT-delete every VALID chunk sharing ``source`` — stamp
+        ``invalidated_at`` so the whole ingest leaves recall at once while the rows
+        survive for a grace window. Backs the console's bulk "delete all chunks
+        from this source" (#1770); reversible via :meth:`restore_by_source`, made
+        permanent by :meth:`purge_invalidated`. Empty/whitespace ``source`` is a
+        no-op (0) — never an ``invalidated_at = everything`` sweep. Returns the
+        count newly invalidated (already-invalidated rows aren't recounted)."""
+        if not source or not source.strip():
+            return 0
+        db = self._get_db()
+        if db is None:
+            return 0
+        try:
+            now = _now_iso()
+            cur = db.execute(
+                "UPDATE chunks SET invalidated_at = ?, updated_at = ? WHERE source = ? AND invalidated_at IS NULL",
+                (now, now, source),
+            )
+            db.commit()
+            return int(cur.rowcount)
+        except sqlite3.DatabaseError as exc:
+            log.warning("[knowledge] invalidate_by_source failed: %s", exc)
+            return 0
+        finally:
+            db.close()
+
+    def restore_by_source(self, source: str) -> int:
+        """Clear ``invalidated_at`` on every INVALIDATED chunk sharing ``source``
+        — the inverse of :meth:`invalidate_by_source`, backing the console's Undo
+        toast (#1770). Only rows still present (not yet swept by
+        :meth:`purge_invalidated`) can be restored. Empty ``source`` is a no-op.
+        Returns the count restored."""
+        if not source or not source.strip():
+            return 0
+        db = self._get_db()
+        if db is None:
+            return 0
+        try:
+            cur = db.execute(
+                "UPDATE chunks SET invalidated_at = NULL, updated_at = ? "
+                "WHERE source = ? AND invalidated_at IS NOT NULL",
+                (_now_iso(), source),
+            )
+            db.commit()
+            return int(cur.rowcount)
+        except sqlite3.DatabaseError as exc:
+            log.warning("[knowledge] restore_by_source failed: %s", exc)
+            return 0
+        finally:
+            db.close()
+
+    def _invalidated_cutoff(self, older_than_seconds: int) -> str:
+        """The ``invalidated_at`` boundary for :meth:`purge_invalidated`: rows
+        stamped at or before this UTC-ISO instant are past the grace window. Shared
+        with the hybrid override so both delete under ONE cutoff (no orphan-vector
+        window from a second ``now()``)."""
+        return (datetime.now(UTC) - timedelta(seconds=max(0, int(older_than_seconds)))).isoformat()
+
+    def purge_invalidated(self, older_than_seconds: int = 0, *, _cutoff: str | None = None) -> int:
+        """HARD-delete soft-deleted chunks whose ``invalidated_at`` is at or older
+        than ``older_than_seconds`` ago — the grace sweep that makes a bulk soft
+        delete (#1770) eventually permanent. Rows invalidated by
+        :meth:`invalidate_by_source` (or auto-supersession, ADR 0069 D9) that have
+        aged past the recovery period are removed outright.
+        ``older_than_seconds<=0`` purges every invalidated row now. Returns the
+        count removed.
+
+        The FTS delete trigger keeps ``chunks_fts`` in sync; a hybrid store
+        overrides this to drop the side-table vectors first (no FK cascade).
+        ``_cutoff`` is an internal seam for that override to share one boundary."""
+        db = self._get_db()
+        if db is None:
+            return 0
+        try:
+            cutoff = _cutoff if _cutoff is not None else self._invalidated_cutoff(older_than_seconds)
+            cur = db.execute(
+                "DELETE FROM chunks WHERE invalidated_at IS NOT NULL AND invalidated_at <= ?",
+                (cutoff,),
+            )
+            db.commit()
+            return int(cur.rowcount)
+        except sqlite3.DatabaseError as exc:
+            log.warning("[knowledge] purge_invalidated failed: %s", exc)
             return 0
         finally:
             db.close()

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -89,6 +89,10 @@ class Chunk:
     namespace: str | None = None
     invalidated_at: str | None = None
     epoch: str | None = None
+    # Why the row was invalidated: NULL = auto-supersession audit history (ADR 0069
+    # D9, kept forever); ``_BULK_DELETE_REASON`` = a reversible bulk delete-by-source
+    # (#1770) that the grace sweep may eventually reap.
+    invalidation_reason: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -253,6 +257,14 @@ def _has_fts5(db: sqlite3.Connection) -> bool:
         return False
 
 
+# Discriminator stamped on ``invalidation_reason`` by :meth:`KnowledgeStore.invalidate_by_source`
+# (the #1770 bulk soft-delete). It's what lets :meth:`KnowledgeStore.purge_invalidated`
+# reap ONLY bulk-deleted ingests once they age past the grace window, while leaving
+# auto-supersession audit rows (ADR 0069 D9, which stamp ``invalidated_at`` with a NULL
+# reason and are kept forever) untouched. Both paths set ``invalidated_at``, so without
+# this marker they'd be indistinguishable and the sweep would wipe supersession history.
+_BULK_DELETE_REASON = "source_delete"
+
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS chunks (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -266,7 +278,8 @@ CREATE TABLE IF NOT EXISTS chunks (
     epoch         TEXT,
     created_at    TEXT NOT NULL,
     updated_at    TEXT NOT NULL,
-    invalidated_at TEXT
+    invalidated_at TEXT,
+    invalidation_reason TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_chunks_domain     ON chunks(domain);
@@ -385,6 +398,18 @@ class KnowledgeStore:
                 db.execute("CREATE INDEX IF NOT EXISTS idx_chunks_invalidated_at ON chunks(invalidated_at)")
             except sqlite3.DatabaseError as exc:
                 log.debug("[knowledge] invalidated_at migration skipped: %s", exc)
+            # Migration: add the invalidation_reason column (#1770 — bulk soft delete).
+            # Same additive+nullable pattern. NULL means "invalidated but kept for audit"
+            # (auto-supersession, ADR 0069 D9); ``_BULK_DELETE_REASON`` marks a bulk
+            # delete-by-source so the grace sweep reaps only those. Rows soft-deleted on a
+            # pre-migration build carry a NULL reason and are therefore preserved by the
+            # sweep — the safe (never-lose-audit-history) default.
+            try:
+                cols = {r[1] for r in db.execute("PRAGMA table_info(chunks)")}
+                if "invalidation_reason" not in cols:
+                    db.execute("ALTER TABLE chunks ADD COLUMN invalidation_reason TEXT")
+            except sqlite3.DatabaseError as exc:
+                log.debug("[knowledge] invalidation_reason migration skipped: %s", exc)
             # Migration: add the epoch column (#1634 — knowledge lifecycle). Same
             # additive+nullable pattern; an epoch tag ("2026-06-29") scopes a chunk
             # to one era of a resettable world, so a wipe is a new tag rather than
@@ -1106,7 +1131,12 @@ class KnowledgeStore:
         from this source" (#1770); reversible via :meth:`restore_by_source`, made
         permanent by :meth:`purge_invalidated`. Empty/whitespace ``source`` is a
         no-op (0) — never an ``invalidated_at = everything`` sweep. Returns the
-        count newly invalidated (already-invalidated rows aren't recounted)."""
+        count newly invalidated (already-invalidated rows aren't recounted).
+
+        Stamps ``invalidation_reason = _BULK_DELETE_REASON`` alongside
+        ``invalidated_at`` so :meth:`purge_invalidated` can tell a reapable bulk
+        soft-delete apart from an auto-supersession audit row (ADR 0069 D9), which
+        leaves the reason NULL and is kept forever."""
         if not source or not source.strip():
             return 0
         db = self._get_db()
@@ -1115,8 +1145,9 @@ class KnowledgeStore:
         try:
             now = _now_iso()
             cur = db.execute(
-                "UPDATE chunks SET invalidated_at = ?, updated_at = ? WHERE source = ? AND invalidated_at IS NULL",
-                (now, now, source),
+                "UPDATE chunks SET invalidated_at = ?, invalidation_reason = ?, updated_at = ? "
+                "WHERE source = ? AND invalidated_at IS NULL",
+                (now, _BULK_DELETE_REASON, now, source),
             )
             db.commit()
             return int(cur.rowcount)
@@ -1127,11 +1158,16 @@ class KnowledgeStore:
             db.close()
 
     def restore_by_source(self, source: str) -> int:
-        """Clear ``invalidated_at`` on every INVALIDATED chunk sharing ``source``
-        — the inverse of :meth:`invalidate_by_source`, backing the console's Undo
-        toast (#1770). Only rows still present (not yet swept by
+        """Clear ``invalidated_at`` on every BULK-SOFT-DELETED chunk sharing
+        ``source`` — the inverse of :meth:`invalidate_by_source`, backing the
+        console's Undo toast (#1770). Only rows still present (not yet swept by
         :meth:`purge_invalidated`) can be restored. Empty ``source`` is a no-op.
-        Returns the count restored."""
+        Returns the count restored.
+
+        Scoped to ``invalidation_reason = _BULK_DELETE_REASON`` so an Undo can only
+        resurrect what THIS feature soft-deleted — never an auto-supersession audit
+        row (ADR 0069 D9) that happens to share the ``source`` string. Clears the
+        reason marker on the way back out."""
         if not source or not source.strip():
             return 0
         db = self._get_db()
@@ -1139,9 +1175,9 @@ class KnowledgeStore:
             return 0
         try:
             cur = db.execute(
-                "UPDATE chunks SET invalidated_at = NULL, updated_at = ? "
-                "WHERE source = ? AND invalidated_at IS NOT NULL",
-                (_now_iso(), source),
+                "UPDATE chunks SET invalidated_at = NULL, invalidation_reason = NULL, updated_at = ? "
+                "WHERE source = ? AND invalidation_reason = ?",
+                (_now_iso(), source, _BULK_DELETE_REASON),
             )
             db.commit()
             return int(cur.rowcount)
@@ -1159,12 +1195,18 @@ class KnowledgeStore:
         return (datetime.now(UTC) - timedelta(seconds=max(0, int(older_than_seconds)))).isoformat()
 
     def purge_invalidated(self, older_than_seconds: int = 0, *, _cutoff: str | None = None) -> int:
-        """HARD-delete soft-deleted chunks whose ``invalidated_at`` is at or older
-        than ``older_than_seconds`` ago — the grace sweep that makes a bulk soft
-        delete (#1770) eventually permanent. Rows invalidated by
-        :meth:`invalidate_by_source` (or auto-supersession, ADR 0069 D9) that have
-        aged past the recovery period are removed outright.
-        ``older_than_seconds<=0`` purges every invalidated row now. Returns the
+        """HARD-delete BULK-SOFT-DELETED chunks whose ``invalidated_at`` is at or
+        older than ``older_than_seconds`` ago — the grace sweep that makes a bulk
+        delete-by-source (#1770) eventually permanent.
+
+        Reaps ONLY rows stamped ``invalidation_reason = _BULK_DELETE_REASON`` by
+        :meth:`invalidate_by_source`. Auto-supersession rows (ADR 0069 D9, which set
+        ``invalidated_at`` with a NULL reason) are deliberately excluded and kept
+        forever as audit history — the ``include_invalidated`` escape hatch stays
+        populated. Without this reason filter the sweep would silently wipe that
+        supersession history on the first bulk delete.
+
+        ``older_than_seconds<=0`` purges every bulk-soft-deleted row now. Returns the
         count removed.
 
         The FTS delete trigger keeps ``chunks_fts`` in sync; a hybrid store
@@ -1176,8 +1218,9 @@ class KnowledgeStore:
         try:
             cutoff = _cutoff if _cutoff is not None else self._invalidated_cutoff(older_than_seconds)
             cur = db.execute(
-                "DELETE FROM chunks WHERE invalidated_at IS NOT NULL AND invalidated_at <= ?",
-                (cutoff,),
+                "DELETE FROM chunks "
+                "WHERE invalidated_at IS NOT NULL AND invalidated_at <= ? AND invalidation_reason = ?",
+                (cutoff, _BULK_DELETE_REASON),
             )
             db.commit()
             return int(cur.rowcount)

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -23,6 +23,14 @@ from runtime.state import STATE
 
 log = logging.getLogger("protoagent.server")
 
+# Recovery window for the reversible bulk delete-by-source (#1770). A bulk delete
+# only SOFT-deletes (invalidates) the chunks; they survive this long so the Undo
+# toast / restore-by-source can bring them back. There's no scheduler hook for
+# knowledge here, so the sweep runs OPPORTUNISTICALLY at the top of the next bulk
+# delete — anything invalidated longer ago than this is then hard-purged. 24h is a
+# generous recovery period for an operator who deleted the wrong ingest.
+_INVALIDATED_GRACE_SECONDS = 24 * 3600
+
 
 # ── Playbooks (skills) helpers ────────────────────────────────────────────────
 # Operator-authored skills are persisted as real SKILL.md files under the writable
@@ -637,3 +645,62 @@ def register_knowledge_routes(app) -> None:
             return {"enabled": False, "deleted": False}
         deleted = await asyncio.to_thread(STATE.knowledge_store.delete_by_id, chunk_id)
         return {"enabled": True, "deleted": bool(deleted)}
+
+    # --- Bulk delete-by-source (reversible soft delete, #1770) ---------------
+    # Removing a whole ingest (an article / transcript / doc = dozens of chunks,
+    # all sharing one ``source``) one chunk at a time is impractical. These two
+    # routes bulk-delete/restore a source. The delete is SOFT — it invalidates the
+    # rows (they leave recall immediately) but keeps them for a grace window, so the
+    # console's Undo toast (restore-by-source) can bring them back. Past the window
+    # they're hard-swept by ``purge_invalidated``. Both methods are optional store
+    # capabilities (getattr-guarded): a plugin backend without them degrades to a
+    # 0-count no-op instead of 500ing. On a layered store the lifecycle delegates to
+    # the PRIVATE tier (the commons is curated via forget only), same as purge_domain.
+
+    @app.post("/api/knowledge/delete-by-source")
+    async def _api_knowledge_delete_by_source(body: dict | None = None):
+        store = STATE.knowledge_store
+        if store is None:
+            return {"enabled": False, "deleted": 0}
+        source = str((body or {}).get("source", "")).strip()
+        if not source:
+            return JSONResponse({"detail": "source is required"}, status_code=400)
+        invalidate = getattr(store, "invalidate_by_source", None)
+        if invalidate is None:
+            return {"enabled": True, "deleted": 0, "error": "this knowledge backend can't bulk-delete by source"}
+        # Opportunistic grace sweep: no scheduler owns knowledge here, so each bulk
+        # delete first hard-purges anything invalidated past the recovery window —
+        # that's what makes the "permanent removal" of AC4 real. Best-effort; a
+        # sweep failure must never block the delete the operator actually asked for.
+        purge = getattr(store, "purge_invalidated", None)
+        if purge is not None:
+            try:
+                swept = await asyncio.to_thread(purge, _INVALIDATED_GRACE_SECONDS)
+                if swept:
+                    log.info("[knowledge] swept %d past-grace invalidated chunk(s)", swept)
+            except Exception:  # noqa: BLE001 — the sweep is opportunistic, never fatal
+                log.exception("[knowledge] purge_invalidated sweep failed")
+        try:
+            deleted = await asyncio.to_thread(invalidate, source)
+        except Exception as exc:  # noqa: BLE001 — never 500 the console
+            log.exception("[knowledge] delete-by-source failed")
+            return {"enabled": True, "deleted": 0, "error": str(exc)}
+        return {"enabled": True, "deleted": int(deleted)}
+
+    @app.post("/api/knowledge/restore-by-source")
+    async def _api_knowledge_restore_by_source(body: dict | None = None):
+        store = STATE.knowledge_store
+        if store is None:
+            return {"enabled": False, "restored": 0}
+        source = str((body or {}).get("source", "")).strip()
+        if not source:
+            return JSONResponse({"detail": "source is required"}, status_code=400)
+        restore = getattr(store, "restore_by_source", None)
+        if restore is None:
+            return {"enabled": True, "restored": 0, "error": "this knowledge backend can't restore by source"}
+        try:
+            restored = await asyncio.to_thread(restore, source)
+        except Exception as exc:  # noqa: BLE001 — never 500 the console
+            log.exception("[knowledge] restore-by-source failed")
+            return {"enabled": True, "restored": 0, "error": str(exc)}
+        return {"enabled": True, "restored": int(restored)}

--- a/tests/test_knowledge_lifecycle.py
+++ b/tests/test_knowledge_lifecycle.py
@@ -24,6 +24,15 @@ def _backdate(path, chunk_id: int, created_at: str) -> None:
     db.close()
 
 
+def _set_invalidated(path, chunk_id: int, invalidated_at: str) -> None:
+    """Age a soft-deleted row's invalidated_at so a grace sweep can be tested
+    without sleeping (the grace window is real wall-clock seconds otherwise)."""
+    db = sqlite3.connect(str(path))
+    db.execute("UPDATE chunks SET invalidated_at = ? WHERE id = ?", (invalidated_at, chunk_id))
+    db.commit()
+    db.close()
+
+
 # ── purge_domain: base store ────────────────────────────────────────────────
 
 
@@ -226,3 +235,89 @@ def test_epoch_migration_on_preexisting_db(tmp_path):
     # Old (untagged) rows drop out of an epoch-filtered search, stay in unfiltered.
     assert [r["content"] for r in store.search("row", k=10, epoch="e1")] == ["new era row"]
     assert len(store.search("row", k=10)) == 2
+
+
+# ── bulk delete-by-source lifecycle (#1770): soft delete → restore → grace sweep ─
+
+
+def test_invalidate_by_source_hides_rows_then_restore_brings_them_back(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    for i in range(3):
+        store.add_chunk(f"kevin tip {i}", domain="media", source="kevin")
+    store.add_chunk("keep me", domain="general", source="daily-log")
+
+    # Soft delete the whole ingest at once.
+    assert store.invalidate_by_source("kevin") == 3
+    # Gone from default list + search (out of recall immediately)…
+    assert [c.content for c in store.list_chunks()] == ["keep me"]
+    assert store.search("tip") == []
+    # …but the rows survive for the grace window, reachable via the audit hatch.
+    hidden = [c for c in store.list_chunks(include_invalidated=True) if c.source == "kevin"]
+    assert len(hidden) == 3 and all(c.invalidated_at for c in hidden)
+    # Re-invalidating is a no-op (only VALID rows are counted).
+    assert store.invalidate_by_source("kevin") == 0
+
+    # Undo: restore re-validates exactly those rows.
+    assert store.restore_by_source("kevin") == 3
+    assert sorted(r["content"] for r in store.search("tip")) == ["kevin tip 0", "kevin tip 1", "kevin tip 2"]
+    assert store.restore_by_source("kevin") == 0  # nothing left invalidated
+
+
+def test_bulk_source_guards_empty_source(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("x", domain="d", source="s")
+    # Empty/whitespace source never becomes an "invalidate everything" sweep.
+    assert store.invalidate_by_source("") == 0
+    assert store.invalidate_by_source("   ") == 0
+    assert store.restore_by_source("") == 0
+    assert len(store.list_chunks()) == 1
+
+
+def test_purge_invalidated_removes_only_past_grace_rows(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    old = store.add_chunk("stale ingest", domain="d", source="src-a")
+    fresh = store.add_chunk("recent ingest", domain="d", source="src-b")
+    assert store.invalidate_by_source("src-a") == 1
+    assert store.invalidate_by_source("src-b") == 1
+    _set_invalidated(store.path, old, "2026-01-01T00:00:00+00:00")  # aged past grace
+
+    # A 1h-grace sweep hard-deletes only the aged soft-delete; the recent one stays
+    # recoverable. This is the "permanent removal after a recovery period" of AC4.
+    assert store.purge_invalidated(3600) == 1
+    surviving = {c.id for c in store.list_chunks(include_invalidated=True)}
+    assert surviving == {fresh}
+
+
+def test_purge_invalidated_never_touches_valid_rows(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("live fact", domain="d", source="s")
+    # Nothing invalidated → the sweep is a no-op even at zero grace.
+    assert store.purge_invalidated(0) == 0
+    assert len(store.list_chunks()) == 1
+
+
+def test_hybrid_purge_invalidated_clears_vectors(tmp_path):
+    path = tmp_path / "kb.db"
+    store = HybridKnowledgeStore(path, embed_fn=_const_embed)
+    cid = store.add_chunk("vector-backed chunk", domain="d", source="s")
+    assert store.invalidate_by_source("s") == 1
+    _set_invalidated(path, cid, "2026-01-01T00:00:00+00:00")
+
+    assert store.purge_invalidated(3600) == 1
+    db = sqlite3.connect(str(path))
+    n = db.execute("SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id = ?", (cid,)).fetchone()[0]
+    db.close()
+    assert n == 0  # no orphan vector left behind for a swept chunk
+
+
+def test_layered_bulk_source_targets_private_never_commons(tmp_path):
+    private = KnowledgeStore(tmp_path / "private.db")
+    commons = KnowledgeStore(tmp_path / "commons.db")
+    layered = LayeredKnowledgeStore(private, commons)
+    private.add_chunk("my ingest chunk", domain="d", source="shared-src")
+    commons.add_chunk("fleet ingest chunk", domain="d", source="shared-src")
+
+    assert layered.invalidate_by_source("shared-src") == 1  # __getattr__ → private only
+    assert private.search("ingest") == []  # private row left recall
+    assert [r["content"] for r in commons.search("ingest")] == ["fleet ingest chunk"]  # commons untouched
+    assert layered.restore_by_source("shared-src") == 1

--- a/tests/test_knowledge_lifecycle.py
+++ b/tests/test_knowledge_lifecycle.py
@@ -296,6 +296,42 @@ def test_purge_invalidated_never_touches_valid_rows(tmp_path):
     assert len(store.list_chunks()) == 1
 
 
+def test_purge_invalidated_preserves_supersession_audit_history(tmp_path):
+    # Regression guard: the grace sweep must reap ONLY bulk delete-by-source
+    # soft-deletes, never auto-supersession audit rows (ADR 0069 D9). Both stamp
+    # invalidated_at, so an undiscriminated sweep would silently wipe supersession
+    # history the moment bulk-delete is first used.
+    store = KnowledgeStore(tmp_path / "kb.db")
+    superseded = store.add_chunk("old fact, superseded", domain="fact", source="thread-1")
+    assert store.invalidate_chunk(superseded)  # ADR 0069 D9 — NULL invalidation_reason
+    bulk = store.add_chunk("bad ingest", domain="media", source="bad-article")
+    assert store.invalidate_by_source("bad-article") == 1  # #1770 — reason stamped
+
+    # Age BOTH well past the grace window.
+    _set_invalidated(store.path, superseded, "2026-01-01T00:00:00+00:00")
+    _set_invalidated(store.path, bulk, "2026-01-01T00:00:00+00:00")
+
+    # Even at zero grace the sweep removes only the bulk soft-delete…
+    assert store.purge_invalidated(0) == 1
+    surviving = {c.id for c in store.list_chunks(include_invalidated=True)}
+    assert bulk not in surviving  # the bulk-deleted ingest is gone
+    assert superseded in surviving  # the supersession audit row is kept forever
+
+
+def test_restore_by_source_never_resurrects_supersession_row(tmp_path):
+    # An Undo (restore_by_source) must only re-validate what the bulk delete
+    # soft-deleted — never an auto-supersession row that happens to share the source.
+    store = KnowledgeStore(tmp_path / "kb.db")
+    superseded = store.add_chunk("superseded fact", domain="fact", source="shared")
+    assert store.invalidate_chunk(superseded)  # NULL reason, stays invalidated
+    store.add_chunk("bulk ingest chunk", domain="media", source="shared")
+    assert store.invalidate_by_source("shared") == 1  # only the valid (non-superseded) row
+
+    assert store.restore_by_source("shared") == 1  # only the bulk row comes back
+    still_invalid = {c.id for c in store.list_chunks(include_invalidated=True) if c.invalidated_at}
+    assert still_invalid == {superseded}  # the audit row is untouched by the Undo
+
+
 def test_hybrid_purge_invalidated_clears_vectors(tmp_path):
     path = tmp_path / "kb.db"
     store = HybridKnowledgeStore(path, embed_fn=_const_embed)
@@ -308,6 +344,22 @@ def test_hybrid_purge_invalidated_clears_vectors(tmp_path):
     n = db.execute("SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id = ?", (cid,)).fetchone()[0]
     db.close()
     assert n == 0  # no orphan vector left behind for a swept chunk
+
+
+def test_hybrid_purge_invalidated_keeps_supersession_vectors(tmp_path):
+    # The hybrid override must mirror the base's reason filter — a superseded
+    # (ADR 0069 D9) chunk's vector is audit history and survives the sweep.
+    path = tmp_path / "kb.db"
+    store = HybridKnowledgeStore(path, embed_fn=_const_embed)
+    cid = store.add_chunk("superseded vector chunk", domain="fact", source="s")
+    assert store.invalidate_chunk(cid)  # NULL reason
+    _set_invalidated(path, cid, "2026-01-01T00:00:00+00:00")
+
+    assert store.purge_invalidated(0) == 0  # nothing bulk-deleted to reap
+    db = sqlite3.connect(str(path))
+    n = db.execute("SELECT COUNT(*) FROM chunk_vectors WHERE chunk_id = ?", (cid,)).fetchone()[0]
+    db.close()
+    assert n == 1  # the supersession vector is preserved
 
 
 def test_layered_bulk_source_targets_private_never_commons(tmp_path):

--- a/tests/test_knowledge_routes.py
+++ b/tests/test_knowledge_routes.py
@@ -112,6 +112,106 @@ def test_chunk_crud_disabled_without_store(monkeypatch):
     assert c.delete("/api/knowledge/chunks/1").json() == {"enabled": False, "deleted": False}
 
 
+# ── bulk delete/restore by source (reversible soft delete, #1770) ─────────────
+class _SourceKS:
+    """Backend double for the bulk delete-by-source lifecycle: soft
+    invalidate/restore by source + the opportunistic grace sweep."""
+
+    def __init__(self, *, invalidated=3, restored=3):
+        self.invalidated = invalidated
+        self.restored = restored
+        self.invalidate_calls: list[str] = []
+        self.restore_calls: list[str] = []
+        self.purge_calls: list[int] = []
+        self.purge_returns = 0
+
+    def invalidate_by_source(self, source):
+        self.invalidate_calls.append(source)
+        return self.invalidated
+
+    def restore_by_source(self, source):
+        self.restore_calls.append(source)
+        return self.restored
+
+    def purge_invalidated(self, older_than_seconds=0):
+        self.purge_calls.append(older_than_seconds)
+        return self.purge_returns
+
+
+def test_delete_by_source_soft_deletes_and_sweeps(monkeypatch):
+    ks = _SourceKS(invalidated=3)
+    c = _client(monkeypatch, knowledge=ks)
+    body = c.post("/api/knowledge/delete-by-source", json={"source": "Hiking with Kevin"}).json()
+    assert body == {"enabled": True, "deleted": 3}
+    assert ks.invalidate_calls == ["Hiking with Kevin"]
+    # The opportunistic grace sweep ran with a positive recovery window before the
+    # invalidate (AC4 — past-grace rows become permanent).
+    assert ks.purge_calls and ks.purge_calls[0] > 0
+
+
+def test_restore_by_source(monkeypatch):
+    ks = _SourceKS(restored=3)
+    c = _client(monkeypatch, knowledge=ks)
+    body = c.post("/api/knowledge/restore-by-source", json={"source": "Hiking with Kevin"}).json()
+    assert body == {"enabled": True, "restored": 3}
+    assert ks.restore_calls == ["Hiking with Kevin"]
+
+
+def test_delete_by_source_requires_source(monkeypatch):
+    c = _client(monkeypatch, knowledge=_SourceKS())
+    assert c.post("/api/knowledge/delete-by-source", json={"source": "   "}).status_code == 400
+    assert c.post("/api/knowledge/restore-by-source", json={}).status_code == 400
+
+
+def test_delete_by_source_disabled_without_store(monkeypatch):
+    c = _client(monkeypatch)
+    assert c.post("/api/knowledge/delete-by-source", json={"source": "x"}).json() == {
+        "enabled": False,
+        "deleted": 0,
+    }
+    assert c.post("/api/knowledge/restore-by-source", json={"source": "x"}).json() == {
+        "enabled": False,
+        "restored": 0,
+    }
+
+
+def test_delete_by_source_backend_without_capability_no_ops(monkeypatch):
+    """A plugin backend that never implemented the lifecycle degrades to a 0-count
+    hint instead of 500ing (getattr guard, mirrors purge_domain)."""
+    c = _client(monkeypatch, knowledge=_CrudKS())  # only add/delete_by_id
+    d = c.post("/api/knowledge/delete-by-source", json={"source": "x"}).json()
+    assert d["enabled"] is True and d["deleted"] == 0 and "error" in d
+    r = c.post("/api/knowledge/restore-by-source", json={"source": "x"}).json()
+    assert r["enabled"] is True and r["restored"] == 0 and "error" in r
+
+
+def test_delete_by_source_end_to_end_on_real_store(monkeypatch, tmp_path):
+    """The real KnowledgeStore: a bulk delete hides the whole source from browse,
+    and restore brings every chunk back — the console's optimistic-remove + Undo."""
+    from knowledge.store import KnowledgeStore
+
+    store = KnowledgeStore(str(tmp_path / "k.db"))
+    for i in range(3):
+        store.add_chunk(f"hiking tip {i}", domain="media", source="Hiking with Kevin")
+    store.add_chunk("unrelated fact", domain="general", source="daily-log")
+    c = _client(monkeypatch, knowledge=store)
+
+    assert c.post("/api/knowledge/delete-by-source", json={"source": "Hiking with Kevin"}).json() == {
+        "enabled": True,
+        "deleted": 3,
+    }
+    rows = c.get("/api/knowledge/search?q=").json()["results"]
+    sources = [r["source"] for r in rows]
+    assert "Hiking with Kevin" not in sources and "daily-log" in sources  # only the group left recall
+
+    assert c.post("/api/knowledge/restore-by-source", json={"source": "Hiking with Kevin"}).json() == {
+        "enabled": True,
+        "restored": 3,
+    }
+    rows = c.get("/api/knowledge/search?q=").json()["results"]
+    assert sum(1 for r in rows if r["source"] == "Hiking with Kevin") == 3  # all back
+
+
 def test_playbooks_sorted_pinned_first(monkeypatch):
     class _SK:
         def all_skills(self):


### PR DESCRIPTION
Closes #1770

## What

The Knowledge view could only delete chunks **one at a time**. After ingesting an article, a YouTube transcript, or a batch of docs you can end up with dozens or hundreds of chunks from a single ingest — impractical to prune by hand. All chunks from one ingest share a `source`, and a source with several loaded chunks already collapses into a group (#1575). This adds a **bulk delete on that group**, as a **reversible soft-delete lifecycle**.

Meets every AC:

1. **More than one chunk at a time** — one trash button deletes a whole source.
2. **One/two-click delete-by-source** — trash on the group header → confirm.
3. **Counted confirmation** — `Delete all {N} chunks from "{source}"?`.
4. **Reversible** — an **Undo toast** (`restore-by-source`) plus a real **grace/recovery period**: the delete only *soft*-deletes (invalidates); rows survive a window and are hard-swept later by `purge_invalidated`.
5. **Per-chunk delete unchanged** — bulk delete is additive.

## How

**Store (`knowledge/store.py`)** — three lifecycle methods + a `source` index:
- `invalidate_by_source(source) -> int` — stamps `invalidated_at` on every *valid* row for `source` (leaves search/list/hot-memory at once, ADR 0069 D9). Empty source guarded (never an "invalidate everything" sweep).
- `restore_by_source(source) -> int` — clears `invalidated_at` (the Undo).
- `purge_invalidated(older_than_seconds, *, _cutoff=None) -> int` — hard-deletes soft-deleted rows aged past the grace window. `_cutoff` is an internal seam so the hybrid override shares **one** boundary (no orphan-vector window).
- **Hybrid** (`hybrid_store.py`) overrides `purge_invalidated` to drop side-table `chunk_vectors` first (no FK cascade) — same pattern as `delete_by_namespace`/`purge_domain`.
- **Layered** delegates the whole lifecycle to the **private** tier via `__getattr__` (the commons is curated via forget, never bulk-deleted) — like `purge_domain`.

**Route (`operator_api/knowledge_routes.py`)** — `POST /api/knowledge/delete-by-source` (`{deleted}`) and `POST /api/knowledge/restore-by-source` (`{restored}`), both `getattr`-guarded so a plugin backend without the methods degrades to a 0-count no-op instead of 500ing.
- **Grace-sweep wiring (design note):** there's no scheduler hook that owns knowledge here, so rather than invent one, the sweep runs **opportunistically** at the top of each bulk delete — it first `purge_invalidated(_INVALIDATED_GRACE_SECONDS)` (24h) to make aged-out soft-deletes permanent, then invalidates the new source. Best-effort; a sweep failure never blocks the delete.

**Frontend (`KnowledgeStore.tsx`)** — a trash button on the group header (a **sibling** of the toggle — a `<button>` can't nest inside the header button), a counted `ConfirmDialog`, **optimistic** group removal (with rollback on failure), and a success toast whose message embeds an **Undo** `<Button>` that calls `restoreKnowledgeBySource` + re-invalidates. Shift+click skips the confirm, mirroring the per-chunk quick-delete. Docs (`operator-api.md`, `knowledge.md`) + CHANGELOG updated.

## Gates (run locally)

Python — `.venv/bin/python -m ruff check .`:
\`\`\`
All checks passed!
\`\`\`

Import contracts — `lint-imports`:
\`\`\`
graph does not import server or operator_api KEPT
operator_api does not import server KEPT
infra packages do not import server or operator_api KEPT
Contracts: 3 kept, 0 broken.
\`\`\`

Python — `.venv/bin/python -m pytest tests/test_knowledge_routes.py tests/test_knowledge_lifecycle.py -q`:
\`\`\`
53 passed, 1 warning in 1.24s
\`\`\`

Frontend — `tsc -p tsconfig.json --noEmit` (app) and `tsconfig.node.json` both exit 0; `vitest run`:
\`\`\`
Test Files  44 passed (44)
     Tests  445 passed (445)
\`\`\`
`check-css-comments.mjs`: `OK — no glued */ in any src CSS comment.`

## Testing notes

- **Draft** because this is a console/UX change — CI can't judge the UX; a human gates the merge.
- **Playwright e2e defers to CI** (worktree serves stale dist). The spec (`knowledge.spec.ts`: counted-confirm → bulk delete → Undo restores) + mock-server handlers are written. The existing #1575 group-header locator was anchored (`/^Hiking with Kevin/`) so it still selects the toggle, not the new delete button.
- FE gates were run against the main checkout's `node_modules` (package.json + lockfile verified byte-identical to `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)