### PR TITLE
feat(palette): toggle fleet agents on/off from ⌘K (#1769)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.91.0] - 2026-07-04
 
 ### Added
+- **Toggle fleet agents from the command palette** (#1769). Bringing a fleet member online or
+  taking it offline used to mean diving several clicks into Settings. A new **"Toggle Fleet
+  Agent"** command in the ⌘K palette opens a picker of your local fleet members, each with its
+  live on/off state, and selecting one starts or stops it (`POST /api/fleet/{name}/start|stop`)
+  with a confirmation toast. The host agent and remote members are never listed (they can't be
+  controlled from here), and the agent whose console this window is viewing is shown disabled so
+  you can't stop your own session out from under yourself.
 - **Goal completion contracts** (ADR 0073). A goal can now carry an optional, structured
   *completion contract* — `outcome` (the single required end-state), `constraints` (invariants
   the agent must not violate/regress), `boundaries` (files/dirs/systems in scope), and

--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -178,3 +178,59 @@ test("discover → add to fleet → switch into the remote member (ADR 0042 §I)
     .getByRole("button", { name: /Remove from this fleet/ }).click();
   await expect(page.locator(".fleet-row", { hasText: "remy" })).toHaveCount(0);
 });
+
+// ── Command-palette fleet toggle (#1769) ───────────────────────────────────────────
+// Toggle a local, non-host member on/off straight from ⌘K — no Settings dive. The
+// picker lists togglable members with their live process state; picking one flips it and
+// toasts. Reuses this file's per-spec fleet scope (beforeEach resets to baseline).
+
+// The DS palette morphs views with a popLayout cross-fade, so the exiting root list lingers
+// in the DOM for a beat next to the entering sub-view. A sub-view row's accessible name is
+// "<name> <state>" (e.g. "ava on") — and the sub-view states ("on"/"off") never collide with
+// the root quick-chat's hints ("switch"/"stopped"/"unreachable"), so keying every assertion
+// on the exact "<name> <state>" name sidesteps the transient overlap entirely.
+async function openToggleFleet(page) {
+  await page.keyboard.press("ControlOrMeta+k");
+  await expect(page.locator(".pl-cmdk__panel")).toBeVisible();
+  // A reopen momentarily re-morphs the last sub-view back to the root view (the DS palette
+  // resets its stack on open), so the sub-view's search box lingers next to the root one for a
+  // beat — wait for it to leave before filling, or `.pl-cmdk-commands__input` is ambiguous.
+  await expect(page.getByPlaceholder("Toggle a fleet agent on/off…")).toHaveCount(0);
+  // Filter the root list to the toggle command, then enter its submorph.
+  await page.locator(".pl-cmdk__panel .pl-cmdk-commands__input").fill("Toggle Fleet Agent");
+  await page.getByRole("option", { name: "Toggle Fleet Agent" }).click();
+  await expect(page.locator(".pl-cmdk__title")).toHaveText("Toggle Fleet Agent"); // in the sub-view
+}
+
+const row = (page, name, state) => page.getByRole("option", { name: `${name} ${state}`, exact: true });
+
+test("⌘K → Toggle Fleet Agent lists non-host members with state and flips one", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await openToggleFleet(page);
+
+  // Local members are listed with their live process state; the host (main) never is.
+  await expect(row(page, "ava", "on")).toBeVisible(); // running in baseline
+  await expect(row(page, "roxy", "off")).toBeVisible(); // stopped, still listed
+  await expect(page.getByRole("option", { name: /^main\b/ })).toHaveCount(0); // host excluded
+
+  // Toggle ava off — the palette closes, a toast confirms, and the roster flips.
+  await row(page, "ava", "on").click();
+  await expect(page.locator(".pl-cmdk__panel")).toHaveCount(0);
+  await expect(page.locator(".pl-toast", { hasText: "Stopping ava" })).toBeVisible();
+
+  // Reopen the picker: ava now reads "off" (its running state flipped on the invalidated poll).
+  await openToggleFleet(page);
+  await expect(row(page, "ava", "off")).toBeVisible();
+});
+
+test("⌘K → Toggle Fleet Agent starts a stopped member", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await openToggleFleet(page);
+
+  await expect(row(page, "roxy", "off")).toBeVisible(); // stopped in baseline
+  await row(page, "roxy", "off").click();
+  await expect(page.locator(".pl-toast", { hasText: "Starting roxy" })).toBeVisible();
+
+  await openToggleFleet(page);
+  await expect(row(page, "roxy", "on")).toBeVisible();
+});

--- a/apps/web/src/app/fleetPalette.test.ts
+++ b/apps/web/src/app/fleetPalette.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 
-import { fleetPaletteEntries, markAgentOpened, readAgentRecency } from "./fleetPalette";
+import { fleetPaletteEntries, markAgentOpened, readAgentRecency, togglableFleetAgents } from "./fleetPalette";
 import type { FleetAgent } from "../lib/types";
 
 function agent(over: Partial<FleetAgent>): FleetAgent {
@@ -41,6 +41,52 @@ describe("fleetPaletteEntries (#1733)", () => {
     const [only] = fleetPaletteEntries([agent({ name: "r", id: "r", remote: true, running: true })], "me");
     expect(only.disabled).toBe(false);
     expect(only.hint).toBe("remote · switch");
+  });
+});
+
+describe("togglableFleetAgents (#1769)", () => {
+  it("excludes the host — it serves this console and can't be stopped from itself", () => {
+    const agents = [
+      agent({ name: "main", id: "main", host: true }),
+      agent({ name: "ava", id: "ava" }),
+    ];
+    const out = togglableFleetAgents(agents);
+    expect(out.map((a) => a.name)).toEqual(["ava"]);
+    expect(out.find((a) => a.host)).toBeUndefined();
+  });
+
+  it("excludes remotes — they have no local process to start/stop from here", () => {
+    const agents = [
+      agent({ name: "ava", id: "ava" }),
+      agent({ name: "remy", id: "remy", remote: true, running: true }),
+    ];
+    expect(togglableFleetAgents(agents).map((a) => a.name)).toEqual(["ava"]);
+  });
+
+  it("lists both running and stopped local members (on/off is live process state)", () => {
+    const agents = [
+      agent({ name: "up", id: "up", running: true }),
+      agent({ name: "down", id: "down", running: false, pid: null }),
+    ];
+    const out = togglableFleetAgents(agents);
+    expect(out.map((a) => a.name)).toEqual(["down", "up"]); // both present, name-sorted
+    expect(out.map((a) => a.running)).toEqual([false, true]);
+  });
+
+  it("sorts stably by display name", () => {
+    const agents = [
+      agent({ name: "zed", id: "zed" }),
+      agent({ name: "ava", id: "ava" }),
+      agent({ name: "bob", id: "bob" }),
+    ];
+    expect(togglableFleetAgents(agents).map((a) => a.name)).toEqual(["ava", "bob", "zed"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const agents = [agent({ name: "zed", id: "zed" }), agent({ name: "ava", id: "ava" })];
+    const snapshot = agents.map((a) => a.name);
+    togglableFleetAgents(agents);
+    expect(agents.map((a) => a.name)).toEqual(snapshot);
   });
 });
 

--- a/apps/web/src/app/fleetPalette.ts
+++ b/apps/web/src/app/fleetPalette.ts
@@ -68,3 +68,17 @@ export function fleetPaletteEntries(
         a.label.localeCompare(b.label), // then alphabetical
     );
 }
+
+/** The fleet agents whose live process can be toggled on/off from the palette (#1769).
+ *  ON/OFF is the live process state (`FleetAgent.running`), not a persisted flag: "on" =
+ *  `POST /api/fleet/<name>/start`, "off" = `POST /api/fleet/<name>/stop`. Only LOCAL,
+ *  non-host members qualify — the SAME gate FleetManagerPanel uses to show Start/Stop:
+ *   • the host serves this console, so stopping it would kill the session — never listed;
+ *   • a REMOTE member has no local process here (its `/start|/stop` 400s) — excluded too.
+ *  Sorted stably by display name so the picker order is deterministic across polls. */
+export function togglableFleetAgents(agents: FleetAgent[]): FleetAgent[] {
+  return agents
+    .filter((a) => !a.host && !a.remote)
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -12,14 +12,16 @@ import type { ReactNode } from "react";
 import { useEffect, useMemo } from "react";
 import { commandsView, createPaletteRegistry, pluginView } from "@protolabsai/ui/command-palette";
 import type { Command, PaletteRegistry, PaletteView } from "@protolabsai/ui/command-palette";
+import { useToast } from "@protolabsai/ui/overlays";
 import { useUI } from "../state/uiStore";
 import type { View } from "../lib/viewRegistry";
 import { registerPaletteCommand, registeredPaletteCommands } from "../ext/paletteRegistry";
 import type { PaletteCommand } from "../ext/paletteRegistry";
-import { useQuery } from "@tanstack/react-query";
-import { agentHref, currentSlug } from "../lib/api";
-import { fleetQuery } from "../lib/queries";
-import { fleetPaletteEntries, markAgentOpened, readAgentRecency } from "./fleetPalette";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { agentHref, api, currentSlug } from "../lib/api";
+import { errMsg } from "../lib/format";
+import { fleetQuery, queryKeys } from "../lib/queries";
+import { fleetPaletteEntries, markAgentOpened, readAgentRecency, togglableFleetAgents } from "./fleetPalette";
 
 /** Optional inline chat with the focused agent (ADR 0057). App builds the native chat
  *  PaletteView (it needs JSX + the focused agent name); the adapter registers it + a
@@ -178,6 +180,9 @@ export function usePaletteRegistry(
 ): PaletteRegistry {
   const registry = useMemo(() => createPaletteRegistry(), []);
   const inlineIds = useMemo(() => new Set(inlineViews.map((v) => v.id)), [inlineViews]);
+  // Stable across renders — closed over by the fleet-toggle command's `run` (#1769).
+  const toast = useToast();
+  const qc = useQueryClient();
 
   // The live fleet roster (polled) → a "Quick-chat with any fleet agent" section (#1733). Works
   // in both the console window and the desktop launcher (both sit under QueryClientProvider).
@@ -291,7 +296,52 @@ export function usePaletteRegistry(
       };
     });
     const offPlugins = pluginCommands.length ? registry.registerCommands(pluginCommands) : undefined;
-    // Commands group: `Open ▸` (morphs to the built-in surfaces) + the deep-link actions.
+    // Fleet on/off (#1769): a `Toggle Fleet Agent ▸` submorph listing every LOCAL, non-host
+    // member with its live process state as a hint chip ("on"/"off"). ON/OFF isn't a persisted
+    // flag — it's `FleetAgent.running`: picking a stopped agent starts it, a running one stops
+    // it, then we invalidate the roster (so its dot + this list's hint flip on the next poll)
+    // and toast the outcome. The row for the agent THIS window is proxied to is disabled
+    // ("current") so the operator can't kill their own console from here.
+    const focused = currentSlug();
+    const toggleCommands: Command[] = togglableFleetAgents(agents).map((a) => {
+      const on = a.running;
+      const isCurrent = a.id === focused;
+      return {
+        id: `fleet-toggle:${a.id}`,
+        label: a.name,
+        hint: isCurrent ? "current" : on ? "on" : "off",
+        group: "Agents",
+        keywords: ["fleet", "agent", "toggle", on ? "disable" : "enable", on ? "stop" : "start", a.name],
+        disabled: isCurrent, // can't stop the agent serving this very window
+        run: (c) => {
+          c.close();
+          const action = on ? api.stopAgent(a.name) : api.startAgent(a.name);
+          action
+            .then(() => {
+              qc.invalidateQueries({ queryKey: queryKeys.fleet });
+              toast({
+                tone: "success",
+                title: on ? `Stopping ${a.name}…` : `Starting ${a.name}…`,
+                message: on ? `${a.name} is going offline.` : `${a.name} is coming online.`,
+              });
+            })
+            .catch((e) => toast({ tone: "error", title: "Couldn't toggle agent", message: errMsg(e) }));
+        },
+      };
+    });
+    const offToggleView = registry.registerViews([
+      {
+        ...commandsView({
+          commands: toggleCommands,
+          placeholder: "Toggle a fleet agent on/off…",
+          emptyLabel: "No fleet agents to toggle",
+        }),
+        id: "fleet-toggle",
+        title: "Toggle Fleet Agent",
+      },
+    ]);
+    // Commands group: `Open ▸` (morphs to the built-in surfaces), `Toggle Fleet Agent ▸`, and
+    // the deep-link actions.
     const openCommand: Command = {
       id: "open",
       label: "Open…",
@@ -300,11 +350,24 @@ export function usePaletteRegistry(
       keywords: ["open", "go to", "surface", "view", "navigate", "switch", "panel"],
       run: (c) => c.enter("open"),
     };
-    const offCommands = registry.registerCommands([openCommand, ...registeredPaletteCommands().map(toDsCommand)]);
+    const toggleCommand: Command = {
+      id: "fleet:toggle",
+      label: "Toggle Fleet Agent",
+      hint: "on / off",
+      group: "Commands",
+      keywords: ["fleet", "agent", "toggle", "enable", "disable", "start", "stop", "on", "off"],
+      run: (c) => c.enter("fleet-toggle"),
+    };
+    const offCommands = registry.registerCommands([
+      openCommand,
+      toggleCommand,
+      ...registeredPaletteCommands().map(toDsCommand),
+    ]);
     return () => {
       offChat?.();
       offFleet?.();
       offPlugins?.();
+      offToggleView();
       offCommands();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/docs/guides/command-palette.md
+++ b/docs/guides/command-palette.md
@@ -10,6 +10,11 @@ hunting through rails and menus ([ADR 0057](/adr/0057-command-palette)).
   Settings, plugin rail views) is a "go to" command, listed first.
 - **Deep links** — jump straight to Activity/Inbox, Plugins → Discover/Install, or a
   specific Settings tab.
+- **Toggle a fleet agent** — **Toggle Fleet Agent** opens a picker of the local,
+  non-host fleet members with their live on/off state; picking one brings it online (or
+  takes it offline) and confirms with a toast — no Settings dive. The host is never
+  listed (stopping it would kill the session), and the agent this window is proxied to is
+  disabled ("current") so you can't stop your own console out from under yourself.
 - **Inline chat** — start typing a question and the palette morphs into a quick chat
   with the focused agent (its own thread, persisted locally) — handy for a one-off ask
   without leaving what you're doing.

--- a/docs/guides/fleet.md
+++ b/docs/guides/fleet.md
@@ -183,7 +183,10 @@ navigate to it; "+ New agent" runs the archetype picker. A plugin view served by
 that opens a **WebSocket** (e.g. `agent_browser`'s live viewport) works through the hub too:
 the slug proxy forwards WS upgrades, not just HTTP/SSE ([#883](https://github.com/protoLabsAI/protoAgent/issues/883), shipped v0.35.0). Settings → Agents is the fleet manager
 (create / start / stop / rename / remove), and **Discover** finds other protoAgents on the
-box, the LAN (mDNS) and your **tailnet** (via the Tailscale CLI).
+box, the LAN (mDNS) and your **tailnet** (via the Tailscale CLI). To flip a local member
+on or off without opening Settings, press **⌘K → Toggle Fleet Agent** and pick it from the
+picker (the host and remote members are never listed) — see
+[command palette](./command-palette.md).
 
 **Fleet settings are hub-only.** The topbar dropdown's **Fleet settings** item is enabled
 on the host window (and on a standalone instance — that's where you create your first


### PR DESCRIPTION
Closes #1769

## What

Adds a **Toggle Fleet Agent** command to the console command palette (⌘K), so an operator can bring a local fleet member online or offline without diving into **Settings → Agents**. The command morphs into a picker listing every **local, non-host** member with its **live process state** as a hint chip (`on`/`off`); picking one:

- starts a stopped agent or stops a running one — `POST /api/fleet/<name>/start|stop` (`api.startAgent`/`api.stopAgent`),
- invalidates the fleet roster (`queryKeys.fleet`) so its status dot **and** this list's hint flip on the next 3s poll,
- confirms with a success toast (`Starting <name>…` / `Stopping <name>…`); failures surface an error-tone toast.

### Design notes / acceptance criteria

- **On/off is not a persisted flag** — it's the live `FleetAgent.running` process state (start = enable, stop = disable).
- **Host is never listed** (AC #2, #5) — stopping it would kill the session. **Remotes are excluded** too (no local process here; their `/start|/stop` 400s). This is the same `!host && !remote` gate `FleetManagerPanel` uses to show Start/Stop.
- **Reflects current state** (AC #4) — each row shows an `on`/`off` hint chip; the existing `fleetSig` re-register effect keys on `a.running`, so labels refresh live on the poll.
- **Confirmation toast** (AC #3) — via the global `useToast()` (`.pl-toast`).
- **Self-protection (nice-to-have):** the row for the agent this window is proxied to (`currentSlug()`) is disabled with a `current` hint, so the operator can't stop their own console out from under themselves.
- **Empty state:** with no togglable members the picker shows `No fleet agents to toggle`.
- Registered through the ADR 0061 palette registry seam (`registerViews` sub-view `fleet-toggle` + a root `Commands`-group command) — same path a fork/plugin uses. Command ids namespaced `fleet-toggle:<id>` / view `fleet-toggle` to avoid colliding with the existing quick-chat `fleet:<slug>` commands.

## Files

- `apps/web/src/app/fleetPalette.ts` — pure `togglableFleetAgents()` helper (filter `!host && !remote`, stable name sort).
- `apps/web/src/app/fleetPalette.test.ts` — colocated vitest tests (host excluded, remote excluded, running+stopped both listed, stable sort, no input mutation).
- `apps/web/src/app/usePaletteRegistry.ts` — the sub-view + root command wiring.
- `apps/web/e2e/fleet.spec.ts` — Playwright e2e (lists non-host members with state, flips one, starts a stopped one).
- `docs/guides/command-palette.md`, `docs/guides/fleet.md` — docs.

Frontend only — no backend changes.

## Gates (run locally from the worktree)

**`npm run test:unit --workspace @protoagent/web`** — includes the 5 new `togglableFleetAgents` tests:
\`\`\`
 Test Files  44 passed (44)
      Tests  450 passed (450)
   Duration  4.69s
\`\`\`

**`npm run build --workspace @protoagent/web`** (= `tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build`) — typecheck + build:
\`\`\`
> tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build
✓ built in 4.03s
\`\`\`

**Playwright e2e** — ran the two new specs + the full `fleet.spec.ts` file locally against the fresh dist (twice, for stability). Per house rules FE Playwright in a worktree can serve stale dist, so **CI is the source of truth** for e2e:
\`\`\`
npx playwright test fleet.spec.ts
  9 passed (14.9s)   # run 1
  9 passed (15.3s)   # run 2
\`\`\`

> This is a console/UX change, so opening as a **draft** — CI can't judge UX; a human gates the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-palette flow to toggle local fleet agents on or off.
  * The picker shows live status, excludes host and remote agents, and disables the current session’s agent.

* **Bug Fixes**
  * Added safeguards to keep the agent list sorted consistently and avoid mutating the original roster.

* **Tests**
  * Added end-to-end and unit coverage for listing, ordering, and toggling fleet agents.

* **Documentation**
  * Updated fleet and command-palette guides with the new toggle workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->