### PR TITLE
feat(lifecycle): system lifecycle events on the bus + hook/config reaction seams (#1653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **System lifecycle events** (#1653, ADR 0074). The agent now broadcasts its own lifecycle
+  transitions on the [event bus](docs/guides/lifecycle-events.md) (ADR 0039): `app.loaded` when
+  boot finishes (graph + scheduler + surfaces + fleet-autostart up) and `agent.active` when it
+  goes idle → active (the first turn since boot, or the first after an idle gap — **debounced**,
+  not every turn). `system.wake` (desktop shell wake) is **reserved**: the bus, hook seam, and
+  config accept it now; the Tauri emit is a follow-up. Every payload carries a `ts` and the
+  `previous_state`. Two opt-in ways to react, both error-isolated (a bad hook/webhook/prompt can
+  never break boot or a turn): a **plugin hook** — `registry.register_lifecycle_hook(on_app_loaded
+  / on_agent_active / on_system_wake=…)` (or a plain `registry.on("app.loaded", …)` bus
+  subscription); and an operator-facing **config reaction** — a top-level `lifecycle_hooks:` list
+  of `{event, prompt?, webhook?, session?}` entries in `langgraph-config.yaml` that enqueue a
+  follow-up turn (`run_in_session`) or POST a webhook. Empty by default ⇒ nothing fires beyond the
+  broadcast. A read-only `/lifecycle` chat command lists the events, configured reactions, and
+  registered hooks.
 - **Bulk delete-by-source in the Knowledge view** (#1770). Ingesting an article,
   transcript, or batch of docs can leave dozens or hundreds of chunks that used to be
   removable only one at a time. A source with several loaded chunks now collapses into a

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -83,6 +83,7 @@ export default defineConfig({
           items: [
             { text: "Goal mode", link: "/guides/goal-mode" },
             { text: "Watches", link: "/guides/watches" },
+            { text: "System lifecycle events", link: "/guides/lifecycle-events" },
             { text: "File GitHub issues (/issue)", link: "/guides/file-github-issues" },
             { text: "Schedule future work", link: "/guides/scheduler" },
             { text: "Middleware", link: "/guides/middleware" },

--- a/docs/adr/0074-system-lifecycle-events.md
+++ b/docs/adr/0074-system-lifecycle-events.md
@@ -1,0 +1,96 @@
+# 0074 — System lifecycle events
+
+- Status: Accepted
+- Date: 2026-07-04
+- Builds on: ADR 0039 (the plugin event bus), ADR 0028 (plugin goal hooks — the seam this
+  mirrors), ADR 0003/0053 (scheduler / `run_in_session` — the reaction primitive).
+
+## Context
+
+The event bus (ADR 0039) lets plugins broadcast and subscribe, but every topic today is a
+*plugin* event (`artifact.created`, `<plugin>.<thing>`). Nothing broadcasts the **system's own
+lifecycle** — that the process finished booting, that the agent just went from idle to active,
+that the desktop shell woke from sleep. An operator who wants "when the agent boots, DM me a
+summary" or "when it wakes up, catch up on what happened while it slept" has no seam: they'd have
+to fork `server/` and hand-wire an emit.
+
+Three lifecycle transitions are worth a first-class, stable contract:
+
+- **`app.loaded`** — boot finished: the graph is compiled and the scheduler, surfaces, and
+  fleet-autostart members are up. The "I'm ready" beacon.
+- **`agent.active`** — the agent went **idle → active** (a turn started after a quiet gap). Not
+  *every* turn (that fires constantly) — the leading edge of a work session.
+- **`system.wake`** — the desktop shell woke / regained focus. **Reserved** in this ADR: the
+  bus/seam/config accept it now; the Tauri emit (Focused → `POST /api/events/publish`) is a
+  deliberate follow-up so this PR carries no desktop work.
+
+## Decision
+
+Add a **system lifecycle** layer over the ADR 0039 bus with three coordinated surfaces, all
+**opt-in** and all **error-isolated** (a bad hook / webhook / prompt can never break boot or a
+turn).
+
+### D1 — A dispatcher in `graph/lifecycle/` (`fire(event, payload)`)
+
+One entry point every server emit site calls. It does three things per event:
+
+1. **Broadcasts** the event on the bus (ADR 0039) under a **dot-namespaced** topic
+   (`app.loaded`, `agent.active`, `system.wake`) — so any plugin/console subscriber reacts with
+   zero wiring.
+2. **Fires plugin hooks** (D2).
+3. **Runs config reactions** (D3).
+
+It lives in `graph/` and imports only `graph.sdk` / `graph.plugins.host` / `runtime` (via the
+SDK) / `httpx` — **never `server` or `operator_api`** (the import-layering contract). The config
+event name (`app_loaded`) → bus topic (`app.loaded`) mapping lives in exactly one place
+(`graph/lifecycle/dispatch.py:TOPICS`).
+
+### D2 — A plugin hook seam (`register_lifecycle_hook`)
+
+Mirrors the goal-hook seam (ADR 0028 D4) exactly. A plugin calls
+`registry.register_lifecycle_hook(on_app_loaded=…, on_agent_active=…, on_system_wake=…)`; the
+loader collects the hooks (`PluginLoadResult.lifecycle_hooks`) and the server installs them into
+the live module registry (`graph/lifecycle/hooks.py`, re-set on config reload alongside the goal /
+watch hooks). Each callback takes the event **payload** dict, may be sync or async, and a raising
+hook is logged + swallowed. (A hook is the direct-callback form; `registry.on("app.loaded", …)` is
+the zero-config bus alternative.)
+
+### D3 — An operator-facing config reaction path (`lifecycle_hooks`)
+
+A top-level `lifecycle_hooks:` list in `langgraph-config.yaml`, each entry
+`{event, prompt?, webhook?, session?}`:
+
+- `event` — `app_loaded` | `agent_active` | `system_wake`.
+- `prompt` — enqueue a follow-up agent turn via `sdk.run_in_session` (ADR 0053) in `session` (or,
+  for `agent_active`, the event's own session).
+- `webhook` — POST `{event, data}` to a URL (async, short timeout).
+
+**Default empty ⇒ nothing fires** beyond the bus broadcast — opt-in by construction. Being a
+list-of-dicts (not a scalar), it round-trips through `config_io.py` §B like `filesystem.projects` /
+`mcp.servers`, not the string-typed settings `FIELDS`.
+
+### D4 — Payloads carry a timestamp + previous state
+
+Every payload carries `ts` (epoch) and `previous_state`. `agent.active` also carries `session_id`
+and `idle_seconds`; `app.loaded` carries `agent` + `port`. `agent.active` is **debounced** by a
+pure, unit-testable helper (`should_emit_active(now, last_activity_ts, threshold=300s)`): emit on
+the first turn since boot (`previous_state="boot"`) or the first turn after ≥ threshold idle
+(`previous_state="idle"`), suppress otherwise. The last-activity timestamp lives on
+`runtime.state.STATE`.
+
+### D5 — A read-only `/lifecycle` chat command
+
+A reserved core command (like `/goal`) that lists the three events and the currently-configured
+config reactions + registered plugin hooks. **Listing only** for v1 — the config file is the
+source of truth; no runtime mutation.
+
+## Consequences
+
+- A new **event contract** (three system topics) that forks and plugins can rely on. This ADR is
+  the reference for their names + payloads.
+- Plugins get system-awareness (`register_lifecycle_hook` **or** a bus subscription) and operators
+  get a no-fork reaction path — both without touching `server/`.
+- `system.wake` is reserved but inert until the desktop emit ships; emitting it is purely additive
+  (the seam already accepts it).
+- This is a small, additive extension of ADR 0039 (a new *producer* of system events on the same
+  bus), plus the hook/config seams goal mode already established (ADR 0028) — no new subsystem.

--- a/docs/guides/lifecycle-events.md
+++ b/docs/guides/lifecycle-events.md
@@ -1,0 +1,88 @@
+# System lifecycle events
+
+The agent broadcasts a few **system lifecycle** events on the [event bus](/guides/plugins#the-event-bus-adr-0039) —
+that it finished booting, that it just woke up from an idle stretch, that the desktop shell came
+back. An operator can react to them from a config file; a plugin can react in code. Both are
+**opt-in** and both are **error-isolated** — a broken webhook or a bad hook can never break boot or
+a turn (ADR 0074).
+
+## The events
+
+| Event (bus topic) | Fires when | Payload |
+| --- | --- | --- |
+| `app.loaded` | Boot finished — the graph is compiled and the scheduler, surfaces, and fleet-autostart members are up. | `ts`, `agent`, `port`, `previous_state: "boot"` |
+| `agent.active` | The agent went **idle → active**: a turn started after a quiet gap (the first turn since boot, or the first after ~5 min idle — **debounced**, so a busy session doesn't fire it every turn). | `ts`, `session_id`, `idle_seconds`, `previous_state: "boot" \| "idle"` |
+| `system.wake` | *Reserved.* The desktop shell woke / regained focus. The bus, hook seam, and config all accept it today; the desktop emit is a follow-up. | `ts`, `previous_state` |
+
+Every payload carries a `ts` (epoch seconds) and a `previous_state`, so a reaction knows *when* the
+transition happened and *what it came from*.
+
+## React from config (no code)
+
+Add a top-level `lifecycle_hooks:` list to `langgraph-config.yaml`. Each entry names an `event`
+and one or both of a `prompt` (enqueue a follow-up agent turn) and a `webhook` (POST the event).
+**Empty by default ⇒ nothing fires** beyond the bus broadcast — this is opt-in.
+
+```yaml
+lifecycle_hooks:
+  # When boot finishes, run a turn in the "ops" session catching me up.
+  - event: app_loaded
+    prompt: "You just started up. Check the inbox and scheduler and brief me on anything waiting."
+    session: ops                       # app_loaded carries no session, so name one
+
+  # Ping an external endpoint on every boot.
+  - event: app_loaded
+    webhook: https://hooks.example.com/protoagent/boot
+
+  # When the agent comes back after being idle, review what happened.
+  - event: agent_active
+    prompt: "Welcome back — summarize anything that changed while you were idle."
+    # no `session:` → runs in the session whose turn woke the agent
+```
+
+Fields per entry:
+
+- **`event`** — `app_loaded` · `agent_active` · `system_wake` (the config uses underscores; the bus
+  topic is the dotted form, e.g. `app.loaded`).
+- **`prompt`** — the message the agent processes as a one-shot turn ([`run_in_session`](/guides/scheduler)).
+  Runs in **`session`**, or — for `agent_active` — the event's own session when `session` is omitted.
+  `app_loaded` / `system_wake` carry no session, so those **must** set `session`.
+- **`webhook`** — a URL that receives `POST {"event": "<topic>", "data": <payload>}` (async, short
+  timeout).
+
+## React from a plugin (in code)
+
+A plugin has two ways to react. The zero-config way is a **bus subscription** — subscribe to the
+dotted topic in `register()`:
+
+```python
+def register(registry):
+    registry.on("app.loaded", lambda ev: print("booted:", ev["data"]))
+    registry.on("agent.active", on_active)   # ev["data"] has session_id, idle_seconds, …
+```
+
+The direct-callback way is a **lifecycle hook** (mirrors [`register_goal_hook`](/guides/goal-mode#reacting-to-a-goal)):
+
+```python
+def register(registry):
+    registry.register_lifecycle_hook(
+        on_app_loaded=lambda payload: ...,      # sync or async; payload is the event dict
+        on_agent_active=on_active,
+        # on_system_wake=...,                    # reserved
+    )
+```
+
+Provide any of the three callbacks. A raising hook is logged and swallowed. Hooks are re-installed
+on a config reload, so enabling/updating a plugin picks them up without a restart.
+
+## Inspect what's wired — `/lifecycle`
+
+Run `/lifecycle` in chat for a read-only listing of the three events, the currently-configured
+config reactions, and any registered plugin hooks. (Listing only — the config file is the source of
+truth; there's no runtime mutation.)
+
+## See also
+
+- [Plugins ▸ the event bus](/guides/plugins#the-event-bus-adr-0039) — the underlying pub/sub.
+- [Schedule future work](/guides/scheduler) — `run_in_session`, the prompt-reaction primitive.
+- ADR 0074 (system lifecycle events) · ADR 0039 (the plugin event bus).

--- a/graph/config.py
+++ b/graph/config.py
@@ -718,6 +718,16 @@ class LangGraphConfig:
     # (comma-separated). See graph/fleet/supervisor.start_autostart_members.
     fleet_autostart: list[str] = field(default_factory=list)
 
+    # System lifecycle reactions (ADR 0074) — a top-level ``lifecycle_hooks:`` YAML list
+    # of ``{event, prompt?, webhook?, session?}`` entries the runtime runs when a system
+    # lifecycle event fires. ``event`` is one of ``app_loaded`` / ``agent_active`` /
+    # ``system_wake``; ``prompt`` enqueues a follow-up turn (in ``session``, or the event's
+    # own session for agent_active); ``webhook`` POSTs the event. **Opt-in**: empty ⇒ NOTHING
+    # fires beyond the ADR 0039 bus broadcast (plugins can still react via the bus / a
+    # ``register_lifecycle_hook`` hook). List of dicts, so it round-trips via config_io.py §B
+    # (like ``filesystem_projects`` / ``mcp_servers``), not the string_list-typed FIELDS.
+    lifecycle_hooks: list[dict] = field(default_factory=list)
+
     # Operator-console directory allowlist — the extra directories the
     # React console's tasks/notes APIs may read and write. The protoAgent
     # repo root is always allowed implicitly (it's the default project);
@@ -1031,6 +1041,9 @@ class LangGraphConfig:
                 )
                 or []
             ),
+            # System lifecycle reactions (ADR 0074) — top-level ``lifecycle_hooks:`` list.
+            # Opt-in: absent/empty ⇒ [] ⇒ nothing fires beyond the bus broadcast.
+            lifecycle_hooks=list(data.get("lifecycle_hooks", []) or []),
             operator_allowed_dirs=list(operator.get("allowed_dirs", []) or []),
             operator_project_dir=str(operator.get("project_dir", "") or ""),
             filesystem_enabled=data.get("filesystem", {}).get("enabled", cls.filesystem_enabled),

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -442,6 +442,10 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
     _deep_merge(
         d,
         {
+            # System lifecycle reactions (ADR 0074) — a top-level list of
+            # {event, prompt?, webhook?, session?} dicts, so it round-trips here (like
+            # filesystem.projects / mcp.servers) rather than through the string_list FIELDS.
+            "lifecycle_hooks": list(config.lifecycle_hooks),
             # background_keep is an operational knob (not a settings-schema field),
             # so emit it here for round-trip completeness like the breaker knobs.
             "checkpoint": {

--- a/graph/lifecycle/__init__.py
+++ b/graph/lifecycle/__init__.py
@@ -1,0 +1,39 @@
+"""System lifecycle events (ADR 0074, extends the ADR 0039 event bus).
+
+Emit system-state transitions — ``app.loaded`` (boot finished), ``agent.active``
+(idle → active), ``system.wake`` (reserved) — on the event bus, with a plugin hook
+seam (``register_lifecycle_hook``) and a config-driven reaction path (``lifecycle_hooks``
+in ``langgraph-config.yaml``) so an operator or plugin can react.
+
+- :func:`fire` — the one dispatcher every server emit site calls.
+- :func:`set_lifecycle_hooks` / :func:`fire_lifecycle_hook` — the plugin hook seam.
+- :func:`should_emit_active` — the pure ``agent.active`` debounce helper.
+"""
+
+from graph.lifecycle.dispatch import (
+    EVENTS,
+    IDLE_THRESHOLD_S,
+    TOPICS,
+    config_reactions,
+    describe,
+    fire,
+    should_emit_active,
+)
+from graph.lifecycle.hooks import (
+    fire_lifecycle_hook,
+    lifecycle_hooks,
+    set_lifecycle_hooks,
+)
+
+__all__ = [
+    "EVENTS",
+    "TOPICS",
+    "IDLE_THRESHOLD_S",
+    "fire",
+    "config_reactions",
+    "describe",
+    "should_emit_active",
+    "fire_lifecycle_hook",
+    "set_lifecycle_hooks",
+    "lifecycle_hooks",
+]

--- a/graph/lifecycle/dispatch.py
+++ b/graph/lifecycle/dispatch.py
@@ -1,0 +1,181 @@
+"""System lifecycle dispatch (ADR 0074, extends ADR 0039).
+
+One entry point — :func:`fire` — that every emit site in ``server/`` calls when a
+system lifecycle event happens. It does three things, each error-isolated so a bad
+hook / webhook / prompt can never break boot or a turn:
+
+1. **Broadcast on the event bus** (ADR 0039) under a dot-namespaced topic, so any
+   plugin/console subscriber can react with no wiring.
+2. **Fire plugin hooks** (``fire_lifecycle_hook`` — ``registry.register_lifecycle_hook``).
+3. **Run config reactions** — the operator-facing half: ``lifecycle_hooks`` entries in
+   ``langgraph-config.yaml`` that enqueue a follow-up prompt (``run_in_session``) or POST a
+   webhook. **Opt-in**: with no config, nothing fires beyond the bus broadcast.
+
+This module lives in ``graph/`` and imports only ``graph.sdk`` / ``graph.plugins.host`` /
+``graph.lifecycle.hooks`` / ``runtime`` (via the SDK) / ``httpx`` — never ``server`` or
+``operator_api`` (the import-layering contract). The server emit sites call in.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from graph.lifecycle.hooks import fire_lifecycle_hook
+
+log = logging.getLogger(__name__)
+
+# Config-event name (``app_loaded``) → dot-namespaced bus topic (``app.loaded``). The
+# ONE place the two naming conventions are bridged: config + slash command speak
+# ``app_loaded``; the bus (ADR 0039) speaks ``app.loaded``.
+TOPICS: dict[str, str] = {
+    "app_loaded": "app.loaded",
+    "agent_active": "agent.active",
+    "system_wake": "system.wake",
+}
+# The canonical event names, in emit order. ``system_wake`` is reserved (the bus/seam/
+# config accept it now; the desktop emit lands in a follow-up PR).
+EVENTS: tuple[str, ...] = ("app_loaded", "agent_active", "system_wake")
+
+# agent.active debounce: a turn fires the chat path constantly, so only emit on the
+# FIRST turn since boot or the first turn after this much idle time.
+IDLE_THRESHOLD_S = 300.0
+
+
+def should_emit_active(
+    now: float, last_activity_ts: float | None, *, threshold: float = IDLE_THRESHOLD_S
+) -> tuple[bool, float, str]:
+    """Pure debounce for ``agent.active``. Emit on the FIRST turn since boot
+    (``last_activity_ts is None``) or the first turn after an idle gap ≥ ``threshold``.
+
+    Returns ``(emit, idle_seconds, previous_state)`` where ``previous_state`` is
+    ``"boot"`` for the first turn or ``"idle"`` otherwise. Pure + side-effect free so
+    it's unit-testable without a clock or STATE."""
+    if last_activity_ts is None:
+        return True, 0.0, "boot"
+    idle = max(0.0, now - last_activity_ts)
+    return (idle >= threshold), idle, "idle"
+
+
+def config_reactions(event: str) -> list[dict]:
+    """The configured ``lifecycle_hooks`` entries whose ``event`` matches (opt-in;
+    empty by default ⇒ nothing fires). Reads the live ``LangGraphConfig`` via the SDK."""
+    from graph.sdk import config as _config
+
+    cfg = _config()
+    hooks = getattr(cfg, "lifecycle_hooks", None) or []
+    return [h for h in hooks if isinstance(h, dict) and h.get("event") == event]
+
+
+def _publish(event: str, payload: dict) -> None:
+    """Broadcast the event on the bus (ADR 0039). Best-effort — a bus hiccup (or no bus
+    wired, e.g. headless/tests) must never break the lifecycle path."""
+    topic = TOPICS.get(event, event)
+    try:
+        from graph.plugins.host import HOST
+
+        if HOST.publish:
+            HOST.publish(topic, payload)
+    except Exception:  # noqa: BLE001
+        log.debug("[lifecycle] %s bus emit failed", topic, exc_info=True)
+
+
+async def _post_webhook(url: str, event: str, payload: dict) -> None:
+    """POST the event to a webhook (async, short timeout). Isolated — a slow/broken
+    endpoint must never stall boot or a turn."""
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            await client.post(url, json={"event": TOPICS.get(event, event), "data": payload})
+    except Exception:  # noqa: BLE001 — a bad webhook is the operator's problem, not ours
+        log.warning("[lifecycle] %s webhook POST to %s failed", event, url, exc_info=True)
+
+
+async def _run_reaction(reaction: dict, event: str, payload: dict) -> None:
+    """Run one configured reaction — a ``prompt`` (enqueue a follow-up turn via
+    ``run_in_session``) and/or a ``webhook`` (POST). Both are optional; both are
+    error-isolated."""
+    prompt = str(reaction.get("prompt") or "").strip()
+    webhook = str(reaction.get("webhook") or "").strip()
+    # Prompt reactions run in the configured session, else the event's own session
+    # (agent.active carries one; app.loaded/system.wake don't, so those need `session`).
+    session = str(reaction.get("session") or payload.get("session_id") or "").strip()
+    if prompt:
+        try:
+            from graph.sdk import run_in_session
+
+            if session:
+                run_in_session(session, prompt)
+            else:
+                log.warning(
+                    "[lifecycle] %s prompt reaction has no session (set `session:` on the "
+                    "lifecycle_hooks entry) — skipped",
+                    event,
+                )
+        except Exception:  # noqa: BLE001 — a bad reaction must not break the lifecycle path
+            log.exception("[lifecycle] %s prompt reaction failed", event)
+    if webhook:
+        await _post_webhook(webhook, event, payload)
+
+
+_EVENT_BLURB = {
+    "app_loaded": "boot finished — graph, scheduler, surfaces + fleet autostart up",
+    "agent_active": "the agent went idle → active (first turn after a quiet gap, debounced)",
+    "system_wake": "reserved — the desktop shell woke (emitted in a follow-up PR)",
+}
+
+
+def _reaction_summary(reaction: dict) -> str:
+    parts = []
+    if str(reaction.get("prompt") or "").strip():
+        sess = str(reaction.get("session") or "").strip()
+        parts.append(f"prompt→{sess}" if sess else "prompt (own session)")
+    if str(reaction.get("webhook") or "").strip():
+        parts.append(f"webhook {reaction['webhook']}")
+    return " · ".join(parts) or "(no prompt/webhook)"
+
+
+def describe() -> str:
+    """A read-only, human-readable summary of the three lifecycle events, their configured
+    ``lifecycle_hooks`` reactions, and registered plugin hooks — backs the ``/lifecycle``
+    chat command (AC#3). Listing only; the config file is the source of truth."""
+    from graph.lifecycle.hooks import lifecycle_hooks as _plugin_hooks
+
+    lines = [
+        "**System lifecycle events** (ADR 0074) — broadcast on the event bus (ADR 0039); "
+        "reactions are opt-in via the `lifecycle_hooks:` config list.",
+        "",
+    ]
+    hooks_by_event: dict[str, list[str]] = {e: [] for e in EVENTS}
+    for hook in _plugin_hooks():
+        pid = hook.get("plugin_id") or "?"
+        for event in EVENTS:
+            if hook.get(f"on_{event}"):
+                hooks_by_event[event].append(pid)
+    for event in EVENTS:
+        topic = TOPICS[event]
+        lines.append(f"- `{topic}` — {_EVENT_BLURB[event]}")
+        reactions = config_reactions(event)
+        if reactions:
+            for r in reactions:
+                lines.append(f"    - config reaction: {_reaction_summary(r)}")
+        plugins = hooks_by_event.get(event) or []
+        if plugins:
+            lines.append(f"    - plugin hooks: {', '.join(plugins)}")
+        if not reactions and not plugins:
+            lines.append("    - no reactions configured")
+    return "\n".join(lines)
+
+
+async def fire(event: str, payload: dict) -> None:
+    """Emit a system lifecycle ``event``: broadcast on the bus, fire plugin hooks, run
+    configured reactions. Every stage is error-isolated. ``event`` is a canonical name
+    (``app_loaded`` / ``agent_active`` / ``system_wake``); ``payload`` carries at least
+    ``ts`` + ``previous_state``."""
+    _publish(event, payload)
+    try:
+        await fire_lifecycle_hook(event, payload)
+    except Exception:  # noqa: BLE001 — defense in depth (fire_lifecycle_hook already isolates)
+        log.exception("[lifecycle] %s hook dispatch failed", event)
+    for reaction in config_reactions(event):
+        await _run_reaction(reaction, event, payload)

--- a/graph/lifecycle/hooks.py
+++ b/graph/lifecycle/hooks.py
@@ -1,0 +1,62 @@
+"""System lifecycle hooks (ADR 0074, extends ADR 0039).
+
+A plugin can react when the *system* changes state — the app finished booting
+(``app.loaded``), the agent went from idle to active (``agent.active``), or the
+desktop shell woke from sleep/focus (``system.wake``, reserved). This mirrors the
+goal-hook seam (``graph/goals/hooks.py``): hooks are module-level, populated by the
+loader at graph build via ``set_lifecycle_hooks`` and re-set on config reload, and
+fired from the lifecycle dispatcher (``graph/lifecycle/dispatch.py``).
+
+A hook fn takes the event ``payload`` (a plain dict — ``ts`` + ``previous_state`` +
+event-specific keys); it may be sync or async. A hook that raises is logged and
+swallowed — a bad hook must never break boot or a turn.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+
+log = logging.getLogger(__name__)
+
+# Config-event name → the hook-dict callback key it fires. The three system events
+# (kept in one place so the emit sites, the config, and the hooks agree on names).
+_CALLBACK_KEY = {
+    "app_loaded": "on_app_loaded",
+    "agent_active": "on_agent_active",
+    "system_wake": "on_system_wake",
+}
+
+# Each entry: {"plugin_id", "on_app_loaded": fn|None, "on_agent_active": fn|None,
+# "on_system_wake": fn|None}.
+_LIFECYCLE_HOOKS: list[dict] = []
+
+
+def set_lifecycle_hooks(hooks: list[dict] | None) -> None:
+    """Replace the registered lifecycle hooks (called at build + reload)."""
+    _LIFECYCLE_HOOKS[:] = list(hooks or [])
+
+
+def lifecycle_hooks() -> list[dict]:
+    """The live registered lifecycle hooks (read-only view for /lifecycle + tests)."""
+    return list(_LIFECYCLE_HOOKS)
+
+
+async def fire_lifecycle_hook(event: str, payload: dict) -> None:
+    """Fire the matching plugin hook for a system lifecycle ``event`` (``app_loaded`` →
+    ``on_app_loaded``, ``agent_active`` → ``on_agent_active``, ``system_wake`` →
+    ``on_system_wake``). An unknown event is a no-op; a hook may be sync or async; a
+    raising hook is logged and swallowed."""
+    key = _CALLBACK_KEY.get(event)
+    if key is None:
+        return
+    for hook in _LIFECYCLE_HOOKS:
+        fn = hook.get(key)
+        if fn is None:
+            continue
+        try:
+            result = fn(payload)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:  # noqa: BLE001 — a bad hook must not break the lifecycle path
+            log.exception("[lifecycle] %s hook (plugin %s) failed", key, hook.get("plugin_id"))

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -35,6 +35,7 @@ class PluginLoadResult:
     goal_verifiers: dict = field(default_factory=dict)  # name -> verifier fn (ADR 0028)
     goal_hooks: list = field(default_factory=list)  # {on_achieved, on_failed} (ADR 0028)
     watch_hooks: list = field(default_factory=list)  # {on_met, on_expired, on_stalled} (ADR 0067)
+    lifecycle_hooks: list = field(default_factory=list)  # {on_app_loaded, on_agent_active, on_system_wake} (ADR 0074)
     knowledge_stores: dict = field(default_factory=dict)  # name -> backend factory (ADR 0031)
     embedders: dict = field(default_factory=dict)  # name -> embed_fn factory (ADR 0031)
     a2a_skills: list = field(default_factory=list)  # A2A card skill specs (#570)
@@ -538,6 +539,7 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
             result.goal_verifiers[name] = fn
         result.goal_hooks.extend(registry.goal_hooks)  # ADR 0028 D4
         result.watch_hooks.extend(registry.watch_hooks)  # ADR 0067
+        result.lifecycle_hooks.extend(registry.lifecycle_hooks)  # ADR 0074
         for name, factory in registry.knowledge_stores.items():  # ADR 0031
             if name in result.knowledge_stores:
                 log.warning("[plugins] %s: knowledge backend %s collides — skipped", manifest.id, name)

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -77,6 +77,7 @@ class PluginRegistry:
         self.goal_verifiers: dict = {}  # name -> async (spec, ctx) -> VerifyResult (ADR 0028)
         self.goal_hooks: list = []  # {on_achieved, on_failed, on_stalled} reactions (ADR 0028 + 0030 D5)
         self.watch_hooks: list = []  # {on_met, on_expired, on_stalled} watch reactions (ADR 0067)
+        self.lifecycle_hooks: list = []  # {on_app_loaded, on_agent_active, on_system_wake} (ADR 0074)
         self.knowledge_stores: dict = {}  # name -> (config) -> KnowledgeBackend (ADR 0031)
         self.embedders: dict = {}  # name -> (config) -> (text -> vector) embed_fn (ADR 0031)
         self.chat_commands: dict = {}  # token -> async (rest, session_id) -> str|None (user-only control commands)
@@ -134,8 +135,8 @@ class PluginRegistry:
         a reply string or another form (a multi-step wizard).
 
         The token is slugified + lowercased (``/Issue`` == ``/issue``). The reserved
-        core token ``goal`` is refused; a collision with a token another enabled
-        plugin already registered keeps the first and warns (resolved in the loader).
+        core tokens ``goal`` / ``lifecycle`` are refused; a collision with a token another
+        enabled plugin already registered keeps the first and warns (resolved in the loader).
         """
         from graph.slash_commands import slugify_slash  # intra-graph, import-safe
 
@@ -145,7 +146,7 @@ class PluginRegistry:
                 "[plugins] %s: register_chat_command needs a name + callable: %r / %r", self.plugin_id, name, handler
             )
             return
-        if token == "goal":
+        if token in ("goal", "lifecycle"):  # reserved core control commands (ADR 0074)
             log.warning("[plugins] %s: chat command /%s is reserved — skipped", self.plugin_id, token)
             return
         if token in self.chat_commands:
@@ -270,6 +271,31 @@ class PluginRegistry:
                 "on_met": on_met if callable(on_met) else None,
                 "on_expired": on_expired if callable(on_expired) else None,
                 "on_stalled": on_stalled if callable(on_stalled) else None,
+            }
+        )
+
+    def register_lifecycle_hook(self, *, on_app_loaded=None, on_agent_active=None, on_system_wake=None) -> None:
+        """React to a system lifecycle event (ADR 0074) — ``on_app_loaded`` (boot finished:
+        graph compiled + scheduler/surfaces/fleet up), ``on_agent_active`` (the agent went
+        idle → active — the first turn after a quiet gap, debounced), ``on_system_wake``
+        (reserved — the desktop shell woke; emitted in a follow-up). Each takes the event
+        ``payload`` dict (``ts`` + ``previous_state`` + event-specific keys), sync or async.
+        Provide ANY of the three. A raising hook is logged + swallowed — a bad hook must never
+        break boot or a turn. (These are *broadcast* on the bus too, so ``registry.on(...)`` is
+        the zero-config alternative; a hook is the direct callback form.)"""
+        if not (callable(on_app_loaded) or callable(on_agent_active) or callable(on_system_wake)):
+            log.warning(
+                "[plugins] %s: register_lifecycle_hook needs on_app_loaded, on_agent_active, "
+                "and/or on_system_wake",
+                self.plugin_id,
+            )
+            return
+        self.lifecycle_hooks.append(
+            {
+                "plugin_id": self.plugin_id,
+                "on_app_loaded": on_app_loaded if callable(on_app_loaded) else None,
+                "on_agent_active": on_agent_active if callable(on_agent_active) else None,
+                "on_system_wake": on_system_wake if callable(on_system_wake) else None,
             }
         )
 

--- a/graph/plugins/testkit.py
+++ b/graph/plugins/testkit.py
@@ -273,6 +273,7 @@ class FakeRegistry:
         self.verifiers: dict = {}
         self.goal_hooks: list = []
         self.watch_hooks: list = []
+        self.lifecycle_hooks: list = []
         self.knowledge_stores: dict = {}
         self.embedders: dict = {}
         self.chat_commands: dict = {}  # slugified token -> handler
@@ -349,6 +350,9 @@ class FakeRegistry:
 
     def register_watch_hook(self, *, on_met=None, on_expired=None, on_stalled=None) -> None:
         self.watch_hooks.append((on_met, on_expired, on_stalled))
+
+    def register_lifecycle_hook(self, *, on_app_loaded=None, on_agent_active=None, on_system_wake=None) -> None:
+        self.lifecycle_hooks.append((on_app_loaded, on_agent_active, on_system_wake))
 
     def register_knowledge_store(self, name: str, factory) -> None:
         self.knowledge_stores[name] = factory

--- a/graph/slash_commands.py
+++ b/graph/slash_commands.py
@@ -168,11 +168,14 @@ def slash_kind(name: str) -> str | None:
     goal > plugin chat command > workflow > subagent > user-facing skill. Returns
     ``None`` for an unknown token. (Plugin commands/workflows/subagents match the
     bare name or its slug; skills match a slug.) ``/issue`` is no longer core — the
-    github plugin owns it, so it resolves as a ``plugin_command``."""
+    github plugin owns it, so it resolves as a ``plugin_command``. ``lifecycle`` is a
+    reserved read-only core command (ADR 0074), like ``goal``."""
     if not name:
         return None
     if name == "goal" or slugify_slash(name) == "goal":
         return "goal"
+    if name == "lifecycle" or slugify_slash(name) == "lifecycle":
+        return "lifecycle"
     if find_plugin_chat_command(name) is not None:
         return "plugin_command"
     if STATE.workflow_registry is not None and STATE.workflow_registry.get(name) is not None:

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -658,5 +658,15 @@ def _operator_chat_commands() -> dict:
                 "usage": "/goal <condition>   ·   /goal  (status)   ·   /goal clear",
             }
         )
+    # /lifecycle (ADR 0074) — read-only listing of the system lifecycle events + their
+    # configured reactions and registered plugin hooks (a core control command, like /goal).
+    commands.append(
+        {
+            "name": "lifecycle",
+            "kind": "control",
+            "description": "List the system lifecycle events and their configured reactions + plugin hooks.",
+            "usage": "/lifecycle",
+        }
+    )
     commands.extend(resolve_slash_commands())
     return {"commands": commands}

--- a/plugins/docs/nav.json
+++ b/plugins/docs/nav.json
@@ -54,6 +54,10 @@
           "title": "Watches"
         },
         {
+          "path": "guides/lifecycle-events.md",
+          "title": "System lifecycle events"
+        },
+        {
           "path": "guides/file-github-issues.md",
           "title": "File GitHub issues (/issue)"
         },
@@ -643,6 +647,10 @@
         {
           "path": "adr/0073-goal-completion-contracts.md",
           "title": "0073 — Goal completion contracts"
+        },
+        {
+          "path": "adr/0074-system-lifecycle-events.md",
+          "title": "0074 — System lifecycle events"
         },
         {
           "path": "adr/index.md",

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -77,6 +77,9 @@ class AppState:
     main_loop: Any = None
     # The port this process actually bound to (populated by _main).
     active_port: int = 7870
+    # Epoch of the last chat-turn start, for the ADR 0074 ``agent.active`` idle debounce.
+    # None ⇒ no turn yet this process (the first turn emits with previous_state="boot").
+    last_activity_ts: float | None = None
 
 
 STATE = AppState()

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -609,6 +609,26 @@ def _main():
         except Exception:
             log.exception("[fleet] boot version reconcile failed")
 
+        # System lifecycle: app.loaded (ADR 0074). Boot is done — graph compiled, scheduler
+        # + surfaces + fleet autostart up — so broadcast it on the bus, fire plugin
+        # lifecycle hooks, and run any configured `lifecycle_hooks` reactions (opt-in; empty
+        # config ⇒ just the broadcast). Fire-and-forget on the loop so a webhook/prompt
+        # reaction never stalls the last step of boot; the dispatcher isolates every failure.
+        try:
+            import time as _time
+
+            from graph import lifecycle as _lifecycle
+
+            payload = {
+                "ts": _time.time(),
+                "agent": agent_name(),
+                "port": getattr(STATE, "active_port", None),
+                "previous_state": "boot",
+            }
+            asyncio.create_task(_lifecycle.fire("app_loaded", payload))
+        except Exception:
+            log.exception("[lifecycle] app.loaded emit failed")
+
     @fastapi_app.on_event("shutdown")
     async def _scheduler_shutdown() -> None:
         # Drop the co-location heartbeat (#706). Best-effort.

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -1406,11 +1406,13 @@ def _apply_plugin_registries(plugins) -> None:
     caller already holds the config-write lock (init runs once at boot, uncontended)."""
     from graph.goals import hooks as _goal_hooks
     from graph.goals import verifiers as _goal_verifiers
+    from graph.lifecycle import hooks as _lifecycle_hooks
     from graph.watches import hooks as _watch_hooks
 
     _goal_verifiers.set_plugin_verifiers(plugins.goal_verifiers)  # ADR 0028
     _goal_hooks.set_goal_hooks(plugins.goal_hooks)
     _watch_hooks.set_watch_hooks(plugins.watch_hooks)  # ADR 0067
+    _lifecycle_hooks.set_lifecycle_hooks(plugins.lifecycle_hooks)  # ADR 0074
 
 
 @_serialized_config_write

--- a/server/chat.py
+++ b/server/chat.py
@@ -1138,6 +1138,47 @@ def seconds_since_last_turn() -> float:
     return max(0.0, time.monotonic() - _LAST_TURN_MONOTONIC)
 
 
+def _lifecycle_command_reply(message: str) -> str | None:
+    """If ``message`` is the core ``/lifecycle`` command (ADR 0074), return its read-only
+    listing — the three lifecycle events plus the currently-configured config reactions and
+    registered plugin hooks. Else ``None`` (fall through). Reserved like ``/goal``, so no
+    plugin/workflow/skill can shadow it; listing only (the config file is the source of
+    truth for v1 — no runtime mutation)."""
+    name, _rest = _parse_slash_command(message)
+    if not name or _slash_kind(name) != "lifecycle":
+        return None
+    from graph.lifecycle import describe
+
+    return describe()
+
+
+def _note_agent_active(session_id: str) -> None:
+    """Emit the ``agent.active`` lifecycle event (ADR 0074) when the agent goes idle →
+    active — the FIRST turn since boot, or the first turn after an idle gap (debounced by
+    ``graph.lifecycle.should_emit_active`` so a busy session doesn't broadcast every turn).
+
+    Fire-and-forget on the running loop; best-effort so it can never break a turn.
+    ``STATE.last_activity_ts`` is updated every turn regardless of whether we emit."""
+    from graph.lifecycle import fire, should_emit_active
+
+    now = time.time()
+    last = STATE.last_activity_ts
+    STATE.last_activity_ts = now
+    emit, idle_seconds, previous_state = should_emit_active(now, last)
+    if not emit:
+        return
+    payload = {
+        "ts": now,
+        "session_id": session_id,
+        "idle_seconds": idle_seconds,
+        "previous_state": previous_state,
+    }
+    try:
+        asyncio.create_task(fire("agent_active", payload))
+    except Exception:  # noqa: BLE001 — a lifecycle emit must never break a turn
+        log.debug("[lifecycle] agent.active emit failed", exc_info=True)
+
+
 async def _chat_langgraph_stream(
     message: str,
     session_id: str,
@@ -1151,6 +1192,7 @@ async def _chat_langgraph_stream(
     lifetime — including early ``aclose()`` and errors — then delegate. Keeps the
     public name/signature so every caller (A2A executor, console) is unchanged."""
     _turn_started()
+    _note_agent_active(session_id)  # ADR 0074 — idle→active lifecycle event (debounced)
     try:
         async for _ev in _chat_langgraph_stream_impl(
             message,
@@ -1227,6 +1269,13 @@ async def _chat_langgraph_stream_impl(
                 if reply is not None:
                     yield ("done", reply)
                     return
+
+            # Core /lifecycle command (ADR 0074) — read-only listing of the lifecycle
+            # events + configured reactions + registered hooks. Reserved like /goal.
+            lc_reply = _lifecycle_command_reply(message)
+            if lc_reply is not None:
+                yield ("done", lc_reply)
+                return
 
             # Plugin-registered chat control command (/<name> …) short-circuits the
             # turn with the plugin's reply — user-only, like /goal (e.g. the github
@@ -1533,6 +1582,7 @@ async def _chat_langgraph(
     """Idle-beacon wrapper (#1720): mark a turn in flight for the call's lifetime,
     then delegate. Keeps the public name/signature for every caller."""
     _turn_started()
+    _note_agent_active(session_id)  # ADR 0074 — idle→active lifecycle event (debounced)
     try:
         return await _chat_langgraph_impl(
             message, session_id, model=model, incognito=incognito, hitl_resume=hitl_resume
@@ -1574,6 +1624,11 @@ async def _chat_langgraph_impl(
                 reply = await STATE.goal_controller.parse_control(message, session_id, trusted=False)
                 if reply is not None:
                     return [{"role": "assistant", "content": reply}]
+
+            # Core /lifecycle command (ADR 0074) — read-only listing. Reserved like /goal.
+            lc_reply = _lifecycle_command_reply(message)
+            if lc_reply is not None:
+                return [{"role": "assistant", "content": lc_reply}]
 
             # Plugin-registered chat control command (/<name> …) short-circuits —
             # user-only, like /goal (e.g. the github plugin's /issue). No plugin

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -135,7 +135,9 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     # schema's top-level keys, plus two legacy sections config_io §B emits that have no
     # FIELDS entry (subagents.researcher and the plugins.* knobs). Deriving from FIELDS
     # means a new field doesn't require re-typing the section list here.
-    _LEGACY_SECTIONS = {"subagents", "plugins"}
+    # lifecycle_hooks (ADR 0074) is a top-level list emitted by config_io §B (like the
+    # subagents/plugins knobs), not a FIELDS-typed field — so it joins the legacy set.
+    _LEGACY_SECTIONS = {"subagents", "plugins", "lifecycle_hooks"}
     assert set(d.keys()) == {f.key.split(".", 1)[0] for f in FIELDS} | _LEGACY_SECTIONS
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -123,6 +123,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "knowledge_hot_write_confirm": False,
     "knowledge_middleware": True,
     "knowledge_top_k": 5,
+    "lifecycle_hooks": [],
     "knowledge_vector_k": 20,
     "knowledge_rrf_k": 60,
     "knowledge_min_score": 0.0,
@@ -275,6 +276,7 @@ def test_config_to_dict_shape_and_redaction():
 # identity_org, knowledge_scope and skills_scope were all missing from round-trip coverage.)
 _LEGACY_EMITTED_ATTRS = {
     "researcher",  # subagents.researcher (a SubagentDef)
+    "lifecycle_hooks",  # top-level lifecycle_hooks list (ADR 0074) — a list of dicts, config_io.py §B
     "filesystem_projects",  # filesystem.projects (registry of {name,path,write} dicts)
     "checkpoint_background_keep",
     "knowledge_db_path",

--- a/tests/test_lifecycle_hooks.py
+++ b/tests/test_lifecycle_hooks.py
@@ -1,0 +1,166 @@
+"""System lifecycle hooks + dispatch (ADR 0074, extends ADR 0039).
+
+Mirrors tests/test_goal_hooks.py: the module-level hook registry fires the right
+callback per event, a raising hook is swallowed, the registry guard, the config-driven
+reaction path (prompt + webhook), the pure agent.active debounce, and the bus broadcast.
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import pytest
+
+from graph.lifecycle import (
+    IDLE_THRESHOLD_S,
+    TOPICS,
+    describe,
+    fire,
+    should_emit_active,
+)
+from graph.lifecycle import dispatch as lc_dispatch
+from graph.lifecycle.hooks import fire_lifecycle_hook, set_lifecycle_hooks
+from graph.plugins.registry import PluginRegistry
+
+
+@pytest.mark.asyncio
+async def test_fire_routes_by_event():
+    fired: list[str] = []
+    set_lifecycle_hooks(
+        [
+            {
+                "plugin_id": "p",
+                "on_app_loaded": lambda pl: fired.append("loaded"),
+                "on_agent_active": lambda pl: fired.append("active"),
+                "on_system_wake": lambda pl: fired.append("wake"),
+            }
+        ]
+    )
+    try:
+        await fire_lifecycle_hook("app_loaded", {})
+        await fire_lifecycle_hook("agent_active", {})
+        await fire_lifecycle_hook("system_wake", {})
+        await fire_lifecycle_hook("bogus_event", {})  # unknown → no-op
+        assert fired == ["loaded", "active", "wake"]
+    finally:
+        set_lifecycle_hooks([])
+
+
+@pytest.mark.asyncio
+async def test_async_hook_runs_and_a_raising_hook_is_swallowed():
+    seen: list[str] = []
+
+    async def _ok(payload):
+        seen.append("ok")
+
+    def _boom(payload):
+        raise RuntimeError("kaboom")
+
+    set_lifecycle_hooks(
+        [
+            {"plugin_id": "q", "on_app_loaded": _boom, "on_agent_active": None, "on_system_wake": None},
+            {"plugin_id": "p", "on_app_loaded": _ok, "on_agent_active": None, "on_system_wake": None},
+        ]
+    )
+    try:
+        await fire_lifecycle_hook("app_loaded", {})  # must not raise
+        assert seen == ["ok"]
+    finally:
+        set_lifecycle_hooks([])
+
+
+def test_registry_register_lifecycle_hook_guards():
+    reg = PluginRegistry("p", Path("."))
+    reg.register_lifecycle_hook(on_app_loaded=lambda pl: None)
+    reg.register_lifecycle_hook()  # no callables → ignored
+    reg.register_lifecycle_hook(on_agent_active="nope")  # non-callable → ignored
+    assert len(reg.lifecycle_hooks) == 1
+    hook = reg.lifecycle_hooks[0]
+    assert hook["plugin_id"] == "p"
+    assert callable(hook["on_app_loaded"])
+    assert hook["on_agent_active"] is None and hook["on_system_wake"] is None
+
+
+def test_debounce_emits_when_idle_and_suppresses_when_busy():
+    # First turn since boot → always emit, previous_state "boot".
+    emit, idle, prev = should_emit_active(1000.0, None)
+    assert emit is True and idle == 0.0 and prev == "boot"
+
+    # A turn after a long idle gap → emit, previous_state "idle".
+    emit, idle, prev = should_emit_active(1000.0 + IDLE_THRESHOLD_S + 5, 1000.0)
+    assert emit is True and idle == IDLE_THRESHOLD_S + 5 and prev == "idle"
+
+    # A turn during a busy session (gap < threshold) → suppressed.
+    emit, idle, prev = should_emit_active(1010.0, 1000.0)
+    assert emit is False and idle == 10.0 and prev == "idle"
+
+
+@pytest.mark.asyncio
+async def test_config_reactions_dispatch(monkeypatch):
+    """A configured lifecycle_hooks entry enqueues a prompt (run_in_session) and POSTs a
+    webhook — both captured via monkeypatch, both isolated from the real subsystems."""
+    enqueued: list[tuple[str, str]] = []
+    posted: list[tuple[str, str]] = []
+
+    def _fake_run_in_session(session_id, prompt, **kwargs):
+        enqueued.append((session_id, prompt))
+        return {"ok": True}
+
+    async def _fake_post(url, event, payload):
+        posted.append((url, event))
+
+    # run_in_session is imported lazily from graph.sdk inside _run_reaction.
+    monkeypatch.setattr("graph.sdk.run_in_session", _fake_run_in_session, raising=True)
+    monkeypatch.setattr(lc_dispatch, "_post_webhook", _fake_post)
+
+    # config() reads STATE.graph_config; give it an app_loaded reaction with a session
+    # (app.loaded carries no session, so it must be configured) + a webhook.
+    from runtime.state import STATE
+
+    prev_cfg = STATE.graph_config
+    STATE.graph_config = types.SimpleNamespace(
+        lifecycle_hooks=[
+            {"event": "app_loaded", "prompt": "review the boot", "session": "ops"},
+            {"event": "app_loaded", "webhook": "https://example.test/hook"},
+            {"event": "agent_active", "prompt": "ignored — different event"},
+        ]
+    )
+    try:
+        await fire("app_loaded", {"ts": 1.0, "previous_state": "boot"})
+    finally:
+        STATE.graph_config = prev_cfg
+
+    assert enqueued == [("ops", "review the boot")]
+    assert posted == [("https://example.test/hook", "app_loaded")]
+
+
+@pytest.mark.asyncio
+async def test_fire_emits_lifecycle_event_on_the_bus(monkeypatch):
+    """fire() broadcasts the dot-namespaced topic on the event bus (ADR 0039) so ANY
+    plugin/console can react — no lifecycle_hook required. Mirrors the goal-bus test."""
+    from graph.plugins.host import HOST
+    from runtime.state import STATE
+
+    events: list[tuple[str, dict]] = []
+    orig = HOST.publish
+    HOST.publish = lambda topic, data: events.append((topic, data))
+    prev_cfg = STATE.graph_config
+    STATE.graph_config = None  # no config reactions — isolate the bus broadcast
+    try:
+        payload = {"ts": 42.0, "agent": "protoagent", "previous_state": "boot"}
+        await fire("app_loaded", payload)
+    finally:
+        HOST.publish = orig
+        STATE.graph_config = prev_cfg
+
+    assert events, "no event broadcast on the bus"
+    topic, data = events[0]
+    assert topic == "app.loaded" == TOPICS["app_loaded"]
+    assert data["previous_state"] == "boot" and data["ts"] == 42.0
+
+
+def test_describe_lists_the_three_events():
+    text = describe()
+    for topic in ("app.loaded", "agent.active", "system.wake"):
+        assert topic in text

--- a/tests/test_reload_rebuild_deps.py
+++ b/tests/test_reload_rebuild_deps.py
@@ -143,6 +143,7 @@ def test_reload_refreshes_plugin_verifier_registry(tmp_path, monkeypatch):
             mcp_servers=[], tools=[], tool_plugins={}, skill_dirs=[], meta=[],
             chat_commands={}, subagents=[], middleware=[], late_tool_factories=[], routers=[],
             goal_verifiers={"demo:brand_new": _new_verifier}, goal_hooks=[], watch_hooks=[],
+            lifecycle_hooks=[],
         ),
     )
     # Let the graph rebuild SUCCEED so the commit block (with the registry refresh) runs.


### PR DESCRIPTION
Closes #1653.

## What

Emit **system lifecycle events** on the [ADR 0039 event bus](docs/adr/0039-plugin-event-bus.md), with a **plugin hook seam** and an operator-facing **config reaction path**, so an operator or plugin can react to the agent's own state transitions without forking `server/`. New **ADR 0074**.

**Events (dot-namespaced bus topics):**

| Event | Fires | Payload |
| --- | --- | --- |
| `app.loaded` | Boot finished — graph compiled, scheduler + surfaces + fleet-autostart up | `ts`, `agent`, `port`, `previous_state: "boot"` |
| `agent.active` | Agent went idle → active — first turn since boot / after an idle gap (**debounced**, not every turn) | `ts`, `session_id`, `idle_seconds`, `previous_state: "boot"\|"idle"` |
| `system.wake` | **Reserved** — desktop shell wake (bus/seam/config accept it; the Tauri emit is a deliberate follow-up) | `ts`, `previous_state` |

Every payload carries `ts` (epoch) + `previous_state` (AC#4).

## Why / the contract

Plugins could already broadcast/subscribe (ADR 0039), but nothing emitted the *system's own* lifecycle. This adds a small, stable producer layer over the same bus, plus the two reaction seams goal mode already established (ADR 0028):

- **Plugin hook** — `registry.register_lifecycle_hook(on_app_loaded / on_agent_active / on_system_wake=…)` (mirrors `register_goal_hook`; the zero-config alternative is a plain `registry.on("app.loaded", …)` subscription). Loader → `agent_init` install, re-set on config reload alongside the goal/watch hooks. (AC#2)
- **Config reaction** — a top-level `lifecycle_hooks:` list of `{event, prompt?, webhook?, session?}` in `langgraph-config.yaml`: `prompt` enqueues a follow-up turn (`sdk.run_in_session`), `webhook` POSTs the event. (AC#1/AC#3)
- **`/lifecycle`** — a read-only core chat command listing the events, configured reactions, and registered hooks. (AC#3)

## Opt-in safety posture

**Empty `lifecycle_hooks` ⇒ nothing fires beyond the bus broadcast.** Every stage of dispatch is **error-isolated** — a bad hook, a slow/broken webhook (5s timeout), or a failing prompt reaction is logged and swallowed and can **never break boot or a turn**. `graph/lifecycle/` imports only `graph.sdk` / `graph.plugins.host` / `runtime` — never `server`/`operator_api` (verified by `lint-imports`).

## Follow-up (out of scope here)

Desktop `system.wake` — Tauri `Focused` → `POST /api/events/publish` — is a **deliberate follow-up PR**. This PR does no Tauri work; the bus, hook seam, and config already accept the reserved event.

## Files

- `graph/lifecycle/` — `dispatch.py` (the `fire` dispatcher + `should_emit_active` pure debounce + `describe`), `hooks.py` (module registry, mirrors `graph/goals/hooks.py`), `__init__.py`.
- `graph/plugins/registry.py` (+ `testkit.py`), `graph/plugins/loader.py`, `server/agent_init.py` — the hook seam wiring.
- `graph/config.py`, `graph/config_io.py` — the `lifecycle_hooks` field + round-trip (§B, list-of-dicts).
- `server/__init__.py` (`app.loaded` emit), `server/chat.py` (`agent.active` emit + debounce + `/lifecycle`), `runtime/state.py` (`last_activity_ts`), `graph/slash_commands.py` + `operator_api/console_handlers.py` (reserved `/lifecycle` + palette).
- Tests: `tests/test_lifecycle_hooks.py`; goldens updated in `test_config_roundtrip.py` / `test_config_io.py` / `test_reload_rebuild_deps.py`.
- Docs: ADR `0074`, guide `docs/guides/lifecycle-events.md` (+ sidebar + regenerated `nav.json`), CHANGELOG.

## Gate output (run from the worktree)

**`ruff check .`**
```
All checks passed!
```

**`pytest tests/test_lifecycle_hooks.py tests/test_config_roundtrip.py tests/test_event_bus.py tests/test_goal_hooks.py -q`**
```
53 passed in 0.48s
```

**Broader regression set (testkit / reload / config_io / docs sync):** `pytest test_lifecycle_hooks test_config_roundtrip test_event_bus test_goal_hooks test_docs_plugin test_plugin_testkit test_reload_rebuild_deps test_config_io -q`
```
137 passed, 5 warnings in 1.70s
```

**Full suite:** `pytest tests/ -q`
```
3131 passed, 5 skipped, 188 warnings in 57.45s
```

**`lint-imports`**
```
graph does not import server or operator_api KEPT
operator_api does not import server KEPT
infra packages do not import server or operator_api KEPT

Contracts: 3 kept, 0 broken.
```

`docs/gen_docs_nav.py --check` → `nav.json is in sync with the sidebar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)