### PR TITLE
fix(lifecycle): run webhook reactions through the egress guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subscription); and an operator-facing **config reaction** — a top-level `lifecycle_hooks:` list
   of `{event, prompt?, webhook?, session?}` entries in `langgraph-config.yaml` that enqueue a
   follow-up turn (`run_in_session`) or POST a webhook. Empty by default ⇒ nothing fires beyond the
-  broadcast. A read-only `/lifecycle` chat command lists the events, configured reactions, and
+  broadcast. Webhook reactions pass through the same egress guard as `fetch_url` (LAN/tailnet
+  peers allowed, cloud-metadata/reserved refused, and any `egress.allowed_hosts` allowlist
+  enforced). A read-only `/lifecycle` chat command lists the events, configured reactions, and
   registered hooks.
 - **Bulk delete-by-source in the Knowledge view** (#1770). Ingesting an article,
   transcript, or batch of docs can leave dozens or hundreds of chunks that used to be

--- a/graph/lifecycle/dispatch.py
+++ b/graph/lifecycle/dispatch.py
@@ -81,7 +81,20 @@ def _publish(event: str, payload: dict) -> None:
 
 async def _post_webhook(url: str, event: str, payload: dict) -> None:
     """POST the event to a webhook (async, short timeout). Isolated — a slow/broken
-    endpoint must never stall boot or a turn."""
+    endpoint must never stall boot or a turn.
+
+    The URL is operator-configured, but it still passes through the egress guard
+    (``security.egress`` — the same one ``fetch_url`` and the operator ``api_base`` use):
+    a configured ``egress.allowed_hosts`` allowlist is enforced, and ``allow_private=True``
+    permits LAN/tailnet peers (an operator may point a hook at a local automation) while
+    still refusing link-local / cloud-metadata / reserved addresses. A blocked host is
+    logged and skipped, not raised."""
+    from security import egress
+
+    blocked = egress.check_url(url, allow_private=True, block_unresolvable=False)
+    if blocked:
+        log.warning("[lifecycle] %s webhook to %s skipped by egress guard — %s", event, url, blocked)
+        return
     try:
         import httpx
 

--- a/tests/test_lifecycle_hooks.py
+++ b/tests/test_lifecycle_hooks.py
@@ -136,6 +136,44 @@ async def test_config_reactions_dispatch(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_webhook_reaction_respects_egress_guard(monkeypatch):
+    """A lifecycle webhook runs through security.egress (like fetch_url / the operator
+    api_base): a link-local / cloud-metadata host is skipped (SSRF defense), a normal host
+    is POSTed. Guards against a compromised/typo'd config steering a hook at 169.254.169.254."""
+    posted: list[str] = []
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, **kwargs):
+            posted.append(url)
+
+    monkeypatch.setattr("httpx.AsyncClient", _FakeClient)
+
+    # No allowlist ⇒ exercise the default SSRF-guard branch deterministically.
+    from security import egress
+
+    saved = egress.allowed_hosts()
+    egress.set_allowed_hosts([])
+    try:
+        # Link-local / cloud-metadata — blocked even with allow_private=True → never POSTed.
+        await lc_dispatch._post_webhook("http://169.254.169.254/hook", "app_loaded", {"ts": 1.0})
+        assert posted == []
+        # A normal (unresolvable-in-CI) host passes (block_unresolvable=False) → POSTed.
+        await lc_dispatch._post_webhook("https://hooks.example.test/x", "system_wake", {"ts": 1.0})
+        assert posted == ["https://hooks.example.test/x"]
+    finally:
+        egress.set_allowed_hosts(saved)
+
+
+@pytest.mark.asyncio
 async def test_fire_emits_lifecycle_event_on_the_bus(monkeypatch):
     """fire() broadcasts the dot-namespaced topic on the event bus (ADR 0039) so ANY
     plugin/console can react — no lifecycle_hook required. Mirrors the goal-bus test."""


### PR DESCRIPTION
## What

Follow-up hardening to #1653 (system lifecycle events). Config-driven `lifecycle_hooks` **webhook** reactions were POSTing to the operator-configured URL directly, bypassing the egress policy.

Now they pass through `security.egress.check_url` — the same guard `fetch_url` and the operator `api_base` already use — with `allow_private=True, block_unresolvable=False`:

- A configured **`egress.allowed_hosts` allowlist is enforced** (consistency with the rest of the app's outbound policy).
- **LAN/tailnet peers are allowed** — an operator may legitimately point a hook at a local automation.
- **Cloud-metadata / link-local / reserved addresses are refused** — SSRF defense so a compromised or typo'd config can't steer a hook at `169.254.169.254`.
- A blocked host is logged + skipped, never raised (still error-isolated).

Operator-configured ≈ self-authorized, so this isn't a hole so much as policy consistency + defense-in-depth.

## Test
`test_webhook_reaction_respects_egress_guard` — a link-local/metadata host is skipped (no POST), a normal host POSTs. Deterministic (clears the allowlist to exercise the SSRF-guard branch).

## Gates
- `ruff check` — clean
- `import-linter` — 3 kept, 0 broken (`graph/lifecycle` imports `security`, like `graph/config_io`)
- `pytest tests/test_lifecycle_hooks.py` — 8 passed

Changelog: folded a clause into the still-`[Unreleased]` #1653 entry rather than a redundant line.

Closes the webhook-egress follow-up noted on #1653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook delivery now respects outbound security checks, preventing requests to blocked destinations.
  * Blocked webhook URLs are skipped and logged instead of being sent.
  * Webhook error handling remains isolated, so failures are still caught without affecting other processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->