### PR TITLE
feat(desktop): emit system.wake on window foreground (#1653)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Desktop `system.wake` lifecycle event** (#1653 follow-up, ADR 0074). The desktop shell now
+  emits the third lifecycle event: when its window returns to the foreground it POSTs `system.wake`
+  to the sidecar's `/api/events/publish`, which broadcasts it on the event bus so `lifecycle_hooks`
+  reactions (resume interrupted work, refresh state, check the inbox) fire on wake. Debounced (once
+  per 60 s) so an alt-tab doesn't spam it; the boot focus is suppressed. Rounds out `app.loaded` +
+  `agent.active`. (Foreground-focus is the v1 signal; true OS sleep/wake would need native power
+  observers — a later lift.)
 - **System lifecycle events** (#1653, ADR 0074). The agent now broadcasts its own lifecycle
   transitions on the [event bus](docs/guides/lifecycle-events.md) (ADR 0039): `app.loaded` when
   boot finishes (graph + scheduler + surfaces + fleet-autostart up) and `agent.active` when it

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 use std::net::TcpListener;
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
@@ -205,6 +206,45 @@ struct SidecarProcess(Mutex<Option<CommandChild>>);
 /// Set when the app is tearing down — a sidecar `Terminated` event during shutdown
 /// is the clean kill, not a crash to alert on.
 static QUITTING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Holds the sidecar port + a throttle clock for the `system.wake` lifecycle event
+/// (ADR 0074). The window's `Focused(true)` fires on every alt-tab, so `last_wake`
+/// debounces it down to "came back after being away".
+struct WakeSignal {
+    port: u16,
+    last_wake: Mutex<Instant>,
+}
+
+/// Debounced `system.wake` (ADR 0074): the desktop window regained focus (a proxy for
+/// the shell coming back to the foreground). Emitted at most once per `WAKE_THROTTLE` so
+/// a quick tab-flick doesn't spam it. Best-effort, fire-and-forget: POST `system.wake` to
+/// the sidecar's `/api/events/publish`, which broadcasts it on the event bus (ADR 0039) so
+/// lifecycle hooks / config reactions can respond. A dead/booting sidecar just logs.
+fn maybe_signal_wake<R: Runtime>(app: &AppHandle<R>) {
+    const WAKE_THROTTLE: Duration = Duration::from_secs(60);
+    let Some(state) = app.try_state::<WakeSignal>() else {
+        return;
+    };
+    // Take the throttle decision under the lock, then drop it before the await.
+    {
+        let mut last = state.last_wake.lock().unwrap();
+        if last.elapsed() < WAKE_THROTTLE {
+            return;
+        }
+        *last = Instant::now();
+    }
+    let port = state.port;
+    tauri::async_runtime::spawn(async move {
+        let url = format!("http://127.0.0.1:{port}/api/events/publish");
+        let body = serde_json::json!({
+            "topic": "system.wake",
+            "data": { "previous_state": "background", "source": "desktop" },
+        });
+        if let Err(e) = reqwest::Client::new().post(&url).json(&body).send().await {
+            log::debug!("desktop: system.wake POST failed (sidecar down/booting?): {e}");
+        }
+    });
+}
 
 /// A blocking, user-visible "the server didn't come up / died" alert with the log
 /// location — a launch that silently shows a dead console is undebuggable from the
@@ -793,6 +833,13 @@ pub fn run() {
                 );
             }
             spawn_sidecar(app.handle(), port);
+            // Seed the wake-signal state (ADR 0074). last_wake starts "now" so the
+            // window's own boot Focused(true) is inside the throttle and doesn't fire a
+            // redundant system.wake right after app.loaded.
+            app.manage(WakeSignal {
+                port,
+                last_wake: Mutex::new(Instant::now()),
+            });
             let app_url = || WebviewUrl::App(format!("index.html?__apiPort={port}").into());
             let init = format!(
                 "window.__PROTOAGENT_API_BASE__ = \"http://127.0.0.1:{port}\";"
@@ -903,6 +950,8 @@ pub fn run() {
             // polling); sync_hotkeys is a no-op when everything is registered.
             if let RunEvent::WindowEvent { event: WindowEvent::Focused(true), .. } = &event {
                 sync_hotkeys(app_handle);
+                // System woke to the foreground (ADR 0074) — debounced system.wake.
+                maybe_signal_wake(app_handle);
             }
             // Tear the bundled server down with the app rather than orphaning it.
             if let RunEvent::Exit = event {


### PR DESCRIPTION
## What

Completes the third ADR 0074 lifecycle event. The server-side bus contract for `system.wake` shipped with #1653 (reserved in the seam/config); this wires the **desktop origination**: on `WindowEvent::Focused(true)` the Tauri shell POSTs `system.wake` to the sidecar's existing `/api/events/publish`, which broadcasts it on the event bus so `lifecycle_hooks` reactions (resume interrupted work, refresh state, check inbox) fire on wake.

## Design
- **Debounced** to once per 60 s — focus fires on every alt-tab, so a `WakeSignal` (sidecar port + a throttle `Instant`, in Tauri managed state) suppresses rapid re-focus. It's seeded to "now" at setup, so the window's own **boot focus is suppressed** (no redundant `system.wake` right after `app.loaded`).
- **Fire-and-forget** via `tauri::async_runtime::spawn`; a down/booting sidecar just logs at debug. Never blocks the UI thread; the throttle lock is dropped before the await.
- Reuses the existing `reqwest` + port-resolution plumbing — no new endpoint.

## Scope
Foreground-focus is the v1 signal. **True OS sleep/wake** (laptop lid, display sleep) has no Tauri primitive — it'd need native `NSWorkspace.didWakeNotification` / Windows `WM_POWERBROADCAST` observers, a deliberate later lift.

## Verification
- **`cargo check` passes** (compiled `lib.rs` clean in a worktree, after stubbing the bundled sidecar binary that isn't present there — the stub is **not** committed).
- **DRAFT** because the actual wake behavior can't be CI-verified — it needs a desktop build + manual test: run the app, blur it >60 s, refocus, and confirm a `system.wake` broadcast (e.g. a `lifecycle_hooks` reaction fires, or watch the sidecar `/api/events` stream). No Python/CI surface changes.

Closes the desktop `system_wake` follow-up on #1653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)