### PR TITLE
fix(desktop): wire the bundled CA bundle so web_search works when frozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   too). Per-chunk delete is unchanged. On a layered store the lifecycle targets the
   **private** tier only, like `purge_domain`.
 
+### Fixed
+- **`web_search` (DuckDuckGo) failed with `CERTIFICATE_VERIFY_FAILED` in the desktop app.**
+  `ddgs` verifies TLS over OpenSSL via its `primp` backend, whose OS trust-store discovery
+  doesn't resolve inside the PyInstaller onefile sidecar — so DuckDuckGo search failed cert
+  verification even though httpx calls (the model gateway, GitHub) worked. The frozen sidecar
+  now exports `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE` to the bundled
+  `certifi` bundle at startup (frozen-only, and never overriding an operator's explicit value),
+  so every agent's `web_search` works in the desktop build.
+
 ## [0.91.0] - 2026-07-04
 
 ### Added

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -87,6 +87,34 @@ def _bundle_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
+def _ensure_ca_bundle_env() -> None:
+    """Point native TLS clients at the bundled CA certificates when frozen.
+
+    In a PyInstaller onefile build (the desktop sidecar) the OS trust-store
+    discovery a native TLS client relies on doesn't resolve — so ``ddgs`` (the
+    ``web_search`` backend, which verifies over OpenSSL via ``primp``) fails with
+    ``CERTIFICATE_VERIFY_FAILED``, even though ``httpx`` calls work (httpx loads
+    ``certifi.where()`` directly). Export ``SSL_CERT_FILE`` / ``REQUESTS_CA_BUNDLE`` /
+    ``CURL_CA_BUNDLE`` to the bundled ``certifi`` bundle so OpenSSL-backed clients
+    verify against it.
+
+    Frozen-only, ``setdefault`` so an operator's explicit override always wins, and a
+    no-op in a source checkout (system discovery already works there). Must run before
+    the first outbound TLS request."""
+    if not getattr(sys, "frozen", False):
+        return
+    try:
+        import certifi
+
+        ca = certifi.where()
+    except Exception:  # noqa: BLE001 — a missing/broken certifi must never block boot
+        return
+    if not ca or not os.path.exists(ca):
+        return
+    for var in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+        os.environ.setdefault(var, ca)
+
+
 def _resolve_operator_project_root() -> str:
     """The operator console's default project root (+ its always-allowed dir).
 
@@ -266,6 +294,10 @@ from server.agent_init import (  # noqa: E402,F401 — re-export of the extracte
 
 
 def _main():
+    # Frozen sidecar TLS: point native clients (primp → ddgs → web_search) at the
+    # bundled certifi CA bundle before any outbound request, else DuckDuckGo search
+    # fails CERTIFICATE_VERIFY_FAILED in the desktop app. No-op in a source checkout.
+    _ensure_ca_bundle_env()
 
     # Plugin management subcommand (ADR 0027): `python -m server plugin install
     # <git-url>` (+ list/uninstall/sync). Handled before the server argparse —

--- a/tests/test_frozen_ca_bundle.py
+++ b/tests/test_frozen_ca_bundle.py
@@ -1,0 +1,47 @@
+"""The frozen desktop sidecar must point native TLS clients at the bundled certifi
+CA bundle. ``ddgs`` (behind ``web_search``) verifies over OpenSSL via ``primp``, whose
+OS trust-store discovery doesn't resolve in a PyInstaller onefile build — so without
+this, DuckDuckGo search fails ``CERTIFICATE_VERIFY_FAILED`` in the desktop app while
+httpx calls (github/gateway) still work. Frozen-only, never clobbers an override."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import certifi
+
+import server
+
+_VARS = ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE")
+
+
+def test_source_checkout_is_a_noop(monkeypatch):
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    for v in _VARS:
+        monkeypatch.delenv(v, raising=False)
+    server._ensure_ca_bundle_env()
+    for v in _VARS:
+        assert v not in os.environ  # dev/source TLS discovery already works — untouched
+
+
+def test_frozen_points_clients_at_bundled_certifi(monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    for v in _VARS:
+        monkeypatch.delenv(v, raising=False)
+    server._ensure_ca_bundle_env()
+    ca = certifi.where()
+    assert ca and os.path.exists(ca)
+    for v in _VARS:
+        assert os.environ[v] == ca
+
+
+def test_frozen_never_clobbers_operator_override(monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setenv("SSL_CERT_FILE", "/custom/corp-ca.pem")
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    server._ensure_ca_bundle_env()
+    # An explicit operator SSL_CERT_FILE (e.g. a corporate MITM bundle) is preserved;
+    # the unset sibling still gets the bundled default.
+    assert os.environ["SSL_CERT_FILE"] == "/custom/corp-ca.pem"
+    assert os.environ["REQUESTS_CA_BUNDLE"] == certifi.where()


### PR DESCRIPTION
## Problem

`web_search` (DuckDuckGo, via `ddgs`) fails with `[SSL: CERTIFICATE_VERIFY_FAILED]` in the **desktop app** — so any desktop-app agent's web search is dead (found while diagnosing a jobCoach freeze: its job/company research kept failing).

**Diagnosis** (empirically isolated to the frozen build):
- From **source** (dev venv): `ddgs` returns results, direct HTTPS to all DDG hosts is `200/202`, `certifi` is current. Not the network, DDG's certs, or an env-wide issue.
- In the **frozen sidecar**: DDG fails cert verification, *while the same sidecar's httpx calls (model gateway, GitHub) succeed*.
- Cause: `ddgs` does its requests through **`primp`** (a Rust client that verifies over OpenSSL), whose OS trust-store discovery doesn't resolve inside the **PyInstaller onefile** bundle. httpx works because it loads `certifi.where()` directly; primp doesn't.

## Fix

At the top of `_main()`, when `sys.frozen`, export `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE` to the bundled `certifi` bundle before any outbound TLS request. OpenSSL-backed clients (primp) then verify against it.

- **Frozen-only** — a source checkout already discovers certs; it's a no-op there.
- **`setdefault`** — an operator's explicit override (e.g. a corporate MITM CA) always wins.

## Tests
`tests/test_frozen_ca_bundle.py` (mirrors `test_operator_project_root.py`'s `sys.frozen` monkeypatch pattern): no-op in source, sets all three vars to `certifi.where()` when frozen, never clobbers an operator override.

## Gates
- `ruff check` — clean
- `pytest test_frozen_ca_bundle.py test_operator_project_root.py` — 7 passed
- `import-linter` — 3 kept, 0 broken

## Note
The env-wiring logic is CI-verified here; the actual frozen TLS behavior can only be confirmed by a **desktop rebuild** — it reaches the running app on the next build/reinstall, not in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS certificate handling in the desktop app so secure connections are less likely to fail with certificate verification errors.
  * Preserved any existing certificate configuration when already set, while still filling in missing secure-connection settings.
* **Tests**
  * Added coverage for frozen and non-frozen startup behavior to verify certificate settings are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->