### PR TITLE
chore: release v0.92.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.92.0] - 2026-07-05
+
 ### Added
 - **System lifecycle events** (#1653, ADR 0074). The agent now broadcasts its own lifecycle
   transitions on the [event bus](docs/guides/lifecycle-events.md) (ADR 0039): `app.loaded` when

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.91.0"
+version = "0.92.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.92.0",
+    "date": "2026-07-05",
+    "changes": [
+      "System lifecycle events",
+      "Bulk delete-by-source in the Knowledge view",
+      "web_search (DuckDuckGo) failed with CERTIFICATE_VERIFY_FAILED in the desktop app."
+    ]
+  },
+  {
     "version": "v0.91.0",
     "date": "2026-07-04",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.92.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.92.0 -m 'Release v0.92.0' && git push origin v0.92.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system lifecycle events.
  * Added bulk delete-by-source support in the Knowledge view.

* **Bug Fixes**
  * Fixed an issue where web search in the desktop app could fail with a certificate verification error.

* **Chores**
  * Updated the app version to 0.92.0 and added the latest changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->