### PR TITLE
fix(plugins): complete the plugin load summary (chat commands + middleware)

### DIFF
--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -568,13 +568,14 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
         result.meta.append(entry)
         log.info(
             "[plugins] loaded %s: %d tool(s), %d skill dir(s), %d route(s), "
-            "%d surface(s), %d subagent(s), %d mcp server(s), %d chat command(s)",
+            "%d surface(s), %d subagent(s), %d middleware, %d mcp server(s), %d chat command(s)",
             manifest.id,
             len(kept),
             len(registry.skill_dirs),
             len(registry.routers),
             len(registry.surfaces),
             len(registry.subagents),
+            len(registry.middleware),
             len(registry.mcp_servers),
             len(registry.chat_commands),
         )

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -568,7 +568,7 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
         result.meta.append(entry)
         log.info(
             "[plugins] loaded %s: %d tool(s), %d skill dir(s), %d route(s), "
-            "%d surface(s), %d subagent(s), %d mcp server(s)",
+            "%d surface(s), %d subagent(s), %d mcp server(s), %d chat command(s)",
             manifest.id,
             len(kept),
             len(registry.skill_dirs),
@@ -576,6 +576,7 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
             len(registry.surfaces),
             len(registry.subagents),
             len(registry.mcp_servers),
+            len(registry.chat_commands),
         )
 
     return result


### PR DESCRIPTION
## Summary

- The plugin load summary log counted every contribution type **except `chat_commands` and `middleware`** — so a plugin that registers user-only `/`-commands (`register_chat_command`) or an `AgentMiddleware` (`register_middleware`) showed nothing in the log to confirm they loaded.
- Add `%d chat command(s)` and `%d middleware` to the line. Both counts are already captured in the structured `meta` entry; this surfaces them in the human-facing log too.

## Closes

## Test plan

- [x] Plugin with 3 chat commands → log reads `… 3 chat command(s)` (was silent).
- [x] Plugin with an AgentMiddleware → log reads `… 1 middleware` (was silent).
- [x] Plain plugin reads `… 0 middleware, 0 mcp server(s), 0 chat command(s)`; no other behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)