### PR TITLE
feat(fleet): mDNS discovery off by default — agents stay quiet on the LAN (#1802)

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -316,7 +316,7 @@ fleet:
   discovery:
     port_min: 7860          # LAN/tailnet discovery scan window (inclusive)
     port_max: 7910
-    mdns: true              # advertise + browse the _protoagent._tcp mDNS channel
+    mdns: false             # opt-in (#1802): advertise + browse _protoagent._tcp on the LAN. Off = stay quiet on the network
   warm:
     max: 0                  # warm-agent cap (0 = unlimited)
     grace_seconds: 0        # spare agents touched within N seconds from LRU eviction

--- a/docs/guides/fleet.md
+++ b/docs/guides/fleet.md
@@ -183,7 +183,12 @@ navigate to it; "+ New agent" runs the archetype picker. A plugin view served by
 that opens a **WebSocket** (e.g. `agent_browser`'s live viewport) works through the hub too:
 the slug proxy forwards WS upgrades, not just HTTP/SSE ([#883](https://github.com/protoLabsAI/protoAgent/issues/883), shipped v0.35.0). Settings → Agents is the fleet manager
 (create / start / stop / rename / remove), and **Discover** finds other protoAgents on the
-box, the LAN (mDNS) and your **tailnet** (via the Tailscale CLI). To flip a local member
+box, the LAN (mDNS) and your **tailnet** (via the Tailscale CLI). **mDNS is off by default**
+([#1802](https://github.com/protoLabsAI/protoAgent/issues/1802)) — an agent stays quiet on the
+network and won't announce itself over LAN Bonjour unless you enable `fleet.discovery.mdns`
+(Settings → Host → Discovery), a privacy/security-first default. Local-box and tailnet discovery
+and manual register are unaffected, and the fleet console still lists your own members (it reads
+them from disk, not mDNS). To flip a local member
 on or off without opening Settings, press **⌘K → Toggle Fleet Agent** and pick it from the
 picker (the host and remote members are never listed) — see
 [command palette](./command-palette.md).

--- a/graph/config.py
+++ b/graph/config.py
@@ -707,7 +707,12 @@ class LangGraphConfig:
     fleet_port_base: int = 7870  # workspace agents get port_base+1, +2, …
     discovery_port_min: int = 7860  # fleet discovery scan window (inclusive)
     discovery_port_max: int = 7910
-    discovery_mdns: bool = True  # advertise + browse the _protoagent._tcp mDNS channel
+    # Off by default (#1802) — an agent should not announce itself on the LAN unless
+    # the operator opts in. mDNS advertises this agent (and browses siblings) on the
+    # _protoagent._tcp channel; default-off keeps a fleet quiet on the network
+    # (privacy/security). Local-fleet enumeration is disk-based, so the console is
+    # unaffected; set fleet.discovery.mdns: true to restore LAN auto-discovery.
+    discovery_mdns: bool = False  # advertise + browse the _protoagent._tcp mDNS channel
     fleet_max_warm: int = 0  # warm-agent cap (0 = unlimited); env: PROTOAGENT_FLEET_MAX_WARM
     fleet_warm_grace_seconds: int = (
         0  # spare agents touched within N s from LRU eviction; env: PROTOAGENT_FLEET_WARM_GRACE

--- a/graph/fleet/discovery.py
+++ b/graph/fleet/discovery.py
@@ -90,8 +90,10 @@ def _cfg():
 
 
 def _mdns_enabled() -> bool:
+    # Default OFF (#1802): mDNS advertise/browse is opt-in — no live config (CLI/test
+    # context) also means quiet, so an agent never announces itself on the LAN by default.
     cfg = _cfg()
-    return bool(getattr(cfg, "discovery_mdns", True)) if cfg is not None else True
+    return bool(getattr(cfg, "discovery_mdns", False)) if cfg is not None else False
 
 
 def _config_port_range() -> tuple[int, int]:

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -764,8 +764,10 @@ FIELDS: list[Field] = [
         "bool",
         "Discovery",
         "Advertise + browse the _protoagent._tcp mDNS/Bonjour channel so LAN siblings "
-        "find each other automatically. Off = no mDNS (tailnet + manual register still "
-        "work); useful where multicast is noisy or blocked.",
+        "find each other automatically. Off by default (#1802) — an agent stays quiet on "
+        "the network unless you opt in (privacy/security). On = this agent announces itself "
+        "and discovers siblings on the LAN; tailnet + manual register work either way, and "
+        "the local fleet console is unaffected (it enumerates from disk, not mDNS).",
         scope="host",
     ),
     Field(

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -84,7 +84,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "compaction_keep_messages": 20,
     "compaction_model": "",
     "compaction_trigger": "fraction:0.8",
-    "discovery_mdns": True,
+    "discovery_mdns": False,
     "discovery_port_max": 7910,
     "discovery_port_min": 7860,
     "egress_allowed_hosts": [],

--- a/tests/test_fleet_discovery.py
+++ b/tests/test_fleet_discovery.py
@@ -24,6 +24,10 @@ def _reset_zc(monkeypatch):
     monkeypatch.setattr(discovery, "_info", None)
     monkeypatch.setattr(discovery, "_peer_cache", {})  # fresh boot-sweep cache per test
     monkeypatch.setattr(discovery, "_sweep_task", None)
+    # mDNS is opt-in / off by default (#1802). These tests exercise the advertise +
+    # browse machinery, so they assume the operator turned it on; the default-off
+    # bail is covered explicitly by test_advertise_skips_when_mdns_disabled.
+    monkeypatch.setattr(discovery, "_mdns_enabled", lambda: True)
 
 
 class _FakeZeroconf:
@@ -58,6 +62,14 @@ def test_advertise_registers_off_loop(fake_zeroconf):
     discovery.advertise("alpha", 7871)  # idempotent — second call is a no-op
     discovery.stop_advertise()
     assert discovery._zc is None and discovery._info is None
+
+
+def test_advertise_skips_when_mdns_disabled(fake_zeroconf, monkeypatch):
+    """Default-off (#1802): with fleet.discovery.mdns disabled, advertise() bails
+    before touching zeroconf — an agent never announces itself on the network."""
+    monkeypatch.setattr(discovery, "_mdns_enabled", lambda: False)
+    discovery.advertise("alpha", 7871)
+    assert discovery._zc is None  # never registered a service
 
 
 def test_advertise_refuses_on_event_loop(fake_zeroconf, caplog):

--- a/tests/test_settings_cascade.py
+++ b/tests/test_settings_cascade.py
@@ -457,7 +457,7 @@ def test_d8_app_defaults_when_nothing_set(monkeypatch):
     assert cfg.bind_host == "127.0.0.1"
     assert cfg.fleet_port_base == 7870
     assert (cfg.discovery_port_min, cfg.discovery_port_max) == (7860, 7910)
-    assert cfg.discovery_mdns is True
+    assert cfg.discovery_mdns is False  # opt-in / off by default (#1802)
     assert cfg.fleet_max_warm == 0
     assert cfg.fleet_warm_grace_seconds == 0
 


### PR DESCRIPTION
Closes #1802.

## What
Flip the default of the existing `fleet.discovery.mdns` toggle from **on → off**, so an agent no longer advertises itself on the LAN (`_protoagent._tcp` Bonjour) unless the operator opts in. A privacy/security-first default: *an agent doing sensitive work shouldn't be announcing itself on the network.*

## Why this is small
The issue reads like "build a broadcast toggle system," but the toggle, the per-agent scope, the persistence, and the Settings surface **already exist** — the only reason every agent broadcast was the default value. This is a default flip, not a new mechanism.

## Blast radius (contained)
- ✅ **Local fleet console is unaffected** — it enumerates members from disk (`list_workspaces` + `fleet.json`), not mDNS.
- ✅ **Tailnet discovery, local-box scan, and manual register all still work** — `advertise()` and the mDNS `_browse_mdns` path are both gated by `_mdns_enabled()`, while `_scan_local`/`_scan_tailnet` are not.
- ⚠️ **Only cross-host LAN auto-discovery becomes opt-in** — the intended change. Restore with `fleet.discovery.mdns: true` (Settings → Host → Discovery).

## Changes
- `graph/config.py` — `discovery_mdns` default `True → False`
- `graph/fleet/discovery.py` — `_mdns_enabled()` no-config fallback `→ False` (CLI/test context stays quiet too)
- `config/langgraph-config.example.yaml` — seeded template `mdns: false` (else a fresh install would re-enable it)
- `tests/test_config_roundtrip.py` — golden value updated
- `graph/settings_schema.py` — Settings copy reflects the opt-in default + rationale
- `docs/guides/fleet.md` — documents the opt-in default

## Release-note flag
Behavior change on upgrade: operators who relied on LAN mDNS auto-discovery must now set `fleet.discovery.mdns: true`.

## Verification
Ran locally against the worktree: `ruff` clean, `lint-imports` clean, `pytest tests/test_config_roundtrip.py tests/test_config_drift_guard.py` (358 passed), and a functional smoke confirming a default instance reports `discovery_mdns=False` and `advertise()` no-ops (no Zeroconf registered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed fleet discovery to stay off by default, so agents no longer announce themselves on the local network unless explicitly enabled.
  * Local console listing, tailnet discovery, and manual registration continue to work as expected.
* **Documentation**
  * Updated configuration and fleet guidance to clarify the new default behavior and how to turn discovery back on.
* **Tests**
  * Adjusted configuration validation expectations to match the updated default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->