### PR TITLE
fix(installer): authenticate private GitHub clones on the default git path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`plugin install` of a PRIVATE GitHub repo now works on the default git path.** A runtime
+  install of a private repo (a private plugin or bundle — e.g. a team-member archetype)
+  failed with `could not read Username for 'https://github.com'`: in a container with only a
+  token env (no ssh key, no credential helper), `git clone` got no credential, and only the
+  git-less **archive** fetch (`PROTOAGENT_PLUGIN_FETCH=archive`) authenticated. The clone path
+  now hands `git` a GitHub auth header (`http.extraheader`) for `https://github.com/` URLs when
+  `GITHUB_TOKEN` / `GH_TOKEN` is set — so private installs work without the archive workaround.
+  Delivered via `GIT_CONFIG_*` env, so the token is **not** in argv (no `ps` leak) and **not**
+  written to the clone's `.git/config` (never lands on disk); scoped to `github.com` so it never
+  rides a redirect off-host. SSH / non-github / no-token are unchanged (git's own auth applies).
+
 ## [0.92.0] - 2026-07-05
 
 ### Added

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -89,10 +89,11 @@ def live_plugins_dir() -> Path:
     return instance_paths().plugins_dir
 
 
-def _git(*args: str, cwd: Path | None = None, timeout: float | None = None) -> str:
+def _git(*args: str, cwd: Path | None = None, timeout: float | None = None, env: dict | None = None) -> str:
     proc = subprocess.run(
         ["git", *args],
         cwd=str(cwd) if cwd else None,
+        env=env,  # None ⇒ inherit os.environ (default); a dict carries scoped auth (see _git_auth_env)
         capture_output=True,
         text=True,
         timeout=timeout,
@@ -202,6 +203,38 @@ def _summary(m: PluginManifest, *, source: str, ref: str, sha: str) -> dict:
     }
 
 
+def _git_auth_env(url: str) -> dict[str, str]:
+    """Env that hands ``git`` a GitHub auth header for an ``https://github.com/`` URL when a
+    ``GITHUB_TOKEN`` / ``GH_TOKEN`` is set — so a runtime ``plugin install`` of a **private**
+    repo works on the DEFAULT git path (the "git handles private auth" design intent), not only
+    the archive path. Without it a plain ``git clone`` of a private HTTPS repo in a container
+    (no ssh key, no credential helper — just the token env) fails with
+    ``could not read Username for 'https://github.com'``.
+
+    Delivered via ``GIT_CONFIG_*`` env, deliberately:
+    - **not argv** → the token never shows up in ``ps`` (unlike ``-c http.extraheader=…``),
+    - **not the clone's ``.git/config``** → env-config is per-command, so the token never lands
+      on disk in the cloned repo,
+    - **scoped** to ``http.https://github.com/.extraheader`` → the header never rides a redirect
+      to a non-github host.
+
+    SSH / ``git@`` / non-github / no-token → ``{}`` (git's own auth — ssh keys, credential
+    helpers — applies unchanged)."""
+    token = (os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or "").strip()
+    if not token or not url.startswith("https://github.com/"):
+        return {}
+    import base64
+
+    # GitHub accepts Basic ``x-access-token:<token>`` for git-over-HTTPS (the pattern
+    # actions/checkout uses); the archive path uses a Bearer header for the API/codeload.
+    basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    return {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.https://github.com/.extraheader",
+        "GIT_CONFIG_VALUE_0": f"Authorization: Basic {basic}",
+    }
+
+
 def _clone(url: str, ref: str | None, dest: Path) -> str:
     """Clone ``url`` at ``ref`` into ``dest``; return the resolved commit SHA.
 
@@ -219,16 +252,21 @@ def _clone(url: str, ref: str | None, dest: Path) -> str:
     it's a no-op for the file:// and remote cases."""
     if url.startswith("/"):
         url = Path(url).resolve().as_uri()
+    # Authenticate a private github HTTPS clone with the token env (scoped, off-argv, off-disk).
+    # ``None`` for local/ssh/non-github/no-token ⇒ git inherits os.environ unchanged. Only the
+    # network op (clone) needs it; checkout/rev-parse are local.
+    auth = _git_auth_env(url)
+    clone_env = {**os.environ, **auth} if auth else None
     if ref and _SHA_RE.match(ref):
         # A specific commit: full clone (shallow can't reliably check out an
         # arbitrary SHA), then check it out.
-        _git("clone", "--no-hardlinks", "--no-recurse-submodules", url, str(dest), timeout=_CLONE_TIMEOUT_S)
+        _git("clone", "--no-hardlinks", "--no-recurse-submodules", url, str(dest), timeout=_CLONE_TIMEOUT_S, env=clone_env)
         _git("checkout", ref, cwd=dest)
     elif ref:
         # A tag or branch: shallow clone of just that ref.
-        _git("clone", "--depth", "1", "--no-hardlinks", "--no-recurse-submodules", "--branch", ref, url, str(dest), timeout=_CLONE_TIMEOUT_S)
+        _git("clone", "--depth", "1", "--no-hardlinks", "--no-recurse-submodules", "--branch", ref, url, str(dest), timeout=_CLONE_TIMEOUT_S, env=clone_env)
     else:
-        _git("clone", "--depth", "1", "--no-hardlinks", "--no-recurse-submodules", url, str(dest), timeout=_CLONE_TIMEOUT_S)
+        _git("clone", "--depth", "1", "--no-hardlinks", "--no-recurse-submodules", url, str(dest), timeout=_CLONE_TIMEOUT_S, env=clone_env)
     return _git("rev-parse", "HEAD", cwd=dest)
 
 
@@ -237,8 +275,9 @@ def _clone(url: str, ref: str | None, dest: Path) -> str:
 # already discovers + importlib-loads plugins from the live root in frozen mode.
 # So the only gap is *fetching* the code: download a GitHub archive tarball over
 # HTTPS (the bundled httpx) and extract it — an on-disk result identical to a
-# shallow clone. `git` stays the path on a dev/server box (history, ssh, private
-# auth); the archive path is preferred when git is absent or we're frozen.
+# shallow clone. `git` stays the path on a dev/server box (history, ssh, and
+# private auth — over ssh keys / credential helpers, or a github HTTPS token via
+# `_git_auth_env`); the archive path is preferred when git is absent or we're frozen.
 
 _GH_RE = re.compile(r"github\.com[/:]([^/]+)/([^/]+?)(?:\.git)?/?$")
 

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -430,3 +430,77 @@ def test_install_bundle_member_missing_url_errors(env):
     _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init")
     with pytest.raises(installer.InstallError):
         installer.install(str(repo))
+
+
+# ── private-repo clone auth (github HTTPS token) ──────────────────────────────
+# A runtime `plugin install` of a PRIVATE github repo used to fail on the default git
+# path ("could not read Username for 'https://github.com'") — git got no credential in a
+# container with only a token env. `_git_auth_env` hands git a scoped http.extraheader via
+# GIT_CONFIG_* so the private clone authenticates, off-argv and off-.git/config.
+
+
+def test_git_auth_env_github_https_with_token(monkeypatch):
+    import base64
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    e = installer._git_auth_env("https://github.com/org/repo")
+    assert e["GIT_CONFIG_COUNT"] == "1"
+    assert e["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraheader"
+    scheme, b64 = e["GIT_CONFIG_VALUE_0"].removeprefix("Authorization: ").split()
+    assert scheme == "Basic"
+    assert base64.b64decode(b64).decode() == "x-access-token:tok"
+
+
+def test_git_auth_env_prefers_github_token_over_gh_token(monkeypatch):
+    import base64
+
+    monkeypatch.setenv("GITHUB_TOKEN", "gh")
+    monkeypatch.setenv("GH_TOKEN", "alt")
+    e = installer._git_auth_env("https://github.com/o/r")
+    assert base64.b64decode(e["GIT_CONFIG_VALUE_0"].split()[-1]).decode() == "x-access-token:gh"
+
+
+def test_git_auth_env_empty_for_ssh_nongithub_or_no_token(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    assert installer._git_auth_env("git@github.com:o/r.git") == {}       # ssh → git's own auth
+    assert installer._git_auth_env("https://gitlab.com/o/r") == {}       # non-github
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert installer._git_auth_env("https://github.com/o/r") == {}       # no token
+
+
+def test_clone_authenticates_private_github_via_scoped_env(monkeypatch, tmp_path):
+    """_clone passes the auth env to the network `clone` (not to local checkout/rev-parse),
+    the token never appears in argv, and the header is scoped to github.com HTTPS."""
+    import base64
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "s3cr3t")
+    calls = []
+
+    def fake_git(*args, cwd=None, timeout=None, env=None):
+        calls.append({"args": args, "env": env})
+        return "b" * 40  # stands in for `rev-parse HEAD`
+
+    monkeypatch.setattr(installer, "_git", fake_git)
+    installer._clone("https://github.com/protoLabsAI/frontend-bundle", None, tmp_path / "dest")
+
+    clone = next(c for c in calls if c["args"][0] == "clone")
+    env = clone["env"]
+    assert env and env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraheader"
+    assert base64.b64decode(env["GIT_CONFIG_VALUE_0"].split()[-1]).decode() == "x-access-token:s3cr3t"
+    assert not any("s3cr3t" in str(a) for a in clone["args"])  # off-argv: no `ps` leak
+    rev = next(c for c in calls if c["args"][0] == "rev-parse")
+    assert rev["env"] is None  # local op inherits os.environ, no auth injected
+
+
+def test_clone_no_auth_env_without_token(monkeypatch, tmp_path):
+    """No token → clone runs with env=None (git's own auth), unchanged behavior."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    calls = []
+    monkeypatch.setattr(installer, "_git", lambda *a, cwd=None, timeout=None, env=None: calls.append({"args": a, "env": env}) or "b" * 40)
+    installer._clone("https://github.com/o/r", None, tmp_path / "dest")
+    clone = next(c for c in calls if c["args"][0] == "clone")
+    assert clone["env"] is None


### PR DESCRIPTION
## Problem

A runtime `plugin install` of a **private** GitHub repo (a private plugin or bundle — e.g. a team-member archetype) fails on the default git path:

```
✗ git clone … failed: fatal: could not read Username for 'https://github.com': No such device or address
```

In a deployed container there's usually only a **token env** (`GH_TOKEN`) — no ssh key, no credential helper — so `git clone https://github.com/org/private-repo` gets no credential and prompts for a username (→ fails non-interactively). Only the git-less **archive** fetch authenticated (it sends a Bearer header via httpx), so consuming private repos meant setting `PROTOAGENT_PLUGIN_FETCH=archive` as a workaround. The design comment in `installer.py` even claims git "handles private auth" — but nothing ever handed git the token.

This surfaced standing up private, config-as-code fleet-member bundles (ADR 0072 archetypes): the hub couldn't install them at runtime without the archive flag.

## Fix

`_clone` now hands `git` a GitHub auth header (`http.extraheader`) for `https://github.com/` URLs when `GITHUB_TOKEN` / `GH_TOKEN` is set — so private installs work on the default git path, no workaround. It's delivered via `GIT_CONFIG_*` env, deliberately:

- **not argv** → the token never shows up in `ps` (the trap with `-c http.extraheader=…`),
- **not the clone's `.git/config`** → env-config is per-command, so the token never lands on disk in the cloned repo,
- **scoped** to `http.https://github.com/.extraheader` → the header never rides a redirect to a non-github host.

SSH / `git@` / non-github / no-token paths are untouched (git's own auth — ssh keys, credential helpers — applies unchanged). The archive path is unchanged; this just makes the default git path reach parity for private github over HTTPS.

## Verification

Beyond unit tests, driven **end-to-end against a real private repo** with the git path forced (archive disabled):

```
cloned private repo via git path OK — HEAD 70aec5d7dd5a
files: ['README.md', 'SOUL.md', 'protoagent.bundle.yaml']
token in .git/config?  no ✓
```

## Tests

`tests/test_plugin_installer.py` — `_git_auth_env` (github+token → scoped Basic `x-access-token` header; ssh / non-github / no-token → `{}`; `GITHUB_TOKEN` precedence over `GH_TOKEN`), and `_clone` passes the auth env to the **network clone only** (not local `checkout`/`rev-parse`), with the token off-argv. Installer suites green — **91 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)