### PR TITLE
feat(knowledge): preview dialog before ingest — confirm what's about to be ingested (#1801)

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1920,6 +1920,24 @@ textarea {
 }
 .knowledge-ingest-note { color: var(--fg-muted); font-size: 12px; align-self: center; }
 
+/* Ingest preview (dry-run gate, #1801) — shown in place of the drop-zone once a
+   source is picked; Confirm ingests, Cancel returns to selection. */
+.knowledge-ingest-preview { display: flex; flex-direction: column; gap: 10px; }
+.knowledge-ingest-preview-meta { display: flex; gap: 6px; flex-wrap: wrap; align-items: center; }
+.knowledge-ingest-preview-source {
+  font-size: 12px; color: var(--fg-muted);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 100%;
+}
+.knowledge-ingest-preview-snippet {
+  margin: 0; padding: 10px 12px;
+  border: 1px solid var(--pl-color-border);
+  border-radius: 8px;
+  background: var(--pl-color-bg-inset);
+  font-size: 12px; line-height: 1.5;
+  white-space: pre-wrap; word-break: break-word;
+  max-height: 220px; overflow-y: auto;
+}
+
 /* ── Delegates panel (ADR 0025) — moved to src/settings/delegates.css (#832). ── */
 
 /* Plugin-contributed console views (ADR 0026) — optional subnav above, iframe fills. */

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -97,6 +97,10 @@ const INGEST_ACCEPT =
   ".mp3,.wav,.m4a,.flac,.ogg,.opus,.aac," +
   ".mp4,.mov,.mkv,.webm,.avi,.m4v";
 
+// The source a preview is holding, so Confirm can re-send the exact same thing.
+type PendingSource = { kind: "file"; file: File } | { kind: "url"; url: string };
+type IngestPreview = Awaited<ReturnType<typeof api.previewKnowledgeIngest>>;
+
 function IngestForm({
   onDone,
   onError,
@@ -110,34 +114,128 @@ function IngestForm({
   const [domain, setDomain] = useState("general");
   const [drag, setDrag] = useState(false);
   const [note, setNote] = useState("");
+  // Preview gate (#1801): picking a source runs a no-persist dry-run; the result
+  // is held here and shown in-place until the operator Confirms (ingest) or
+  // Cancels. `pending` is the source Confirm re-sends; `title` is editable here.
+  const [pending, setPending] = useState<PendingSource | null>(null);
+  const [preview, setPreview] = useState<IngestPreview | null>(null);
+  const [title, setTitle] = useState("");
+
+  function formFor(src: PendingSource): FormData {
+    const f = new FormData();
+    if (src.kind === "file") f.append("file", src.file);
+    else f.append("url", src.url);
+    return f;
+  }
+
+  function resetPreview() {
+    setPending(null);
+    setPreview(null);
+    setTitle("");
+  }
+
+  const previewMut = useMutation({
+    mutationFn: (src: PendingSource) => api.previewKnowledgeIngest(formFor(src)),
+    onSuccess: (r, src) => {
+      setPending(src);
+      setPreview(r);
+      setTitle(r.title ?? "");
+    },
+    onError: (e) => onError(errMsg(e)),
+  });
 
   const ingest = useMutation({
-    mutationFn: (form: FormData) => {
-      form.set("domain", domain.trim() || "general");
-      return api.ingestKnowledge(form);
+    // Confirm re-sends the source to /ingest (extraction reruns there, preserving
+    // each source's real provenance — a PDF stays a PDF, not "pasted text").
+    mutationFn: (src: PendingSource) => {
+      const f = formFor(src);
+      f.set("domain", domain.trim() || "general");
+      if (title.trim()) f.set("title", title.trim());
+      return api.ingestKnowledge(f);
     },
     onSuccess: (r) => {
       setNote(`Added ${r.chunks} chunk${r.chunks === 1 ? "" : "s"}${r.title ? ` from “${r.title}”` : ""}.`);
       setUrl("");
+      resetPreview();
       onDone();
     },
     onError: (e) => onError(errMsg(e)),
   });
-  const busy = ingest.isPending;
 
-  function ingestFile(file: File) {
-    const f = new FormData();
-    f.append("file", file);
+  const busy = previewMut.isPending || ingest.isPending;
+
+  function previewFile(file: File) {
     setNote("");
-    ingest.mutate(f);
+    previewMut.mutate({ kind: "file", file });
+  }
+  function previewUrl() {
+    if (!url.trim()) return;
+    setNote("");
+    previewMut.mutate({ kind: "url", url: url.trim() });
   }
 
-  function ingestUrl() {
-    if (!url.trim()) return;
-    const f = new FormData();
-    f.append("url", url.trim());
-    setNote("");
-    ingest.mutate(f);
+  // Confirm step — the dry-run result held in-place; nothing is ingested until
+  // the operator clicks Confirm (or Cancel goes back to source selection).
+  if (pending && preview) {
+    const srcLabel = pending.kind === "file" ? pending.file.name : pending.url;
+    const sizeKb = pending.kind === "file" ? `${(pending.file.size / 1024).toFixed(1)} KB` : null;
+    const chunkLabel = `${preview.chunks} chunk${preview.chunks === 1 ? "" : "s"}`;
+    return (
+      <div className="knowledge-chunk-form">
+        <div className="knowledge-ingest-preview">
+          <div className="knowledge-ingest-preview-meta">
+            <Badge status="neutral">{preview.source_type}</Badge>
+            <Badge status="success">{chunkLabel}</Badge>
+            <Badge status="neutral">~{preview.approx_tokens.toLocaleString()} tokens</Badge>
+            {sizeKb ? <Badge status="neutral">{sizeKb}</Badge> : null}
+          </div>
+          <div className="knowledge-ingest-preview-source" title={srcLabel}>
+            {srcLabel}
+          </div>
+          <pre className="knowledge-ingest-preview-snippet" aria-label="content preview">
+            {preview.snippet}
+            {preview.truncated ? "\n…" : ""}
+          </pre>
+          <div className="knowledge-chunk-form-row">
+            <Input
+              type="text"
+              placeholder="title (optional)"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              aria-label="ingest title"
+              disabled={busy}
+            />
+            <Input
+              type="text"
+              placeholder="domain"
+              value={domain}
+              onChange={(e) => setDomain(e.target.value)}
+              aria-label="ingest domain"
+              style={{ maxWidth: 160 }}
+              disabled={busy}
+            />
+          </div>
+          <div className="knowledge-chunk-form-row">
+            <Button
+              type="button"
+              variant="primary"
+              size="sm"
+              disabled={busy || preview.chunks === 0}
+              onClick={() => ingest.mutate(pending)}
+            >
+              {ingest.isPending
+                ? "Ingesting…"
+                : preview.chunks === 0
+                  ? "Nothing to ingest"
+                  : `Confirm — ingest ${chunkLabel}`}
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={resetPreview} disabled={busy}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -150,7 +248,7 @@ function IngestForm({
           e.preventDefault();
           setDrag(false);
           const file = e.dataTransfer.files?.[0];
-          if (file) ingestFile(file);
+          if (file) previewFile(file);
         }}
       >
         <FileUp size={18} />
@@ -165,7 +263,7 @@ function IngestForm({
               disabled={busy}
               onChange={(e) => {
                 const file = e.target.files?.[0];
-                if (file) ingestFile(file);
+                if (file) previewFile(file);
                 e.target.value = "";
               }}
             />
@@ -179,23 +277,14 @@ function IngestForm({
           placeholder="…or paste a web / YouTube URL"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") ingestUrl(); }}
+          onKeyDown={(e) => { if (e.key === "Enter") previewUrl(); }}
           aria-label="source url"
-          disabled={busy}
-        />
-        <Input
-          type="text"
-          placeholder="domain"
-          value={domain}
-          onChange={(e) => setDomain(e.target.value)}
-          aria-label="ingest domain"
-          style={{ maxWidth: 160 }}
           disabled={busy}
         />
       </div>
       <div className="knowledge-chunk-form-row">
-        <Button type="button" variant="primary" size="sm" disabled={busy || !url.trim()} onClick={ingestUrl}>
-          {busy ? "Importing…" : "Import URL"}
+        <Button type="button" variant="primary" size="sm" disabled={busy || !url.trim()} onClick={previewUrl}>
+          {previewMut.isPending ? "Reading…" : "Preview URL"}
         </Button>
         <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={busy}>
           Close

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -847,6 +847,24 @@ export const api = {
     }>("/api/knowledge/ingest", form);
   },
 
+  // Dry-run an ingest (#1801) — extract + count chunks for a file/URL/text WITHOUT
+  // persisting anything, so the upload dialog can show what's about to be ingested
+  // (chunk count, token estimate, a text snippet) and gate it behind a Confirm.
+  // Same FormData shape as `ingestKnowledge` minus `domain` (chosen at confirm time).
+  previewKnowledgeIngest(form: FormData) {
+    return requestForm<{
+      enabled: boolean;
+      chunks: number;
+      chars: number;
+      approx_tokens: number;
+      title: string | null;
+      source_type: string;
+      source: string;
+      snippet: string;
+      truncated: boolean;
+    }>("/api/knowledge/ingest/preview", form);
+  },
+
   // --- Memory inspector (ADR 0069 D7) — the delivery-layer audit surface -----
   // Session summaries: the files behind the <prior_sessions> digest.
   memorySessions() {

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -109,6 +109,47 @@ def _knowledge_row(d: dict) -> dict:
     }
 
 
+# Chars of extracted text shown in the ingest preview snippet (#1801) — enough to
+# eyeball that the right document extracted correctly, without shipping a whole PDF.
+_PREVIEW_SNIPPET_CHARS = 1500
+
+
+async def _extract_source(file, url: str, text: str, title: str):
+    """Shared extraction half of ingest + preview (#1801): turn a
+    (file | url | pasted text) source into an ``ExtractResult`` via the ingestion
+    engine (ADR 0021), off the event loop.
+
+    Returns ``(result, source_label)``, or ``(None, "")`` when no source was
+    given. Raises the engine's typed errors (``MissingDependency`` /
+    ``UnsupportedSource`` / …) for the caller to map to a status code. Extraction
+    NEVER persists, so ``/ingest`` (which then embeds) and ``/ingest/preview``
+    (which only counts) share exactly this step. Inputs are assumed already
+    stripped by the caller."""
+    from ingestion import ExtractResult, extract_bytes, extract_url
+
+    # Gateway STT for audio/video (None if no transcribe_model configured →
+    # audio/video raise a clean "not configured" error; text/pdf unaffected).
+    transcribe = None
+    try:
+        from graph.llm import create_transcribe_fn
+
+        transcribe = create_transcribe_fn(STATE.graph_config) if STATE.graph_config else None
+    except Exception as exc:  # noqa: BLE001 — transcription stays optional
+        log.warning("[knowledge] transcribe fn unavailable: %s", exc)
+
+    if file is not None:
+        data = await file.read()
+        result = await asyncio.to_thread(
+            extract_bytes, file.filename or "upload", data, file.content_type, transcribe=transcribe
+        )
+        return result, (file.filename or "upload")
+    if url:
+        return await asyncio.to_thread(extract_url, url, transcribe=transcribe), url
+    if text:
+        return ExtractResult(text=text, title=title or None, source_type="text"), "console"
+    return None, ""
+
+
 def register_knowledge_routes(app) -> None:
     """Register the ``/api/playbooks*`` + ``/api/knowledge/search`` routes."""
 
@@ -455,41 +496,12 @@ def register_knowledge_routes(app) -> None:
         embedding run off the event loop. Returns the created chunk ids."""
         if STATE.knowledge_store is None:
             return {"enabled": False, "ids": []}
-        from ingestion import (
-            ExtractResult,
-            MissingDependency,
-            UnsupportedSource,
-            extract_bytes,
-            extract_url,
-        )
+        from ingestion import MissingDependency, UnsupportedSource
         from knowledge import add_document
 
-        # Gateway STT for audio/video (None if no transcribe_model configured →
-        # audio/video raise a clean "not configured" error, text/pdf unaffected).
-        transcribe = None
-        try:
-            from graph.llm import create_transcribe_fn
-
-            transcribe = create_transcribe_fn(STATE.graph_config) if STATE.graph_config else None
-        except Exception as exc:  # noqa: BLE001 — transcription stays optional
-            log.warning("[knowledge] transcribe fn unavailable: %s", exc)
-
         url, text, title = url.strip(), text.strip(), title.strip()
-        source = "console"
         try:
-            if file is not None:
-                data = await file.read()
-                result = await asyncio.to_thread(
-                    extract_bytes, file.filename or "upload", data, file.content_type, transcribe=transcribe
-                )
-                source = file.filename or "upload"
-            elif url:
-                result = await asyncio.to_thread(extract_url, url, transcribe=transcribe)
-                source = url
-            elif text:
-                result = ExtractResult(text=text, title=title or None, source_type="text")
-            else:
-                return JSONResponse({"detail": "provide a file, url, or text"}, status_code=400)
+            result, source = await _extract_source(file, url, text, title)
         except MissingDependency as exc:
             return JSONResponse({"detail": str(exc)}, status_code=501)
         except UnsupportedSource as exc:
@@ -497,6 +509,8 @@ def register_knowledge_routes(app) -> None:
         except Exception as exc:  # noqa: BLE001 — surface extraction failure, never 500
             log.warning("[knowledge] ingest extraction failed: %s", exc)
             return JSONResponse({"detail": f"extraction failed: {exc}"}, status_code=400)
+        if result is None:
+            return JSONResponse({"detail": "provide a file, url, or text"}, status_code=400)
 
         heading = title or result.title or None
         ids = await asyncio.to_thread(
@@ -518,6 +532,68 @@ def register_knowledge_routes(app) -> None:
             "title": heading,
             "source_type": result.source_type,
             "chars": len(result.text),
+        }
+
+    @app.post("/api/knowledge/ingest/preview")
+    async def _api_knowledge_ingest_preview(
+        file: UploadFile | None = File(default=None),
+        url: str = Form(default=""),
+        text: str = Form(default=""),
+        title: str = Form(default=""),
+    ):
+        """Dry-run an ingest: extract + count chunks for a source WITHOUT persisting
+        anything (#1801).
+
+        Backs the pre-ingest preview dialog — filename/type/size, how many chunks
+        the file will split into, an approximate token count, and a text snippet —
+        so the operator can verify the right content (and that extraction worked)
+        lands in the right bucket before committing. Runs the *same* extraction as
+        ``/ingest`` (ADR 0021) but stops before ``add_document``: it writes zero
+        rows and skips embedding + LLM enrichment entirely. Chunk count uses the
+        live store's chunk knobs, so the preview matches what ingestion will
+        actually produce. Confirm re-POSTs to ``/ingest`` (extraction reruns there,
+        which preserves each source's real provenance)."""
+        if STATE.knowledge_store is None:
+            return {"enabled": False}
+        from ingestion import MissingDependency, UnsupportedSource
+        from knowledge.chunking import chunk_text
+
+        url, text, title = url.strip(), text.strip(), title.strip()
+        try:
+            result, source = await _extract_source(file, url, text, title)
+        except MissingDependency as exc:
+            return JSONResponse({"detail": str(exc)}, status_code=501)
+        except UnsupportedSource as exc:
+            return JSONResponse({"detail": str(exc)}, status_code=415)
+        except Exception as exc:  # noqa: BLE001 — surface extraction failure, never 500
+            log.warning("[knowledge] ingest preview extraction failed: %s", exc)
+            return JSONResponse({"detail": f"extraction failed: {exc}"}, status_code=400)
+        if result is None:
+            return JSONResponse({"detail": "provide a file, url, or text"}, status_code=400)
+
+        # Count chunks with the live store's knobs so the preview matches production
+        # ingestion exactly; fall back to the chunker defaults for a store (e.g. a
+        # plugin backend) that doesn't expose them. chunk_text is pure — no I/O, no
+        # LLM enrichment (enrichment only prepends a context line; it never changes
+        # the count), so the previewed number is exact.
+        store = STATE.knowledge_store
+        chunks = chunk_text(
+            result.text,
+            max_chars=getattr(store, "_chunk_max_chars", 1200),
+            overlap_chars=getattr(store, "_chunk_overlap_chars", 150),
+            min_chars=getattr(store, "_chunk_min_chars", 200),
+        )
+        snippet = result.text[:_PREVIEW_SNIPPET_CHARS]
+        return {
+            "enabled": True,
+            "chunks": len(chunks),
+            "chars": len(result.text),
+            "approx_tokens": max(1, len(result.text) // 4),  # house heuristic (graph.middleware.*)
+            "title": title or result.title or None,
+            "source_type": result.source_type,
+            "source": source,
+            "snippet": snippet,
+            "truncated": len(result.text) > len(snippet),
         }
 
     @app.post("/api/knowledge/attach")

--- a/tests/test_knowledge_routes.py
+++ b/tests/test_knowledge_routes.py
@@ -377,6 +377,77 @@ def test_ingest_audio_without_transcribe_model_returns_501(monkeypatch):
     assert c.post("/api/knowledge/ingest", files=files).status_code == 501
 
 
+# ── ingest preview (/api/knowledge/ingest/preview) — dry-run, persists nothing ─
+def test_ingest_preview_text_persists_nothing(monkeypatch):
+    ks = _IngestKS()
+    c = _client(monkeypatch, knowledge=ks)
+    body = c.post(
+        "/api/knowledge/ingest/preview", data={"text": "a pasted note body", "title": "My Note"}
+    ).json()
+    assert body["enabled"] is True
+    assert body["chunks"] == 1 and body["chars"] == len("a pasted note body")
+    assert body["approx_tokens"] >= 1
+    assert body["source_type"] == "text" and body["title"] == "My Note"
+    assert body["snippet"] == "a pasted note body" and body["truncated"] is False
+    # The whole point: preview writes nothing to the store.
+    assert ks.docs == []
+
+
+def test_ingest_preview_file_upload_no_persist(monkeypatch):
+    ks = _IngestKS()
+    c = _client(monkeypatch, knowledge=ks)
+    files = {"file": ("notes.md", b"# Heading\n\nsome body text", "text/markdown")}
+    body = c.post("/api/knowledge/ingest/preview", files=files).json()
+    assert body["enabled"] is True and body["source_type"] == "markdown"
+    assert body["source"] == "notes.md" and "some body text" in body["snippet"]
+    assert ks.docs == []
+
+
+def test_ingest_preview_url_no_persist(monkeypatch):
+    import ingestion
+    from ingestion import ExtractResult
+
+    monkeypatch.setattr(
+        ingestion,
+        "extract_url",
+        lambda u, **kw: ExtractResult(text="fetched article body", title="Article", source_type="html"),
+    )
+    ks = _IngestKS()
+    c = _client(monkeypatch, knowledge=ks)
+    body = c.post("/api/knowledge/ingest/preview", data={"url": "https://example.com/post"}).json()
+    assert body["enabled"] is True and body["source_type"] == "html"
+    assert body["source"] == "https://example.com/post" and body["title"] == "Article"
+    assert ks.docs == []
+
+
+def test_ingest_preview_counts_multiple_chunks(monkeypatch):
+    """A long document previews the same multi-chunk count ingestion would produce
+    (chunker defaults when the store double exposes no knobs)."""
+    ks = _IngestKS()
+    c = _client(monkeypatch, knowledge=ks)
+    long_text = " ".join(f"word{i}" for i in range(1200))  # well over the 1200-char default
+    body = c.post("/api/knowledge/ingest/preview", data={"text": long_text}).json()
+    assert body["chunks"] > 1
+    assert body["truncated"] is True and len(body["snippet"]) == 1500
+    assert ks.docs == []
+
+
+def test_ingest_preview_requires_a_source(monkeypatch):
+    c = _client(monkeypatch, knowledge=_IngestKS())
+    assert c.post("/api/knowledge/ingest/preview", data={}).status_code == 400
+
+
+def test_ingest_preview_unsupported_type_returns_415(monkeypatch):
+    c = _client(monkeypatch, knowledge=_IngestKS())
+    files = {"file": ("blob.bin", b"\x00\x01\x02\x03", "application/octet-stream")}
+    assert c.post("/api/knowledge/ingest/preview", files=files).status_code == 415
+
+
+def test_ingest_preview_disabled_when_store_off(monkeypatch):
+    c = _client(monkeypatch)  # no knowledge store
+    assert c.post("/api/knowledge/ingest/preview", data={"text": "x"}).json() == {"enabled": False}
+
+
 # ── chat attachments (/api/knowledge/attach) — tiered, session-scoped ─────────
 import types as _types  # noqa: E402
 


### PR DESCRIPTION
Closes #1801. **Draft** — frontend UX change; CI runs the web unit/e2e gates (they can't run in a worktree), and it wants a human eye on the interaction before merge.

## What
A no-persist **dry-run gate** between selecting a source and ingesting it. Picking a file/URL now shows, in place of the drop-zone:
- **source type** + **chunk count** + **~token estimate** (+ file size for uploads)
- an editable **title** and **domain** (choose the bucket before committing)
- a **content snippet** of the extracted text (verify the right doc extracted correctly)
- **Confirm** / **Cancel** — ingestion only happens on Confirm.

Matches the issue's acceptance criteria (selection no longer auto-ingests; metadata + chunk estimate + editable domain/title + snippet + explicit confirm; files and URLs flow through one consistent path).

## How it stays cheap & correct
- **Backend:** new read-only `POST /api/knowledge/ingest/preview`. Extraction is factored into a shared `_extract_source()` helper that **both** `/ingest` and the preview call (one dispatch, no drift). The preview ends at `chunk_text` — pure, no I/O, **no embedding, no LLM enrichment, zero rows written** — using the *live store's chunk knobs*, so the previewed count equals what ingestion will actually produce.
- **Provenance-safe:** Confirm re-POSTs the source to the existing `/ingest`, so extraction reruns there and each source keeps its real `source_type` (a PDF stays a PDF, not `text`). The only cost is a second extraction on confirm — negligible for text/HTML/PDF; a follow-up could cache the STT/YouTube path.
- **Frontend:** the existing "Add a source" dialog swaps its body in place (no nested dialog), reusing the DS `Badge`/`Input`/`Button`. Confirm disables when a source extracts to 0 chunks.

## Tests
7 new route tests: **preview persists nothing** (asserts the store double is never written), multi-chunk count on a long doc, snippet truncation, file/URL/text paths, and 415/400/disabled. The `/ingest` refactor is covered by the existing route tests.

## Verified locally
`ruff` clean, `lint-imports` clean (3 kept / 0 broken), `pytest tests/test_knowledge_routes.py` (40 passed), and `tsc -p apps/web/tsconfig.json --noEmit` (0 errors). Web unit/e2e deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)