### PR TITLE
docs: close the fleet-autostart + surface-resume gap

### DIFF
--- a/docs/guides/fleet.md
+++ b/docs/guides/fleet.md
@@ -130,7 +130,7 @@ a `fleet.json` registry. Because each agent's chat history is scoped to its own
 checkpoints, a **stopped agent's session resumes** when you restart it — and a **running**
 one keeps its background work (schedules, an in-flight loop) going while you're elsewhere.
 
-## Deploying a team — config-as-code (`fleet.autostart`)
+## Deploying a team — config-as-code (`fleet.autostart`) {#deploying-a-team}
 
 The commands above are **imperative** — you create members and start them by hand. That's
 fine at the console, but a team you *deploy* (a lead plus the specialist members it delegates
@@ -152,6 +152,13 @@ fleet:
 version-reconcile: **idempotent** (an already-running member is skipped), **best-effort** (a
 missing workspace or a failed spawn is logged and skipped — never blocks boot), and **hub-only**
 (a member's own scoped config carries no roster, so it no-ops inside a member).
+
+> Autostart restarts the member **process**; it does not by itself resume the **work** that
+> process was doing. A member whose job is a long-running background loop (a trading engine, a
+> poller) needs its *plugin* to resume that loop when it boots — see
+> [surfaces that resume across reloads](./plugins.md#surface-resume). The two compose: autostart
+> brings the agent back, the surface pattern brings its work back, and a host restart recovers
+> the whole crew with no manual steps.
 
 **2. Bake the lead + personas as seeds.** The lead's own config and persona seed from
 `PROTOAGENT_SEED_CONFIG` and `PROTOAGENT_SEED_SOUL` on first boot (seed-not-force — operator

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -97,6 +97,45 @@ def register(registry):
     registry.register_thread_id_resolver(lambda md, sid: f"proj:{md.get('project')}:{sid}")
 ```
 
+#### Surfaces that resume their work across reloads {#surface-resume}
+
+A surface's `start` runs on every server boot **and** after a plugin reload; `stop` runs on
+shutdown/reload; `reload(cfg)` runs on a config save. So a surface that manages ongoing
+background work — a trading loop, a poller, a long-running job — has a subtle obligation: a
+reload/restart is **not** "the operator turned it off," so the surface must *resume* that work
+rather than leave it stopped. Restarting the process alone doesn't bring the *work* back;
+[`fleet.autostart`](/guides/fleet#deploying-a-team) restarts the **agent**, this pattern
+restarts what it was **doing**. The recipe:
+
+1. **Persist the operator's INTENT, not the run state.** When the operator starts the work,
+   write a durable flag (`wanted: true`); when they *deliberately* stop it, clear the flag.
+   Module-level state resets on reload, so the flag lives on disk — a small JSON in the
+   per-agent config dir (`PROTOAGENT_CONFIG_DIR`), the same store your watch/plan state uses.
+2. **Distinguish a lifecycle stop from an operator stop.** The surface `stop` hook
+   (shutdown/reload) must halt the task **without** clearing the intent — a reload isn't a
+   decision. Only the operator's own stop clears it. (A single `stop_ops()` that both halts
+   *and* clears would make every reload read as "turned off," and it would never resume.)
+3. **Resume in `start` when the intent stands.** The `start` hook reads the flag and
+   re-launches the work if it was wanted; otherwise it stays idle.
+
+```python
+async def _start():                       # runs on boot AND after a reload
+    if _intended():                       # persisted flag — survived the module reset
+        _resume_work()                    # re-launch what the operator had running
+
+async def _stop():                        # runs on shutdown/reload
+    _lifecycle_halt()                     # stop the task, KEEP the intent (not an operator stop)
+```
+
+**Safety rule — the clear direction must fail *safe*.** The failure modes are asymmetric: a
+lost *start*-write leaves the flag absent → no resume → safe; a lost *stop*-write leaves it
+`true` → a reload would **resurrect deliberately-stopped work** → not safe. So verify the clear
+landed (read it back), and if it genuinely can't persist, make that **loud** rather than
+silent — never let a write failure resume work the operator turned off. protoTrader's
+SpaceTraders plugin is the worked example: `st_autopilot_start` persists `autopilot_wanted`, a
+`lifecycle_stop()` halts the trading engine on reload while keeping the flag, and the surface
+`start` resumes it — so a host restart brings the *trading* back, not just the process.
+
 ### Managed MCP servers — `register_mcp_server`
 
 A plugin can ship a **managed MCP server** the agent connects to, instead of

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -42,6 +42,7 @@ The hub spawns local fleet members as detached `--ui none` processes on their ow
 
 | Variable | Default | Purpose |
 |---|---|---|
+| `PROTOAGENT_FLEET_AUTOSTART` | (unset) | Comma-separated member ids or display names the hub **(re)starts on boot** (ADR 0072) — a container recreate or host restart kills the members' detached processes and `fleet.json` keeps now-dead pids, so without this a declared crew stays down until re-activated by hand. The config key `fleet.autostart: [id, …]` is the durable form; this env var is the Docker/headless fallback. Idempotent (already-running members skipped), best-effort (a missing workspace is logged and skipped), and hub-only. Pairs with the config-as-code deploy pattern — see the [fleet guide](../guides/fleet.md#deploying-a-team). |
 | `PROTOAGENT_FLEET_KEEP_MEMBERS_ON_EXIT` | (unset) | By default the hub **spins its local members down when it shuts down** ("host down → fleet down" — keeps a rebuilt hub from leaving members running stale code; sessions resume from their `instance.id`-scoped checkpoints on the next switch, so it stops processes, not work). Set `1`/`true` to keep members running across a hub restart — for genuinely long-running detached agents. |
 | `PROTOAGENT_FLEET_MAX_WARM` | `0` | Keep-N-warm cap: at most this many members stay running; switching to another resumes it and evicts the least-recently-active beyond the cap (`0`/unset = unlimited). |
 | `PROTOAGENT_FLEET_WARM_GRACE` | `0` | Seconds a just-active member is spared from keep-warm eviction (may be mid background turn); `0` = pure LRU. |


### PR DESCRIPTION
## Summary
Configuring `fleet.autostart` to keep protoTrader (a fleet member) running across host restarts surfaced a documentation gap: autostart (ADR 0072) restarts the member **process**, but nothing documented how a plugin resumes the **work** that process was doing — the pattern that makes autostart actually useful for an agent whose job is a long-running background loop (a trading engine, a poller). That plugin-author half had to be reverse-engineered from `registry.register_surface`.

Three coordinated additions:
- **`reference/environment-variables.md`** — `PROTOAGENT_FLEET_AUTOSTART` added to the Fleet section (it lived in the fleet guide but was absent from the canonical env-var reference the Docker/headless operator scans).
- **`guides/plugins.md`** — new *"Surfaces that resume their work across reloads"* subsection: persist **intent** (not run-state), distinguish a lifecycle-stop from an operator-stop, resume in the surface `start` hook, and **fail safe on the clear direction** so a write failure never resurrects deliberately-stopped work. protoTrader's trading autopilot is the worked example.
- **`guides/fleet.md`** — a callout in the autostart section making the composition explicit: autostart brings the agent back, the surface pattern brings its work back; cross-linked both directions.

## Test plan
- [x] `npm run docs:build` passes locally (VitePress dead-link + parse gate)
- [ ] CI (docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how fleet members and plugin surfaces behave across restarts and reloads.
  * Added guidance on resuming long-running work safely after a host reboot or plugin reload.
  * Documented a new environment variable for hub-side fleet startup behavior, including best-effort restart details and missing-workspace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->