### PR TITLE
fix(chat): incognito + cue is hover-only, matching quick-delete (#1809)

### DIFF
--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -280,14 +280,15 @@
 
 /* Incognito cue (#1744): while Shift is held, the DS TabBar's add "+" becomes the incognito
    EyeOff glyph — a Shift+click there opens a new incognito chat (#1697), matching the EyeOff
-   that incognito tabs and the composer chip already wear. Unlike the per-tab delete trash this
-   is NOT :hover-scoped — the "+" is a single button, so it flips the instant Shift goes down.
-   Swap the DS + svg for an EyeOff outline (stroke masked, tinted via currentColor); the
-   Shift+click handler is unchanged, this only adds the visual cue. */
-.chat-tabbar-wrap--incognito .pl-tabbar__add svg {
+   that incognito tabs and the composer chip already wear. :hover-scoped (#1809) so the swap
+   reveals only while pointing at the "+", exactly like the per-tab quick-delete trash above —
+   a Shift held elsewhere no longer flips it unprompted. Swap the DS + svg for an EyeOff outline
+   (stroke masked, tinted via currentColor); the Shift+click handler is unchanged (Shift+click
+   still opens incognito regardless of hover), this only narrows the visual cue. */
+.chat-tabbar-wrap--incognito .pl-tabbar__add:hover svg {
   display: none;
 }
-.chat-tabbar-wrap--incognito .pl-tabbar__add::after {
+.chat-tabbar-wrap--incognito .pl-tabbar__add:hover::after {
   content: "";
   display: inline-block;
   width: 14px;


### PR DESCRIPTION
Closes #1809.

## What
The Shift-held cue that swaps the chat tab-strip's add **+** into the incognito EyeOff glyph was **global** — the moment Shift went down (anywhere on the page) the + flipped, whether or not you were pointing at it. The original code even called this out as deliberate (`chat.css:284`: *"NOT :hover-scoped — the + is a single button, so it flips the instant Shift goes down"*). #1809 asks for the opposite: reveal it only on hover, consistent with the sibling affordances.

## Change
One CSS scope narrowing — `.chat-tabbar-wrap--incognito .pl-tabbar__add` → `…__add:hover`, so the incognito glyph reveals **only while pointing at the +**, exactly mirroring the per-tab quick-delete trash (`.chat-tabbar-wrap--del .pl-tabbar__close:hover`) right above it in the same file.

- Default (non-hover): + shows the standard new-chat icon ✓
- Shift + hover over +: shows the incognito EyeOff ✓
- **Shift+click still opens an incognito chat regardless of hover** — the handler (`isIncognitoAddClick`) is untouched; this is a visual-only narrowing ✓

## Tests
The `shiftCue.test.ts` pure-function tests (class toggle on Shift keydown/keyup + the incognito click path) are unaffected — they assert the JS logic, which is unchanged. This PR only changes *when the glyph paints*.

**Draft** per our UI-layout gate — CI can't judge the hover interaction. Quick manual check: hold Shift with the pointer away from + (should stay +), then hover + (should show EyeOff), Shift+click to confirm it still opens incognito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)