### PR TITLE
feat(api): expose incognito on /v1/chat/completions

### DIFF
--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -275,7 +275,14 @@ def register_chat_routes(app, ui: str) -> None:
         req_model = (req.get("model") or "").strip()
         model = req_model if req_model and req_model != agent_name() else None
 
-        result = await chat(prompt, session_id, model=model)
+        # Incognito (ADR 0069): opt-in per request via an `incognito` field (OpenAI
+        # clients pass it through `extra_body`). Off by default — unchanged behavior —
+        # so a programmatic caller (e.g. an eval/benchmark harness) can run a turn with
+        # no memory injection, persistence, or harvest, for reproducible, uncontaminated
+        # runs. A2A and /api/chat already expose this; /v1 was the gap.
+        incognito = bool(req.get("incognito", False))
+
+        result = await chat(prompt, session_id, model=model, incognito=incognito)
         parts = [m["content"] for m in result if m.get("role") == "assistant" and m.get("content")]
         content = "\n\n".join(parts)
         created = int(time.time())

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -316,6 +316,25 @@ def test_openai_models_and_completion(monkeypatch):
     assert comp["model"] == "protoagent"
 
 
+def test_openai_completions_threads_incognito(monkeypatch):
+    # /v1 must expose incognito (ADR 0069) like /api/chat + A2A do, so a programmatic
+    # caller (eval/benchmark harness) can run a turn with no memory injection.
+    import operator_api.chat_routes as cr
+
+    seen: list[bool] = []
+
+    async def _fake_chat(message, session_id, *, model=None, incognito=False, hitl_resume=False):
+        seen.append(incognito)
+        return [{"role": "assistant", "content": "ok"}]
+
+    c = _client(monkeypatch)
+    monkeypatch.setattr(cr, "chat", _fake_chat)
+
+    c.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}]})
+    c.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}], "incognito": True})
+    assert seen == [False, True]  # default off (unchanged); opt-in honored
+
+
 def test_openai_streaming(monkeypatch):
     c = _client(monkeypatch)
     r = c.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "yo"}], "stream": True})


### PR DESCRIPTION
## Summary

- `incognito` (ADR 0069 — no memory injection / persistence / harvest) was reachable via **A2A** message metadata and **`/api/chat`**, but **not** the OpenAI-compatible **`/v1/chat/completions`** endpoint. A programmatic caller on `/v1` had no way to opt out of memory injection.
- Thread an `incognito` request field into `chat()` (OpenAI clients pass it via `extra_body`). **Off by default — behavior unchanged.**

## Closes

## Test plan

- [x] `tests/test_chat_routes.py::test_openai_completions_threads_incognito` — default off; `incognito: true` reaches `chat()`. Full file 19 passing.
- [x] Verified live on a fork: `/v1` with `incognito: true` runs a turn with no session-memory injection (the agent uses its first-class tools instead of inheriting a prior turn's shell command).

<sub>Motivation: an eval/benchmark harness driving `/v1` needs reproducible, uncontaminated turns — a benchmark turn silently inheriting a prior turn's injected memory changed tool selection and the answer. A2A/`/api/chat` already expose the opt-out; `/v1` was the gap.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)