### PR TITLE
feat(mcp): operator-MCP profiles + trust override + HITL-hang fix (ADR 0075 D3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Operator-MCP profiles + an env override, so "operate over MCP" is safe by default (ADR 0075, slice 2).**
+  The operator MCP server can now take a curated **`operator_mcp.profile`** instead of enumerating
+  tools: `read-only` (reads/queries only), `full` (everything), or unset (deny-by-default, unchanged).
+  A profile unions with any explicitly-named `tools`. **`PROTOAGENT_MCP_TRUST=full`** forces full for a
+  trusted/headless box. (The middle `safe-operator` tier lands with the ops layer, ADR 0075 D2.)
 - **React artifacts get a full design-system component set (`@pl/ui`), not just 9 primitives.**
   The `plugin-kit.css` injected into every artifact already styles ~90 `.pl-*` components, but
   `@pl/ui` only exposed **9** ergonomic React wrappers (Button/Card/Badge/Alert/Tag/Kbd/Input/Stat/Icon)
@@ -26,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without hand-rolled markup. The `rendering-artifacts` skill + README list the full set.
 
 ### Fixed
+- **The operator MCP no longer hands a foreign client HITL tools that hang it (ADR 0075).** `ask_human`
+  and `request_user_input` pause the turn via a LangGraph interrupt only the lead-turn runner resumes;
+  exposed over a stdio/HTTP MCP (Claude Desktop, Cursor) they had no runner to resume them and hung the
+  client. They're now hard-excluded from the operator MCP — even under `"*"` or when named explicitly.
 - **`plugin install` of a PRIVATE GitHub repo now works on the default git path.** A runtime
   install of a private repo (a private plugin or bundle — e.g. a team-member archetype)
   failed with `could not read Username for 'https://github.com'`: in a container with only a

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -185,6 +185,32 @@ operator_mcp:
   tools: [memory_recall, memory_ingest, task_list, task_create, notes_read, run_workflow]
 ```
 
+### Profiles (ADR 0075)
+
+Instead of enumerating tools, pick a **profile** — a curated preset over the same allowlist:
+
+```yaml
+operator_mcp:
+  profile: read-only        # reads/queries only, no state change
+  # profile: full           # everything (≡ tools: ["*"])
+  tools: [show_component]   # optional — a profile UNIONs with any explicit names
+```
+
+- **`read-only`** — a stable, principled set (recall/list/search/status; no writes).
+- **`full`** — everything (`"*"`), minus the danger set below.
+- **unset** (default) — deny-by-default: a foreign client gets *only* what `tools` names.
+- The safe middle tier **`safe-operator`** (reads + non-destructive writes) lands with the ops
+  layer (ADR 0075 D2), which carries per-op read/write metadata so it isn't a hand-maintained list.
+
+**Env override:** `PROTOAGENT_MCP_TRUST=full` forces the `full` profile — for a trusted or
+headless box where you vouch for the client (CI, your own machine). Per-op grants stay the
+`tools` allowlist.
+
+**Two tools are never exposed over MCP, even when named or via `"*"`:** `ask_human` and
+`request_user_input` are HITL tools that pause the turn via an interrupt only the lead runner
+resumes — over a foreign MCP client they'd hang it. (`execute_code` is dropped from `"*"` but
+can be re-added by name — a coding-agent brain already has its own.)
+
 Run it standalone:
 
 ```bash

--- a/graph/config.py
+++ b/graph/config.py
@@ -595,6 +595,12 @@ class LangGraphConfig:
     # exposed (empty = none). Served standalone via ``python -m server.operator_mcp``.
     operator_mcp_enabled: bool = False
     operator_mcp_tools: list[str] = field(default_factory=list)
+    # Curated profile preset over the allowlist (ADR 0075 D3): "" (default) = use
+    # ``operator_mcp_tools`` verbatim (deny-by-default); "read-only" = reads/queries
+    # only; "full" = everything (≡ "*"). A profile UNIONs with any explicit names.
+    # env PROTOAGENT_MCP_TRUST=full forces "full" (vouch for the client). The safe
+    # middle tier "safe-operator" arrives with the ops layer (ADR 0075 D2).
+    operator_mcp_profile: str = ""
 
     # Agent runtime (ADR 0033) — which brain executes a turn. "native" = the built-in
     # LangGraph loop (default). "acp:<agent>" (e.g. "acp:codex", "acp:claude") = an
@@ -1007,6 +1013,7 @@ class LangGraphConfig:
             mcp_scope=mcp.get("scope", cls.mcp_scope),
             operator_mcp_enabled=operator_mcp.get("enabled", cls.operator_mcp_enabled),
             operator_mcp_tools=list(operator_mcp.get("tools", []) or []),
+            operator_mcp_profile=str(operator_mcp.get("profile", "") or "").strip(),
             agent_runtime=str(data.get("agent_runtime", cls.agent_runtime) or "native"),
             developer_channel=str((data.get("developer", {}) or {}).get("channel", cls.developer_channel) or "prod"),
             acp_agents=dict(acp.get("agents", {}) or {}),

--- a/server/operator_mcp.py
+++ b/server/operator_mcp.py
@@ -78,11 +78,64 @@ def _boot_stores_only(config):
     STATE.skills_index = ai._build_skills_index(config, extra_skill_dirs=plugins.skill_dirs)
 
 
+# Tools "*" skips — a coding-agent brain already has its own code execution / file tools,
+# so exposing protoAgent's execute_code over the bus is redundant. Not a security gate
+# (you can still allowlist it by name); just avoids handing it a tool it already has.
+_STAR_EXCLUDE = {"execute_code"}
+
+# NEVER exposed over MCP, even when named explicitly — ask_human / request_user_input are
+# HITL tools that pause the turn via a LangGraph ``interrupt`` only the lead-turn runner
+# resumes. Called over a foreign stdio/HTTP MCP client (Claude Desktop, Cursor) there's no
+# runner to resume them, so they HANG the client (ADR 0075 D3 — a real bug, not a gate).
+_MCP_INCOMPATIBLE = {"ask_human", "request_user_input"}
+
+# Curated profile presets over the allowlist (ADR 0075 D3). A profile is just a preset set
+# of names layered on ``operator_mcp_tools`` — unset keeps deny-by-default (a foreign client
+# gets only what you name). ``read-only`` is a stable, principled set (reads/queries, no state
+# change). ``full`` = ``"*"``. The middle tier ``safe-operator`` (read + non-destructive
+# writes) lands with the ops layer (ADR 0075 D2), which carries per-op read/write metadata so
+# it's principled rather than a hand-maintained list — so it's deliberately NOT hardcoded here.
+_READ_ONLY_TOOLS = frozenset(
+    {
+        "current_time", "calculator", "web_search", "fetch_url", "load_skill",
+        "search_tools", "list_skills", "recent_activity", "list_agents",
+        "memory_recall", "recall_session", "memory_list", "memory_stats",
+        "list_schedules", "check_inbox", "task_list", "list_watches", "read_note",
+    }
+)
+
+
+def _profile_allow(profile: str) -> set[str] | None:
+    """A profile name → its allowlist set (or ``{"*"}`` for full), or ``None`` when the
+    profile is unset/unknown so the caller falls back to the explicit tools list."""
+    p = (profile or "").strip().lower().replace("_", "-")
+    if p in ("", "custom", "none"):
+        return None
+    if p in ("full", "all"):
+        return {"*"}
+    if p in ("read-only", "readonly"):
+        return set(_READ_ONLY_TOOLS)
+    log.warning("[operator-mcp] unknown profile %r — falling back to the tools allowlist", profile)
+    return None
+
+
+def resolve_allow(config) -> set[str]:
+    """The effective allowlist: ``PROTOAGENT_MCP_TRUST=full`` env override > the profile
+    (unioned with any explicit names) > the explicit ``operator_mcp_tools`` list."""
+    if os.environ.get("PROTOAGENT_MCP_TRUST", "").strip().lower() == "full":
+        return {"*"}
+    allow = set(getattr(config, "operator_mcp_tools", []) or [])
+    prof = _profile_allow(getattr(config, "operator_mcp_profile", ""))
+    if prof is not None:
+        allow |= prof
+    return allow
+
+
 def operator_tools(config):
     """The allowlisted tools (core + plugin) to expose — empty allowlist ⇒ none."""
     from tools.lg_tools import get_all_tools
 
-    allow = set(getattr(config, "operator_mcp_tools", []) or [])
+    allow = resolve_allow(config)
     if not allow:
         return []
     tools = list(
@@ -104,16 +157,19 @@ def operator_tools(config):
         name = getattr(t, "name", None)
         if not name or name in seen:
             continue
+        if name in _MCP_INCOMPATIBLE:  # HANGS a foreign client — never expose, even by name
+            continue
         if (name in allow) or (star and name not in _STAR_EXCLUDE):
             seen.add(name)
             out.append(t)
     return out
 
 
-# Tools "*" skips — a coding-agent brain already has its own code execution / file tools,
-# so exposing protoAgent's execute_code over the bus is redundant. Not a security gate
-# (you can still allowlist it by name); just avoids handing it a tool it already has.
-_STAR_EXCLUDE = {"execute_code"}
+def resolve_exposed_names(config) -> list[str]:
+    """The tool names the operator MCP would expose for *config* — powers the
+    ``GET /api/mcp/exposed`` discovery route (the exposed set was previously
+    introspectable only by reading logs). Requires the stores to be booted."""
+    return [t.name for t in operator_tools(config)]
 
 
 def build_server(config, *, name: str = "protoAgent-operator"):

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -152,6 +152,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "operator_project_dir": "",
     "operator_mcp_enabled": False,
     "operator_mcp_tools": [],
+    "operator_mcp_profile": "",
     "plugins_autoupdate_interval_hours": 6,
     "plugins_dir": "",
     "plugins_disabled": [],

--- a/tests/test_operator_mcp.py
+++ b/tests/test_operator_mcp.py
@@ -113,3 +113,67 @@ def test_star_plus_explicit_name_still_includes_it(monkeypatch):
     monkeypatch.setattr(STATE, "plugin_tools", [execute_code], raising=False)
     names = {t.name for t in operator_tools(_cfg(["*", "execute_code"]))}
     assert "execute_code" in names  # naming it explicitly overrides the wildcard exclusion
+
+
+# ── HITL hard-exclusion (ADR 0075 D3 — a real bug: these HANG a foreign MCP client) ──
+
+
+def test_hitl_tools_never_exposed_even_via_star():
+    # ask_human / request_user_input are in the keyless core, so "*" would grab them —
+    # but they pause the turn via a LangGraph interrupt only the lead runner resumes.
+    names = {t.name for t in operator_tools(_cfg(["*"]))}
+    assert "ask_human" not in names and "request_user_input" not in names
+
+
+def test_hitl_tools_never_exposed_even_when_named():
+    names = {t.name for t in operator_tools(_cfg(["ask_human", "request_user_input", "calculator"]))}
+    assert names == {"calculator"}  # the HITL names are dropped, hard
+
+
+# ── profile presets (ADR 0075 D3) ──
+
+
+def _cfg_profile(profile, tools=()):
+    c = _cfg(list(tools))
+    c.operator_mcp_profile = profile
+    return c
+
+
+def test_profile_read_only_exposes_reads_not_writes():
+    names = {t.name for t in operator_tools(_cfg_profile("read-only"))}
+    assert "current_time" in names and "load_skill" in names  # reads/queries
+    assert "web_search" in names
+    # writes are absent (no memory_ingest / write_note in the read-only set)
+    assert "memory_ingest" not in names and "write_note" not in names
+
+
+def test_profile_full_is_wildcard(monkeypatch):
+    from langchain_core.tools import tool
+
+    @tool
+    def plugin_thing(x: str) -> str:
+        """a plugin tool"""
+        return x
+
+    monkeypatch.setattr(STATE, "plugin_tools", [plugin_thing], raising=False)
+    names = {t.name for t in operator_tools(_cfg_profile("full"))}
+    assert "plugin_thing" in names and "calculator" in names  # everything
+    assert "ask_human" not in names  # …still minus the HITL hard-exclusion
+
+
+def test_profile_unions_with_explicit_names():
+    # read-only + an explicitly-named write tool → both
+    names = {t.name for t in operator_tools(_cfg_profile("read-only", tools=["show_component"]))}
+    assert "current_time" in names and "show_component" in names
+
+
+def test_unknown_profile_falls_back_to_allowlist():
+    names = {t.name for t in operator_tools(_cfg_profile("bogus", tools=["calculator"]))}
+    assert names == {"calculator"}  # unknown profile ignored, explicit names honored
+
+
+def test_env_trust_full_overrides_deny_default(monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_MCP_TRUST", "full")
+    names = {t.name for t in operator_tools(_cfg([]))}  # empty allowlist would be deny-all
+    assert "calculator" in names and "current_time" in names  # env forces full
+    assert "ask_human" not in names  # HITL still hard-excluded


### PR DESCRIPTION
**ADR 0075, slice 2** (of 4). Builds on #1816. Makes "operate the instance over MCP" **safe by default** and fixes a real **hang bug** — reusing the existing `operator_mcp_tools` allowlist rather than inventing a consent subsystem (ADR 0071's consent-acks stay unbuilt).

## What
- **Profiles** — `operator_mcp.profile`: `read-only` (a stable reads/queries set, no state change), `full` (≡ `"*"`), or **unset = deny-by-default** (unchanged). A profile *unions* with any explicitly-named `tools`, so you can grant a curated set without enumerating every tool.
- **Env override** — `PROTOAGENT_MCP_TRUST=full` forces `full`, for a trusted/headless box where you vouch for the client (CI, your own machine). Per-op grants stay the `tools` allowlist.
- **HITL-hang fix (the bug)** — `ask_human` / `request_user_input` pause the turn via a LangGraph interrupt only the lead-turn runner resumes. Exposed over a foreign stdio/HTTP MCP (Claude Desktop, Cursor) there's no runner to resume them → they **hang the client**. Now **hard-excluded** — even under `"*"` or when named explicitly. The ACP tool-bridge path is covered too.

This implements the D3 contract locked with @artificialcitizens: *profiles set the ceiling · the allowlist is the per-op grant · an env var is the full override.*

## Why this shape
The mechanism already existed (`operator_mcp_tools`: empty-deny / name / `"*"`). This is **named presets + a hard-exclude over it**, not new machinery. The safe middle tier **`safe-operator`** (read + non-destructive writes) is deliberately *not* a hardcoded list — it lands with the ops layer (D2), which gives per-op read/write metadata so it's principled.

## Scope note
`resolve_exposed_names()` is added for the `/api/mcp/exposed` discovery route, but that route ships in **PR3** — putting it in `operator_api` now would make it import `server`, breaking the import-layering contract.

## Tests + docs
`tests/test_operator_mcp.py`: profile resolution, HITL hard-exclusion (via `"*"` **and** by-name), env override, unknown-profile fallback. Config golden updated (one field). **Full suite green: 3156 passed, 5 skipped.** `docs/guides/mcp.md` + CHANGELOG updated.

## Next
PR3 REST tightening (dedupe namespaces + `/v1` usage + `/api/operations` & `/api/mcp/exposed` catalog) → PR4 model onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)