### PR TITLE
feat(tools): quick-disable deep-link from a chat tool card (#1803)

### DIFF
--- a/apps/web/src/app/ToolsPanel.tsx
+++ b/apps/web/src/app/ToolsPanel.tsx
@@ -2,7 +2,7 @@ import "./tools.css";
 
 import { Input, Switch } from "@protolabsai/ui/forms";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { TerminalSquare } from "lucide-react";
 
@@ -13,6 +13,7 @@ import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { queryKeys, toolsQuery } from "../lib/queries";
 import { QuickSetting } from "../settings/QuickSetting";
+import { useUI } from "../state/uiStore";
 import { StagePanel } from "./ErrorBoundary";
 
 // Runtime → Tools: the live tool inventory the lead agent + subagents can call.
@@ -37,6 +38,31 @@ function ToolsBody() {
   const [q, setQ] = useState("");
   const queryClient = useQueryClient();
   const toast = useToast();
+
+  // Deep-link from a chat tool card's "Manage" (#1803): the target tool name arrives as a
+  // one-shot in the UI store. Prefill the search with it — that both filters to the tool and
+  // auto-expands its group (the AccordionItem's defaultOpen keys off a non-empty query) — then
+  // highlight the row and consume the one-shot so a later manual search isn't hijacked.
+  const toolsTarget = useUI((s) => s.toolsTarget);
+  const setToolsTarget = useUI((s) => s.setToolsTarget);
+  const [highlight, setHighlight] = useState<string | null>(null);
+  useEffect(() => {
+    if (!toolsTarget) return;
+    setQ(toolsTarget);
+    setHighlight(toolsTarget);
+    setToolsTarget(null);
+  }, [toolsTarget, setToolsTarget]);
+  // The highlight is a momentary "here it is" cue, not a persistent selection — drop it after
+  // it's drawn the eye (the prefilled search stays, so the row remains in view).
+  useEffect(() => {
+    if (!highlight) return;
+    const t = setTimeout(() => setHighlight(null), 2600);
+    return () => clearTimeout(t);
+  }, [highlight]);
+  // Scroll the just-highlighted row into view once it mounts (the search remounts the sections).
+  const scrollToTarget = (el: HTMLDivElement | null) => {
+    if (el) el.scrollIntoView({ block: "center", behavior: "smooth" });
+  };
 
   // Per-row on/off = editing the tools.disabled denylist — the same config the YAML /
   // central-settings route writes, enforced over the FULL assembled set (#1612), so a
@@ -176,7 +202,11 @@ function ToolsBody() {
                 >
                   <div className="tools-list">
                     {items.map((t) => (
-                      <div className={`tools-row${t.enabled ? "" : " tools-row--off"}`} key={t.name}>
+                      <div
+                        className={`tools-row${t.enabled ? "" : " tools-row--off"}${t.name === highlight ? " tools-row--target" : ""}`}
+                        key={t.name}
+                        ref={t.name === highlight ? scrollToTarget : undefined}
+                      >
                         <div className="tools-row-main">
                           <code className="tools-name">{t.name}</code>
                           {t.description ? <span className="tools-desc">{t.description}</span> : null}

--- a/apps/web/src/app/tools.css
+++ b/apps/web/src/app/tools.css
@@ -52,6 +52,25 @@
   opacity: 0.65;
 }
 
+/* Deep-link highlight (#1803): a chat tool card's "Manage" lands on this panel with the row
+   filtered + scrolled into view; a brief accent pulse points the eye at it in a long list.
+   Self-clearing (JS drops the class at ~2.6s); the prefilled search keeps the row in view. */
+.tools-row--target {
+  border-radius: 6px;
+  animation: tools-row-target-pulse 2.6s ease-out;
+}
+@keyframes tools-row-target-pulse {
+  0%,
+  25% {
+    background: color-mix(in srgb, var(--accent, #7c8cff) 22%, transparent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent, #7c8cff) 45%, transparent);
+  }
+  100% {
+    background: transparent;
+    box-shadow: 0 0 0 2px transparent;
+  }
+}
+
 /* Contextual settings chips above the search (mirrors .mcp-browse-row). */
 .tools-config-row {
   display: flex;

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -6,6 +6,7 @@ import {
   Globe,
   Network,
   Search,
+  SlidersHorizontal,
   Square,
   Wrench,
 } from "lucide-react";
@@ -15,6 +16,7 @@ import type { ReactNode } from "react";
 import { ToolCard, ToolCardList, ToolCardSummary, ToolSection } from "@protolabsai/ui/tool-card";
 
 import type { ToolCall } from "../lib/types";
+import { useUI } from "../state/uiStore";
 import { ToolValue } from "./tool-renderers";
 
 /** Map a tool name to a recognizable icon; falls back to a generic wrench. */
@@ -221,10 +223,12 @@ function ToolGroup({
       </>
     ) : undefined;
 
+  const openToolSettings = useUI((s) => s.openToolSettings);
+
   // A running subagent delegation can be aborted (Tier 2): Stop cancels just this
   // `task`, the lead keeps working. Lives in the DS ToolCard header `actions` slot
   // (a sibling of the disclosure toggle, so it doesn't expand the card).
-  const actions =
+  const stopBtn =
     onCancelDelegation && call.name === "task" && call.status === "running" ? (
       <button
         type="button"
@@ -239,7 +243,34 @@ function ToolGroup({
         <Square size={11} />
         <span>Stop</span>
       </button>
-    ) : undefined;
+    ) : null;
+
+  // "Manage" deep-link (#1803): the moment you spot a tool you don't want, jump straight to
+  // its row in Capabilities ▸ Tools to disable it or change its policy — no hunting through a
+  // separate settings panel. A deep-link, not an inline toggle, so Tools settings stays the
+  // single source of truth for wiring. Sits in the same header actions slot as Stop; quiet
+  // until hover so the card reads as activity first, curation on intent.
+  const manageBtn = (
+    <button
+      type="button"
+      className="pl-iconbtn tool-manage-btn"
+      title={`Manage “${call.name}” in Tools settings`}
+      aria-label={`Manage ${call.name} in Tools settings`}
+      onClick={(e) => {
+        e.stopPropagation();
+        openToolSettings(call.name);
+      }}
+    >
+      <SlidersHorizontal size={11} />
+    </button>
+  );
+
+  const actions = (
+    <>
+      {stopBtn}
+      {manageBtn}
+    </>
+  );
 
   // A running count of the subagent's tools, in the header — so a collapsed delegation
   // reads "task → researcher · 3 tools" at a glance without expanding.

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -169,6 +169,29 @@
   flex: none;
 }
 
+/* "Manage" deep-link to Tools settings (#1803) — icon-only, in the same header actions slot.
+   Quiet (muted, borderless) so it never competes with the tool's status; accent-toned on
+   hover to read as an intentional jump-to-settings affordance. */
+.tool-manage-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px;
+  width: auto;
+  border-radius: 6px;
+  color: var(--fg-muted);
+  border: 1px solid transparent;
+  opacity: 0.7;
+}
+.tool-manage-btn:hover {
+  color: var(--accent, #7c8cff);
+  background: color-mix(in srgb, var(--accent, #7c8cff) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent, #7c8cff) 28%, transparent);
+  opacity: 1;
+}
+.tool-manage-btn svg {
+  flex: none;
+}
+
 /* Defensive: an ACP coding agent can report a long/unbroken tool NAME (e.g. a verbose
    MCP tool title). Let the header shrink + the name wrap so it can never force the card
    wider than the chat panel — the args/source live in the expandable body, not here. */

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -344,3 +344,26 @@ describe("migrateUiState — v13 hidden bucket", () => {
     expect(out.railOrder.hidden).toEqual(["knowledge"]);
   });
 });
+
+// openToolSettings (#1803): a chat tool card's "Manage" deep-links to Capabilities ▸ Tools,
+// focused on the tool. One atomic action sets the one-shot target AND opens the settings
+// overlay on the Tools section — the Tools panel consumes `toolsTarget` on mount.
+describe("openToolSettings", () => {
+  it("targets the tool and opens the Tools settings section", () => {
+    useUI.setState({ toolsTarget: null, globalSettingsOpen: false, globalSettingsSection: undefined });
+    useUI.getState().openToolSettings("run_command");
+    const s = useUI.getState();
+    expect(s.toolsTarget).toBe("run_command");
+    expect(s.globalSettingsOpen).toBe(true);
+    expect(s.globalSettingsSection).toBe("tools");
+  });
+
+  it("setToolsTarget clears the one-shot after the panel consumes it", () => {
+    useUI.getState().openToolSettings("web_search");
+    expect(useUI.getState().toolsTarget).toBe("web_search");
+    useUI.getState().setToolsTarget(null);
+    expect(useUI.getState().toolsTarget).toBeNull();
+    // Consuming the target does NOT reopen/close the overlay — it's independent.
+    expect(useUI.getState().globalSettingsOpen).toBe(true);
+  });
+});

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -60,6 +60,10 @@ type UIState = {
   // One-shot: the FleetSwitcher's "+ New agent" deep-link routes to Host/App ▸ Fleet
   // and asks the fleet panel to open the new-agent picker on mount, then clears it.
   fleetStartNew: boolean;
+  // One-shot: a chat tool card's "Manage" deep-link (#1803) routes to Capabilities ▸ Tools
+  // carrying the tool name, so the Tools panel filters + highlights that row on mount, then
+  // clears it. Ephemeral (partialized out) — it accompanies the also-ephemeral settings overlay.
+  toolsTarget: string | null;
   // Global settings overlay (the Global home; opened from the header drawer or a
   // command-palette deep-link). EPHEMERAL — partialized out of persistence so a refresh
   // never reopens it. The section deep-links a Global section (e.g. "telemetry").
@@ -127,6 +131,9 @@ type UIState = {
   setPluginsTab: (t: PluginsTab) => void;
   setSettingsSection: (s: string) => void;
   setFleetStartNew: (b: boolean) => void;
+  setToolsTarget: (name: string | null) => void;
+  // Deep-link a chat tool card → Capabilities ▸ Tools, focused on that tool (#1803).
+  openToolSettings: (name: string) => void;
   setRightCollapsed: (b: boolean) => void;
   setLeftCollapsed: (b: boolean) => void;
   setRightWidth: (w: number) => void;
@@ -316,6 +323,7 @@ export const useUI = create<UIState>()(
       // Box section, so it can't be the universal default (a fleet member has no Box group).
       settingsSection: "identity",
       fleetStartNew: false,
+      toolsTarget: null,
       globalSettingsOpen: false,
       globalSettingsSection: undefined,
       openGlobalSettings: (section) => set({ globalSettingsOpen: true, globalSettingsSection: section }),
@@ -446,6 +454,12 @@ export const useUI = create<UIState>()(
       setPluginsTab: (pluginsTab) => set({ pluginsTab }),
       setSettingsSection: (settingsSection) => set({ settingsSection }),
       setFleetStartNew: (fleetStartNew) => set({ fleetStartNew }),
+      setToolsTarget: (toolsTarget) => set({ toolsTarget }),
+      // Land on Capabilities ▸ Tools with the panel focused on this tool (#1803): set the
+      // one-shot target AND open the settings overlay on the Tools section in one atomic set
+      // (mirrors openGlobalSettings's body — the store creator exposes only `set`).
+      openToolSettings: (name) =>
+        set({ toolsTarget: name, globalSettingsOpen: true, globalSettingsSection: "tools" }),
       setRightCollapsed: (rightCollapsed) => set({ rightCollapsed }),
       setLeftCollapsed: (leftCollapsed) => set({ leftCollapsed }),
       // The DS AppShell is a CONTROLLED width: during a divider drag it streams transient
@@ -489,7 +503,7 @@ export const useUI = create<UIState>()(
       // (the Global settings overlay, the per-plugin Configure dialog, the pending
       // rail-menu Update/Uninstall action, and the per-session background-delivery set
       // (#1640) — a view's page re-requests it on every load).
-      partialize: ({ globalSettingsOpen: _o, globalSettingsSection: _s, configurePlugin: _c, pluginUpdate: _pu, pluginUninstall: _pun, pluginBackground: _pb, ...rest }) => rest,
+      partialize: ({ globalSettingsOpen: _o, globalSettingsSection: _s, toolsTarget: _tt, configurePlugin: _c, pluginUpdate: _pu, pluginUninstall: _pun, pluginBackground: _pb, ...rest }) => rest,
     },
   ),
 );


### PR DESCRIPTION
Closes #1803.

## What
Spot a tool you don't want *while it's running in chat*? Each tool card now has a quiet **"Manage"** gear (in the DS `ToolCard` actions slot, next to Stop) that jumps straight to that tool's row in **Capabilities ▸ Tools** — no hunting through a separate settings panel. Per the issue's option 2, this is a **deep-link, not an inline toggle**, so Tools settings stays the single source of truth for wiring (the per-row switch there already edits `tools.disabled`).

## How
- **uiStore**: a one-shot `toolsTarget` + `openToolSettings(name)` action — mirrors the existing `fleetStartNew` deep-link pattern ("+ New agent" → Fleet). One atomic `set` targets the tool and opens the settings overlay on the Tools section. Ephemeral (partialized out of persistence), so a refresh never resurrects a stale target.
- **ToolsPanel**: consumes `toolsTarget` on mount — prefills the search with the tool name, which both filters to it **and auto-expands its accordion group** (reusing the existing `defaultOpen={Boolean(query)}` lever), then highlights + scrolls the row and clears the one-shot.
- **ToolCalls**: the "Manage" icon button; `stopPropagation` so it never toggles the card disclosure. Quiet (muted) until hover, accent-toned on hover.

## Acceptance criteria
- [x] Each tool card surfaces a way to disable the tool (deep-link) → the gear
- [x] Deep-link navigates directly to **that tool's entry** (not the top of the list) → prefilled search + expanded group + highlighted row
- [x] Works consistently across any view where tool cards are shown (spotlight, folded, flat/WorkBlock — all render through `ToolGroup`)

## Tests
2 new `uiStore.test.ts` cases (`openToolSettings` targets the tool + opens the Tools section; `setToolsTarget` clears the one-shot). `vitest` → **38 passed**; `tsc --noEmit` clean.

**Draft** per our UI-layout gate — CI can't judge the interaction. Quick manual check: run a tool in chat → hover its card → click the gear → confirm Settings opens on Tools with that tool filtered, its group expanded, and the row highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)