### PR TITLE
fix(installer): authenticate the update-check ls-remote for private repos (#1805 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without hand-rolled markup. The `rendering-artifacts` skill + README list the full set.
 
 ### Fixed
+- **The plugin update-CHECK now authenticates private repos too, not just install.** #1805 taught the
+  clone/install path to auth private github over a token, but the update-availability check
+  (`check_updates` → `git ls-remote`) still ran unauthenticated — so a **private** plugin showed
+  **"check failed"** in the Plugins panel (couldn't reach the repo to see if a newer release exists),
+  even though the plugin itself installed + ran fine. Both `_ls_remote_sha` and `_ls_remote_tags` now
+  pass the same scoped `_git_auth_env` (Basic `x-access-token` over `GIT_CONFIG_*` env — off-argv,
+  off-disk, github-scoped) when `GITHUB_TOKEN`/`GH_TOKEN` is set. Public/no-token/ssh unchanged.
 - **The operator MCP no longer hands a foreign client HITL tools that hang it (ADR 0075).** `ask_human`
   and `request_user_input` pause the turn via a LangGraph interrupt only the lead-turn runner resumes;
   exposed over a stdio/HTTP MCP (Claude Desktop, Cursor) they had no runner to resume them and hung the

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -864,7 +864,11 @@ def _ls_remote_sha(source_url: str, ref: str) -> str:
     # `<ref>^{}` too and prefer it; branches/HEAD/lightweight tags simply don't
     # match the peeled refspec and fall back to the bare line.
     refspecs = [ref, ref + "^{}"] if ref else ["HEAD"]
-    out = _git("ls-remote", source_url, *refspecs, timeout=_LSREMOTE_TIMEOUT_S)
+    # Authenticate the update-check for a PRIVATE github repo (#1805 parity — that fix covered
+    # the clone/install path; a plain `git ls-remote` of a private repo still failed auth here,
+    # surfacing as "check failed" in the plugins panel). Scoped/off-argv/off-disk via GIT_CONFIG_*.
+    _auth = _git_auth_env(source_url)
+    out = _git("ls-remote", source_url, *refspecs, timeout=_LSREMOTE_TIMEOUT_S, env={**os.environ, **_auth} if _auth else None)
     sha = peeled = ""
     for line in out.splitlines():
         parts = line.split("\t")
@@ -910,7 +914,8 @@ def _ls_remote_tags(source_url: str) -> dict[str, str]:
     hit = _lstags_cache.get(source_url)
     if hit is not None and (now - hit[0]) < _LSREMOTE_TTL_S:
         return hit[1]
-    out = _git("ls-remote", "--tags", source_url, timeout=_LSREMOTE_TIMEOUT_S)
+    _auth = _git_auth_env(source_url)  # authenticate the update-check for a private github repo (#1805 parity)
+    out = _git("ls-remote", "--tags", source_url, timeout=_LSREMOTE_TIMEOUT_S, env={**os.environ, **_auth} if _auth else None)
     tags: dict[str, str] = {}
     for line in out.splitlines():
         parts = line.split("\t")

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -504,3 +504,50 @@ def test_clone_no_auth_env_without_token(monkeypatch, tmp_path):
     installer._clone("https://github.com/o/r", None, tmp_path / "dest")
     clone = next(c for c in calls if c["args"][0] == "clone")
     assert clone["env"] is None
+
+
+# ── private-repo auth for the update CHECK (ls-remote), not just install (#1805 follow-up) ──
+# check_updates ls-remotes each plugin's repo; for a PRIVATE repo the plain ls-remote failed
+# auth → "check failed" in the panel even though the plugin works. Same _git_auth_env, applied
+# to the update-check path.
+
+
+def test_ls_remote_sha_authenticates_private_github(monkeypatch):
+    import base64
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "s3cr3t")
+    cap = {}
+
+    def fake_git(*args, cwd=None, timeout=None, env=None):
+        cap["args"], cap["env"] = args, env
+        return "abc1230000000000000000000000000000000000\trefs/heads/main"
+
+    monkeypatch.setattr(installer, "_git", fake_git)
+    installer._lsremote_cache.clear()
+    installer._ls_remote_sha("https://github.com/protoLabsAI/private-plugin", "main")
+
+    assert cap["args"][0] == "ls-remote"
+    env = cap["env"]
+    assert env and env["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraheader"
+    assert base64.b64decode(env["GIT_CONFIG_VALUE_0"].split()[-1]).decode() == "x-access-token:s3cr3t"
+
+
+def test_ls_remote_tags_authenticates_private_github(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "tok")
+    cap = {}
+    monkeypatch.setattr(installer, "_git", lambda *a, cwd=None, timeout=None, env=None: (cap.update(args=a, env=env) or "sha\trefs/tags/v0.1.0"))
+    installer._lstags_cache.clear()
+    installer._ls_remote_tags("https://github.com/protoLabsAI/private-plugin")
+    assert cap["env"] and cap["env"]["GIT_CONFIG_KEY_0"] == "http.https://github.com/.extraheader"
+
+
+def test_ls_remote_no_auth_env_without_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    cap = {}
+    monkeypatch.setattr(installer, "_git", lambda *a, cwd=None, timeout=None, env=None: (cap.update(env=env) or "sha\tHEAD"))
+    installer._lsremote_cache.clear()
+    installer._ls_remote_sha("https://github.com/protoLabsAI/public-plugin", "")
+    assert cap["env"] is None  # no token → plain env, unchanged behavior


### PR DESCRIPTION
## Problem

A **private** plugin shows **"check failed"** in the Plugins panel even though it installs and runs perfectly. The panel's update-availability check (`check_updates` → `git ls-remote`) runs an **unauthenticated** `ls-remote`, so for a private repo it can't reach the remote to see if a newer release exists → the per-plugin check errors out.

#1805 fixed exactly this class of gap — but only for the **clone/install** path (`_clone`). The **update-check** path (`_ls_remote_sha`, `_ls_remote_tags`) was still plain `git ls-remote` with no auth.

Surfaced on a deployed agent (`matt`) running a private `design-system-plugin`: `enabled: true, incomplete: false`, 6 tools loaded, works fine — but "check failed" because the panel couldn't ls-remote the private repo. Cosmetic, but alarming (reads like the plugin is broken).

## Fix

Pass the same scoped `_git_auth_env` from #1805 to **both** `ls-remote` call sites — `_ls_remote_sha` (moving-ref / HEAD compare) and `_ls_remote_tags` (release-tag compare) — when `GITHUB_TOKEN`/`GH_TOKEN` is set. It's a Basic `x-access-token` header delivered via `GIT_CONFIG_*` env: **off-argv** (no `ps` leak), **not persisted** to any repo, **scoped** to `https://github.com/`. Public / no-token / ssh paths are unchanged.

## Tests

`tests/test_plugin_installer.py` — both ls-remote paths pass the auth env for a private github URL; no auth env when there's no token. Installer + updates suites green (**66 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)