### PR TITLE
feat(cli): `protoagent model` — point at a local / OpenAI-compatible LLM in one line (ADR 0075 D5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`protoagent model` — point at a local LLM in one line (ADR 0075, slice 4).** protoAgent's
+  model is just OpenAI-compatible config (the LiteLLM gateway is the default, not a lock-in), so
+  `protoagent model use --base-url http://127.0.0.1:8080/v1 --model qwen2.5` writes the endpoint +
+  model to the live config non-interactively, and `protoagent model discover` probes the usual
+  local ports (Ollama :11434, LM Studio :1234, llama.cpp/vLLM :8080). That one-liner is the
+  copy-paste target for HuggingFace's "Use this model" local-app snippet (the hermes-agent /
+  openclaw / pi agent-runtime pattern) — it even tolerates HF's `:{{QUANT_TAG}}` placeholder.
 - **Operator-MCP profiles + an env override, so "operate over MCP" is safe by default (ADR 0075, slice 2).**
   The operator MCP server can now take a curated **`operator_mcp.profile`** instead of enumerating
   tools: `read-only` (reads/queries only), `full` (everything), or unset (deny-by-default, unchanged).

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -57,6 +57,23 @@ then exits:
 | `protoagent skills ls` · `promote <name>` | Inspect and curate the SKILL.md library. | [0041](../adr/0041-workspaces-and-tiered-stores.md) |
 | `protoagent config explain` | Print this instance's id, both roots, every resolved path, and the config cascade with provenance. | [0047](../adr/0047-layered-settings-cascade.md) |
 
+### Point at a local model
+
+`protoagent model` points protoAgent at any OpenAI-compatible endpoint — the gateway
+is the default, not a lock-in, so a local Ollama / LM Studio / llama.cpp / vLLM server
+is one line:
+
+```bash
+protoagent model discover                                   # probe :11434 / :1234 / :8080
+protoagent model use --base-url http://127.0.0.1:8080/v1 --model qwen2.5
+protoagent up
+```
+
+`model use` writes the endpoint + model to your live config (a local endpoint ignores
+the key; a placeholder is set so the client constructs — use `--key` or `secrets.yaml`
+for a real gateway key). This one-liner is also the copy-paste target for HuggingFace's
+"Use this model" local-app snippet — a HF model card hands the model id straight to it.
+
 ## Examples
 
 ```bash
@@ -64,6 +81,9 @@ then exits:
 protoagent up --port 7870
 protoagent status
 protoagent config explain
+
+# Point at a local LLM
+protoagent model use --base-url http://127.0.0.1:11434/v1 --model llama3.2
 
 # Install a plugin, then reload isn't needed for a fresh boot
 protoagent plugin install https://github.com/protoLabsAI/careercoach-plugin
@@ -74,6 +94,5 @@ protoagent down
 
 ## Roadmap
 
-Later slices of ADR 0075 add `protoagent model` (point at a local Ollama / HF /
-LM Studio / vLLM endpoint in one command) and a shared operation layer so every
-verb here has a matching MCP tool and REST endpoint. See the ADR for the plan.
+Later slices of ADR 0075 add a shared operation layer so every verb here has a matching
+MCP tool and REST endpoint. See the ADR for the plan.

--- a/graph/model_cli.py
+++ b/graph/model_cli.py
@@ -1,0 +1,151 @@
+"""``protoagent model`` — point protoAgent at a local (or any OpenAI-compatible) LLM.
+
+ADR 0075 D5. protoAgent's model is just gateway config — ``graph.llm.create_llm``
+builds a plain ``ChatOpenAI(base_url, model)``, so the LiteLLM gateway is the
+*default, not a lock-in*. This command writes that config non-interactively, so
+pointing at a local Ollama / LM Studio / llama.cpp / vLLM endpoint is one line:
+
+    protoagent model use --base-url http://127.0.0.1:8080/v1 --model qwen2.5
+
+That one-liner is also the copy-paste target for HuggingFace's "Use this model"
+local-app snippet (the hermes-agent / openclaw / pi agent-runtime pattern): a HF
+model card hands the model id straight to protoAgent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+# Well-known local OpenAI-compatible endpoints, probed by ``discover`` / ``list``.
+_LOCAL_ENDPOINTS: list[tuple[str, str]] = [
+    ("ollama", "http://127.0.0.1:11434/v1"),
+    ("lm-studio", "http://127.0.0.1:1234/v1"),
+    ("llama.cpp / vLLM", "http://127.0.0.1:8080/v1"),
+]
+
+# A non-empty placeholder key. A local endpoint ignores it, but the OpenAI client
+# constructor requires *some* key (empty → "Missing credentials"). Not a secret, so
+# it's fine inline; a real keyed gateway should use secrets.yaml / an env var instead.
+_LOCAL_KEY_PLACEHOLDER = "local"
+
+# HuggingFace passes this literal in the snippet when no specific GGUF file is chosen;
+# the local server picks its own default quant, so we just strip it.
+_HF_QUANT_PLACEHOLDER = ":{{QUANT_TAG}}"
+
+
+def _discover(timeout: float = 1.0) -> list[dict]:
+    """Probe the well-known local endpoints; return ``[{name, base_url, models}]`` for
+    the reachable ones. Best-effort — an unreachable endpoint just isn't listed."""
+    import httpx
+
+    out: list[dict] = []
+    for name, base in _LOCAL_ENDPOINTS:
+        try:
+            r = httpx.get(f"{base}/models", timeout=timeout)
+            if r.status_code != 200:
+                continue
+            data = r.json()
+            models = [m.get("id") for m in (data.get("data") or []) if isinstance(m, dict) and m.get("id")]
+            out.append({"name": name, "base_url": base, "models": models})
+        except Exception:  # noqa: BLE001 — unreachable/parse error ⇒ endpoint not running
+            continue
+    return out
+
+
+def _normalize_model_id(model: str) -> str:
+    """Tolerate the HF snippet's quant-tag placeholder — HF interpolates the literal
+    ``:{{QUANT_TAG}}`` when the user hasn't drilled into a specific GGUF file. Strip it
+    (the server defaults to its own quant, e.g. Q4_K_M); a real ``:quant`` is kept."""
+    return (model or "").replace(_HF_QUANT_PLACEHOLDER, "").strip()
+
+
+def _cmd_use(args) -> int:
+    from graph.config_io import load_yaml_doc, save_yaml_doc
+
+    model_id = _normalize_model_id(args.model)
+    base_url = (args.base_url or "").strip()
+    if not base_url or not model_id:
+        print("model use: --base-url and --model are required", file=sys.stderr)
+        return 2
+
+    doc = load_yaml_doc()
+    model = doc.get("model")
+    if not isinstance(model, dict):
+        model = {}
+        doc["model"] = model
+    model["provider"] = args.provider
+    model["api_base"] = base_url
+    model["name"] = model_id
+    # Local endpoints ignore the key, but the OpenAI client needs a non-empty one. Only
+    # set a placeholder if there isn't a real key already (don't clobber a gateway key).
+    if args.key:
+        model["api_key"] = args.key
+    elif not str(model.get("api_key") or "").strip():
+        model["api_key"] = _LOCAL_KEY_PLACEHOLDER
+    save_yaml_doc(doc)
+
+    print(f"model: now {model_id} @ {base_url} (provider={args.provider})")
+    print("Start it with:  protoagent up")
+    return 0
+
+
+def _cmd_discover(_args) -> int:
+    found = _discover()
+    if not found:
+        print(
+            "No local OpenAI-compatible endpoint found on the usual ports "
+            "(Ollama :11434, LM Studio :1234, llama.cpp/vLLM :8080)."
+        )
+        print("Start one, or point at any URL:  protoagent model use --base-url <url> --model <id>")
+        return 0
+    for ep in found:
+        print(f"{ep['name']}  {ep['base_url']}")
+        for m in ep["models"][:20]:
+            print(f"    {m}")
+        if len(ep["models"]) > 20:
+            print(f"    … +{len(ep['models']) - 20} more")
+    print("\nUse one with:  protoagent model use --base-url <url> --model <id>")
+    return 0
+
+
+def _cmd_list(_args) -> int:
+    from graph.config import LangGraphConfig
+    from graph.config_io import config_yaml_path
+
+    cfg = LangGraphConfig.from_yaml(config_yaml_path())
+    print(f"current:  {cfg.model_name} @ {cfg.api_base} (provider={cfg.model_provider})")
+    found = _discover()
+    if found:
+        print("\ndiscovered local endpoints:")
+        for ep in found:
+            print(f"  {ep['name']}  {ep['base_url']}  ({len(ep['models'])} model(s))")
+    return 0
+
+
+def run_model_cli(argv: list[str]) -> int:
+    """`protoagent model` — see module docstring. Returns a process exit code."""
+    parser = argparse.ArgumentParser(
+        prog="protoagent model",
+        description="Point protoAgent at a local or OpenAI-compatible LLM.",
+    )
+    sub = parser.add_subparsers(dest="cmd", metavar="<use|discover|list>")
+
+    p_use = sub.add_parser("use", help="Point at an endpoint + model (writes the live config)")
+    p_use.add_argument("--base-url", required=True, help="OpenAI-compatible base URL, e.g. http://127.0.0.1:8080/v1")
+    p_use.add_argument("--model", required=True, help="the model id the endpoint serves")
+    p_use.add_argument("--provider", default="openai", help="config provider label (default: openai)")
+    p_use.add_argument("--key", default="", help="API key value (local endpoints don't need one; prefer secrets.yaml for a real key)")
+    p_use.set_defaults(fn=_cmd_use)
+
+    sub.add_parser("discover", help="Probe local endpoints (Ollama / LM Studio / llama.cpp / vLLM)").set_defaults(
+        fn=_cmd_discover
+    )
+    sub.add_parser("list", help="Show the current model + discovered local endpoints").set_defaults(fn=_cmd_list)
+
+    args = parser.parse_args(argv)
+    fn = getattr(args, "fn", None)
+    if fn is None:
+        parser.print_help()
+        return 0
+    return fn(args)

--- a/server/cli.py
+++ b/server/cli.py
@@ -38,6 +38,7 @@ _FORWARD: dict[str, tuple[str, str]] = {
     "skills": ("graph.skills.cli", "run_skills_cli"),
     "fleet": ("graph.fleet.cli", "run_fleet_cli"),
     "config": ("graph.config_explain", "run_config_cli"),
+    "model": ("graph.model_cli", "run_model_cli"),
 }
 
 _FORWARD_HELP = {
@@ -46,6 +47,7 @@ _FORWARD_HELP = {
     "skills": "Inspect and curate the SKILL.md library (ADR 0041)",
     "fleet": "Start / stop / list fleet MEMBER agents as background processes (ADR 0042)",
     "config": "Explain this instance's identity, paths, and config cascade (ADR 0047)",
+    "model": "Point at a local / OpenAI-compatible LLM — Ollama, LM Studio, llama.cpp, vLLM (ADR 0075)",
 }
 
 _LIFECYCLE_HELP = {

--- a/tests/test_model_cli.py
+++ b/tests/test_model_cli.py
@@ -1,0 +1,99 @@
+"""Tests for `protoagent model` (ADR 0075 D5, `graph/model_cli.py`).
+
+`model use` is the load-bearing verb — the non-interactive one-liner that points
+protoAgent at a local / OpenAI-compatible endpoint (and the copy-paste target for
+HuggingFace's "Use this model" local-app snippet)."""
+
+from __future__ import annotations
+
+import yaml
+
+from graph import model_cli
+from graph.model_cli import _normalize_model_id, run_model_cli
+
+
+def _patch_config_path(monkeypatch, path, initial="{}\n"):
+    path.write_text(initial, encoding="utf-8")
+    monkeypatch.setattr("graph.config_io.config_yaml_path", lambda: path)
+
+
+def test_use_writes_base_model_and_placeholder_key(monkeypatch, tmp_path):
+    cfg = tmp_path / "langgraph-config.yaml"
+    _patch_config_path(monkeypatch, cfg, "model:\n  name: old\n")
+    rc = run_model_cli(["use", "--base-url", "http://127.0.0.1:8080/v1", "--model", "qwen2.5"])
+    assert rc == 0
+    doc = yaml.safe_load(cfg.read_text())
+    assert doc["model"]["api_base"] == "http://127.0.0.1:8080/v1"
+    assert doc["model"]["name"] == "qwen2.5"
+    assert doc["model"]["provider"] == "openai"
+    assert doc["model"]["api_key"]  # a non-empty placeholder so the OpenAI client constructs
+
+
+def test_use_keeps_an_existing_real_key(monkeypatch, tmp_path):
+    cfg = tmp_path / "c.yaml"
+    _patch_config_path(monkeypatch, cfg, "model:\n  api_key: real-gateway-key\n")
+    run_model_cli(["use", "--base-url", "http://x/v1", "--model", "m"])
+    assert yaml.safe_load(cfg.read_text())["model"]["api_key"] == "real-gateway-key"  # not clobbered
+
+
+def test_use_explicit_key_wins(monkeypatch, tmp_path):
+    cfg = tmp_path / "c.yaml"
+    _patch_config_path(monkeypatch, cfg)
+    run_model_cli(["use", "--base-url", "http://x/v1", "--model", "m", "--key", "sk-explicit"])
+    assert yaml.safe_load(cfg.read_text())["model"]["api_key"] == "sk-explicit"
+
+
+def test_hf_quant_placeholder_is_stripped():
+    # HF passes the literal :{{QUANT_TAG}} when no GGUF file is chosen — the server
+    # defaults its own quant, so we strip it; a real :quant suffix is kept.
+    assert _normalize_model_id("unsloth/qwen-GGUF:{{QUANT_TAG}}") == "unsloth/qwen-GGUF"
+    assert _normalize_model_id("unsloth/qwen-GGUF:Q4_K_M") == "unsloth/qwen-GGUF:Q4_K_M"
+
+
+def test_use_rejects_model_that_normalizes_to_empty(monkeypatch, tmp_path):
+    cfg = tmp_path / "c.yaml"
+    _patch_config_path(monkeypatch, cfg)
+    rc = run_model_cli(["use", "--base-url", "http://x/v1", "--model", ":{{QUANT_TAG}}"])
+    assert rc == 2  # nothing usable to point at
+
+
+def test_discover_parses_openai_models(monkeypatch):
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"data": [{"id": "qwen2.5"}, {"id": "llama3"}]}
+
+    def _fake_get(url, timeout=None):
+        if "11434" in url:  # only Ollama is "up"
+            return _Resp()
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr("httpx.get", _fake_get)
+    found = model_cli._discover()
+    assert len(found) == 1
+    assert found[0]["name"] == "ollama" and found[0]["models"] == ["qwen2.5", "llama3"]
+
+
+def test_discover_none_reachable_is_empty(monkeypatch):
+    def _fail(url, timeout=None):
+        raise RuntimeError("refused")
+
+    monkeypatch.setattr("httpx.get", _fail)
+    assert model_cli._discover() == []
+
+
+def test_dispatch_routes_model_subcommand(monkeypatch):
+    from server import cli
+
+    seen = {}
+    monkeypatch.setattr(model_cli, "run_model_cli", lambda argv: seen.update(argv=argv) or 0)
+    assert cli.dispatch(["model", "use", "--model", "x"]) == 0
+    assert seen["argv"] == ["use", "--model", "x"]
+
+
+def test_model_appears_in_help(capsys):
+    from server import cli
+
+    cli.main(["--help"])
+    assert "model" in capsys.readouterr().out


### PR DESCRIPTION
**ADR 0075, D5 (model onboarding).** Builds on the merged `protoagent` CLI (#1816). Delivers the **code side** of "power protoAgent with a local LLM."

## What
protoAgent's model is just OpenAI-compatible config — `create_llm` builds a plain `ChatOpenAI(base_url, model)`, so the LiteLLM gateway is the **default, not a lock-in**. This adds the non-interactive verb so a local Ollama / LM Studio / llama.cpp / vLLM endpoint is one line:

```bash
protoagent model discover                                    # probe :11434 / :1234 / :8080
protoagent model use --base-url http://127.0.0.1:8080/v1 --model qwen2.5
protoagent up
```

- **`use`** writes `model.{provider,api_base,name}` to the live config via the comment-preserving `config_io` helpers. Sets a **placeholder key only when none exists** (a local endpoint ignores it, but the OpenAI client constructor needs a non-empty one) — never clobbers a real gateway key; `--key` overrides.
- **`discover` / `list`** probe the well-known local ports (best-effort, short timeout).
- Tolerates HF's **`:{{QUANT_TAG}}`** placeholder.

## Why this shape (the research payoff)
This one-liner is exactly the **copy-paste target for HuggingFace's "Use this model" local-app snippet** — protoAgent maps onto the `hermes-agent`/`openclaw`/`pi` agent-runtime pattern (which are the Hermes/OpenClaw competitors, already registered). Ships in the shared dispatcher, so `protoagent model` and `python -m server model` both route to it.

## The remaining D5 step is external (needs @artificialcitizens)
Registering protoAgent as a HF local-app is a **PR to `huggingface/huggingface.js` `local-apps.ts`** + a "Run with protoAgent" snippet on the team's **HF quant model cards** (your repos / HF account). I can draft both; I can't submit them.

## Tests + docs
`tests/test_model_cli.py` (config write, real-key preservation, explicit-key, quant-placeholder strip, discover parse, dispatch routing, `--help`). **Full suite green: 3189 passed, 5 skipped.** `docs/guides/cli.md` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)