### PR TITLE
feat(api): dedupe the goal API to the canonical plural /api/goals* (ADR 0075 D4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   className contract over the DS classes the theme already ships — so prototypes match the live theme
   without hand-rolled markup. The `rendering-artifacts` skill + README list the full set.
 
+### Changed
+- **BREAKING: the goal API is only under the plural `/api/goals*` now (ADR 0075 D4).** The
+  duplicate singular routes `GET`/`DELETE /api/goal/{session_id}` are removed; use
+  `GET /api/goals` (list), `GET /api/goals/{session_id}` (one), `DELETE /api/goals/{session_id}`
+  (clear). The console already used the plural, so this only affects external callers that hit the
+  singular. (The `memory`/`knowledge` split is intentional domain separation — the RAG chunk API
+  stays `/api/knowledge/*` — so it was NOT renamed.)
+
 ### Fixed
 - **The plugin update-CHECK now authenticates private repos too, not just install.** #1805 taught the
   clone/install path to auth private github over a token, but the update-availability check

--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -60,7 +60,7 @@ In the React console, typing `/` in the chat composer opens a command
 autocomplete (served from `GET /api/chat/commands`) so `/goal` is discoverable;
 ↑/↓ to pick, Enter/Tab to insert.
 
-Programmatic status/clear is also available: `GET /api/goal/{session_id}` and `DELETE /api/goal/{session_id}`.
+Programmatic status/clear is also available: `GET /api/goals/{session_id}` and `DELETE /api/goals/{session_id}`.
 
 ## Manage from the console
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -314,7 +314,7 @@ routing:
 
 **Goal mode** (`graph/goals/`) lets you give the agent a *testable outcome* it self-drives toward. After each terminal turn (the agent stops with a final answer), the goal's **verifier** decides whether it's met; if not, the agent is re-invoked with a continuation prompt — carrying the verifier's evidence and the running plan the agent records with the `update_goal_plan` tool — until the verifier passes, the iteration budget runs out (`exhausted`), or the goal is flagged `unachievable` (a no-progress streak, or the agent calling the `abandon_goal` tool). Unlike a pure-LLM "are we done?" check, completion is backed by a real verifier.
 
-The machinery is wired when `enabled`, but **no goal is active until one is set** via the `/goal` control message (works over A2A / the React console / OpenAI-compat) or the `/api/goal/{session_id}` endpoints. State is persisted per session under `GOAL_PATH` → `/sandbox/goals` → `~/.protoagent/goals`.
+The machinery is wired when `enabled`, but **no goal is active until one is set** via the `/goal` control message (works over A2A / the React console / OpenAI-compat) or the `/api/goals/{session_id}` endpoints. State is persisted per session under `GOAL_PATH` → `/sandbox/goals` → `~/.protoagent/goals`.
 
 ```yaml
 goal:

--- a/docs/reference/operator-api.md
+++ b/docs/reference/operator-api.md
@@ -33,9 +33,9 @@ is a map — `operator_api/*.py` is the source of truth for exact request/respon
 
 | Method | Path | Purpose |
 |---|---|---|
-| GET | `/api/goals` · `/api/goal/{session_id}` | List goals / get a session's goal |
+| GET | `/api/goals` · `/api/goals/{session_id}` | List goals / get a session's goal |
 | POST | `/api/goals` | Set a goal |
-| DELETE | `/api/goals/{session_id}` · `/api/goal/{session_id}` | Clear a goal |
+| DELETE | `/api/goals/{session_id}` | Clear a goal |
 
 ## Subagents & tools
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -144,7 +144,7 @@ after the case.
 Prefer deterministic `command` verifiers (`"true"` → achieved, `"false"` with
 `"max_iterations": 1` → exhausted) so the outcome is independent of model
 competence and needs no host file I/O. `expected_goal_status` is checked
-against `GET /api/goal/{session}`; `expected_patterns` against the reply.
+against `GET /api/goals/{session}`; `expected_patterns` against the reply.
 
 ## Why side-effect verification
 

--- a/evals/client.py
+++ b/evals/client.py
@@ -328,19 +328,19 @@ class AgentClient:
     # ── goal mode ─────────────────────────────────────────────────────────────
 
     async def get_goal(self, session_id: str) -> dict:
-        """GET ``/api/goal/{session_id}`` → ``{enabled, goal}`` (goal is the
+        """GET ``/api/goals/{session_id}`` → ``{enabled, goal}`` (goal is the
         full persisted state dict, or None when no goal is set)."""
         async with httpx.AsyncClient(timeout=10) as client:
-            r = await client.get(f"{self.base_url}/api/goal/{session_id}", headers=self.headers)
+            r = await client.get(f"{self.base_url}/api/goals/{session_id}", headers=self.headers)
             r.raise_for_status()
             return r.json()
 
     async def clear_goal(self, session_id: str) -> dict:
-        """DELETE ``/api/goal/{session_id}`` → ``{enabled, cleared}``."""
+        """DELETE ``/api/goals/{session_id}`` → ``{enabled, cleared}``."""
         async with httpx.AsyncClient(timeout=10) as client:
             r = await client.request(
                 "DELETE",
-                f"{self.base_url}/api/goal/{session_id}",
+                f"{self.base_url}/api/goals/{session_id}",
                 headers=self.headers,
             )
             r.raise_for_status()

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -345,7 +345,7 @@ async def _run_goal_case(client: AgentClient, case: dict) -> CaseResult:
         model competence.
       - ``prompt``: the trigger message that runs the goal loop.
       - ``expected_goal_status``: ``achieved`` / ``exhausted`` / ``unachievable``
-        — checked against ``GET /api/goal/{session}``.
+        — checked against ``GET /api/goals/{session}``.
       - ``expected_patterns``: substrings that must appear in the reply (the
         goal footer, e.g. ``goal achieved``).
 

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -217,22 +217,10 @@ def register_chat_routes(app, ui: str) -> None:
         cancelled = delegations.cancel(session_id, delegation_id)
         return {"cancelled": cancelled, "running": delegations.running(session_id)}
 
-    # --- Goal mode API ------------------------------------------------------
-    # Programmatic status/clear for a session's goal (setting is done via the
-    # `/goal ...` control message through chat/A2A). Returns 404-style payloads
-    # as plain JSON to keep the surface dependency-free.
-    @app.get("/api/goal/{session_id}")
-    async def _api_goal_status(session_id: str):
-        if STATE.goal_controller is None:
-            return {"enabled": False, "goal": None}
-        state = STATE.goal_controller.store.get(session_id)
-        return {"enabled": True, "goal": state.to_dict() if state else None}
-
-    @app.delete("/api/goal/{session_id}")
-    async def _api_goal_clear(session_id: str):
-        if STATE.goal_controller is None:
-            return {"enabled": False, "cleared": False}
-        return {"enabled": True, "cleared": STATE.goal_controller.store.clear(session_id)}
+    # Goal-mode read/clear moved to the canonical plural `/api/goals*` in
+    # operator_api/routes.py (D4 dedupe, ADR 0075): `GET /api/goals` (list),
+    # `GET /api/goals/{session_id}` (one), `DELETE /api/goals/{session_id}` (clear).
+    # The singular `/api/goal/{session_id}` duplicates were retired here.
 
     # --- Health / readiness (ADR 0010) -------------------------------------
     # Reflects whether the graph actually compiled — the only readiness signal

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -454,6 +454,18 @@ def register_operator_routes(
             except Exception as exc:
                 raise _http_error(exc) from exc
 
+    # One session's goal status under the canonical plural shape (D4 dedupe, ADR 0075)
+    # — replaces the retired singular `/api/goal/{session_id}`. Reads the controller
+    # directly, so it degrades to {enabled: False} when goals are off; no injected fn.
+    @app.get("/api/goals/{session_id}")
+    async def _goal_status(session_id: str):
+        from runtime.state import STATE
+
+        if STATE.goal_controller is None:
+            return {"enabled": False, "goal": None}
+        state = STATE.goal_controller.store.get(session_id)
+        return {"enabled": True, "goal": state.to_dict() if state else None}
+
     # Programmatic goal-set (ADR 0028 D3) — accepts ONLY a `plugin` verifier;
     # command/test/ci/data stay operator-only (/goal). 400 on a rejected verifier.
     if goal_set is not None:

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -249,12 +249,6 @@ def test_healthz_503_when_graph_none(monkeypatch):
     assert r.status_code == 503 and r.json()["ok"] is False
 
 
-def test_goal_disabled_when_no_controller(monkeypatch):
-    c = _client(monkeypatch, goal=None)
-    assert c.get("/api/goal/s1").json() == {"enabled": False, "goal": None}
-    assert c.delete("/api/goal/s1").json() == {"enabled": False, "cleared": False}
-
-
 def test_steer_enqueue_then_cancel_roundtrip(monkeypatch):
     # Full HTTP lifecycle of the steer endpoints: POST queues, GET peeks, DELETE
     # cancels a still-queued message, and a second DELETE reports too-late.

--- a/tests/test_operator_api_routes.py
+++ b/tests/test_operator_api_routes.py
@@ -173,6 +173,26 @@ def test_goals_list_and_clear() -> None:
     assert seen["id"] == "s1"
 
 
+def test_goal_single_status_under_plural(monkeypatch) -> None:
+    # GET /api/goals/{session_id} replaces the retired singular /api/goal/{session_id}
+    # (D4 dedupe). It reads the controller directly, so it degrades when goals are off.
+    import runtime.state as rs
+
+    client = _goals_client(goals=[])
+
+    monkeypatch.setattr(rs.STATE, "goal_controller", None, raising=False)
+    assert client.get("/api/goals/s1").json() == {"enabled": False, "goal": None}
+
+    class _Store:
+        def get(self, sid):
+            return type("G", (), {"to_dict": lambda self: {"session_id": "s1", "status": "active"}})() if sid == "s1" else None
+
+    monkeypatch.setattr(rs.STATE, "goal_controller", type("C", (), {"store": _Store()})(), raising=False)
+    body = client.get("/api/goals/s1").json()
+    assert body["enabled"] is True and body["goal"]["status"] == "active"
+    assert client.get("/api/goals/other").json() == {"enabled": True, "goal": None}
+
+
 def test_goals_routes_absent_when_not_wired() -> None:
     app = FastAPI()
     register_operator_routes(


### PR DESCRIPTION
**ADR 0075, D4 (REST tightening).** The genuine dedupe, done aggressively (per @artificialcitizens: "aggressive is fine").

## What
The goal surface was split across two modules: `GET`/`DELETE /api/goal/{session_id}` (singular, chat_routes) duplicated `DELETE /api/goals/{session_id}` and overlapped the plural list. The **console already used the plural**, so the singular was an orphan.

- **Add** `GET /api/goals/{session_id}` (one session's goal status) under the canonical plural — reads the controller directly, degrades to `{enabled: false}` when goals are off (preserves the singular's only unique capability).
- **Remove** the singular `GET`/`DELETE /api/goal/{session_id}`.
- **Repoint** the eval client (`evals/client.py`) to the plural — the one *internal* consumer the console didn't cover (a `grep` caught it before it broke; GET shape is identical). Docs (operator-api ref, goal-mode, configuration, evals) + CHANGELOG (BREAKING) updated.

## Scope call — knowledge/memory left alone (on purpose)
The audit flagged the memory store as "split across `/api/memory` + `/api/knowledge` + `/api/memory/injections`." On inspection those are **distinct sub-resources** (session digests · RAG chunks · injection audit), not duplication — `/api/knowledge/*` is a clear name for the RAG chunk API. A blind 17-endpoint, FE-touching rename (which a worktree can't FE-verify) would be **churn, not "getting the contract right."** So it's deliberately unchanged.

## Tests
Retired the chat_routes singular test; added a plural single-status test in `test_operator_api_routes`. **Full suite green: 3180 passed, 5 skipped.**

## D4 remainder (documented, not in this PR)
- `/api/mcp/exposed` discovery — additive; needs a small extraction of PR2's operator-MCP resolver into a layering-clean module (kept separate to not re-churn just-merged code).
- Real `/v1` usage — a subtle shared-path change (`chat()`'s return contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the session goal status and clear API paths to use `/api/goals/{session_id}` instead of `/api/goal/{session_id}`.
  * Consolidated goal-mode routing so the plural endpoint is the canonical path.

* **Documentation**
  * Updated goal-mode guides, configuration reference, operator API docs, and evals docs to reflect the correct endpoint naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->