### PR TITLE
feat(api): GET /api/mcp/exposed — introspect the operator-MCP tool surface (ADR 0075 D2)

### DIFF
--- a/docs/reference/operator-api.md
+++ b/docs/reference/operator-api.md
@@ -131,6 +131,7 @@ record.
 | DELETE | `/api/plugins/{id}` | Uninstall |
 | POST | `/api/mcp/servers` · `/api/mcp/servers/import` | Add / import an MCP server |
 | DELETE | `/api/mcp/servers/{name}` | Remove an MCP server |
+| GET | `/api/mcp/catalog` · `/api/mcp/exposed` | Curated server catalog / operator-MCP tools this instance exposes (effective allowlist + profile) |
 
 ## Telemetry & theme
 

--- a/operator_api/mcp_routes.py
+++ b/operator_api/mcp_routes.py
@@ -9,6 +9,7 @@ gitignored, so ``env`` values stay local.
 from __future__ import annotations
 
 import logging
+import os
 
 from fastapi import HTTPException
 
@@ -187,6 +188,27 @@ def register_mcp_routes(app) -> None:
             nm = str(tmpl.get("name") or e.get("id") or "").strip().lower()
             out.append({**e, "installed": bool(nm) and nm in configured})
         return {"servers": out}
+
+    @app.get("/api/mcp/exposed")
+    async def _exposed():
+        """The tools THIS instance's operator MCP would expose to a foreign MCP client
+        (Claude Desktop, Cursor, an ACP brain) — the effective set after the
+        ``operator_mcp_profile`` + ``operator_mcp_tools`` allowlist + ``PROTOAGENT_MCP_TRUST``
+        resolve. Previously introspectable only by reading the sidecar's boot logs
+        (ADR 0075 D2/D3). Read-only; behind the standard operator-API auth gate."""
+        from runtime.operator_mcp_tools import resolve_allow, resolve_exposed_names
+
+        cfg = STATE.graph_config
+        allow = resolve_allow(cfg)
+        names = resolve_exposed_names(cfg)
+        profile = str(getattr(cfg, "operator_mcp_profile", "") or "").strip() or None
+        return {
+            "tools": sorted(names),
+            "count": len(names),
+            "profile": profile,
+            "star": "*" in allow,
+            "trust_override": os.environ.get("PROTOAGENT_MCP_TRUST", "").strip().lower() == "full",
+        }
 
     @app.delete("/api/mcp/servers/{name}")
     async def _remove(name: str):

--- a/runtime/acp_runtime.py
+++ b/runtime/acp_runtime.py
@@ -74,7 +74,7 @@ def operator_mcp_server_spec(config) -> dict:
     every tool. There is no "enable tools for ACP" step: ``operator_mcp.tools`` is an
     optional *restriction* (a named allowlist), not a requirement. Empty/unset ⇒ ``"*"``
     (everything, minus the redundant code-exec tool the coding agent already has — see
-    ``server.operator_mcp._STAR_EXCLUDE``)."""
+    ``runtime.operator_mcp_tools._STAR_EXCLUDE``)."""
     configured = list(getattr(config, "operator_mcp_tools", None) or [])
     allow = configured or ["*"]  # empty ⇒ full toolset, parity with the native runtime
     # ACP's stdio MCP-server schema wants env as an array of {name, value} (not a dict).

--- a/runtime/operator_mcp_tools.py
+++ b/runtime/operator_mcp_tools.py
@@ -1,0 +1,118 @@
+"""Operator-MCP tool resolution — the allowlist/profile logic, in a neutral home.
+
+This is the shared spine (ADR 0075 D2) for "which of THIS agent's tools does the
+operator MCP expose for a given config": the ``operator_mcp_tools`` allowlist, the
+curated profiles (``read-only`` / ``full``), the ``PROTOAGENT_MCP_TRUST`` override, and
+the two never-expose sets. It lives in ``runtime/`` — an infra package that must never
+import ``server`` / ``operator_api`` — so *both* the sidecar (``server.operator_mcp``,
+which wraps these as a FastMCP server) and the operator HTTP surface (``operator_api.
+mcp_routes``, which surfaces the exposed set at ``GET /api/mcp/exposed``) can import it
+without tripping the import-layering contract. The FastMCP wrapping + stores boot stay
+in ``server.operator_mcp``; only the pure resolution moved here.
+
+Reads ``runtime.state.STATE`` for the booted stores + plugin tools; in the live server
+those are populated by ``server.agent_init``, in a standalone sidecar by
+``server.operator_mcp._boot_stores_only``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from runtime.state import STATE
+
+log = logging.getLogger(__name__)
+
+# Tools "*" skips — a coding-agent brain already has its own code execution / file tools,
+# so exposing protoAgent's execute_code over the bus is redundant. Not a security gate
+# (you can still allowlist it by name); just avoids handing it a tool it already has.
+_STAR_EXCLUDE = {"execute_code"}
+
+# NEVER exposed over MCP, even when named explicitly — ask_human / request_user_input are
+# HITL tools that pause the turn via a LangGraph ``interrupt`` only the lead-turn runner
+# resumes. Called over a foreign stdio/HTTP MCP client (Claude Desktop, Cursor) there's no
+# runner to resume them, so they HANG the client (ADR 0075 D3 — a real bug, not a gate).
+_MCP_INCOMPATIBLE = {"ask_human", "request_user_input"}
+
+# Curated profile presets over the allowlist (ADR 0075 D3). A profile is just a preset set
+# of names layered on ``operator_mcp_tools`` — unset keeps deny-by-default (a foreign client
+# gets only what you name). ``read-only`` is a stable, principled set (reads/queries, no state
+# change). ``full`` = ``"*"``. The middle tier ``safe-operator`` (read + non-destructive
+# writes) lands with the ops layer (ADR 0075 D2), which carries per-op read/write metadata so
+# it's principled rather than a hand-maintained list — so it's deliberately NOT hardcoded here.
+_READ_ONLY_TOOLS = frozenset(
+    {
+        "current_time", "calculator", "web_search", "fetch_url", "load_skill",
+        "search_tools", "list_skills", "recent_activity", "list_agents",
+        "memory_recall", "recall_session", "memory_list", "memory_stats",
+        "list_schedules", "check_inbox", "task_list", "list_watches", "read_note",
+    }
+)
+
+
+def _profile_allow(profile: str) -> set[str] | None:
+    """A profile name → its allowlist set (or ``{"*"}`` for full), or ``None`` when the
+    profile is unset/unknown so the caller falls back to the explicit tools list."""
+    p = (profile or "").strip().lower().replace("_", "-")
+    if p in ("", "custom", "none"):
+        return None
+    if p in ("full", "all"):
+        return {"*"}
+    if p in ("read-only", "readonly"):
+        return set(_READ_ONLY_TOOLS)
+    log.warning("[operator-mcp] unknown profile %r — falling back to the tools allowlist", profile)
+    return None
+
+
+def resolve_allow(config) -> set[str]:
+    """The effective allowlist: ``PROTOAGENT_MCP_TRUST=full`` env override > the profile
+    (unioned with any explicit names) > the explicit ``operator_mcp_tools`` list."""
+    if os.environ.get("PROTOAGENT_MCP_TRUST", "").strip().lower() == "full":
+        return {"*"}
+    allow = set(getattr(config, "operator_mcp_tools", []) or [])
+    prof = _profile_allow(getattr(config, "operator_mcp_profile", ""))
+    if prof is not None:
+        allow |= prof
+    return allow
+
+
+def operator_tools(config):
+    """The allowlisted tools (core + plugin) to expose — empty allowlist ⇒ none."""
+    from tools.lg_tools import get_all_tools
+
+    allow = resolve_allow(config)
+    if not allow:
+        return []
+    tools = list(
+        get_all_tools(
+            STATE.knowledge_store,
+            scheduler=STATE.scheduler,
+            inbox_store=STATE.inbox_store,
+            tasks_store=STATE.tasks_store,
+            goal_enabled=bool(getattr(config, "goal_enabled", False)),
+        )
+    )
+    tools += list(getattr(STATE, "plugin_tools", None) or [])
+    # "*" = expose everything (minus a small danger set you must opt into by name) — so you
+    # don't have to enumerate every tool. List specific names instead for tight control.
+    star = "*" in allow
+    seen: set[str] = set()
+    out = []
+    for t in tools:
+        name = getattr(t, "name", None)
+        if not name or name in seen:
+            continue
+        if name in _MCP_INCOMPATIBLE:  # HANGS a foreign client — never expose, even by name
+            continue
+        if (name in allow) or (star and name not in _STAR_EXCLUDE):
+            seen.add(name)
+            out.append(t)
+    return out
+
+
+def resolve_exposed_names(config) -> list[str]:
+    """The tool names the operator MCP would expose for *config* — powers the
+    ``GET /api/mcp/exposed`` discovery route (the exposed set was previously
+    introspectable only by reading logs). Requires the stores to be booted."""
+    return [t.name for t in operator_tools(config)]

--- a/server/operator_mcp.py
+++ b/server/operator_mcp.py
@@ -78,98 +78,20 @@ def _boot_stores_only(config):
     STATE.skills_index = ai._build_skills_index(config, extra_skill_dirs=plugins.skill_dirs)
 
 
-# Tools "*" skips — a coding-agent brain already has its own code execution / file tools,
-# so exposing protoAgent's execute_code over the bus is redundant. Not a security gate
-# (you can still allowlist it by name); just avoids handing it a tool it already has.
-_STAR_EXCLUDE = {"execute_code"}
+# The allowlist/profile resolution now lives in ``runtime.operator_mcp_tools`` (a neutral
+# infra module both this sidecar and ``operator_api.mcp_routes`` can import without breaking
+# the import-layering contract — ADR 0075 D2). Re-exported here so existing
+# ``from server.operator_mcp import operator_tools`` callers keep working; only the FastMCP
+# wrapping + stores boot stay in this module.
+from runtime.operator_mcp_tools import operator_tools, resolve_allow, resolve_exposed_names
 
-# NEVER exposed over MCP, even when named explicitly — ask_human / request_user_input are
-# HITL tools that pause the turn via a LangGraph ``interrupt`` only the lead-turn runner
-# resumes. Called over a foreign stdio/HTTP MCP client (Claude Desktop, Cursor) there's no
-# runner to resume them, so they HANG the client (ADR 0075 D3 — a real bug, not a gate).
-_MCP_INCOMPATIBLE = {"ask_human", "request_user_input"}
-
-# Curated profile presets over the allowlist (ADR 0075 D3). A profile is just a preset set
-# of names layered on ``operator_mcp_tools`` — unset keeps deny-by-default (a foreign client
-# gets only what you name). ``read-only`` is a stable, principled set (reads/queries, no state
-# change). ``full`` = ``"*"``. The middle tier ``safe-operator`` (read + non-destructive
-# writes) lands with the ops layer (ADR 0075 D2), which carries per-op read/write metadata so
-# it's principled rather than a hand-maintained list — so it's deliberately NOT hardcoded here.
-_READ_ONLY_TOOLS = frozenset(
-    {
-        "current_time", "calculator", "web_search", "fetch_url", "load_skill",
-        "search_tools", "list_skills", "recent_activity", "list_agents",
-        "memory_recall", "recall_session", "memory_list", "memory_stats",
-        "list_schedules", "check_inbox", "task_list", "list_watches", "read_note",
-    }
-)
-
-
-def _profile_allow(profile: str) -> set[str] | None:
-    """A profile name → its allowlist set (or ``{"*"}`` for full), or ``None`` when the
-    profile is unset/unknown so the caller falls back to the explicit tools list."""
-    p = (profile or "").strip().lower().replace("_", "-")
-    if p in ("", "custom", "none"):
-        return None
-    if p in ("full", "all"):
-        return {"*"}
-    if p in ("read-only", "readonly"):
-        return set(_READ_ONLY_TOOLS)
-    log.warning("[operator-mcp] unknown profile %r — falling back to the tools allowlist", profile)
-    return None
-
-
-def resolve_allow(config) -> set[str]:
-    """The effective allowlist: ``PROTOAGENT_MCP_TRUST=full`` env override > the profile
-    (unioned with any explicit names) > the explicit ``operator_mcp_tools`` list."""
-    if os.environ.get("PROTOAGENT_MCP_TRUST", "").strip().lower() == "full":
-        return {"*"}
-    allow = set(getattr(config, "operator_mcp_tools", []) or [])
-    prof = _profile_allow(getattr(config, "operator_mcp_profile", ""))
-    if prof is not None:
-        allow |= prof
-    return allow
-
-
-def operator_tools(config):
-    """The allowlisted tools (core + plugin) to expose — empty allowlist ⇒ none."""
-    from tools.lg_tools import get_all_tools
-
-    allow = resolve_allow(config)
-    if not allow:
-        return []
-    tools = list(
-        get_all_tools(
-            STATE.knowledge_store,
-            scheduler=STATE.scheduler,
-            inbox_store=STATE.inbox_store,
-            tasks_store=STATE.tasks_store,
-            goal_enabled=bool(getattr(config, "goal_enabled", False)),
-        )
-    )
-    tools += list(getattr(STATE, "plugin_tools", None) or [])
-    # "*" = expose everything (minus a small danger set you must opt into by name) — so you
-    # don't have to enumerate every tool. List specific names instead for tight control.
-    star = "*" in allow
-    seen: set[str] = set()
-    out = []
-    for t in tools:
-        name = getattr(t, "name", None)
-        if not name or name in seen:
-            continue
-        if name in _MCP_INCOMPATIBLE:  # HANGS a foreign client — never expose, even by name
-            continue
-        if (name in allow) or (star and name not in _STAR_EXCLUDE):
-            seen.add(name)
-            out.append(t)
-    return out
-
-
-def resolve_exposed_names(config) -> list[str]:
-    """The tool names the operator MCP would expose for *config* — powers the
-    ``GET /api/mcp/exposed`` discovery route (the exposed set was previously
-    introspectable only by reading logs). Requires the stores to be booted."""
-    return [t.name for t in operator_tools(config)]
+__all__ = [
+    "resolve_allow",
+    "operator_tools",
+    "resolve_exposed_names",
+    "build_server",
+    "main",
+]
 
 
 def build_server(config, *, name: str = "protoAgent-operator"):

--- a/tests/test_mcp_routes.py
+++ b/tests/test_mcp_routes.py
@@ -206,6 +206,59 @@ def test_forget_unknown_is_404(monkeypatch, tmp_path):
     assert _client().post("/api/mcp/servers/nope/forget").status_code == 404
 
 
+# ── GET /api/mcp/exposed — discovery of the operator-MCP tool surface (ADR 0075 D2/D3) ──
+
+
+def _wire_exposed(monkeypatch, *, tools=None, profile=""):
+    """Point STATE at a bare config + null stores, so resolve_exposed_names runs the real
+    allowlist/profile resolver against just the keyless core tools."""
+    from graph.config import LangGraphConfig
+    import runtime.state as rs
+
+    cfg = LangGraphConfig()
+    cfg.operator_mcp_tools = list(tools or [])
+    cfg.operator_mcp_profile = profile
+    cfg.goal_enabled = False
+    monkeypatch.setattr(rs.STATE, "graph_config", cfg, raising=False)
+    for attr in ("knowledge_store", "scheduler", "inbox_store", "tasks_store"):
+        monkeypatch.setattr(rs.STATE, attr, None, raising=False)
+    monkeypatch.setattr(rs.STATE, "plugin_tools", [], raising=False)
+
+
+def test_exposed_lists_allowlisted_tools(monkeypatch):
+    _wire_exposed(monkeypatch, tools=["calculator", "current_time"])
+    body = _client().get("/api/mcp/exposed").json()
+    assert body["tools"] == ["calculator", "current_time"]  # sorted
+    assert body["count"] == 2
+    assert body["profile"] is None and body["star"] is False and body["trust_override"] is False
+
+
+def test_exposed_empty_allowlist_is_nothing(monkeypatch):
+    _wire_exposed(monkeypatch, tools=[])
+    body = _client().get("/api/mcp/exposed").json()
+    assert body["tools"] == [] and body["count"] == 0
+
+
+def test_exposed_read_only_profile_leaks_no_writes(monkeypatch):
+    from runtime.operator_mcp_tools import _READ_ONLY_TOOLS
+
+    _wire_exposed(monkeypatch, profile="read-only")
+    body = _client().get("/api/mcp/exposed").json()
+    assert body["profile"] == "read-only" and body["star"] is False
+    assert set(body["tools"]) <= set(_READ_ONLY_TOOLS)  # only the curated read set
+    assert {"calculator", "current_time"} <= set(body["tools"])
+
+
+def test_exposed_trust_override_forces_star(monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_MCP_TRUST", "full")
+    _wire_exposed(monkeypatch, tools=[])  # empty allowlist would normally expose nothing
+    body = _client().get("/api/mcp/exposed").json()
+    assert body["star"] is True and body["trust_override"] is True
+    assert "calculator" in body["tools"]
+    assert "execute_code" not in body["tools"]  # star-excluded
+    assert "ask_human" not in body["tools"]  # never exposed over MCP
+
+
 def test_mcp_catalog_is_bundled_in_the_desktop_sidecar():
     """The frozen desktop app reads config/mcp-catalog.json from the bundle; if the
     sidecar build forgets it, the picker shows "no servers match". Guard the

--- a/tests/test_operator_mcp.py
+++ b/tests/test_operator_mcp.py
@@ -25,6 +25,18 @@ def _bare_state(monkeypatch):
     monkeypatch.setattr(STATE, "plugin_tools", [], raising=False)
 
 
+def test_resolver_lives_in_runtime_and_is_reexported():
+    """The allowlist/profile resolution moved to runtime/ (ADR 0075 D2) so operator_api can
+    import it without breaking the import-layering contract; server.operator_mcp re-exports
+    the same objects for existing callers."""
+    import runtime.operator_mcp_tools as rt
+    import server.operator_mcp as sm
+
+    assert sm.operator_tools is rt.operator_tools
+    assert sm.resolve_allow is rt.resolve_allow
+    assert sm.resolve_exposed_names is rt.resolve_exposed_names
+
+
 def test_allowlist_filters_to_named_tools():
     names = {t.name for t in operator_tools(_cfg(["calculator", "current_time"]))}
     assert names == {"calculator", "current_time"}


### PR DESCRIPTION
## What

Adds **`GET /api/mcp/exposed`** — the tools this instance's operator MCP would expose to a foreign MCP client (Claude Desktop, Cursor, an ACP brain), i.e. the *effective* set after the `operator_mcp_profile` + `operator_mcp_tools` allowlist + `PROTOAGENT_MCP_TRUST` resolve. Returns `{ tools, count, profile, star, trust_override }` so the console can show the surface **and explain why** it's what it is. Previously this was introspectable only by reading the sidecar's boot logs.

This is the first slice of the **ADR 0075 D2** ops layer ("one op, three projections"): the allowlist/profile resolver is now the single source both the **MCP** projection and the **REST** projection read.

## How — the import-layering unblock

`operator_api` must never import `server` (import-linter contract). To surface the exposed set over REST without a new violation, the pure resolution logic moves out of `server/operator_mcp.py` into a neutral **`runtime/operator_mcp_tools.py`** that both the sidecar and the HTTP surface import:

- `resolve_allow` · `operator_tools` · `resolve_exposed_names` · `_profile_allow` + the profile / never-expose sets → `runtime/operator_mcp_tools.py`
- `server.operator_mcp` **re-exports** the same objects → existing callers, tests, and `build_server` unchanged; only the FastMCP wrapping + stores boot stay there.
- `runtime/acp_runtime.py` docstring pointer updated to the new home.

Net: `server/operator_mcp.py` shrinks by ~90 lines; no behavior change to the sidecar.

## Tests / docs
- New route coverage: explicit allowlist, `read-only` profile leaks no writes, `PROTOAGENT_MCP_TRUST=full` forces `*` (and still drops `execute_code` / `ask_human`).
- Extraction guard: `server.operator_mcp.*` is the same object as `runtime.operator_mcp_tools.*`.
- `docs/reference/operator-api.md`: documents the catalog + exposed GET routes.

## Gates
- `ruff check .` ✅
- `lint-imports` ✅ **3/3 contracts kept** (the whole point of the extraction)
- `pytest tests/` ✅ **3201 passed, 5 skipped**

No frontend changes (FE gates N/A). `live_smoke` needs a live gateway — covered in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new operator discovery endpoint that shows which MCP tools are exposed, along with the active profile and trust status.
  * Updated the API reference to document the new MCP catalog and exposure endpoints.

* **Bug Fixes**
  * Improved consistency in how exposed tools are determined and returned.
  * Ensured read-only and trust-enabled modes expose the expected tool sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->