### PR TITLE
feat(v1): real token usage in the OpenAI-compat response (ADR 0075 D4)

### DIFF
--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -276,7 +276,21 @@ def register_chat_routes(app, ui: str) -> None:
         created = int(time.time())
         completion_id = f"{agent_name()}-{session_id}"
 
+        # Real token usage, summed from the assistant turn(s) (server.chat._sum_usage
+        # already folds every model call — lead + goal continuations + subagents — into the
+        # OpenAI `{prompt,completion,total}_tokens` shape). Absent (a short-circuit / older
+        # reply) ⇒ zeros, same as before (ADR 0075 D4).
+        usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        for _m in result:
+            _u = _m.get("usage")
+            if isinstance(_u, dict):
+                for _k in usage:
+                    usage[_k] += int(_u.get(_k, 0) or 0)
+
         if stream:
+            # OpenAI streams usage only when the client opts in, in a final chunk with
+            # empty `choices` (stream_options.include_usage).
+            include_usage = bool((req.get("stream_options") or {}).get("include_usage"))
 
             async def _stream():
                 chunk = {
@@ -297,6 +311,16 @@ def register_chat_routes(app, ui: str) -> None:
                     "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
                 }
                 yield f"data: {json.dumps(done_chunk)}\n\n"
+                if include_usage:
+                    usage_chunk = {
+                        "id": completion_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": agent_name(),
+                        "choices": [],
+                        "usage": usage,
+                    }
+                    yield f"data: {json.dumps(usage_chunk)}\n\n"
                 yield "data: [DONE]\n\n"
 
             return StreamingResponse(_stream(), media_type="text/event-stream")
@@ -313,7 +337,7 @@ def register_chat_routes(app, ui: str) -> None:
                     "finish_reason": "stop",
                 }
             ],
-            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            "usage": usage,
         }
 
     @app.get("/v1/models")

--- a/server/chat.py
+++ b/server/chat.py
@@ -1571,6 +1571,22 @@ async def rewind_session(
     return {**result, "message": _rewind_message(result)}
 
 
+def _sum_usage(per_model: dict[str, Any]) -> dict[str, int]:
+    """Fold LangChain's per-model ``usage_metadata`` (``{input,output,total}_tokens``) into
+    the OpenAI ``usage`` shape, summed across every model call in the turn — the lead model
+    plus any aux/fallback/subagent calls. Powers the /v1 OpenAI-compat ``usage`` field
+    (ADR 0075 D4); ``/api/chat`` ignores the extra key. ``total`` falls back to
+    prompt+completion for gateways that omit it."""
+    prompt = sum(int((u or {}).get("input_tokens", 0) or 0) for u in per_model.values())
+    completion = sum(int((u or {}).get("output_tokens", 0) or 0) for u in per_model.values())
+    total = sum(int((u or {}).get("total_tokens", 0) or 0) for u in per_model.values())
+    return {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": total or (prompt + completion),
+    }
+
+
 async def _chat_langgraph(
     message: str,
     session_id: str,
@@ -1601,6 +1617,7 @@ async def _chat_langgraph_impl(
 ) -> list[dict[str, Any]]:
     """Non-streaming LangGraph entry — used by the console + OpenAI-compat."""
     from observability import tracing
+    from langchain_core.callbacks import UsageMetadataCallbackHandler
     from langchain_core.messages import HumanMessage, AIMessage
 
     from graph.goals.goal_turn import goal_turn
@@ -1661,7 +1678,17 @@ async def _chat_langgraph_impl(
             # streaming `a2a:{session_id}` ones, so the SAME session reached via
             # both APIs split into two histories. Old `chat:*` checkpoints orphan
             # once on upgrade — non-streaming chat is short-lived, so harmless.
-            config = {"configurable": {"thread_id": _resolve_thread_id(None, session_id)}}
+            # Aggregate token usage across every model call this turn — the initial invoke,
+            # each goal continuation, and any nested subagents (LangChain propagates config
+            # callbacks into nested ainvokes). Read back at the end and attached to the
+            # returned assistant dict; /api/chat ignores the extra key, the /v1 OpenAI-compat
+            # handler reads it for `usage` (ADR 0075 D4). Mirrors the streaming path's
+            # per-call usage accounting, which sums `on_chat_model_end` events for the turn.
+            usage_cb = UsageMetadataCallbackHandler()
+            config = {
+                "configurable": {"thread_id": _resolve_thread_id(None, session_id)},
+                "callbacks": [usage_cb],
+            }
 
             def _last_ai(result) -> str:
                 for msg in reversed(result.get("messages", [])):
@@ -1727,7 +1754,13 @@ async def _chat_langgraph_impl(
                     # continues the thread (the checkpointer kept the history).
                     payload = _interrupt_payload(interrupt_val)
                     question = payload.get("question") or payload.get("title") or "The agent needs input to continue."
-                    return [{"role": "assistant", "content": f"🙋 **Input needed:** {question}"}]
+                    return [
+                        {
+                            "role": "assistant",
+                            "content": f"🙋 **Input needed:** {question}",
+                            "usage": _sum_usage(usage_cb.usage_metadata),
+                        }
+                    ]
 
             # Still nothing (e.g. a `wait` yield, or a tool-only turn): fall back
             # to the last tool result so the caller gets a signal, not a blank.
@@ -1763,7 +1796,9 @@ async def _chat_langgraph_impl(
                                     "session_id": session_id,
                                     **_state_extra,
                                 },
-                                config=cont_config,
+                                # Fresh-context iterations get a scoped config without the
+                                # turn's callbacks — re-attach usage_cb so their tokens count.
+                                config={**cont_config, "callbacks": [usage_cb]},
                             )
                     nxt = extract_output(_last_ai(result))
                     if nxt:
@@ -1771,7 +1806,7 @@ async def _chat_langgraph_impl(
                 if note:
                     response = f"{response}\n\n---\n{note}"
 
-            return [{"role": "assistant", "content": response}]
+            return [{"role": "assistant", "content": response, "usage": _sum_usage(usage_cb.usage_metadata)}]
         except Exception as e:
             from graph.llm import RETRYABLE_STREAM_ERRORS
 

--- a/tests/test_chat_nonstreaming_robustness.py
+++ b/tests/test_chat_nonstreaming_robustness.py
@@ -88,6 +88,46 @@ async def test_ask_human_interrupt_surfaces_the_question(monkeypatch):
     assert "Input needed" in content and "timezone" in content.lower()
 
 
+def test_sum_usage_folds_models_to_openai_shape():
+    from server.chat import _sum_usage
+
+    per_model = {
+        "lead": {"input_tokens": 10, "output_tokens": 4, "total_tokens": 14},
+        "aux": {"input_tokens": 3, "output_tokens": 1, "total_tokens": 4},
+    }
+    assert _sum_usage(per_model) == {"prompt_tokens": 13, "completion_tokens": 5, "total_tokens": 18}
+
+
+def test_sum_usage_empty_and_total_fallback():
+    from server.chat import _sum_usage
+
+    assert _sum_usage({}) == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    # gateway omitted total_tokens → derived from prompt + completion
+    assert _sum_usage({"m": {"input_tokens": 5, "output_tokens": 2}})["total_tokens"] == 7
+
+
+@pytest.mark.asyncio
+async def test_usage_metadata_is_summed_and_attached(monkeypatch):
+    """A model turn attaches the OpenAI-shaped `usage` to the assistant dict (ADR 0075 D4).
+    The fake model reports usage_metadata + model_name, which reaches the turn's
+    UsageMetadataCallbackHandler through the real graph; _sum_usage folds it."""
+    from server.chat import chat
+
+    _install_graph(
+        monkeypatch,
+        [
+            AIMessage(
+                content="the answer",
+                usage_metadata={"input_tokens": 11, "output_tokens": 7, "total_tokens": 18},
+                response_metadata={"model_name": "test-model"},
+            ),
+        ],
+    )
+    out = await chat("hello", "sessU")
+    assert out[0]["content"] == "the answer"
+    assert out[0]["usage"] == {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18}
+
+
 @pytest.mark.asyncio
 async def test_wait_yield_turn_falls_back_to_tool_text(monkeypatch):
     from server.chat import chat

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -102,6 +102,51 @@ def test_openai_completion_honors_model_override(monkeypatch):
     assert comp2["choices"][0]["message"]["content"] == "echo:yo"
 
 
+def _sse_data(text):
+    """Parse an SSE body into its JSON `data:` frames (dropping the `[DONE]` sentinel)."""
+    out = []
+    for line in text.splitlines():
+        if line.startswith("data: ") and not line.strip().endswith("[DONE]"):
+            out.append(json.loads(line[len("data: ") :]))
+    return out
+
+
+def test_openai_completion_reports_real_usage(monkeypatch):
+    # ADR 0075 D4: /v1 usage is no longer stubbed — it reflects the turn's token accounting
+    # attached by server.chat (summed over lead + goal continuations + subagents).
+    reply = [{"role": "assistant", "content": "hi", "usage": {"prompt_tokens": 12, "completion_tokens": 8, "total_tokens": 20}}]
+    c = _client(monkeypatch, chat_reply=reply)
+    body = c.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}]}).json()
+    assert body["usage"] == {"prompt_tokens": 12, "completion_tokens": 8, "total_tokens": 20}
+
+
+def test_openai_completion_usage_defaults_to_zero(monkeypatch):
+    # A short-circuit / older reply carries no usage → zeros, as before (no crash).
+    c = _client(monkeypatch)
+    body = c.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}]}).json()
+    assert body["usage"] == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+
+def test_openai_streaming_usage_only_when_opted_in(monkeypatch):
+    reply = [{"role": "assistant", "content": "hi", "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}}]
+
+    # stream_options.include_usage → a final chunk with empty choices carrying usage.
+    c = _client(monkeypatch, chat_reply=reply)
+    r = c.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hi"}], "stream": True, "stream_options": {"include_usage": True}},
+    )
+    frames = _sse_data(r.text)
+    usage_frames = [f for f in frames if "usage" in f]
+    assert usage_frames and usage_frames[-1]["usage"] == {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8}
+    assert usage_frames[-1]["choices"] == []
+
+    # Default (no opt-in) → OpenAI omits usage from the stream.
+    c2 = _client(monkeypatch, chat_reply=reply)
+    r2 = c2.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "hi"}], "stream": True})
+    assert not any("usage" in f for f in _sse_data(r2.text))
+
+
 def test_delete_session_harvest_is_opt_in(monkeypatch):
     # Deleting a chat must NOT silently copy it into the knowledge base: the
     # route defaults harvest=False and forwards the dialog checkbox explicitly.


### PR DESCRIPTION
## What

`/v1/chat/completions` reported `usage: {prompt_tokens: 0, completion_tokens: 0, total_tokens: 0}` — a hardcoded stub. This populates it with the turn's **actual** token accounting.

## How

`server.chat._chat_langgraph_impl` (the non-streaming entry behind `/api/chat` + `/v1`) now threads a `UsageMetadataCallbackHandler` through the invoke `config`. Because LangChain propagates config callbacks into nested `ainvoke`s, usage aggregates across **every model call in the turn**:

- the initial invoke,
- each **goal-continuation** iteration (same-session *and* fresh-context — re-attached at the fresh-context call site, which otherwise gets a scoped config without the turn's callbacks),
- nested **subagents** (`task()` delegation).

The summed `{prompt,completion,total}_tokens` (OpenAI shape, via a new `_sum_usage` helper) is attached to the returned assistant dict. `/api/chat` ignores the extra key (additive); the `/v1` handler reads and sums it into the response. This mirrors the A2A/streaming path, which already sums per-call `usage` for its cost-v1 artifact.

Streaming `/v1` emits usage too — but **only** when the client opts in via `stream_options.include_usage`, as a final chunk with empty `choices`, per the OpenAI contract.

## Tests
- `_sum_usage`: multi-model sum → OpenAI shape; `total` fallback to prompt+completion; empty → zeros.
- **End-to-end accumulation**: a fake model reporting `usage_metadata` + `model_name` reaches the turn's handler through the *real* graph, and `chat()` attaches the summed usage.
- `/v1` routes: reports real usage; defaults to zeros when a reply carries none; streaming emits the usage chunk only when `include_usage` is set.

## Gates
- `ruff check .` ✅
- `lint-imports` ✅ 3/3 contracts kept
- `pytest tests/` ✅ **3202 passed, 5 skipped**

No frontend changes (FE gates N/A). Completes the `/v1` usage leftover from the ADR 0075 D2 handoff; the `safe-operator` MCP profile (per-op read/write metadata) remains for the ops-layer pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)