### PR TITLE
feat(ops): the shared ops layer, starting with knowledge.ingest (ADR 0075 D2)

### DIFF
--- a/PROTO.md
+++ b/PROTO.md
@@ -126,8 +126,10 @@ These are the failures that actually recur — read them before you edit.
 
 - **Import layering (enforced by `lint-imports`).** `graph/` and the infra
   packages (`a2a_impl/ observability/ security/ infra/ tools/ knowledge/
-  events/ scheduler/ runtime/`) must **never** import `server/` or
-  `operator_api/`; `operator_api/` must never import `server/`. The
+  events/ scheduler/ runtime/ ops/`) must **never** import `server/` or
+  `operator_api/`; `operator_api/` must never import `server/`. (`ops/` is the
+  ADR 0075 D2 shared-operation layer — one op wrapping a core, called by the CLI,
+  REST, and MCP adapters; being neutral is what lets all three import it.) The
   `ignore_imports` lists in `pyproject.toml [tool.importlinter]` are a
   **burndown list** of grandfathered violations — remove entries, never add to
   them. import-linter sees function-level (lazy) imports too, so you can't hide

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -114,40 +114,44 @@ def _knowledge_row(d: dict) -> dict:
 _PREVIEW_SNIPPET_CHARS = 1500
 
 
-async def _extract_source(file, url: str, text: str, title: str):
-    """Shared extraction half of ingest + preview (#1801): turn a
-    (file | url | pasted text) source into an ``ExtractResult`` via the ingestion
-    engine (ADR 0021), off the event loop.
+# Extraction + store live in ``ops.knowledge`` now (ADR 0075 D2) — the same op the agent's
+# ``knowledge_ingest`` tool calls, ending the double-glue. These helpers are the REST adapter:
+# multipart form → an ``IngestSource``, and the op's typed ``IngestError`` → an HTTP status.
+_INGEST_STATUS = {
+    "missing_dependency": 501,
+    "unsupported": 415,
+    "no_source": 400,
+    "not_found": 400,
+    "extraction": 400,
+    "empty": 400,
+}
 
-    Returns ``(result, source_label)``, or ``(None, "")`` when no source was
-    given. Raises the engine's typed errors (``MissingDependency`` /
-    ``UnsupportedSource`` / …) for the caller to map to a status code. Extraction
-    NEVER persists, so ``/ingest`` (which then embeds) and ``/ingest/preview``
-    (which only counts) share exactly this step. Inputs are assumed already
-    stripped by the caller."""
-    from ingestion import ExtractResult, extract_bytes, extract_url
 
-    # Gateway STT for audio/video (None if no transcribe_model configured →
-    # audio/video raise a clean "not configured" error; text/pdf unaffected).
-    transcribe = None
-    try:
-        from graph.llm import create_transcribe_fn
-
-        transcribe = create_transcribe_fn(STATE.graph_config) if STATE.graph_config else None
-    except Exception as exc:  # noqa: BLE001 — transcription stays optional
-        log.warning("[knowledge] transcribe fn unavailable: %s", exc)
+async def _source_from_form(file, url: str, text: str, title: str):
+    """A (file | url | pasted text) multipart form → an ``ops.knowledge.IngestSource``, or
+    ``None`` when no source was given. Inputs are assumed already stripped by the caller."""
+    from ops.knowledge import IngestSource
 
     if file is not None:
-        data = await file.read()
-        result = await asyncio.to_thread(
-            extract_bytes, file.filename or "upload", data, file.content_type, transcribe=transcribe
-        )
-        return result, (file.filename or "upload")
+        return IngestSource.from_upload(await file.read(), file.filename or "upload", file.content_type)
     if url:
-        return await asyncio.to_thread(extract_url, url, transcribe=transcribe), url
+        return IngestSource.from_url(url)
     if text:
-        return ExtractResult(text=text, title=title or None, source_type="text"), "console"
-    return None, ""
+        return IngestSource.from_text(text, title=title or None, label="console")
+    return None
+
+
+def _ingest_error_response(exc):
+    """Map an ``ops.knowledge.IngestError`` to the console's ``{detail}`` + status."""
+    if exc.kind == "extraction":
+        detail = f"extraction failed: {exc.detail}"
+    elif exc.kind == "empty":
+        detail = "nothing ingested (no text after extraction)"
+    elif exc.kind == "no_source":
+        detail = "provide a file, url, or text"
+    else:
+        detail = exc.detail
+    return JSONResponse({"detail": detail}, status_code=_INGEST_STATUS.get(exc.kind, 400))
 
 
 def register_knowledge_routes(app) -> None:
@@ -493,45 +497,29 @@ def register_knowledge_routes(app) -> None:
         contextually enriches + embeds it (ADR 0021) — so a whole PDF, article, or
         recording becomes per-passage recall, not one diluted chunk. Multipart so
         a file upload and the URL/text fields share one endpoint. Extraction +
-        embedding run off the event loop. Returns the created chunk ids."""
+        store run in ``ops.knowledge.ingest`` (the same op the agent tool calls).
+        Returns the created chunk ids."""
         if STATE.knowledge_store is None:
             return {"enabled": False, "ids": []}
-        from ingestion import MissingDependency, UnsupportedSource
-        from knowledge import add_document
+        from ops import OpContext
+        from ops.knowledge import IngestError, ingest
 
-        url, text, title = url.strip(), text.strip(), title.strip()
-        try:
-            result, source = await _extract_source(file, url, text, title)
-        except MissingDependency as exc:
-            return JSONResponse({"detail": str(exc)}, status_code=501)
-        except UnsupportedSource as exc:
-            return JSONResponse({"detail": str(exc)}, status_code=415)
-        except Exception as exc:  # noqa: BLE001 — surface extraction failure, never 500
-            log.warning("[knowledge] ingest extraction failed: %s", exc)
-            return JSONResponse({"detail": f"extraction failed: {exc}"}, status_code=400)
-        if result is None:
+        source = await _source_from_form(file, url.strip(), text.strip(), title.strip())
+        if source is None:
             return JSONResponse({"detail": "provide a file, url, or text"}, status_code=400)
-
-        heading = title or result.title or None
-        ids = await asyncio.to_thread(
-            lambda: add_document(
-                STATE.knowledge_store,
-                result.text,
-                domain=(domain.strip() or "general"),
-                heading=heading,
-                source=source,
-                source_type=result.source_type,
+        try:
+            result = await ingest(
+                source, domain=(domain.strip() or "general"), title=(title.strip() or None), ctx=OpContext.from_state()
             )
-        )
-        if not ids:
-            return JSONResponse({"detail": "nothing ingested (no text after extraction)"}, status_code=400)
+        except IngestError as exc:
+            return _ingest_error_response(exc)
         return {
             "enabled": True,
-            "ids": ids,
-            "chunks": len(ids),
-            "title": heading,
+            "ids": result.ids,
+            "chunks": result.chunks,
+            "title": result.title,
             "source_type": result.source_type,
-            "chars": len(result.text),
+            "chars": result.chars,
         }
 
     @app.post("/api/knowledge/ingest/preview")
@@ -548,52 +536,35 @@ def register_knowledge_routes(app) -> None:
         the file will split into, an approximate token count, and a text snippet —
         so the operator can verify the right content (and that extraction worked)
         lands in the right bucket before committing. Runs the *same* extraction as
-        ``/ingest`` (ADR 0021) but stops before ``add_document``: it writes zero
-        rows and skips embedding + LLM enrichment entirely. Chunk count uses the
-        live store's chunk knobs, so the preview matches what ingestion will
-        actually produce. Confirm re-POSTs to ``/ingest`` (extraction reruns there,
-        which preserves each source's real provenance)."""
+        ``/ingest`` (via ``ops.knowledge.ingest_preview``) but stops before
+        ``add_document``: it writes zero rows and skips embedding + LLM enrichment
+        entirely. Chunk count uses the live store's chunk knobs, so the preview
+        matches what ingestion will actually produce. Confirm re-POSTs to
+        ``/ingest`` (extraction reruns there, preserving real provenance)."""
         if STATE.knowledge_store is None:
             return {"enabled": False}
-        from ingestion import MissingDependency, UnsupportedSource
-        from knowledge.chunking import chunk_text
+        from ops import OpContext
+        from ops.knowledge import IngestError, ingest_preview
 
-        url, text, title = url.strip(), text.strip(), title.strip()
-        try:
-            result, source = await _extract_source(file, url, text, title)
-        except MissingDependency as exc:
-            return JSONResponse({"detail": str(exc)}, status_code=501)
-        except UnsupportedSource as exc:
-            return JSONResponse({"detail": str(exc)}, status_code=415)
-        except Exception as exc:  # noqa: BLE001 — surface extraction failure, never 500
-            log.warning("[knowledge] ingest preview extraction failed: %s", exc)
-            return JSONResponse({"detail": f"extraction failed: {exc}"}, status_code=400)
-        if result is None:
+        source = await _source_from_form(file, url.strip(), text.strip(), title.strip())
+        if source is None:
             return JSONResponse({"detail": "provide a file, url, or text"}, status_code=400)
-
-        # Count chunks with the live store's knobs so the preview matches production
-        # ingestion exactly; fall back to the chunker defaults for a store (e.g. a
-        # plugin backend) that doesn't expose them. chunk_text is pure — no I/O, no
-        # LLM enrichment (enrichment only prepends a context line; it never changes
-        # the count), so the previewed number is exact.
-        store = STATE.knowledge_store
-        chunks = chunk_text(
-            result.text,
-            max_chars=getattr(store, "_chunk_max_chars", 1200),
-            overlap_chars=getattr(store, "_chunk_overlap_chars", 150),
-            min_chars=getattr(store, "_chunk_min_chars", 200),
-        )
-        snippet = result.text[:_PREVIEW_SNIPPET_CHARS]
+        try:
+            preview = await ingest_preview(
+                source, title=(title.strip() or None), ctx=OpContext.from_state(), snippet_chars=_PREVIEW_SNIPPET_CHARS
+            )
+        except IngestError as exc:
+            return _ingest_error_response(exc)
         return {
             "enabled": True,
-            "chunks": len(chunks),
-            "chars": len(result.text),
-            "approx_tokens": max(1, len(result.text) // 4),  # house heuristic (graph.middleware.*)
-            "title": title or result.title or None,
-            "source_type": result.source_type,
-            "source": source,
-            "snippet": snippet,
-            "truncated": len(result.text) > len(snippet),
+            "chunks": preview.chunks,
+            "chars": preview.chars,
+            "approx_tokens": preview.approx_tokens,
+            "title": preview.title,
+            "source_type": preview.source_type,
+            "source": preview.source,
+            "snippet": preview.snippet,
+            "truncated": preview.truncated,
         }
 
     @app.post("/api/knowledge/attach")

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -1,0 +1,79 @@
+"""The ops layer (ADR 0075 D2) — one function per operation, three faithful projections.
+
+An **op** wraps a `graph/**` / infra core *plus* the orchestration that was REST-only,
+so the CLI, the operator MCP, and the HTTP API stop each re-implementing the same glue
+and instead become thin adapters:
+
+- CLI adapter → parse argv → call the op → render text/JSON.
+- REST route → validate body → call the op → JSON.
+- MCP tool / agent tool → the op, wrapped once.
+
+Ops take **plain args + an `OpContext`** (the booted stores/config, injected so ops stay
+testable) and return **plain results**; expected failures raise a typed error the adapter
+maps to its surface (a tool string, an HTTP status). Ops live in `ops/` — a neutral infra
+package that must never import `server` / `operator_api` (import-layering) — so any surface
+can call them.
+
+Each op registers metadata via `@op(...)`: its name, whether it **mutates** state, and a
+one-line summary. That registry is the single source for the `safe-operator` MCP profile
+(read vs. write) and the `GET /api/operations` catalog (ADR 0075 D2/D3/D4) — so those are
+derived, not hand-maintained.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class OpContext:
+    """The handles an op needs, injected rather than reached for. Build it from live
+    process state with :meth:`from_state`, or construct it directly with fakes in tests."""
+
+    knowledge_store: Any = None
+    graph_config: Any = None
+
+    @classmethod
+    def from_state(cls) -> "OpContext":
+        """The context for the running instance — reads ``runtime.state.STATE`` (populated
+        by ``server.agent_init`` in the live server, ``operator_mcp._boot_stores_only`` in a
+        sidecar). Import is local so ``ops`` never hard-depends on a booted process."""
+        from runtime.state import STATE
+
+        return cls(knowledge_store=STATE.knowledge_store, graph_config=STATE.graph_config)
+
+
+@dataclass(frozen=True)
+class OpSpec:
+    """Registered metadata for one op — the seed of the `safe-operator` profile
+    (``mutates``) and the `GET /api/operations` catalog (``name`` / ``summary``)."""
+
+    name: str
+    mutates: bool
+    summary: str
+
+
+_REGISTRY: dict[str, OpSpec] = {}
+
+
+def op(*, name: str, mutates: bool, summary: str) -> Callable:
+    """Decorator that records an op's :class:`OpSpec` in the registry and stamps
+    ``fn.op_spec``. ``mutates`` is the read/write bit the middle MCP tier keys on:
+    ``False`` ops are admissible to ``read-only``/``safe-operator``; ``True`` ops need
+    ``full`` (or an explicit safe-operator allowance)."""
+
+    def deco(fn: Callable) -> Callable:
+        spec = OpSpec(name=name, mutates=mutates, summary=summary)
+        if name in _REGISTRY and _REGISTRY[name] != spec:
+            raise ValueError(f"op {name!r} already registered with different metadata")
+        _REGISTRY[name] = spec
+        fn.op_spec = spec
+        return fn
+
+    return deco
+
+
+def registry() -> dict[str, OpSpec]:
+    """A copy of the registered ops, keyed by name — the source for the catalog + profile."""
+    return dict(_REGISTRY)

--- a/ops/knowledge.py
+++ b/ops/knowledge.py
@@ -1,0 +1,211 @@
+"""Knowledge ops (ADR 0075 D2) — the one op that already spanned both spines.
+
+``ingest`` is the whole extract→store glue that the agent tool (``knowledge_ingest``) and
+the console route (``POST /api/knowledge/ingest``) each used to re-implement. Now both call
+this; ``ingest_preview`` shares the extraction half with a dry-run that never persists.
+
+A source is a small union — URL, local path, uploaded bytes, or already-extracted text —
+so every surface hands the op what it has and the extraction dispatch lives in one place
+(the console route previously built only the STT fn, never the vision one; unifying here
+fixes that gap for image uploads). Expected failures raise :class:`IngestError` with a
+``kind`` the adapter maps to its surface (a tool message, an HTTP status)."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+from ops import OpContext, op
+
+
+class IngestError(Exception):
+    """An expected, legible ingest failure. ``kind`` is a stable token the adapters map:
+    ``no_source`` / ``not_found`` / ``missing_dependency`` / ``unsupported`` / ``extraction``
+    / ``empty``. ``str(err)`` is the underlying detail (safe to show)."""
+
+    def __init__(self, detail: str, *, kind: str):
+        super().__init__(detail)
+        self.kind = kind
+        self.detail = detail
+
+
+@dataclass
+class IngestSource:
+    """What to ingest — exactly one of url / path / (data + filename) / text is meaningful.
+    Use the constructors so callers don't juggle fields."""
+
+    url: str | None = None
+    path: str | None = None
+    data: bytes | None = None
+    filename: str | None = None
+    content_type: str | None = None
+    text: str | None = None
+    text_title: str | None = None
+    label: str | None = None  # override the stored `source` provenance label
+
+    @classmethod
+    def from_url(cls, url: str) -> "IngestSource":
+        return cls(url=url)
+
+    @classmethod
+    def from_path(cls, path: str) -> "IngestSource":
+        return cls(path=path)
+
+    @classmethod
+    def from_upload(cls, data: bytes, filename: str | None, content_type: str | None = None) -> "IngestSource":
+        return cls(data=data, filename=filename, content_type=content_type)
+
+    @classmethod
+    def from_text(cls, text: str, *, title: str | None = None, label: str = "console") -> "IngestSource":
+        return cls(text=text, text_title=title, label=label)
+
+
+@dataclass
+class IngestResult:
+    ids: list[int]
+    chunks: int
+    chars: int
+    title: str | None
+    source_type: str
+    source: str  # provenance label the chunks were stored under
+
+
+@dataclass
+class PreviewResult:
+    chunks: int
+    chars: int
+    approx_tokens: int
+    title: str | None
+    source_type: str
+    source: str
+    snippet: str
+    truncated: bool
+
+
+def _media_fns(graph_config):
+    """Gateway STT + vision fns for media sources, or ``(None, None)`` when no model is
+    configured — audio/video/image then raise a clean "not configured" error while
+    text/URL/PDF paths are unaffected."""
+    if graph_config is None:
+        return None, None
+    try:
+        from graph.llm import create_describe_image_fn, create_transcribe_fn
+
+        return create_transcribe_fn(graph_config), create_describe_image_fn(graph_config)
+    except Exception:  # noqa: BLE001 — media stays optional; text/URL/PDF unaffected
+        return None, None
+
+
+async def _extract(source: IngestSource, ctx: OpContext):
+    """Turn a source into ``(ExtractResult, provenance_label)`` off the event loop — the
+    shared half of ingest + preview. Never persists. Raises :class:`IngestError` on an
+    expected failure; returns ``(None, "")`` when no source was given."""
+    from ingestion import ExtractResult, MissingDependency, UnsupportedSource, extract_bytes, extract_url
+
+    transcribe, describe = _media_fns(ctx.graph_config)
+    try:
+        if source.text is not None:
+            text = source.text
+            return ExtractResult(text=text, title=source.text_title or None, source_type="text"), (source.label or "console")
+        if source.url:
+            return await asyncio.to_thread(extract_url, source.url, transcribe=transcribe), (source.label or source.url)
+        if source.data is not None:
+            name = source.filename or "upload"
+            result = await asyncio.to_thread(
+                extract_bytes, name, source.data, source.content_type, transcribe=transcribe, describe=describe
+            )
+            return result, (source.label or name)
+        if source.path:
+            path = Path(source.path).expanduser()
+            if not path.is_file():
+                raise IngestError(
+                    f"No such file: {source.path} — pass an http(s) URL or an existing local file path.",
+                    kind="not_found",
+                )
+            data = await asyncio.to_thread(path.read_bytes)
+            result = await asyncio.to_thread(
+                extract_bytes, path.name, data, None, transcribe=transcribe, describe=describe
+            )
+            return result, (source.label or str(path))
+        return None, ""
+    except MissingDependency as exc:
+        raise IngestError(str(exc), kind="missing_dependency") from exc
+    except UnsupportedSource as exc:
+        raise IngestError(str(exc), kind="unsupported") from exc
+    except IngestError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — surface extraction failure, never crash the surface
+        raise IngestError(str(exc), kind="extraction") from exc
+
+
+@op(
+    name="knowledge.ingest",
+    mutates=True,
+    summary="Extract a URL / file / text source and index it into long-term knowledge.",
+)
+async def ingest(source: IngestSource, *, domain: str = "general", title: str | None = None, ctx: OpContext) -> IngestResult:
+    """Run the ingestion pipeline for one source and store it. Raises :class:`IngestError`
+    (``no_source`` when nothing was given, ``empty`` when extraction yielded no text)."""
+    from knowledge import add_document
+
+    result, origin = await _extract(source, ctx)
+    if result is None:
+        raise IngestError("provide a url, a file, or text to ingest", kind="no_source")
+
+    heading = (title or "").strip() or result.title or None
+    dom = (domain or "general").strip() or "general"
+    ids = await asyncio.to_thread(
+        lambda: add_document(
+            ctx.knowledge_store,
+            result.text,
+            domain=dom,
+            heading=heading,
+            source=origin,
+            source_type=result.source_type,
+        )
+    )
+    if not ids:
+        raise IngestError("nothing ingested — no text could be extracted from that source", kind="empty")
+    return IngestResult(
+        ids=list(ids),
+        chunks=len(ids),
+        chars=len(result.text),
+        title=heading,
+        source_type=result.source_type,
+        source=origin,
+    )
+
+
+@op(
+    name="knowledge.ingest_preview",
+    mutates=False,
+    summary="Dry-run an ingest: extract + count chunks for a source without persisting.",
+)
+async def ingest_preview(source: IngestSource, *, title: str | None = None, ctx: OpContext, snippet_chars: int = 600) -> PreviewResult:
+    """Extract + count chunks with the live store's knobs WITHOUT persisting (#1801) — the
+    same extraction as :func:`ingest`, stopped before ``add_document``."""
+    from knowledge.chunking import chunk_text
+
+    result, origin = await _extract(source, ctx)
+    if result is None:
+        raise IngestError("provide a url, a file, or text to ingest", kind="no_source")
+
+    store = ctx.knowledge_store
+    chunks = chunk_text(
+        result.text,
+        max_chars=getattr(store, "_chunk_max_chars", 1200),
+        overlap_chars=getattr(store, "_chunk_overlap_chars", 150),
+        min_chars=getattr(store, "_chunk_min_chars", 200),
+    )
+    snippet = result.text[:snippet_chars]
+    return PreviewResult(
+        chunks=len(chunks),
+        chars=len(result.text),
+        approx_tokens=max(1, len(result.text) // 4),  # house heuristic (graph.middleware.*)
+        title=(title or "").strip() or result.title or None,
+        source_type=result.source_type,
+        source=origin,
+        snippet=snippet,
+        truncated=len(result.text) > len(snippet),
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ packages = [
   "knowledge",
   "observability",
   "operator_api",
+  "ops",
   "runtime",
   "scheduler",
   "security",
@@ -124,6 +125,7 @@ root_packages = [
   "knowledge",
   "observability",
   "operator_api",
+  "ops",
   "runtime",
   "scheduler",
   "security",
@@ -164,7 +166,7 @@ name = "infra packages do not import server or operator_api"
 type = "forbidden"
 source_modules = [
   "a2a_impl", "events", "infra", "ingestion", "knowledge", "observability",
-  "runtime", "scheduler", "security", "tools",
+  "ops", "runtime", "scheduler", "security", "tools",
 ]
 forbidden_modules = ["server", "operator_api"]
 

--- a/tests/test_ops_core.py
+++ b/tests/test_ops_core.py
@@ -1,0 +1,49 @@
+"""ops core (ADR 0075 D2) — the op registry + injected context."""
+
+from __future__ import annotations
+
+import pytest
+
+from ops import OpContext, OpSpec, op, registry
+
+
+def test_op_decorator_registers_and_stamps():
+    @op(name="test.sample_op", mutates=False, summary="a sample")
+    async def sample():
+        return 1
+
+    assert sample.op_spec == OpSpec(name="test.sample_op", mutates=False, summary="a sample")
+    assert registry()["test.sample_op"].summary == "a sample"
+
+
+def test_op_duplicate_same_metadata_is_idempotent():
+    @op(name="test.dup_ok", mutates=True, summary="same")
+    async def a():
+        return 1
+
+    @op(name="test.dup_ok", mutates=True, summary="same")  # re-import / re-decorate is fine
+    async def b():
+        return 2
+
+    assert registry()["test.dup_ok"].mutates is True
+
+
+def test_op_duplicate_conflicting_metadata_raises():
+    @op(name="test.dup_bad", mutates=False, summary="v1")
+    async def a():
+        return 1
+
+    with pytest.raises(ValueError):
+
+        @op(name="test.dup_bad", mutates=True, summary="v2")  # same name, different metadata
+        async def b():
+            return 2
+
+
+def test_op_context_from_state(monkeypatch):
+    import runtime.state as rs
+
+    monkeypatch.setattr(rs.STATE, "knowledge_store", "KS", raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", "CFG", raising=False)
+    ctx = OpContext.from_state()
+    assert ctx.knowledge_store == "KS" and ctx.graph_config == "CFG"

--- a/tests/test_ops_knowledge.py
+++ b/tests/test_ops_knowledge.py
@@ -1,0 +1,118 @@
+"""ops.knowledge (ADR 0075 D2) — the shared ingest op both the agent tool and the console
+route now call. Extraction (the ingestion engine) is covered by test_ingestion.py; these
+test the op itself: source dispatch, result shape, typed error kinds, the dry-run preview,
+and the op-registry metadata that seeds the safe-operator profile + operations catalog."""
+
+from __future__ import annotations
+
+import ingestion
+import pytest
+from ingestion import ExtractResult, MissingDependency, UnsupportedSource
+
+from ops import OpContext, registry
+from ops.knowledge import IngestError, IngestSource, ingest, ingest_preview
+
+
+class _FakeStore:
+    def __init__(self):
+        self.docs: list[tuple[str, dict]] = []
+        self._chunk_max_chars = 1000
+        self._chunk_overlap_chars = 100
+        self._chunk_min_chars = 100
+
+    def add_document(self, content, **kw):
+        self.docs.append((content, kw))
+        return [1, 2, 3]
+
+
+def _ctx(store=None):
+    return OpContext(knowledge_store=store if store is not None else _FakeStore(), graph_config=None)
+
+
+async def test_ingest_url_stores_and_returns_result(monkeypatch):
+    monkeypatch.setattr(
+        ingestion, "extract_url", lambda url, **kw: ExtractResult(text="body", title="T", source_type="html")
+    )
+    store = _FakeStore()
+    res = await ingest(IngestSource.from_url("https://x/post"), domain="research", ctx=_ctx(store))
+    assert res.ids == [1, 2, 3] and res.chunks == 3 and res.chars == 4
+    assert res.title == "T" and res.source_type == "html" and res.source == "https://x/post"
+    content, kw = store.docs[0]
+    assert content == "body" and kw["domain"] == "research" and kw["source"] == "https://x/post"
+
+
+async def test_ingest_title_override_wins_over_extracted():
+    res = await ingest(IngestSource.from_text("hello world", title="Extracted"), title="Override", ctx=_ctx())
+    assert res.title == "Override" and res.source == "console" and res.source_type == "text"
+
+
+async def test_ingest_upload_dispatches_to_extract_bytes(monkeypatch):
+    seen: dict = {}
+
+    def _xb(name, data, ctype, **kw):
+        seen.update(name=name, data=data, ctype=ctype, has_describe="describe" in kw)
+        return ExtractResult(text="pdf text", title=None, source_type="pdf")
+
+    monkeypatch.setattr(ingestion, "extract_bytes", _xb)
+    res = await ingest(IngestSource.from_upload(b"%PDF-1.7", "doc.pdf", "application/pdf"), ctx=_ctx())
+    assert seen["name"] == "doc.pdf" and seen["data"] == b"%PDF-1.7" and seen["ctype"] == "application/pdf"
+    assert res.source == "doc.pdf" and res.source_type == "pdf" and res.title is None
+
+
+async def test_ingest_missing_file_is_not_found():
+    with pytest.raises(IngestError) as ei:
+        await ingest(IngestSource.from_path("/no/such/file-xyz.txt"), ctx=_ctx())
+    assert ei.value.kind == "not_found"
+
+
+async def test_ingest_no_source_raises():
+    with pytest.raises(IngestError) as ei:
+        await ingest(IngestSource(), ctx=_ctx())
+    assert ei.value.kind == "no_source"
+
+
+async def test_ingest_empty_when_nothing_lands(monkeypatch):
+    monkeypatch.setattr(
+        ingestion, "extract_url", lambda url, **kw: ExtractResult(text="body", title=None, source_type="html")
+    )
+    store = _FakeStore()
+    store.add_document = lambda content, **kw: []  # store rejected / produced no chunks
+    with pytest.raises(IngestError) as ei:
+        await ingest(IngestSource.from_url("https://x"), ctx=_ctx(store))
+    assert ei.value.kind == "empty"
+
+
+async def test_extract_error_kinds_map(monkeypatch):
+    def _missing(url, **kw):
+        raise MissingDependency("need yt-dlp")
+
+    monkeypatch.setattr(ingestion, "extract_url", _missing)
+    with pytest.raises(IngestError) as ei:
+        await ingest(IngestSource.from_url("https://y"), ctx=_ctx())
+    assert ei.value.kind == "missing_dependency" and "yt-dlp" in str(ei.value)
+
+    def _unsupported(url, **kw):
+        raise UnsupportedSource(".xyz")
+
+    monkeypatch.setattr(ingestion, "extract_url", _unsupported)
+    with pytest.raises(IngestError) as ei:
+        await ingest(IngestSource.from_url("https://z"), ctx=_ctx())
+    assert ei.value.kind == "unsupported"
+
+
+async def test_preview_counts_without_storing(monkeypatch):
+    monkeypatch.setattr(
+        ingestion, "extract_url", lambda url, **kw: ExtractResult(text="x" * 2500, title="Big", source_type="html")
+    )
+    store = _FakeStore()
+    prev = await ingest_preview(IngestSource.from_url("https://x"), ctx=_ctx(store), snippet_chars=100)
+    assert store.docs == []  # nothing persisted — dry run
+    assert prev.chunks >= 1 and prev.chars == 2500 and prev.truncated is True and len(prev.snippet) == 100
+    assert prev.title == "Big" and prev.source == "https://x"
+
+
+def test_registry_seeds_read_write_metadata():
+    reg = registry()
+    assert reg["knowledge.ingest"].mutates is True
+    assert reg["knowledge.ingest_preview"].mutates is False  # dry run — admissible to read-only
+    assert reg["knowledge.ingest"].summary  # non-empty one-liner for the catalog

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -556,6 +556,24 @@ class _KnowledgeIngestError(Exception):
     the inline path returns it; a background work job settles ``failed`` with it."""
 
 
+def _tool_ingest_message(exc) -> str:
+    """Render an ``ops.knowledge.IngestError`` in the tool's voice (the model reads it) —
+    preserving the wording the ``knowledge_ingest`` tool has always returned per failure kind."""
+    kind = getattr(exc, "kind", "extraction")
+    detail = getattr(exc, "detail", str(exc))
+    if kind == "not_found":
+        return detail  # already "No such file: … — pass an http(s) URL or an existing local file path."
+    if kind == "missing_dependency":
+        return f"Can't ingest that source — a required dependency or model isn't available: {detail}"
+    if kind == "unsupported":
+        return f"Unsupported source type: {detail}"
+    if kind == "empty":
+        return "Nothing ingested — no text could be extracted from that source."
+    if kind == "no_source":
+        return "Error: provide a URL or a local file path to ingest."
+    return f"Extraction failed: {detail}"
+
+
 # A small local text/Markdown file ingests inline (instant); everything else — any URL
 # fetch, PDF, or audio/video transcription — goes to a background job (ADR 0050) so it
 # never blocks the chat turn.
@@ -675,74 +693,24 @@ def _build_memory_tools(knowledge_store, graph_config=None, background_mgr=None)
         return f"Stored chunk {chunk_id} in {domain!r}."
 
     async def _do_ingest(src: str, dom: str, title: str | None, is_url: bool) -> str:
-        """Run the ingestion pipeline for one source and store it; return a one-line
-        summary. Raises ``_KnowledgeIngestError`` (legible message) on an expected
-        failure. Shared by the inline path and the background work job."""
-        import asyncio
-        from pathlib import Path
+        """Ingest one source via the shared ``ops.knowledge.ingest`` op and return a
+        one-line summary. Raises ``_KnowledgeIngestError`` (legible message) on an expected
+        failure — the inline path returns it, the background work job settles ``failed``
+        with it. Extraction + store now live in the op (ADR 0075 D2); this is the tool
+        adapter (source shaping + tool-worded errors)."""
+        from ops import OpContext
+        from ops.knowledge import IngestError, IngestSource, ingest
 
-        from ingestion import (
-            MissingDependency,
-            UnsupportedSource,
-            extract_bytes,
-            extract_url,
-        )
-        from knowledge import add_document
-
-        # Gateway STT/vision for media — None if no model is configured, which makes
-        # audio/video/image raise a clean "not configured" error while text/URL/PDF/
-        # YouTube paths are unaffected.
-        transcribe = describe = None
-        if graph_config is not None:
-            try:
-                from graph.llm import create_describe_image_fn, create_transcribe_fn
-
-                transcribe = create_transcribe_fn(graph_config)
-                describe = create_describe_image_fn(graph_config)
-            except Exception:  # noqa: BLE001 — media stays optional; text/URL unaffected
-                pass
-
+        source = IngestSource.from_url(src) if is_url else IngestSource.from_path(src)
         try:
-            if is_url:
-                result = await asyncio.to_thread(extract_url, src, transcribe=transcribe)
-                origin = src
-            else:
-                path = Path(src).expanduser()
-                if not path.is_file():
-                    raise _KnowledgeIngestError(
-                        f"No such file: {src} — pass an http(s) URL or an existing local file path."
-                    )
-                data = await asyncio.to_thread(path.read_bytes)
-                result = await asyncio.to_thread(
-                    extract_bytes, path.name, data, None, transcribe=transcribe, describe=describe
-                )
-                origin = str(path)
-        except MissingDependency as exc:
-            raise _KnowledgeIngestError(
-                f"Can't ingest that source — a required dependency or model isn't available: {exc}"
-            ) from exc
-        except UnsupportedSource as exc:
-            raise _KnowledgeIngestError(f"Unsupported source type: {exc}") from exc
-        except _KnowledgeIngestError:
-            raise
-        except Exception as exc:  # noqa: BLE001 — surface extraction failure, never crash
-            raise _KnowledgeIngestError(f"Extraction failed: {exc}") from exc
-
-        heading = (title or "").strip() or result.title or None
-        ids = await asyncio.to_thread(
-            lambda: add_document(
-                knowledge_store,
-                result.text,
-                domain=dom,
-                heading=heading,
-                source=origin,
-                source_type=result.source_type,
+            result = await ingest(
+                source, domain=dom, title=title, ctx=OpContext(knowledge_store=knowledge_store, graph_config=graph_config)
             )
-        )
-        if not ids:
-            raise _KnowledgeIngestError("Nothing ingested — no text could be extracted from that source.")
-        label = heading or origin
-        return f"Ingested {label!r} ({result.source_type}, {len(result.text)} chars) → {len(ids)} chunk(s) in {dom!r}."
+        except IngestError as exc:
+            raise _KnowledgeIngestError(_tool_ingest_message(exc)) from exc
+
+        label = result.title or result.source
+        return f"Ingested {label!r} ({result.source_type}, {result.chars} chars) → {result.chunks} chunk(s) in {dom!r}."
 
     @tool
     async def knowledge_ingest(


### PR DESCRIPTION
## What

Introduces **`ops/`** — the ADR 0075 **D2** "one operation, three projections" layer — and lands its first, load-bearing op. An op wraps a core *plus* the orchestration that surfaces re-implement, so the CLI, operator MCP, and HTTP API become **thin adapters** over one shared function instead of each carrying its own glue.

`knowledge_ingest` was the single op already living on **both** spines — the agent tool (`_do_ingest`) and the console route (`_api_knowledge_ingest`) each ran their own extract→`add_document` pipeline. This collapses both onto `ops.knowledge.ingest`, ending the double-glue exactly as the ADR (§B) calls for.

## The layer

- **`ops/__init__.py`** — `OpContext` (stores/config injected, so ops stay testable and never reach for globals) + an `@op(name, mutates, summary)` **registry**. `mutates` is the read/write bit the `safe-operator` MCP profile and `GET /api/operations` catalog will *derive* from (next D2/D3/D4 slices) — generated, not hand-maintained.
- **`ops/knowledge.py`** — `ingest` + `ingest_preview` own the whole extract→store glue over a small source union (**url / path / uploaded bytes / raw text**). Typed `IngestError(kind=…)` lets each adapter map failures to its own surface (a tool string, an HTTP status).

## The adapters (behavior-preserving)

- **Tool** (`tools/lg_tools.py`): `_do_ingest` is now source-shaping + tool-worded errors, still raising `_KnowledgeIngestError` for the inline/background paths.
- **REST** (`operator_api/knowledge_routes.py`): `/ingest` + `/ingest/preview` map multipart → `IngestSource` and `IngestError.kind` → HTTP status. **Incidental fix:** the route now builds the vision `describe` fn too (it only ever built STT), so image uploads describe.

## Layering

`ops/` is a **neutral infra package** (registered in `[tool.importlinter]` + packaging) that must never import `server`/`operator_api` — which is precisely what lets the tool, the routes, and a future `protoagent knowledge ingest` CLI verb all import it. `lint-imports`: **3/3 contracts kept**.

## Tests
- The op directly: source dispatch (url/path/upload/text), result shape, every `IngestError` kind, dry-run preview persists nothing, registry read/write metadata.
- All **52 existing** ingest tool + route tests pass **unchanged** — the refactor preserves behavior on both spines.

## Gates
- `ruff check .` ✅
- `lint-imports` ✅ 3/3 kept
- `pytest tests/` ✅ **3220 passed, 5 skipped**

No frontend changes (FE gates N/A). This is the pattern-setter; the `safe-operator` profile, `GET /api/operations` catalog, and the CLI verb build on the registry + op signature established here, and the remaining ops (plugin install-and-activate, fleet up/down, config set) follow the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)