### PR TITLE
feat(ops): plugins.install_and_activate — install over the ops layer (ADR 0075 D2)

### DIFF
--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -56,27 +56,10 @@ def _install_no_enable() -> bool:
     return os.environ.get("PROTOAGENT_PLUGIN_INSTALL_NO_ENABLE", "").strip().lower() in ("1", "true", "yes")
 
 
-def _enabled_ids_from_summary(summary: dict) -> list[str]:
-    """The plugin id(s) to enable for an install summary: a single plugin → its id; a
-    bundle → its declared ``enabled`` set (else every installed member)."""
-    if "bundle" in summary:
-        suggested = [str(x) for x in (summary.get("enabled") or [])]
-        members = [str(s["id"]) for s in (summary.get("installed") or []) if s.get("id")]
-        return suggested or members
-    pid = summary.get("id")
-    return [str(pid)] if pid else []
-
-
-def _installed_ids_from_summary(summary: dict) -> list[str]:
-    """The plugin id(s) whose CODE this install just placed on disk — for a bundle,
-    its fetched members only (``builtin`` members aren't fetched, so they can't have
-    been replaced under a live mount)."""
-    if "bundle" in summary:
-        return [str(s["id"]) for s in (summary.get("installed") or []) if s.get("id")]
-    pid = summary.get("id")
-    return [str(pid)] if pid else []
-
-
+# The install summary → enabled/installed-id parsing moved into ``ops.plugins`` (ADR 0075
+# D2) with the install_and_activate op; ``_has_surface`` / ``_mounted_router_ids`` stay here
+# — they read the LIVE app (mount registry + plugin meta), a REST-surface concern the enable
+# and update routes also use.
 def _has_surface(meta: dict | None) -> bool:
     """True when the plugin contributed a view / router / background surface — the
     contributions FastAPI can't unmount or swap in place (restart territory)."""
@@ -190,79 +173,53 @@ def register_plugin_routes(app) -> None:
             raise HTTPException(status_code=400, detail="url is required")
         ref = str(body.get("ref", "")).strip() or None
         force = bool(body.get("force"))
+
+        # Snapshot the live app BEFORE the op reloads: which just-(re)installed plugins are
+        # already LIVE — a mounted router (mount registry; survives disable) or a loaded
+        # view/router/surface (meta). For those the reload can't deliver fresh routes (the
+        # re-registered router is dropped for the mounted one — FastAPI can't swap in place,
+        # #942), so the OLD code keeps serving → restart. Install (git clone) doesn't touch
+        # the live registry/meta — only the reload does — so this pre-op snapshot is exact.
+        mounted_before = _mounted_router_ids()
+        prev_meta = {p.get("id"): p for p in (STATE.plugin_meta or [])}
+
+        from ops import OpContext
+        from ops.plugins import install_and_activate
+
+        # Install AUTO-ENABLES + runs the code (ADR 0027, trust-by-default): installing IS
+        # the consent (the console flashes a one-time "this runs code" confirm for unofficial
+        # sources first). The op adds it to plugins.enabled + hot-reloads via _apply_settings_
+        # changes — the live-agent rebuild this REST adapter injects. Opt out with
+        # PROTOAGENT_PLUGIN_INSTALL_NO_ENABLE=1 (strict install ≠ enable).
+        from server.agent_init import _apply_settings_changes
+
         try:
-            # git clone + dep work is blocking — offload so it can't stall the
-            # event loop (and with it every chat/A2A/scheduler request) (#DoS).
-            summary = await asyncio.to_thread(
-                installer.install, url, ref, force=force, by="console", allow=_sources_allowlist()
+            result = await install_and_activate(
+                url,
+                ref,
+                force=force,
+                by="console",
+                allow=_sources_allowlist(),
+                activate=not _install_no_enable(),
+                ctx=OpContext.from_state(),
+                apply_settings=lambda updates: _apply_settings_changes(config=updates),
             )
         except installer.InstallError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-        # Install AUTO-ENABLES + runs the code (ADR 0027, trust-by-default posture):
-        # installing IS the consent — the console flashes a one-time "this runs code"
-        # confirm for unofficial sources first. Add the plugin (or every bundle member)
-        # to plugins.enabled and hot-reload, so its tools / views / surfaces go live with
-        # NO separate enable step and NO restart (the router hot-mounts, #822). Opt out
-        # with PROTOAGENT_PLUGIN_INSTALL_NO_ENABLE=1 (back to strict install ≠ enable).
-        ids = _enabled_ids_from_summary(summary)
-        # Snapshot BEFORE the reload: which just-(re)installed plugins were already
-        # LIVE — a mounted router (mount registry; survives disable) or a loaded
-        # view/router/surface (meta). For those, the reload can't deliver the fresh
-        # routes: the re-registered router is dropped in favour of the mounted one
-        # (FastAPI can't swap in place), so the OLD code keeps serving (#942).
-        fresh = _installed_ids_from_summary(summary)
-        mounted = _mounted_router_ids()
-        prev_meta = {p.get("id"): p for p in (STATE.plugin_meta or [])}
-        stale_after_reload = [pid for pid in fresh if pid in mounted or _has_surface(prev_meta.get(pid))]
-        # Same parity for code the reload CAN swap: drop each re-installed plugin's
-        # module subtree so tools/middleware re-exec from the fresh checkout (the
-        # update route's multi-file fix; a first install is a no-op here).
-        for pid in fresh:
-            _purge_plugin_modules(pid)
-
-        enabled_now: list[str] = []
-        reloaded = False
-        enable_error: str | None = None
-        if ids and not _install_no_enable():
-            cfg = STATE.graph_config
-            enabled = list(getattr(cfg, "plugins_enabled", []) or [])
-            disabled = [p for p in (getattr(cfg, "plugins_disabled", []) or []) if p not in ids]
-            for pid in ids:
-                if pid not in enabled:
-                    enabled.append(pid)
-            from server.agent_init import _apply_settings_changes
-
-            config_updates: dict = {"plugins": {"enabled": enabled, "disabled": disabled}}
-            # Seed the bundle's recommended per-plugin config defaults (#1350) — same trust
-            # gate as auto-enable. Defaults only: reduce against the current YAML config so an
-            # operator value (or a key they've already set) is never clobbered.
-            bundle_config = summary.get("config") if "bundle" in summary else None
-            if bundle_config:
-                from graph.config_io import config_yaml_path, load_yaml_doc
-                from graph.plugins.installer import bundle_config_overlay
-
-                current = load_yaml_doc(config_yaml_path())
-                overlay = bundle_config_overlay(bundle_config, current if isinstance(current, dict) else {})
-                config_updates.update(overlay)
-
-            ok, messages = _apply_settings_changes(config=config_updates)
-            if ok:
-                reloaded, enabled_now = True, ids
-            else:
-                # The install itself succeeded (code is on disk + locked); surface the
-                # enable-reload failure without 500ing — it can be enabled manually.
-                enable_error = "; ".join(messages) or "reload failed"
-                log.warning("[plugins] installed %s but auto-enable reload failed: %s", ids, enable_error)
-
+        stale_after_reload = [
+            pid for pid in result.installed_ids if pid in mounted_before or _has_surface(prev_meta.get(pid))
+        ]
+        if result.enable_error:
+            log.warning("[plugins] installed but auto-enable reload failed: %s", result.enable_error)
         return {
-            "installed": summary,
-            "enabled": enabled_now,  # the ids now live
-            "reloaded": reloaded,
+            "installed": result.summary,
+            "enabled": result.enabled,  # the ids now live
+            "reloaded": result.reloaded,
             # A FIRST install hot-mounts fully live (#822); a force re-install over a
             # live router serves stale routes until restart (#942).
             "restart_recommended": bool(stale_after_reload),
-            "enable_error": enable_error,
+            "enable_error": result.enable_error,
         }
 
     @app.post("/api/plugins/{plugin_id}/enabled")

--- a/ops/plugins.py
+++ b/ops/plugins.py
@@ -1,0 +1,121 @@
+"""Plugin ops (ADR 0075 D2) — install a plugin AND activate it, as one op.
+
+`install_and_activate` is the ADR's flagship: it wraps `installer.install` **plus** the
+auto-enable + hot-reload dance that a CLI/MCP install couldn't do before (add to
+`plugins.enabled`, seed the bundle's config defaults, rebuild the running agent). One op,
+shared by the console route, a future `protoagent plugin install`, and the operator MCP.
+
+The terminal step — apply the config change + rebuild the live agent — is a **host
+capability** (`server.agent_init._apply_settings_changes`) that lives above this layer, so
+it's **injected** as `apply_settings`, keeping `ops` free of any `server` import. A live
+surface (REST) passes the real applier; a disk-only caller passes `None` (install to disk,
+no reload). Stale-router detection (does re-installing over a live mount need a restart?) is
+about the live HTTP app, so it stays in the REST adapter — computed there from the
+`installed_ids` this op returns.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Callable
+
+from ops import OpContext, op
+
+
+@dataclass
+class InstallResult:
+    summary: dict  # installer.install's summary (single plugin or bundle)
+    installed_ids: list[str]  # plugin ids whose CODE landed on disk this install
+    enabled: list[str]  # ids added to plugins.enabled + reloaded (empty when not activated)
+    reloaded: bool
+    enable_error: str | None = None
+
+
+def _enabled_ids_from_summary(summary: dict) -> list[str]:
+    """Plugin id(s) to enable: a single plugin → its id; a bundle → its declared ``enabled``
+    set (else every installed member)."""
+    if "bundle" in summary:
+        suggested = [str(x) for x in (summary.get("enabled") or [])]
+        members = [str(s["id"]) for s in (summary.get("installed") or []) if s.get("id")]
+        return suggested or members
+    pid = summary.get("id")
+    return [str(pid)] if pid else []
+
+
+def _installed_ids_from_summary(summary: dict) -> list[str]:
+    """Plugin id(s) whose CODE this install just placed on disk — for a bundle, its fetched
+    members only (``builtin`` members aren't fetched, so can't have been replaced live)."""
+    if "bundle" in summary:
+        return [str(s["id"]) for s in (summary.get("installed") or []) if s.get("id")]
+    pid = summary.get("id")
+    return [str(pid)] if pid else []
+
+
+@op(
+    name="plugins.install_and_activate",
+    mutates=True,
+    summary="Install a plugin from git and (by default) enable + hot-reload it.",
+)
+async def install_and_activate(
+    url: str,
+    ref: str | None = None,
+    *,
+    force: bool = False,
+    by: str = "ops",
+    allow: list[str] | None = None,
+    activate: bool = True,
+    ctx: OpContext,
+    apply_settings: Callable[[dict], tuple[bool, list]] | None = None,
+) -> InstallResult:
+    """Clone + pin the plugin (blocking git work off the event loop), then — when
+    ``activate`` and an ``apply_settings`` applier is given — add it to ``plugins.enabled``,
+    seed the bundle's config defaults, and apply (hot-reload). Raises
+    ``installer.InstallError`` on a failed install (the adapter maps it to its surface)."""
+    from graph.plugins import installer
+    from graph.plugins.loader import purge_plugin_modules
+
+    summary = await asyncio.to_thread(installer.install, url, ref, force=force, by=by, allow=allow)
+
+    installed_ids = _installed_ids_from_summary(summary)
+    # Drop each re-installed plugin's module subtree so the reload re-execs from the fresh
+    # checkout (a first install is a no-op here; matters on force re-install / update).
+    for pid in installed_ids:
+        purge_plugin_modules(pid)
+
+    ids = _enabled_ids_from_summary(summary)
+    if not (activate and ids and apply_settings):
+        return InstallResult(summary=summary, installed_ids=installed_ids, enabled=[], reloaded=False)
+
+    cfg = ctx.graph_config
+    enabled = list(getattr(cfg, "plugins_enabled", []) or [])
+    disabled = [p for p in (getattr(cfg, "plugins_disabled", []) or []) if p not in ids]
+    for pid in ids:
+        if pid not in enabled:
+            enabled.append(pid)
+    config_updates: dict = {"plugins": {"enabled": enabled, "disabled": disabled}}
+
+    # Seed the bundle's recommended per-plugin config defaults (#1350), same trust gate as
+    # auto-enable — defaults only, reduced against the live YAML so an operator value is
+    # never clobbered.
+    bundle_config = summary.get("config") if "bundle" in summary else None
+    if bundle_config:
+        from graph.config_io import config_yaml_path, load_yaml_doc
+        from graph.plugins.installer import bundle_config_overlay
+
+        current = load_yaml_doc(config_yaml_path())
+        overlay = bundle_config_overlay(bundle_config, current if isinstance(current, dict) else {})
+        config_updates.update(overlay)
+
+    ok, messages = apply_settings(config_updates)
+    if ok:
+        return InstallResult(summary=summary, installed_ids=installed_ids, enabled=ids, reloaded=True)
+    # The install itself succeeded (code on disk + locked); surface the enable-reload
+    # failure without failing the whole op — it can be enabled manually.
+    return InstallResult(
+        summary=summary,
+        installed_ids=installed_ids,
+        enabled=[],
+        reloaded=False,
+        enable_error="; ".join(messages) or "reload failed",
+    )

--- a/tests/test_ops_plugins.py
+++ b/tests/test_ops_plugins.py
@@ -1,0 +1,117 @@
+"""ops.plugins.install_and_activate (ADR 0075 D2) — install + auto-enable/hot-reload as one
+op the REST route, a future `protoagent plugin install`, and the operator MCP share.
+``installer.install`` and the live-agent apply are faked here (the real install is covered by
+test_plugin_installer_*); these test the op's orchestration + the injected-applier seam."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from graph.plugins import installer, loader
+from ops import OpContext, registry
+from ops.plugins import install_and_activate
+
+
+def _ctx(enabled=(), disabled=()):
+    cfg = types.SimpleNamespace(plugins_enabled=list(enabled), plugins_disabled=list(disabled))
+    return OpContext(knowledge_store=None, graph_config=cfg)
+
+
+def _capture_apply():
+    captured: dict = {}
+
+    def _apply(updates):
+        captured["updates"] = updates
+        return True, ["reloaded"]
+
+    return captured, _apply
+
+
+async def test_install_single_auto_enables_and_purges(monkeypatch):
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {"id": "demo"})
+    purged: list[str] = []
+    monkeypatch.setattr(loader, "purge_plugin_modules", lambda pid: purged.append(pid))
+    captured, apply = _capture_apply()
+
+    res = await install_and_activate("https://x", ctx=_ctx(enabled=["delegates"]), apply_settings=apply)
+    assert res.enabled == ["demo"] and res.reloaded is True and res.enable_error is None
+    assert res.installed_ids == ["demo"] and purged == ["demo"]  # re-exec-on-reload purge ran
+    assert set(captured["updates"]["plugins"]["enabled"]) == {"delegates", "demo"}
+
+
+async def test_install_bundle_enables_declared_members(monkeypatch):
+    monkeypatch.setattr(
+        installer,
+        "install",
+        lambda url, ref=None, **k: {"bundle": "s", "installed": [{"id": "a"}, {"id": "b"}], "enabled": ["a"]},
+    )
+    monkeypatch.setattr(loader, "purge_plugin_modules", lambda pid: None)
+    captured, apply = _capture_apply()
+
+    res = await install_and_activate("https://x", ctx=_ctx(), apply_settings=apply)
+    assert res.enabled == ["a"] and captured["updates"]["plugins"]["enabled"] == ["a"]
+    assert res.installed_ids == ["a", "b"]  # both members fetched to disk
+
+
+async def test_activate_false_installs_only(monkeypatch):
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {"id": "demo"})
+    monkeypatch.setattr(loader, "purge_plugin_modules", lambda pid: None)
+    captured, apply = _capture_apply()
+
+    res = await install_and_activate("https://x", activate=False, ctx=_ctx(), apply_settings=apply)
+    assert res.enabled == [] and res.reloaded is False and "updates" not in captured  # applier not called
+
+
+async def test_no_applier_installs_only(monkeypatch):
+    """A disk-only caller (a CLI with no running server) passes apply_settings=None."""
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {"id": "demo"})
+    monkeypatch.setattr(loader, "purge_plugin_modules", lambda pid: None)
+
+    res = await install_and_activate("https://x", ctx=_ctx(), apply_settings=None)
+    assert res.enabled == [] and res.reloaded is False and res.installed_ids == ["demo"]
+
+
+async def test_reload_failure_surfaces_enable_error(monkeypatch):
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {"id": "demo"})
+    monkeypatch.setattr(loader, "purge_plugin_modules", lambda pid: None)
+
+    res = await install_and_activate(
+        "https://x", ctx=_ctx(), apply_settings=lambda u: (False, ["graph compile failed"])
+    )
+    assert res.reloaded is False and res.enabled == [] and "graph compile failed" in res.enable_error
+
+
+async def test_bundle_config_overlay_seeds_only_unset(monkeypatch):
+    monkeypatch.setattr(
+        installer,
+        "install",
+        lambda url, ref=None, **k: {
+            "bundle": "s",
+            "installed": [{"id": "browser"}],
+            "enabled": ["browser"],
+            "config": {"browser": {"panel_mode": "full", "timeout": 30}},
+        },
+    )
+    monkeypatch.setattr(loader, "purge_plugin_modules", lambda pid: None)
+    import graph.config_io as cio
+
+    monkeypatch.setattr(cio, "load_yaml_doc", lambda p=None: {"browser": {"panel_mode": "compact"}})
+    captured, apply = _capture_apply()
+
+    await install_and_activate("https://x", ctx=_ctx(), apply_settings=apply)
+    assert captured["updates"]["browser"] == {"timeout": 30}  # operator's panel_mode not clobbered
+
+
+async def test_install_error_propagates(monkeypatch):
+    def _boom(url, ref=None, **k):
+        raise installer.InstallError("bad source")
+
+    monkeypatch.setattr(installer, "install", _boom)
+    with pytest.raises(installer.InstallError):
+        await install_and_activate("https://x", ctx=_ctx(), apply_settings=lambda u: (True, []))
+
+
+def test_op_registered_as_mutating():
+    assert registry()["plugins.install_and_activate"].mutates is True  # never in safe-operator


### PR DESCRIPTION
## What

The **second op** on the ADR 0075 D2 layer (after `knowledge.ingest` in #1826) — and its **flagship**: `ops.plugins.install_and_activate` installs a plugin **and activates it** (the auto-enable + hot-reload dance a CLI/MCP install couldn't do before: add to `plugins.enabled`, seed the bundle's config defaults, rebuild the running agent) as **one op** the console route, a future `protoagent plugin install`, and the operator MCP all share.

## The keystone this op solves

Most admin ops terminate in the same place: **apply a config change + rebuild the live agent** (`server.agent_init._apply_settings_changes`). But `ops/` must never import `server`. The fix is **dependency injection** — the op takes `apply_settings` as a parameter:

- The **REST adapter** passes the real applier (via its already-grandfathered `plugin_routes -> server.agent_init` import).
- A **disk-only caller** (a CLI with no running server — the ADR's open question) passes `None`: the op installs to disk and skips the reload.

`config.set` / `fleet.up` will reuse this exact seam, so solving it here unblocks them.

## Structure

- **`ops/plugins.py`** — `install_and_activate` (install → purge the re-installed module subtree → compute enabled/disabled + bundle-config overlay → injected apply) + `InstallResult`. Registered `mutates=True` → never admissible to the `safe-operator` profile.
- **`operator_api/plugin_routes.py`** — `_install` becomes the REST adapter. It snapshots the live app's mounted-router / surface state (a genuinely surface-specific concern — #942/#822) **before** the op, injects `_apply_settings_changes`, and derives `restart_recommended` from the op's `installed_ids`. The summary→id parsing moved into the op; the live-app helpers (`_has_surface` / `_mounted_router_ids`, shared by the enable + update routes) stay put.

## Tests
- The op directly: single + bundle enable, `activate=False` and no-applier (disk-only) paths, reload-failure `enable_error`, bundle-config overlay seeds only-unset keys, `InstallError` propagates, `mutates=True`.
- **All 22 existing** install / enable / update route tests pass **unchanged** — behavior-preserving on the live (security-sensitive) surface.

## Gates
- `ruff check .` ✅
- `lint-imports` ✅ 3/3 kept
- `pytest tests/` ✅ **3228 passed, 5 skipped**

No frontend changes (FE gates N/A). Same shape now applies to the remaining admin ops (`config.set`, `fleet.up/down`); the `safe-operator` profile and `GET /api/operations` catalog derive from the growing `@op` registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a streamlined plugin install flow that can install and activate plugins in one step.
  - Bundle installs now respect recommended enabled plugins and configuration defaults.

- **Bug Fixes**
  - Improved reload behavior after installs so updated plugin code is picked up reliably.
  - Preserves existing plugin settings when applying bundle defaults.
  - Reports activation/reload failures without losing the install result.

- **Tests**
  - Added coverage for install, activation, bundle handling, reload failure reporting, and install-only modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->