### PR TITLE
feat(ops): config + fleet ops — the remaining admin operations (ADR 0075 D2)

### DIFF
--- a/operator_api/config_routes.py
+++ b/operator_api/config_routes.py
@@ -272,11 +272,18 @@ def register_config_routes(app) -> None:
         ok, err = validate_flat(req.updates)
         if not ok:
             return {"ok": False, "messages": [f"validation: {err}"], "restart_required": []}
-        # Offload off the event loop (#497) — a model change recompiles the graph.
-        ok, messages = await asyncio.to_thread(
-            _apply_settings_changes, config=nest_updates(req.updates), layer=req.layer
+        # Validation + restart-key reporting are this surface's; the apply itself goes through
+        # the shared config.set op (ADR 0075 D2). The op offloads the graph recompile off the
+        # event loop (#497); the live applier is the same _apply_settings_changes as before.
+        from ops import OpContext
+        from ops.config import set_config
+
+        result = await set_config(
+            nest_updates(req.updates),
+            ctx=OpContext.from_state(),
+            apply_settings=lambda u: _apply_settings_changes(config=u, layer=req.layer),
         )
-        return {"ok": ok, "messages": messages, "restart_required": restart_keys(req.updates)}
+        return {"ok": result.ok, "messages": result.messages, "restart_required": restart_keys(req.updates)}
 
     @app.post("/api/settings/reset")
     async def _api_reset_settings(req: SettingsResetRequest):

--- a/ops/config.py
+++ b/ops/config.py
@@ -1,0 +1,76 @@
+"""Config ops (ADR 0075 D2) — read + set config over one op the REST settings route and the
+`protoagent config` CLI share.
+
+`set` applies a nested config-updates dict: **live** (a running server) → the injected
+`apply_settings` rebuilds the agent (`server.agent_init._apply_settings_changes`, the same
+call the settings route always made, offloaded off the event loop per #497); **disk-only**
+(a CLI with no server) → merge into config.yaml and save, so `protoagent config set` works
+headless. `get` reads the live config, or the on-disk doc when no agent is running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Callable
+
+from ops import OpContext, op
+
+
+@dataclass
+class ConfigSetResult:
+    ok: bool
+    messages: list[str]
+    reloaded: bool  # True when a live agent was rebuilt; False for a disk-only write
+
+
+@op(
+    name="config.set",
+    mutates=True,
+    summary="Apply config updates — hot-reload the live agent, or write config.yaml on disk.",
+)
+async def set_config(
+    updates: dict,
+    *,
+    ctx: OpContext | None = None,
+    apply_settings: Callable[[dict], tuple[bool, list]] | None = None,
+) -> ConfigSetResult:
+    """Apply ``updates`` (a nested config dict). With ``apply_settings`` (a live server),
+    rebuild the agent off the event loop; without it, write config.yaml on disk."""
+    if not updates:
+        return ConfigSetResult(ok=True, messages=["no changes"], reloaded=False)
+    if apply_settings is not None:
+        # Heavy — the reload recompiles the graph — so keep it off the event loop (#497).
+        ok, messages = await asyncio.to_thread(apply_settings, updates)
+        return ConfigSetResult(ok=bool(ok), messages=list(messages or []), reloaded=bool(ok))
+
+    # Disk-only (a headless CLI with no running server): merge into the YAML doc + save.
+    from graph.config_io import apply_updates_to_yaml, config_yaml_path, load_yaml_doc, save_yaml_doc
+
+    def _write() -> None:
+        path = config_yaml_path()
+        doc = load_yaml_doc(path)
+        doc = apply_updates_to_yaml(doc if isinstance(doc, dict) else {}, updates)
+        save_yaml_doc(doc, path)
+
+    await asyncio.to_thread(_write)
+    return ConfigSetResult(ok=True, messages=[f"wrote {', '.join(sorted(updates))} to config.yaml"], reloaded=False)
+
+
+@op(
+    name="config.get",
+    mutates=False,
+    summary="Read the live config (or the on-disk config.yaml when no agent is running).",
+)
+async def get_config(*, ctx: OpContext | None = None) -> dict:
+    """The effective config as a plain dict — the live ``graph_config`` when there's a
+    running agent, else the on-disk config.yaml."""
+    from graph.config_io import config_to_dict
+
+    cfg = ctx.graph_config if ctx else None
+    if cfg is not None:
+        return config_to_dict(cfg)
+    from graph.config_io import config_yaml_path, load_yaml_doc
+
+    doc = load_yaml_doc(config_yaml_path())
+    return doc if isinstance(doc, dict) else {}

--- a/ops/fleet.py
+++ b/ops/fleet.py
@@ -1,0 +1,35 @@
+"""Fleet ops (ADR 0075 D2) — start / stop / status the fleet member agents.
+
+Thin ops over ``graph.fleet.supervisor`` — already the neutral shared core the fleet CLI
+(`protoagent fleet …`) and the ``/api/fleet`` routes both project. They exist so fleet
+lifecycle is in the op registry too: enumerated by ``GET /api/operations``, callable over
+the operator MCP, each with the right read/write metadata (``up``/``down`` mutate; ``status``
+reads). The supervisor's calls are blocking (subprocess + file state), so run off the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from ops import op
+
+
+@op(name="fleet.up", mutates=True, summary="Start fleet member agents (named, or all workspaces) as background processes.")
+async def up(names: list[str] | None = None) -> list[dict]:
+    from graph.fleet import supervisor
+
+    return await asyncio.to_thread(supervisor.up, names)
+
+
+@op(name="fleet.down", mutates=True, summary="Stop fleet member agents (named, or all running).")
+async def down(names: list[str] | None = None) -> list[dict]:
+    from graph.fleet import supervisor
+
+    return await asyncio.to_thread(supervisor.down, names)
+
+
+@op(name="fleet.status", mutates=False, summary="List fleet members (host + workspaces + remotes) with live status.")
+async def status() -> list[dict]:
+    from graph.fleet import supervisor
+
+    return await asyncio.to_thread(supervisor.status)

--- a/tests/test_ops_config.py
+++ b/tests/test_ops_config.py
@@ -1,0 +1,66 @@
+"""ops.config (ADR 0075 D2) — read + set config over the op the settings route + CLI share."""
+
+from __future__ import annotations
+
+import types
+
+from ops import OpContext, registry
+from ops.config import get_config, set_config
+
+
+async def test_set_live_uses_injected_applier():
+    seen: dict = {}
+
+    def _apply(updates):
+        seen["updates"] = updates
+        return True, ["reloaded"]
+
+    res = await set_config({"model": {"name": "x"}}, apply_settings=_apply)
+    assert res.ok is True and res.reloaded is True and res.messages == ["reloaded"]
+    assert seen["updates"] == {"model": {"name": "x"}}
+
+
+async def test_set_live_failure_surfaces_messages():
+    res = await set_config({"a": 1}, apply_settings=lambda u: (False, ["compile failed"]))
+    assert res.ok is False and res.reloaded is False and "compile failed" in res.messages
+
+
+async def test_set_empty_is_noop():
+    res = await set_config({}, apply_settings=lambda u: (True, ["x"]))
+    assert res.ok is True and res.reloaded is False and res.messages == ["no changes"]
+
+
+async def test_set_disk_only_writes_yaml(monkeypatch):
+    import graph.config_io as cio
+
+    captured: dict = {}
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: "cfg.yaml")
+    monkeypatch.setattr(cio, "load_yaml_doc", lambda p=None: {"a": 1})
+    monkeypatch.setattr(cio, "apply_updates_to_yaml", lambda doc, updates: {**doc, **updates})
+    monkeypatch.setattr(cio, "save_yaml_doc", lambda doc, p=None: captured.update(doc=doc))
+
+    res = await set_config({"b": 2}, apply_settings=None)  # no applier → disk-only
+    assert res.ok is True and res.reloaded is False
+    assert captured["doc"] == {"a": 1, "b": 2}
+
+
+async def test_get_live_config(monkeypatch):
+    import graph.config_io as cio
+
+    monkeypatch.setattr(cio, "config_to_dict", lambda cfg: {"live": True})
+    ctx = OpContext(knowledge_store=None, graph_config=types.SimpleNamespace())
+    assert await get_config(ctx=ctx) == {"live": True}
+
+
+async def test_get_disk_config_when_no_agent(monkeypatch):
+    import graph.config_io as cio
+
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: "cfg.yaml")
+    monkeypatch.setattr(cio, "load_yaml_doc", lambda p=None: {"disk": 1})
+    assert await get_config(ctx=None) == {"disk": 1}
+
+
+def test_config_ops_registered_with_metadata():
+    reg = registry()
+    assert reg["config.set"].mutates is True  # full-profile only
+    assert reg["config.get"].mutates is False  # read-only admissible

--- a/tests/test_ops_fleet.py
+++ b/tests/test_ops_fleet.py
@@ -1,0 +1,30 @@
+"""ops.fleet (ADR 0075 D2) — start/stop/status wrap graph.fleet.supervisor with op metadata."""
+
+from __future__ import annotations
+
+from graph.fleet import supervisor
+from ops import registry
+from ops.fleet import down, status, up
+
+
+async def test_up_wraps_supervisor(monkeypatch):
+    seen: dict = {}
+    monkeypatch.setattr(supervisor, "up", lambda names=None: (seen.update(names=names) or [{"name": "a", "started": True}]))
+    rows = await up(["a"])
+    assert rows == [{"name": "a", "started": True}] and seen["names"] == ["a"]
+
+
+async def test_down_wraps_supervisor(monkeypatch):
+    monkeypatch.setattr(supervisor, "down", lambda names=None: [{"name": "a", "stopped": True}])
+    assert await down() == [{"name": "a", "stopped": True}]
+
+
+async def test_status_wraps_supervisor(monkeypatch):
+    monkeypatch.setattr(supervisor, "status", lambda: [{"name": "host", "running": True}])
+    assert await status() == [{"name": "host", "running": True}]
+
+
+def test_fleet_ops_registered_with_metadata():
+    reg = registry()
+    assert reg["fleet.up"].mutates is True and reg["fleet.down"].mutates is True
+    assert reg["fleet.status"].mutates is False  # read-only admissible


### PR DESCRIPTION
## What

Lands the last two ADR-named admin ops onto the layer. All four now live in the `@op` registry: `knowledge.ingest`, `plugins.install_and_activate`, **`config.set`**, **`fleet.up/down`**.

## `ops.config` — set / get

- **`config.set`** (mutates) reuses #1827's **injected-applier** seam: **live** (a running server) rebuilds the agent via the injected `_apply_settings_changes`, offloaded off the event loop (#497); **disk-only** (a headless CLI with no server) merges into `config.yaml` and saves — so `protoagent config set` will work headless.
- **`config.get`** (read) — the live config, or the on-disk doc when no agent is running.
- The `/api/settings` route now applies **through `config.set`** (validation + restart-key reporting stay in the route, as surface concerns). The config**+soul** reload route (`POST /api/config`) is deliberately left alone — it legitimately does more than a pure config-set.

## `ops.fleet` — up / down / status

Thin ops over `graph.fleet.supervisor` (already the neutral core the fleet CLI and `/api/fleet` routes both project), run off the loop. They exist so fleet lifecycle is enumerated by the coming operations catalog and MCP-callable with the right metadata (`up`/`down` mutate; `status` reads).

## Tests
- Both ops directly: live-applier + disk-only config paths, `config.get` live vs on-disk, supervisor wrapping, registry read/write metadata.
- Config/settings route + cascade tests pass **unchanged**.

## Gates
- `ruff check .` ✅
- `lint-imports` ✅ 3/3 kept
- `pytest tests/` ✅ **3239 passed, 5 skipped**

Next (PR B): the eager-import registrar + `GET /api/operations` catalog + the `protoagent` CLI verbs over these ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API support to view and update settings with live updates or disk-only saves.
  * Added fleet controls to start, stop, and check the status of fleet members.

* **Bug Fixes**
  * Settings updates now return clearer success, message, and reload information.
  * Empty settings updates are handled as a no-op instead of causing unnecessary work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->