### PR TITLE
fix(fleet): don't run autostart inside a member (spurious "no workspace" warning)

### DIFF
--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -755,6 +755,13 @@ def start_autostart_members() -> list[str]:
     Members are started sequentially (each ``start`` briefly boot-watches the child); call
     off the event loop (the boot hook does via ``asyncio.to_thread``).
     """
+    # Hub-only — enforced, not merely "by construction". A member inherits the hub's
+    # PROTOAGENT_FLEET_AUTOSTART env, so autostart_members() returns a NON-empty roster
+    # inside a member too (the config-carries-no-roster guarantee only covers the config
+    # source, not the env fallback). Acting on it there scans the member's own empty
+    # workspaces root and logs a spurious "no workspace <id> — skipping" for every id.
+    if manager.is_workspace_member():
+        return []
     roster = autostart_members()
     if not roster:
         return []

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -562,6 +562,18 @@ def test_start_autostart_no_roster_is_noop(fleet, monkeypatch):
     assert supervisor.start_autostart_members() == []
 
 
+def test_start_autostart_is_hub_only_even_with_inherited_env(fleet, monkeypatch):
+    # A member inherits the hub's PROTOAGENT_FLEET_AUTOSTART, so the roster is non-empty
+    # inside a member too. Acting on it would scan the member's own (empty) workspaces root
+    # and warn "no workspace <id> — skipping" for every id. It must bail before that.
+    manager.create("cindi", port=7891)
+    monkeypatch.setattr(supervisor, "autostart_members", lambda: ["cindi", "matt"])
+    monkeypatch.setattr(supervisor.manager, "is_workspace_member", lambda: True)
+
+    assert supervisor.start_autostart_members() == []
+    assert not supervisor.is_running("cindi")  # nothing spawned inside a member
+
+
 def test_reconcile_on_boot_stamps_and_returns_previous(tmp_path, monkeypatch):
     import infra.paths as paths_mod
 


### PR DESCRIPTION
## Problem
On every boot, fleet **members** log:
```
[fleet] autostart: no workspace 'matt-7689' — skipping (create it first)
```
for every id in the roster — even though the fleet is healthy and those members are running. Confusing and noisy.

## Root cause
`start_autostart_members()` is meant to be hub-only. The guarantee was *"by construction"*: a member runs `PROTOAGENT_INSTANCE`-scoped, so its own **config** carries no autostart roster → no-op.

But that only covers the **config** source. `autostart_members()` falls back to the `PROTOAGENT_FLEET_AUTOSTART` **env**, and a member inherits that env from the hub that spawned it. So inside a member the roster is non-empty, and the loop scans the member's *own* (empty) workspaces root (`<member>/workspaces`) → `_find` returns `None` → the spurious warning, once per id.

Verified live: a member's env carries `PROTOAGENT_FLEET_AUTOSTART=cindy-0ccd,matt-7689`, its `workspaces_root()` is its own empty dir, and `is_workspace_member()` is `True`.

## Fix
Enforce hub-only rather than assume it: bail when `manager.is_workspace_member()` — the same guard `shutdown_all` already uses. `reconcile_on_boot` is unaffected (it self-scopes harmlessly).

## Test
`test_start_autostart_is_hub_only_even_with_inherited_env` — a non-empty roster + `is_workspace_member()=True` returns `[]` and spawns nothing. Full autostart/reconcile suite green (6 passed).