### PR TITLE
feat(ops+cli): operations catalog + protoagent CLI verbs over the ops (ADR 0075 D2)

### DIFF
--- a/docs/reference/operator-api.md
+++ b/docs/reference/operator-api.md
@@ -109,6 +109,7 @@ record.
 | POST | `/api/config/models` · `/api/config/test-model` | List gateway models / test the connection |
 | GET | `/api/settings/schema` | Settings UI schema |
 | POST | `/api/settings` · `/api/settings/reset` | Apply / reset settings |
+| GET | `/api/operations` | The ops-layer catalog — every operation (name, read/write, summary); mirrors `protoagent operations` (ADR 0075 D2) |
 
 ## Fleet & agents
 

--- a/graph/config_explain.py
+++ b/graph/config_explain.py
@@ -120,15 +120,38 @@ def render_config_explain(data: dict) -> str:
     return "\n".join(lines)
 
 
-def run_config_cli(argv: list[str]) -> int:
-    """``python -m server config <action>`` dispatch. Today the one action is
-    ``explain`` (read-only); ``--json`` emits the raw payload for scripting."""
-    import argparse
+def _parse_set_pairs(pairs: list[str]) -> dict:
+    """``["a.b=1", "x=true"]`` → a flat dotted map with JSON-typed values (so ``8080``/
+    ``true`` become an int/bool; a bare word stays a string). ``nest_updates`` then nests it."""
     import json
 
+    flat: dict = {}
+    for p in pairs:
+        if "=" not in p:
+            raise ValueError(f"expected key=value, got {p!r}")
+        key, val = p.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"empty key in {p!r}")
+        try:
+            flat[key] = json.loads(val)
+        except ValueError:
+            flat[key] = val  # a bare string
+    return flat
+
+
+def run_config_cli(argv: list[str]) -> int:
+    """``protoagent config <action>`` dispatch: ``explain`` (read-only diagnostic),
+    ``get`` (print config.yaml), ``set key=value …`` (write config.yaml on disk, via the
+    shared ``ops.config.set`` op). ``--json`` on explain/get emits the raw payload."""
+    import argparse
+    import asyncio
+    import json
+    import sys
+
     parser = argparse.ArgumentParser(
-        prog="python -m server config",
-        description="Inspect this instance's config resolution (read-only diagnostic).",
+        prog="protoagent config",
+        description="Inspect and edit this instance's config.",
     )
     sub = parser.add_subparsers(dest="action", required=True)
     ep = sub.add_parser(
@@ -136,13 +159,43 @@ def run_config_cli(argv: list[str]) -> int:
         help="print this instance's identity, roots, every resolved path, and per-field cascade provenance",
     )
     ep.add_argument("--json", action="store_true", help="emit the raw payload as JSON instead of the human table")
+    gp = sub.add_parser("get", help="print the on-disk config.yaml")
+    gp.add_argument("--json", action="store_true", help="emit JSON instead of YAML")
+    sp = sub.add_parser("set", help="write config keys to config.yaml on disk (dotted key=value, JSON-typed)")
+    sp.add_argument("pairs", nargs="+", metavar="key=value", help="e.g. fleet.mdns.enabled=false server.port=7871")
     args = parser.parse_args(argv)
 
     if args.action == "explain":
         data = build_config_explain()
-        if args.json:
-            print(json.dumps(data, indent=2))
-        else:
-            print(render_config_explain(data))
+        print(json.dumps(data, indent=2) if args.json else render_config_explain(data))
         return 0
+
+    if args.action == "get":
+        from ops.config import get_config
+
+        cfg = asyncio.run(get_config(ctx=None))  # ctx=None ⇒ read the on-disk doc
+        if args.json:
+            print(json.dumps(cfg, indent=2))
+        else:
+            import yaml
+
+            print(yaml.safe_dump(cfg, sort_keys=False).rstrip())
+        return 0
+
+    if args.action == "set":
+        from graph.settings_schema import nest_updates
+        from ops.config import set_config
+
+        try:
+            flat = _parse_set_pairs(args.pairs)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        result = asyncio.run(set_config(nest_updates(flat), apply_settings=None))  # disk-only
+        for m in result.messages:
+            print(m)
+        if not result.reloaded:
+            print("(written to disk — restart / reload a running server to apply)", file=sys.stderr)
+        return 0 if result.ok else 1
+
     return 2  # unreachable: argparse rejects an unknown action first

--- a/operator_api/operations_routes.py
+++ b/operator_api/operations_routes.py
@@ -1,0 +1,26 @@
+"""Operations catalog route (ADR 0075 D2) — ``GET /api/operations``.
+
+Enumerates every op on the shared ``ops/`` layer (name, whether it mutates state, a one-line
+summary) — "one operation, three projections" made introspectable, and the source the CLI
+help + the safe-operator MCP profile derive from rather than hand-maintaining. Read-only,
+behind the standard operator-API auth gate; derived from ``ops.registry()`` via ``load_all``
+so it reflects every op module, not just the ones some surface happened to import.
+"""
+
+from __future__ import annotations
+
+
+def register_operations_routes(app) -> None:
+    """Register ``GET /api/operations``."""
+
+    @app.get("/api/operations")
+    async def _api_operations():
+        from ops import load_all
+
+        specs = load_all()
+        return {
+            "operations": [
+                {"name": s.name, "mutates": s.mutates, "summary": s.summary}
+                for s in sorted(specs.values(), key=lambda s: s.name)
+            ]
+        }

--- a/ops/__init__.py
+++ b/ops/__init__.py
@@ -77,3 +77,21 @@ def op(*, name: str, mutates: bool, summary: str) -> Callable:
 def registry() -> dict[str, OpSpec]:
     """A copy of the registered ops, keyed by name — the source for the catalog + profile."""
     return dict(_REGISTRY)
+
+
+# Every op module — importing one runs its `@op` decorators, which is what populates the
+# registry. They're imported lazily elsewhere (a tool / route pulls in just the module it
+# needs), so nothing guarantees the WHOLE registry is loaded. `load_all()` forces it, for the
+# `GET /api/operations` catalog + `protoagent operations` + the safe-operator profile, which
+# must see every op, not just the ones some surface happened to import.
+_OP_MODULES = ("ops.knowledge", "ops.plugins", "ops.config", "ops.fleet")
+
+
+def load_all() -> dict[str, OpSpec]:
+    """Import every op module so the registry is complete, then return it. Idempotent — a
+    re-import is a cheap no-op. Call before reading :func:`registry` for a full enumeration."""
+    import importlib
+
+    for mod in _OP_MODULES:
+        importlib.import_module(mod)
+    return registry()

--- a/ops/cli.py
+++ b/ops/cli.py
@@ -1,0 +1,33 @@
+"""``protoagent operations`` — list the operations on the shared ops layer (ADR 0075 D2).
+
+The CLI projection of the operations catalog (the same registry `GET /api/operations` serves),
+so an operator can see every op — name, read/write, one-liner — from the terminal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def run_operations_cli(argv: list[str]) -> int:
+    from ops import load_all
+
+    parser = argparse.ArgumentParser(
+        prog="protoagent operations", description="List the operations on the ops layer (ADR 0075 D2)."
+    )
+    parser.add_argument("--json", action="store_true", help="emit the raw catalog for scripting")
+    args = parser.parse_args(argv)
+
+    specs = sorted(load_all().values(), key=lambda s: s.name)
+    if args.json:
+        print(json.dumps([{"name": s.name, "mutates": s.mutates, "summary": s.summary} for s in specs], indent=2))
+        return 0
+    if not specs:
+        print("no operations registered")
+        return 0
+    width = max(len(s.name) for s in specs)
+    for s in specs:
+        tag = "write" if s.mutates else "read "
+        print(f"  [{tag}] {s.name:<{width}}  {s.summary}")
+    return 0

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -756,6 +756,11 @@ def _main():
     # (ADR 0023 phase 3).
     register_config_routes(fastapi_app)
 
+    # GET /api/operations — the ops-layer catalog (ADR 0075 D2), derived from ops.registry().
+    from operator_api.operations_routes import register_operations_routes
+
+    register_operations_routes(fastapi_app)
+
     # OpenAI-compatible /v1/chat/completions + /v1/models are registered above
     # by register_chat_routes (operator_api/chat_routes.py, ADR 0023 phase 3).
 

--- a/server/cli.py
+++ b/server/cli.py
@@ -39,6 +39,7 @@ _FORWARD: dict[str, tuple[str, str]] = {
     "fleet": ("graph.fleet.cli", "run_fleet_cli"),
     "config": ("graph.config_explain", "run_config_cli"),
     "model": ("graph.model_cli", "run_model_cli"),
+    "operations": ("ops.cli", "run_operations_cli"),
 }
 
 _FORWARD_HELP = {
@@ -46,8 +47,9 @@ _FORWARD_HELP = {
     "workspace": "Create / list / run / remove isolated workspace agents (ADR 0041)",
     "skills": "Inspect and curate the SKILL.md library (ADR 0041)",
     "fleet": "Start / stop / list fleet MEMBER agents as background processes (ADR 0042)",
-    "config": "Explain this instance's identity, paths, and config cascade (ADR 0047)",
+    "config": "Explain / get / set this instance's config (ADR 0047)",
     "model": "Point at a local / OpenAI-compatible LLM — Ollama, LM Studio, llama.cpp, vLLM (ADR 0075)",
+    "operations": "List the operations on the ops layer — name, read/write, summary (ADR 0075)",
 }
 
 _LIFECYCLE_HELP = {

--- a/tests/test_ops_catalog.py
+++ b/tests/test_ops_catalog.py
@@ -1,0 +1,82 @@
+"""ops catalog (ADR 0075 D2) — load_all + GET /api/operations + the operations/config CLI."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_load_all_registers_every_op_family():
+    from ops import load_all
+
+    names = set(load_all())
+    assert {
+        "knowledge.ingest",
+        "knowledge.ingest_preview",
+        "plugins.install_and_activate",
+        "config.set",
+        "config.get",
+        "fleet.up",
+        "fleet.down",
+        "fleet.status",
+    } <= names
+
+
+def test_operations_route_lists_sorted_catalog():
+    from operator_api.operations_routes import register_operations_routes
+
+    app = FastAPI()
+    register_operations_routes(app)
+    body = TestClient(app).get("/api/operations").json()
+    by_name = {o["name"]: o for o in body["operations"]}
+    assert by_name["config.set"]["mutates"] is True
+    assert by_name["config.get"]["mutates"] is False and by_name["fleet.status"]["mutates"] is False
+    assert by_name["knowledge.ingest"]["summary"]
+    names = [o["name"] for o in body["operations"]]
+    assert names == sorted(names)
+
+
+def test_operations_cli_prints_catalog(capsys):
+    from ops.cli import run_operations_cli
+
+    assert run_operations_cli([]) == 0
+    out = capsys.readouterr().out
+    assert "config.set" in out and "fleet.status" in out
+
+    assert run_operations_cli(["--json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert any(o["name"] == "plugins.install_and_activate" for o in data)
+
+
+def test_config_cli_set_writes_disk(monkeypatch, capsys):
+    import graph.config_io as cio
+    from graph.config_explain import run_config_cli
+
+    captured: dict = {}
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: "cfg.yaml")
+    monkeypatch.setattr(cio, "load_yaml_doc", lambda p=None: {})
+    monkeypatch.setattr(cio, "apply_updates_to_yaml", lambda doc, updates: {**doc, **updates})
+    monkeypatch.setattr(cio, "save_yaml_doc", lambda doc, p=None: captured.update(doc=doc))
+
+    assert run_config_cli(["set", "fleet.mdns_enabled=false", "server.port=7871"]) == 0
+    assert captured["doc"]["fleet"]["mdns_enabled"] is False  # JSON-typed + nested
+    assert captured["doc"]["server"]["port"] == 7871
+
+
+def test_config_cli_get_reads_disk(monkeypatch, capsys):
+    import graph.config_io as cio
+    from graph.config_explain import run_config_cli
+
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: "cfg.yaml")
+    monkeypatch.setattr(cio, "load_yaml_doc", lambda p=None: {"server": {"port": 7870}})
+    assert run_config_cli(["get", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out) == {"server": {"port": 7870}}
+
+
+def test_config_cli_set_rejects_bad_pair(capsys):
+    from graph.config_explain import run_config_cli
+
+    assert run_config_cli(["set", "noequalssign"]) == 2
+    assert "expected key=value" in capsys.readouterr().err


### PR DESCRIPTION
## What

The **third projection** of the ops layer — introspection + the terminal. Makes "one operation, three projections" both **visible** (`GET /api/operations`) and **drivable from the CLI**.

- **`ops.load_all()`** — force-import every op module so `registry()` is complete. Ops are otherwise imported lazily by whichever surface needs one, so nothing guaranteed the whole set was registered; the catalog and the (future) `safe-operator` profile need all of it.
- **`GET /api/operations`** (`operator_api/operations_routes.py`) — the catalog: `{name, mutates, summary}` per op, derived from `registry()`, behind the standard auth gate. Wired into the server boot.
- **`protoagent operations`** (`ops/cli.py`) — the CLI projection of the same catalog (read/write tag + one-liner; `--json` for scripting).
- **`protoagent config get` / `config set key=value …`** — the `config` verb was explain-only; now it reads `config.yaml` and writes it on disk via `ops.config.set` (JSON-typed values, dotted keys nested). Disk-op, so it works headless.

## Verified end-to-end
```
$ protoagent operations
  [read ] config.get                   Read the live config …
  [write] config.set                   Apply config updates …
  [write] fleet.up                     Start fleet member agents …
  [write] knowledge.ingest             Extract a URL / file / text …
  [write] plugins.install_and_activate Install a plugin from git …
$ protoagent config get --json   # → the live config.yaml as JSON
```

## Deferred (noted, not silently dropped)
A headless **`protoagent knowledge ingest`** verb needs a standalone knowledge-store build (embeddings/backends live in `server.agent_init`) **and** would resolve the ADR's open *CLI disk-ops vs live-ops* question — better decided explicitly than smuggled in. `config set` is the clean disk-op; ingest is the live-op case that wants a design call.

## Tests / docs
- `load_all` covers every op family; the `/api/operations` route (sorted + metadata); the `operations` + `config get/set` CLI verbs (incl. bad-pair rejection).
- `docs/reference/operator-api.md`: the `/api/operations` row.

## Gates
- `ruff check .` ✅
- `lint-imports` ✅ 3/3 kept
- `pytest tests/` ✅ **3245 passed, 5 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)