### PR TITLE
feat(cli): protoagent knowledge ingest — the third projection of knowledge.ingest (ADR 0075 D2)

### DIFF
--- a/server/cli.py
+++ b/server/cli.py
@@ -40,6 +40,8 @@ _FORWARD: dict[str, tuple[str, str]] = {
     "config": ("graph.config_explain", "run_config_cli"),
     "model": ("graph.model_cli", "run_model_cli"),
     "operations": ("ops.cli", "run_operations_cli"),
+    # `knowledge` lives in server/ (not graph/**) — it boots the instance's stores standalone.
+    "knowledge": ("server.knowledge_cli", "run_knowledge_cli"),
 }
 
 _FORWARD_HELP = {
@@ -50,6 +52,7 @@ _FORWARD_HELP = {
     "config": "Explain / get / set this instance's config (ADR 0047)",
     "model": "Point at a local / OpenAI-compatible LLM — Ollama, LM Studio, llama.cpp, vLLM (ADR 0075)",
     "operations": "List the operations on the ops layer — name, read/write, summary (ADR 0075)",
+    "knowledge": "Ingest a URL / file into this instance's knowledge base (ADR 0075)",
 }
 
 _LIFECYCLE_HELP = {

--- a/server/knowledge_cli.py
+++ b/server/knowledge_cli.py
@@ -1,0 +1,57 @@
+"""``protoagent knowledge ingest <source>`` — ingest a URL / file into this instance's
+knowledge base from the terminal (ADR 0075 D2).
+
+The CLI projection of the ``knowledge_ingest`` agent tool + the ``/api/knowledge/ingest``
+route: all three now run the one shared ``ops.knowledge.ingest`` op. This verb lives in
+``server/`` (not a ``graph/**/cli.py`` forward) because it needs to boot the instance's
+stores standalone — it reuses the operator-MCP sidecar's ``_boot_stores_only`` (which also
+applies any plugin knowledge backend, so the CLI writes to the SAME store the running
+instance uses; WAL makes it safe against a live server). Ingest runs inline here — a big
+URL/media source blocks the command until it's indexed (there's no background loop in a
+one-shot CLI process).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+
+def run_knowledge_cli(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="protoagent knowledge", description="Ingest sources into this instance's knowledge base (ADR 0075)."
+    )
+    sub = parser.add_subparsers(dest="action", required=True)
+    ip = sub.add_parser("ingest", help="fetch/extract a URL or local file and index it")
+    ip.add_argument("source", help="an http(s) URL or a local file path")
+    ip.add_argument("--domain", default="general", help="knowledge bucket to file it under (default: general)")
+    ip.add_argument("--title", default=None, help="optional heading (else the source's own title)")
+    args = parser.parse_args(argv)
+
+    if args.action == "ingest":
+        return _ingest(args.source, args.domain, args.title)
+    return 2  # unreachable: argparse rejects an unknown action first
+
+
+def _ingest(source: str, domain: str, title: str | None) -> int:
+    from graph.config import LangGraphConfig
+    from graph.config_io import config_yaml_path
+    from ops import OpContext
+    from ops.knowledge import IngestError, IngestSource, ingest
+    from server.operator_mcp import _boot_stores_only
+
+    config = LangGraphConfig.from_yaml(config_yaml_path())
+    _boot_stores_only(config)  # build just the stores (+ plugin knowledge backend), no graph/loops
+
+    src = source.strip()
+    is_url = src.lower().startswith(("http://", "https://"))
+    ingest_source = IngestSource.from_url(src) if is_url else IngestSource.from_path(src)
+    try:
+        result = asyncio.run(ingest(ingest_source, domain=domain, title=title, ctx=OpContext.from_state()))
+    except IngestError as exc:
+        print(f"error: {exc.detail}", file=sys.stderr)
+        return 1
+    label = result.title or result.source
+    print(f"ingested {label!r} ({result.source_type}, {result.chars} chars) → {result.chunks} chunk(s) in {domain!r}")
+    return 0

--- a/tests/test_knowledge_cli.py
+++ b/tests/test_knowledge_cli.py
@@ -1,0 +1,61 @@
+"""protoagent knowledge ingest (ADR 0075 D2) — the CLI projection of ops.knowledge.ingest.
+The store boot + the op are faked (covered elsewhere); this tests the CLI wiring."""
+
+from __future__ import annotations
+
+
+def _patch(monkeypatch, ingest_fn):
+    import graph.config as gc
+    import graph.config_io as cio
+    import ops.knowledge as opk
+    import server.operator_mcp as omcp
+
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: "cfg.yaml")
+    monkeypatch.setattr(gc.LangGraphConfig, "from_yaml", classmethod(lambda cls, p: gc.LangGraphConfig()))
+    monkeypatch.setattr(omcp, "_boot_stores_only", lambda config: None)
+    monkeypatch.setattr(opk, "ingest", ingest_fn)
+
+
+def test_knowledge_ingest_url(monkeypatch, capsys):
+    from ops.knowledge import IngestResult, IngestSource
+    from server.knowledge_cli import run_knowledge_cli
+
+    seen: dict = {}
+
+    async def _fake(src, *, domain, title, ctx):
+        seen.update(src=src, domain=domain, title=title)
+        return IngestResult(ids=[1, 2], chunks=2, chars=120, title="Doc", source_type="html", source="https://x")
+
+    _patch(monkeypatch, _fake)
+    assert run_knowledge_cli(["ingest", "https://x/post", "--domain", "research"]) == 0
+    out = capsys.readouterr().out
+    assert "2 chunk(s)" in out and "research" in out and "Doc" in out
+    assert isinstance(seen["src"], IngestSource) and seen["src"].url == "https://x/post"
+    assert seen["domain"] == "research"
+
+
+def test_knowledge_ingest_file_path_uses_from_path(monkeypatch, capsys):
+    from ops.knowledge import IngestResult
+    from server.knowledge_cli import run_knowledge_cli
+
+    seen: dict = {}
+
+    async def _fake(src, *, domain, title, ctx):
+        seen["src"] = src
+        return IngestResult(ids=[1], chunks=1, chars=10, title=None, source_type="text", source="/tmp/a.txt")
+
+    _patch(monkeypatch, _fake)
+    assert run_knowledge_cli(["ingest", "/tmp/a.txt"]) == 0
+    assert seen["src"].path == "/tmp/a.txt" and seen["src"].url is None  # non-URL → from_path
+
+
+def test_knowledge_ingest_error_returns_1(monkeypatch, capsys):
+    from ops.knowledge import IngestError
+    from server.knowledge_cli import run_knowledge_cli
+
+    async def _fake(src, *, domain, title, ctx):
+        raise IngestError("No such file: x", kind="not_found")
+
+    _patch(monkeypatch, _fake)
+    assert run_knowledge_cli(["ingest", "/no/such"]) == 1
+    assert "No such file" in capsys.readouterr().err


### PR DESCRIPTION
## What

`protoagent knowledge ingest <source>` — ingest a URL / file into this instance's knowledge base from the terminal. This **completes "one operation, three projections" for `knowledge.ingest`**: the agent tool, the `/api/knowledge/ingest` route, and now the CLI all run the one shared `ops.knowledge.ingest` op.

## How

- **`server/knowledge_cli.py`** — parses `ingest <source> [--domain] [--title]`, boots the instance's stores standalone (reusing the operator-MCP sidecar's `_boot_stores_only`, which also applies any **plugin knowledge backend** — so the CLI writes to the *same* store the running instance uses; WAL keeps it safe against a live server), then runs the op inline.
- It lives in `server/` (not a `graph/**/cli.py` forward) precisely because it needs that server-level store boot — the one op whose CLI projection can't be pure disk-ops. `server/cli.py` registers the `knowledge` verb.

```
$ protoagent knowledge ingest https://example.com/post --domain research
ingested 'An Article' (html, 4213 chars) → 6 chunk(s) in 'research'
```

Ingest runs **inline** (a big URL/media source blocks the command until it's indexed — there's no background loop in a one-shot CLI process).

## Tests
- The CLI wiring (boot + op faked): URL vs path source split, the success line, `IngestError` → exit 1. Smoke: `protoagent knowledge ingest --help` dispatches.

## Gates
- `ruff check .` ✅
- `lint-imports` ✅ 3/3 kept
- `pytest tests/` ✅ **3248 passed, 5 skipped**

With this, all four ADR-named ops and all their sensible CLI/REST/MCP projections are done. The remaining ADR-0075 item — the `safe-operator` MCP profile — is distinct MCP-profile wiring (exposing admin ops as MCP tools + the ADR-0071 consent gate), left as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)