### PR TITLE
docs: changelog + ADR status + CLI guide for the ops layer (ADR 0075 D2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The operator MCP server can now take a curated **`operator_mcp.profile`** instead of enumerating
   tools: `read-only` (reads/queries only), `full` (everything), or unset (deny-by-default, unchanged).
   A profile unions with any explicitly-named `tools`. **`PROTOAGENT_MCP_TRUST=full`** forces full for a
-  trusted/headless box. (The middle `safe-operator` tier lands with the ops layer, ADR 0075 D2.)
+  trusted/headless box. (The ops layer has since landed; the middle `safe-operator` tier still needs
+  the admin ops exposed as MCP-callable tools first — a follow-up.)
 - **A first-class `protoagent` command — the terminal control plane (ADR 0075, slice 1).**
   `python -m server <sub>` was the only way to install/manage a runtime, and its subcommands
   were hidden `if sys.argv[1] == …` branches invisible to `--help`. There's now an installable
@@ -46,6 +47,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   · `IconButton`/`Link`/`Dot`/`Spinner`/`Skeleton` (type + primitives). Each is a thin, correct
   className contract over the DS classes the theme already ships — so prototypes match the live theme
   without hand-rolled markup. The `rendering-artifacts` skill + README list the full set.
+- **The shared `ops/` layer — one operation, three projections (ADR 0075, slice 2).** The admin
+  operations were each re-implemented per surface: `knowledge_ingest` had its extract→store glue
+  duplicated across the agent tool and the `/api/knowledge/ingest` route; the plugin-install
+  auto-enable/hot-reload dance was REST-only, so a CLI or MCP install couldn't run it. There's now
+  an **`ops/`** package — one function per operation (`knowledge.ingest` · `plugins.install_and_activate`
+  · `config.set`/`get` · `fleet.up`/`down`/`status`), each registered with read/write metadata, that
+  the agent tool, the REST route, and the CLI all call. New surfaces on top of it: **`GET /api/operations`**
+  (the catalog — every op, its read/write bit, a one-liner) and **`protoagent` CLI verbs** —
+  `operations` (list the catalog), `config get` / `config set key=value` (edit `config.yaml` headless,
+  JSON-typed dotted keys), and `knowledge ingest <url|file>` (ingest from the terminal). The terminal
+  "apply config + rebuild the live agent" step is injected, so an op never imports the server and a
+  headless CLI can run it disk-only. `ops/` is a neutral infra package the import contracts enforce.
+- **`GET /api/mcp/exposed` — see which tools the operator MCP would hand a foreign client (ADR 0075,
+  slice 2).** The exposed set (after the profile + `operator_mcp.tools` allowlist + `PROTOAGENT_MCP_TRUST`
+  resolve) was introspectable only by reading the sidecar's boot logs; a route now returns it —
+  `{tools, count, profile, star, trust_override}` — so the console can show, and explain, the surface.
 
 ### Changed
 - **BREAKING: the goal API is only under the plural `/api/goals*` now (ADR 0075 D4).** The
@@ -54,6 +71,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (clear). The console already used the plural, so this only affects external callers that hit the
   singular. (The `memory`/`knowledge` split is intentional domain separation — the RAG chunk API
   stays `/api/knowledge/*` — so it was NOT renamed.)
+- **`/v1/chat/completions` reports real token usage now, not zeros (ADR 0075 D4).** The
+  OpenAI-compatible endpoint stubbed `usage` to `{0, 0, 0}`; it now reflects the turn's actual
+  token accounting — summed across the initial model call, every goal-continuation iteration, and
+  nested subagents (the same numbers the A2A cost-v1 artifact reports) — so OpenAI-SDK clients and
+  cost tooling see true prompt/completion/total counts. Streaming includes usage only when the
+  client opts in via `stream_options.include_usage` (a final chunk with empty `choices`).
 
 ### Fixed
 - **The plugin update-CHECK now authenticates private repos too, not just install.** #1805 taught the

--- a/docs/adr/0075-external-interfaces-cli-mcp-api.md
+++ b/docs/adr/0075-external-interfaces-cli-mcp-api.md
@@ -1,7 +1,15 @@
 # 0075 — External interfaces: a first-class `protoagent` CLI + tightened MCP / API / model onboarding
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-05
+- Implementation: D1 CLI (#1816), D3 MCP profiles + HITL-hang fix (#1817), D5 `protoagent model`
+  (#1821), D4 goal-API dedupe (#1822) · real `/v1` usage (#1825), and **D2 the shared `ops/` layer**
+  — `GET /api/mcp/exposed` + resolver extraction (#1824), the `ops/` package + `knowledge.ingest`
+  (#1826), `plugins.install_and_activate` (#1827), `config` + `fleet` ops (#1828), the
+  `GET /api/operations` catalog + `protoagent operations`/`config get·set` CLI (#1830), and
+  `protoagent knowledge ingest` (#1831) — are shipped. Remaining: the `safe-operator` MCP profile
+  (needs the admin ops exposed as MCP tools + the ADR 0071 consent gate) and the D5 HuggingFace
+  local-app registration (external PR).
 - Builds on: ADR 0033 (ACP runtime + operator MCP server), 0027 (plugin CLI + installer),
   0041 (workspace CLI + tiered stores), 0042 (fleet CLI + supervisor), 0047 (settings
   cascade + `config explain`), 0019 (managed / consumed MCP), 0066 (federation token +

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -55,7 +55,9 @@ then exits:
 | `protoagent workspace new` · `ls` · `run` · `rm` | Named, isolated agents on one host. | [0041](../adr/0041-workspaces-and-tiered-stores.md) |
 | `protoagent fleet up` · `down` · `ls` | Run fleet **member** agents as background processes. | [0042](../adr/0042-fleet-supervisor-unified-console.md) |
 | `protoagent skills ls` · `promote <name>` | Inspect and curate the SKILL.md library. | [0041](../adr/0041-workspaces-and-tiered-stores.md) |
-| `protoagent config explain` | Print this instance's id, both roots, every resolved path, and the config cascade with provenance. | [0047](../adr/0047-layered-settings-cascade.md) |
+| `protoagent config explain` · `get` · `set key=value …` | Explain the config cascade; print `config.yaml`; write dotted keys (JSON-typed) to disk. | [0047](../adr/0047-layered-settings-cascade.md) · [0075](../adr/0075-external-interfaces-cli-mcp-api.md) |
+| `protoagent knowledge ingest <url\|file>` | Fetch/extract a source and index it into this instance's knowledge base. | [0075](../adr/0075-external-interfaces-cli-mcp-api.md) |
+| `protoagent operations` | List the operations on the shared ops layer — name, read/write, one-line summary. | [0075](../adr/0075-external-interfaces-cli-mcp-api.md) |
 
 ### Point at a local model
 
@@ -87,6 +89,11 @@ protoagent model use --base-url http://127.0.0.1:11434/v1 --model llama3.2
 
 # Install a plugin, then reload isn't needed for a fresh boot
 protoagent plugin install https://github.com/protoLabsAI/careercoach-plugin
+
+# Edit config headless, ingest a doc, list what operations exist
+protoagent config set fleet.mdns.enabled=false
+protoagent knowledge ingest https://example.com/post --domain research
+protoagent operations
 
 # Stop it
 protoagent down


### PR DESCRIPTION
## Why

The ops-layer PRs (#1824–#1831) merged **without** their CHANGELOG entries / doc upserts — the per-PR `[Unreleased]` convention got missed in the push to ship. This backfills them so the release notes and docs reflect what actually landed.

## What

- **`CHANGELOG.md` [Unreleased]** — adds:
  - the shared **`ops/` layer** (one op, three projections; the four ops; `GET /api/operations`; the `operations` / `config get·set` / `knowledge ingest` CLI verbs),
  - **`GET /api/mcp/exposed`**,
  - real **`/v1` usage**.
  - Also corrects the operator-MCP-profiles entry — it claimed `safe-operator` "lands with the ops layer"; the ops layer landed, but `safe-operator` still needs the admin ops exposed as MCP tools first.
- **ADR 0075**: `Proposed` → **`Accepted`**, with a per-slice implementation map (which PR shipped what; what remains — `safe-operator` + the HF local-app registration).
- **`docs/guides/cli.md`**: the new verbs (`config get/set`, `knowledge ingest`, `operations`) in the management table + an example.

## Verification
- Docs-only (`.md`). `test_changelog.py` (12) + `test_docs_plugin.py` (10) pass.
- Separately, I live-smoked the runtime side of this work: a fresh isolated server booted clean and `GET /api/operations` returned **200** with the full 8-op catalog; the CLI verbs (`operations`, `config get`, `knowledge ingest --help`) run end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)