### PR TITLE
chore: release v0.93.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.93.0] - 2026-07-05
+
 ### Added
 - **`protoagent model` — point at a local LLM in one line (ADR 0075, slice 4).** protoAgent's
   model is just OpenAI-compatible config (the LiteLLM gateway is the default, not a lock-in), so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.92.0"
+version = "0.93.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,22 @@
 [
   {
+    "version": "v0.93.0",
+    "date": "2026-07-05",
+    "changes": [
+      "protoagent model — point at a local LLM in one line.",
+      "Operator-MCP profiles + an env override, so \"operate over MCP\" is safe by default.",
+      "A first-class protoagent command — the terminal control plane.",
+      "React artifacts get a full design-system component set (@pl/ui), not just 9 primitives.",
+      "The shared ops/ layer — one operation, three projections.",
+      "GET /api/mcp/exposed — see which tools the operator MCP would hand a foreign client.",
+      "BREAKING: the goal API is only under the plural /api/goals* now.",
+      "/v1/chat/completions reports real token usage now, not zeros.",
+      "The plugin update-CHECK now authenticates private repos too, not just install.",
+      "The operator MCP no longer hands a foreign client HITL tools that hang it.",
+      "plugin install of a PRIVATE GitHub repo now works on the default git path."
+    ]
+  },
+  {
     "version": "v0.92.0",
     "date": "2026-07-05",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.93.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.93.0 -m 'Release v0.93.0' && git push origin v0.93.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new release entry for version **v0.93.0** with an updated list of product improvements.
* **Chores**
  * Bumped the app version to **0.93.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->