### PR TITLE
fix(cli): protoagent config get crashed on default YAML output (ADR 0075 D2)

### DIFF
--- a/ops/config.py
+++ b/ops/config.py
@@ -73,4 +73,13 @@ async def get_config(*, ctx: OpContext | None = None) -> dict:
     from graph.config_io import config_yaml_path, load_yaml_doc
 
     doc = load_yaml_doc(config_yaml_path())
-    return doc if isinstance(doc, dict) else {}
+    if not isinstance(doc, dict):
+        return {}
+    # load_yaml_doc returns a ruamel CommentedMap (comment-preserving) when ruamel is
+    # installed — a dict subclass PyYAML's safe_dump can't represent (RepresenterError).
+    # Normalize to plain types so every consumer (`protoagent config get`'s YAML dump, JSON,
+    # an API caller) gets a clean dict. JSON round-trip is exact for config (plain scalars /
+    # lists / maps); default=str is a belt-and-braces fallback for any exotic ruamel scalar.
+    import json
+
+    return json.loads(json.dumps(doc, default=str))

--- a/tests/test_ops_catalog.py
+++ b/tests/test_ops_catalog.py
@@ -75,6 +75,24 @@ def test_config_cli_get_reads_disk(monkeypatch, capsys):
     assert json.loads(capsys.readouterr().out) == {"server": {"port": 7870}}
 
 
+def test_config_cli_get_yaml_renders_from_ruamel(monkeypatch, capsys):
+    """Regression: `protoagent config get` (default YAML, no --json) crashed with
+    yaml.representer.RepresenterError when the on-disk doc loaded as a ruamel CommentedMap."""
+    import io
+
+    import pytest
+
+    yaml_rt = pytest.importorskip("ruamel.yaml")
+    import graph.config_io as cio
+    from graph.config_explain import run_config_cli
+
+    cm = yaml_rt.YAML(typ="rt").load(io.StringIO("server:\n  port: 7870\n"))
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: "cfg.yaml")
+    monkeypatch.setattr(cio, "load_yaml_doc", lambda p=None: cm)
+    assert run_config_cli(["get"]) == 0  # was exit 1 + a traceback
+    assert "port: 7870" in capsys.readouterr().out
+
+
 def test_config_cli_set_rejects_bad_pair(capsys):
     from graph.config_explain import run_config_cli
 

--- a/tests/test_ops_config.py
+++ b/tests/test_ops_config.py
@@ -60,6 +60,29 @@ async def test_get_disk_config_when_no_agent(monkeypatch):
     assert await get_config(ctx=None) == {"disk": 1}
 
 
+async def test_get_config_normalizes_ruamel_to_plain(monkeypatch):
+    """Regression: load_yaml_doc returns a ruamel CommentedMap (a dict subclass), which
+    PyYAML's safe_dump can't represent — `protoagent config get` crashed on it. get_config
+    must hand back PLAIN types."""
+    import io
+
+    import pytest
+
+    yaml_rt = pytest.importorskip("ruamel.yaml")
+    import graph.config_io as cio
+
+    cm = yaml_rt.YAML(typ="rt").load(io.StringIO("server:\n  port: 7870\nlist:\n  - a\n  - b\n"))
+    assert type(cm) is not dict  # it IS a CommentedMap — the thing that broke
+    monkeypatch.setattr(cio, "config_yaml_path", lambda: "cfg.yaml")
+    monkeypatch.setattr(cio, "load_yaml_doc", lambda p=None: cm)
+
+    result = await get_config(ctx=None)
+    assert type(result) is dict and result == {"server": {"port": 7870}, "list": ["a", "b"]}
+    import yaml
+
+    yaml.safe_dump(result)  # must NOT raise RepresenterError
+
+
 def test_config_ops_registered_with_metadata():
     reg = registry()
     assert reg["config.set"].mutates is True  # full-profile only


### PR DESCRIPTION
## The bug

`protoagent config get` (without `--json`) crashed:
```
yaml.representer.RepresenterError: ('cannot represent an object', {...})
```
and exited 1. `load_yaml_doc` returns a ruamel **`CommentedMap`** (a dict subclass that preserves comments) when ruamel is installed, and the CLI's PyYAML `safe_dump` can't represent it. `--json` worked (json handles the subclass), which is why unit tests + my earlier `--json` smoke missed it.

**Found by an end-to-end CLI smoke before tagging v0.93.0.** The feature shipped to `main` in #1830 but has **not** been released — so no user ever hit it.

## The fix

At the **op** level, so every consumer gets clean data: `ops.config.get_config` normalizes the on-disk doc to plain types (JSON round-trip) instead of leaking the ruamel structure. The live path (`config_to_dict`) was already plain; only the disk path leaked.

## Tests
Both regressions drive a **real ruamel `CommentedMap`** (the exact thing that broke):
- op: `get_config(ctx=None)` returns `type dict` and `yaml.safe_dump(result)` doesn't raise.
- CLI: `run_config_cli(["get"])` (default YAML) exits 0 and renders.

Re-smoked live: `protoagent config get` now exits 0 and prints YAML.

## Gates
- `ruff` ✅ · `lint-imports` 3/3 ✅ · full suite running

**This blocks the v0.93.0 release** — merge before the tag push so 0.93.0 ships with a working `config get`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)