### PR TITLE
feat(delegates): delegate_to(background=True) — detached delegations (ADR 0050)

### DIFF
--- a/plugins/delegates/__init__.py
+++ b/plugins/delegates/__init__.py
@@ -15,8 +15,10 @@ until then), so the gate is the delegate, not a plugin toggle.
 from __future__ import annotations
 
 import logging
+from typing import Annotated, Any
 
 from langchain_core.tools import tool
+from langgraph.prebuilt import InjectedState
 
 from .adapters import DelegateError
 from .registry import DelegateRegistry
@@ -28,21 +30,39 @@ def _build_delegate_to(registry: DelegateRegistry):
     listing = registry.listing()
 
     @tool
-    async def delegate_to(target: str, query: str) -> str:
+    async def delegate_to(
+        target: str,
+        query: str,
+        background: bool = False,
+        state: Annotated[Any, InjectedState] = None,
+    ) -> str:
         """Hand a question or task to one of your configured delegates and return its reply.
 
         Use this to reach beyond your own context: ask a fleet **agent**, consult
         another **model endpoint**, or hand a repo-scoped coding job to a **coding
         agent**. Pick the delegate whose description best fits the task.
 
+        By default this WAITS for the delegate's reply (fine for a quick consult).
+        For a LONG delegation — a coding agent building a PR, a deep-research run —
+        set ``background=True``: the delegation runs detached, you get a job handle
+        back immediately, and the delegate's reply is delivered to you when it
+        finishes (you don't hold your turn open waiting). In-flight background jobs
+        are tracked in the background panel (``GET /api/background``). Prefer
+        ``background=True`` whenever the delegate might take minutes, or when you
+        want to fan out several delegations without blocking on each.
+
         Args:
             target: the delegate name (see the available list in this tool's
                 description).
             query: the full, self-contained question or instruction — the delegate
                 does not see this conversation, so restate what it needs.
+            background: run the delegation detached and get the reply back on
+                completion, instead of waiting inline (default False).
         """
         if not str(query).strip():
             return "Error: `query` is empty — give the delegate something to do."
+        if background:
+            return await _spawn_background_delegation(registry, target, query, state)
         try:
             return await registry.dispatch(target, query)
         except DelegateError as exc:
@@ -53,6 +73,56 @@ def _build_delegate_to(registry: DelegateRegistry):
 
     delegate_to.description = f"{delegate_to.description}\n\nAvailable delegates: {listing or '(none configured)'}."
     return delegate_to
+
+
+async def _spawn_background_delegation(registry: DelegateRegistry, target: str, query: str, state: Any) -> str:
+    """Run a delegation as a detached background job (ADR 0050): return a handle now and
+    drain the delegate's reply back into the spawning session on completion — the same
+    durable store + concurrency cap + drain-on-next-turn notification that
+    ``task(run_in_background=True)`` uses, so a slow delegate (a coding agent building a
+    PR) never holds the caller's turn open.
+
+    Degrades gracefully: an unknown target fails fast (no orphan job), and if no
+    ``BackgroundManager`` is wired (a lean/CLI/test context) it falls back to a plain
+    inline dispatch so ``background=True`` is never worse than the synchronous path.
+    """
+    if registry.get(target) is None:
+        return f"Error: unknown delegate {target!r}. Available: {registry.listing() or '(none)'}."
+
+    try:
+        from runtime.state import STATE
+
+        mgr = getattr(STATE, "background_mgr", None)
+    except Exception:  # noqa: BLE001 — no runtime state (e.g. a unit test) → inline
+        mgr = None
+    if mgr is None:
+        return await registry.dispatch(target, query)
+
+    try:
+        from tools.lg_tools import _session_id_from
+
+        # Injected graph state, not the tracing contextvar (empty in a tool body) — the
+        # session id is what the completion drains back to (ADR 0050).
+        session = _session_id_from(state) or ""
+    except Exception:  # noqa: BLE001 — best-effort; job still runs, drain is degraded
+        session = ""
+
+    async def _work() -> str:
+        return await registry.dispatch(target, query)
+
+    snippet = " ".join(query.split())[:80]
+    job_id = await mgr.spawn_work(
+        origin_session=session,
+        kind="delegate",
+        description=f"delegate → {target}: {snippet}",
+        detail=query,
+        work=_work,
+    )
+    return (
+        f"Started a background delegation to {target!r} (job `{job_id}`). It runs detached — "
+        f"its reply comes back to me when it finishes, so I don't need to wait. In-flight "
+        f"background jobs are listed in the background panel (GET /api/background)."
+    )
 
 
 def _build_list_agents(registry: DelegateRegistry):

--- a/tests/test_delegates_plugin.py
+++ b/tests/test_delegates_plugin.py
@@ -245,6 +245,73 @@ async def test_delegate_to_unknown_and_empty(monkeypatch):
     assert "empty" in (await tool.ainvoke({"target": "opus", "query": "  "})).lower()
 
 
+# ── delegate_to background=True (ADR 0050) ─────────────────────────────────────
+
+
+class _FakeBgManager:
+    """Records spawn_work calls; returns a fixed job id WITHOUT running the work — so the
+    test asserts the detach happened, not the delegate dispatch."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def spawn_work(self, **kwargs):
+        self.calls.append(kwargs)
+        return "job-abc123"
+
+
+async def test_delegate_to_background_spawns_detached_job(monkeypatch):
+    r = _register([{"name": "opus", "type": "openai", "url": "https://g/v1", "model": "m"}], monkeypatch)
+    tool = r.tools[0]
+    # Wire a fake BackgroundManager onto the runtime state the tool reaches for.
+    import runtime.state as rs
+
+    fake = _FakeBgManager()
+    monkeypatch.setattr(rs.STATE, "background_mgr", fake, raising=False)
+    # dispatch must NOT run inline — the fake spawn_work never calls work.
+    monkeypatch.setattr(DelegateRegistry, "dispatch", _unexpected_dispatch)
+
+    out = await tool.ainvoke({"target": "opus", "query": "build the thing", "background": True})
+    assert "job-abc123" in out and "background" in out.lower()
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["kind"] == "delegate"
+    assert "opus" in call["description"] and call["detail"] == "build the thing"
+    # The queued work, when awaited, dispatches to the delegate.
+    monkeypatch.setattr(DelegateRegistry, "dispatch", _fake_dispatch)
+    assert await call["work"]() == "dispatched:build the thing"
+
+
+async def test_delegate_to_background_unknown_fails_fast(monkeypatch):
+    r = _register([{"name": "opus", "type": "openai", "url": "https://g/v1", "model": "m"}], monkeypatch)
+    tool = r.tools[0]
+    import runtime.state as rs
+
+    monkeypatch.setattr(rs.STATE, "background_mgr", _FakeBgManager(), raising=False)
+    out = await tool.ainvoke({"target": "nope", "query": "hi", "background": True})
+    assert "unknown delegate" in out  # no orphan job for a bad target
+
+
+async def test_delegate_to_background_falls_back_inline_without_manager(monkeypatch):
+    r = _register([{"name": "opus", "type": "openai", "url": "https://g/v1", "model": "m"}], monkeypatch)
+    tool = r.tools[0]
+    import runtime.state as rs
+
+    monkeypatch.setattr(rs.STATE, "background_mgr", None, raising=False)
+    monkeypatch.setattr(DelegateRegistry, "dispatch", _fake_dispatch)
+    # No manager → background degrades to a normal inline dispatch, never worse than sync.
+    out = await tool.ainvoke({"target": "opus", "query": "quick q", "background": True})
+    assert out == "dispatched:quick q"
+
+
+async def _fake_dispatch(self, name, query):
+    return f"dispatched:{query}"
+
+
+async def _unexpected_dispatch(self, name, query):
+    raise AssertionError("dispatch must not run inline when a background job is spawned")
+
+
 # ── dispatch with fakes ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Motivation
`delegate_to(target, query)` is synchronous — it holds the caller's turn open until the delegate replies. That's fine for a quick consult, but a **coding-agent delegate building a PR** (or a deep-research run) takes minutes: the caller is blocked, an HTTP client sits open in front of it, and you can't fan out several delegations without serializing them.

Real case that motivated this: `matt` (a fleet member) delegates a build to `roxy` (a coding agent); roxy's coder takes ~3 min to open a PR. It works today only because the a2a adapter's poll budget is generous — but it doesn't scale to longer builds, parallel delegations, or freeing the caller to do other work meanwhile.

## What this does
Adds a `background` flag to `delegate_to`. With `background=True`, the delegation runs **detached** on the existing **background-subagent machinery** (ADR 0050): the tool returns a job handle immediately, and the delegate's reply **drains back into the spawning session on completion** — the same durable store + concurrency cap + drain-on-next-turn notification that `task(run_in_background=True)` already uses.

```
matt: delegate_to("roxy", "build #397", background=True)
  → "Started a background delegation to 'roxy' (job abc123)…"   # returns now, turn ends
  → roxy builds the PR detached
  → on completion, roxy's reply (the PR link) drains back to matt's session
```

## Why it's small
This is **wiring, not new infrastructure** — the background job system, durable store, and completion-drain all exist:
- `delegate_to` gains `background: bool` + an `InjectedState` param (to resolve the origin session — exactly how `knowledge_ingest` and `task` do it).
- `background=True` → `BackgroundManager.spawn_work(kind="delegate", work=<the same registry.dispatch>)`.
- **Tracking comes free**: the job is stored with `kind="delegate"`, so in-flight delegations show in the background panel / `GET /api/background` alongside subagent tasks.
- **Graceful degradation**: unknown target fails fast (no orphan job); no `BackgroundManager` wired (lean/CLI/test) → falls back to inline dispatch, so `background=True` is never *worse* than synchronous.

## Tests
`test_delegate_to_background_*`: detached spawn records a `delegate` job and queues the dispatch as `work` without running it inline; unknown-target fast-fail; no-manager inline fallback. Full delegates suite green (35 passed).

## Follow-ups (not in this PR)
- A caller-side `check_delegation(job_id)` pull tool (the drain-on-completion push covers the common case; polling is a nicety).
- Teaching fleet leads (e.g. matt) to prefer `background=True` for coder delegations in their SOUL.