### PR TITLE
docs(coding-agents): running an ACP coder in a container, wired to a gateway

### DIFF
--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -164,6 +164,60 @@ The subprocess **inherits protoAgent's environment** (plus any per-delegate `env
 above. Run protoAgent under an account whose ambient credentials you're willing to lend
 the coding agent, or scope the `workdir` to a throwaway checkout.
 
+### In a container, wired to a gateway
+
+The setup above assumes the coder binary is already on `PATH` — true for a local run,
+but a **containerized** protoAgent starts from a bare image with no coder and no model
+credentials. Two things to add to your **deploy** (not the template — this is your
+Dockerfile + entrypoint, `COPY . /opt/protoagent/` already ships your config):
+
+**1. Bake the coder into the image.** For `proto` (a Node CLI), that's Node + one
+`npm i -g`; the other adapters install the same way (`@agentclientprotocol/claude-agent-acp`,
+`@zed-industries/codex-acp`, …):
+
+```dockerfile
+ARG PROTOCLI_VERSION=latest
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g "@protolabsai/proto@${PROTOCLI_VERSION}" \
+    && proto --version   # fail the build if it didn't land
+```
+
+**2. Point the coder at your gateway, not a cloud key.** A CLI coder normally wants its
+own provider API key. To reuse the **same OpenAI-compatible gateway** protoAgent already
+uses — one key, one bill, local models available — write the coder's config at
+**entrypoint** rather than baking it: the sandbox `$HOME` is typically a tmpfs mount that
+would shadow a baked file, and writing at start keeps it idempotent and env-tunable.
+`proto` reads `~/.proto/settings.json`; the shape differs per CLI but the idea is the same
+(base URL → your gateway, key from an env var):
+
+```sh
+# entrypoint.sh — before `exec … python -m server`
+if command -v proto >/dev/null 2>&1; then
+    GATEWAY_URL="${CODER_GATEWAY_URL:-http://gateway:4000/v1}"
+    mkdir -p "$HOME/.proto"
+    cat > "$HOME/.proto/settings.json" <<JSON
+{ "modelProviders": { "openai": [
+    { "id": "my/coder-model", "baseUrl": "${GATEWAY_URL}", "envKey": "OPENAI_API_KEY" }
+  ] },
+  "security": { "auth": { "selectedType": "openai" } },
+  "model": { "name": "my/coder-model" } }
+JSON
+fi
+```
+
+Because the ACP child **inherits protoAgent's environment** (see above), `OPENAI_API_KEY`
+— the gateway key protoAgent already has — flows straight through, and so does anything
+else the coder needs from its shell (e.g. a `GH_TOKEN` so it can `git push` / `gh pr
+create` from its `workdir`). No second secret store.
+
+> The `workdir` still has to be a real, writable checkout of the repo the coder edits —
+> provision it however you like (bake a clone, or `git clone` it at entrypoint with a
+> token). A neat trick to keep the token out of the persisted `.git/config`: set it via a
+> global `url.<https://x-access-token:$TOK@github.com/>.insteadOf` rewrite in the tmpfs
+> `$HOME` — written fresh each boot, never stored in the volume.
+
 ## How it works
 
 ```


### PR DESCRIPTION
## Gap
`docs/guides/coding-agents.md` documents configuring an `acp` delegate and stresses that the coder binary must be on `PATH` — but only covers the **local** case (PATH, macOS desktop `launchd`). A **containerized** protoAgent starts from a bare image: no coder binary, and no model credentials for it. Nothing documents how to close that, even though the `coding_agent`/`acp` delegate is otherwise ready to use.

## What this adds
A new **"In a container, wired to a gateway"** subsection under *Environment*, covering the two things a container deploy needs — framed as **your Dockerfile + entrypoint**, not a core/template edit:

1. **Bake the coder into the image** — Node + `npm i -g` (shown for `proto`; the other adapters install identically).
2. **Point the coder at your gateway, not a cloud key** — write its config at **entrypoint** (the sandbox tmpfs `$HOME` shadows a baked file; writing at start is idempotent + env-tunable) so it reuses the **same OpenAI-compatible gateway** protoAgent already uses. One key, one bill, local models available.

Plus the two things that make it "just work":
- the ACP child **inherits protoAgent's env**, so `OPENAI_API_KEY` (gateway key) and `GH_TOKEN` (for `git push` / `gh pr create` from the `workdir`) flow straight through — no second secret store;
- a tmpfs `url.…insteadOf` trick to keep a clone token out of the persisted `.git/config`.

Docs-only. Generalized from a live deploy (a delivery-manager agent driving `proto` against the fleet gateway) — no product/instance specifics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running coder-based ACP delegates in a container.
  * Included setup steps for using the same gateway configuration and inherited environment credentials.
  * Clarified workspace requirements and shared a safe approach for handling Git credentials without persisting them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->