### PR TITLE
feat(supervisor): on_crash bounded retry — RetryAfter + on_crash_max_attempts (#1823)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Supervisor `on_crash` bounded retry — `RetryAfter` + `on_crash_max_attempts` (#1823).** The
+  plugin-SDK `supervise()` primitive called `on_crash` **at most once per crash streak**, then
+  blind-re-kicked a doomed runner: a fault that re-crashes faster than the watchdog interval (e.g.
+  an API that 503s until a backend rebuilds) never got its recovery re-run, so a plugin had to
+  hand-roll a multi-minute *blocking* retry inside `on_crash` (blocking the watchdog). `on_crash`
+  may now return **`RetryAfter(seconds)`** ("not fixed yet — wait and call me again"), and a new
+  **`on_crash_max_attempts`** (default **1**, unchanged) re-invokes it on repeated crashes with the
+  retry cadence kept *in the watchdog* (observable via `status()`, cancellable) — and bounds the
+  previously-unbounded re-kick loop. Fully backward-compatible: `on_crash -> bool` and the default
+  are byte-identical. `RetryAfter` is exported on `graph.sdk`.
+
 ## [0.93.0] - 2026-07-05
 
 ### Added

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 # Re-export the supervised background-task helper as part of the consumption surface, so a
 # plugin writes `from graph.sdk import supervise` for a self-perpetuating, watchdog-backed
 # engine instead of hand-rolling task/restart machinery (graph/supervisor.py is host-free).
-from graph.supervisor import Supervisor, supervise  # noqa: F401
+from graph.supervisor import RetryAfter, Supervisor, supervise  # noqa: F401
 
 # Re-export the telemetry + decision-log kit, so a plugin writes
 # `from graph.sdk import DecisionLog, telemetry, render_html` for a standard observability

--- a/graph/supervisor.py
+++ b/graph/supervisor.py
@@ -19,11 +19,25 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
 log = logging.getLogger("protoagent.supervisor")
 
 WorkFn = Callable[[], Awaitable[Any]]
+
+
+@dataclass(frozen=True)
+class RetryAfter:
+    """Return this from ``on_crash`` to say "the fault ISN'T fixed yet, but it's still
+    recoverable — wait ``seconds`` and call me again." The supervisor sleeps ``seconds`` in
+    the watchdog (so it stays observable in ``status()`` and is cancelled by ``aclose()``,
+    unlike a blocking sleep inside ``on_crash``) and re-invokes ``on_crash`` WITHOUT re-kicking
+    the runner (the fault isn't fixed, so a re-kick would just re-crash) — up to
+    ``on_crash_max_attempts`` per down-streak. Use it to poll a slow external recovery (e.g.
+    an API that 503s until a backend finishes rebuilding) at your own cadence."""
+
+    seconds: float
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -44,11 +58,21 @@ class Supervisor:
         loop: run ``work`` back-to-back (default) vs once.
         breath: seconds to pause between work units when looping.
         interval: watchdog check period (seconds).
-        on_crash: ``(result) -> bool`` (sync/async) called when the runner crashed or stopped
-            while still wanted-running. Return True if the fault was handled (the watchdog
-            then re-kicks), False to clear want-running and stop the storm (an unrecoverable
-            fault). Called at most once per down-streak. ``result`` is the last
-            ``{"error": …}`` / ``{"stopped": …}``.
+        on_crash: ``(result) -> bool | RetryAfter`` (sync/async) called when the runner
+            crashed or stopped while still wanted-running. Return **True** if the fault was
+            handled (the watchdog then re-kicks), **False** to clear want-running and stop the
+            storm (an unrecoverable fault), or **``RetryAfter(seconds)``** to say "not fixed
+            yet — wait and call me again" (see ``on_crash_max_attempts``). ``result`` is the
+            last ``{"error": …}`` / ``{"stopped": …}``. By default it's called at most once
+            per down-streak (``on_crash_max_attempts=1``).
+        on_crash_max_attempts: how many times ``on_crash`` may be invoked within a single
+            down-streak (default ``1`` — the historical one-shot). Set > 1 for a fault that
+            takes several attempts to clear: ``on_crash`` is re-invoked on repeated same-streak
+            crashes, and a ``RetryAfter`` return re-invokes it after the delay **without**
+            re-kicking. When the attempts are exhausted, a bounded (> 1) supervisor **stops**
+            (clears want-running) instead of blind-re-kicking forever; the default (1) keeps the
+            historical behavior (one ``on_crash``, then blind re-kick). The counter resets once
+            the runner is seen running again.
         progress: ``() -> Any`` (sync/async) — a token that CHANGES while the task makes
             progress (e.g. ``len(log)``). The watchdog flags a stall when it stops changing.
         stall_check: ``() -> bool`` (sync/async) — confirm a *real* stall (e.g. "no ship in
@@ -68,6 +92,7 @@ class Supervisor:
         breath: float = 3.0,
         interval: float = 90.0,
         on_crash: Callable[[Any], Any] | None = None,
+        on_crash_max_attempts: int = 1,
         progress: Callable[[], Any] | None = None,
         stall_check: Callable[[], Any] | None = None,
         stall_ticks: int = 3,
@@ -80,12 +105,14 @@ class Supervisor:
         self._breath = breath
         self._interval = interval
         self._on_crash = on_crash
+        self._on_crash_max_attempts = max(1, int(on_crash_max_attempts))
         self._progress = progress
         self._stall_check = stall_check
         self._stall_ticks = stall_ticks
         self._rekicks_warn = rekicks_warn
         self._event_cap = event_cap
 
+        self._on_crash_attempts = 0  # on_crash invocations this down-streak; reset when running
         self._task: asyncio.Task | None = None
         self._watchdog: asyncio.Task | None = None
         self._want = False  # operator wants it running; the watchdog keeps it there
@@ -99,6 +126,7 @@ class Supervisor:
     def start(self) -> str:
         """Start (or ensure running). Idempotent; also (re)starts the watchdog."""
         self._want = True
+        self._on_crash_attempts = 0  # a fresh operator start gets a fresh recovery budget
         self._ensure_watchdog()
         if self.running():
             return f"{self.name}: already running"
@@ -181,10 +209,45 @@ class Supervisor:
         self._restarts += 1
         self._spawn_runner()
 
+    async def _drive_on_crash(self) -> str:
+        """Handle a down-streak crash via ``on_crash``; return ``"rekick"`` or ``"stop"``.
+
+        Invokes ``on_crash`` up to ``on_crash_max_attempts`` per down-streak (the counter is
+        reset by ``_watch`` when the runner is seen running). ``True`` → re-kick; ``False`` /
+        an exception → stop; ``RetryAfter(s)`` → wait ``s`` (cancellable, in the watchdog) and
+        re-invoke WITHOUT re-kicking. When attempts run out: a bounded (> 1) supervisor stops
+        rather than blind-re-kicking; the default (1) preserves the historical blind re-kick.
+        """
+        while self._on_crash_attempts < self._on_crash_max_attempts:
+            self._on_crash_attempts += 1
+            try:
+                outcome = await _maybe_await(self._on_crash(self._result))
+            except Exception as e:  # noqa: BLE001 — a throwing hook is an unrecoverable fault
+                self._event(f"on_crash errored: {e}")
+                return "stop"
+            if isinstance(outcome, RetryAfter):
+                self._event(
+                    f"on_crash: not yet — retry in {outcome.seconds:g}s "
+                    f"(attempt {self._on_crash_attempts}/{self._on_crash_max_attempts})"
+                )
+                await asyncio.sleep(max(0.0, outcome.seconds))  # in the watchdog: observable + aclose-cancellable
+                if not self._want:  # stop() during backoff
+                    return "stop"
+                continue  # re-invoke on_crash, no re-kick (the fault isn't fixed yet)
+            if bool(outcome):
+                self._event("recovered via on_crash")
+                return "rekick"
+            self._event("unrecoverable — want_running cleared")
+            return "stop"
+        # Attempts exhausted this down-streak without a decisive recovery.
+        if self._on_crash_max_attempts > 1:
+            self._event(f"on_crash exhausted {self._on_crash_max_attempts} attempts — stopping")
+            return "stop"
+        return "rekick"  # default one-shot mode: historical blind re-kick
+
     async def _watch(self) -> None:
         frozen = 0
         rekicks = 0
-        recovered = False
         last_token: Any = object()  # sentinel so the first compare is never "frozen"
         while True:
             try:
@@ -200,18 +263,9 @@ class Supervisor:
                         self._want = False
                         self._event("completed")
                         continue
-                    if self._on_crash is not None and not recovered:
-                        recovered = True
-                        try:
-                            handled = bool(await _maybe_await(self._on_crash(self._result)))
-                        except Exception as e:  # noqa: BLE001
-                            handled = False
-                            self._event(f"on_crash errored: {e}")
-                        if not handled:
-                            self._want = False  # unrecoverable → don't spin
-                            self._event("unrecoverable — want_running cleared")
-                            continue
-                        self._event("recovered via on_crash")
+                    if self._on_crash is not None and await self._drive_on_crash() == "stop":
+                        self._want = False  # unrecoverable / retries exhausted → don't spin
+                        continue
                     rekicks += 1
                     if rekicks == self._rekicks_warn:
                         self._event("persistently failing — may need attention")
@@ -220,7 +274,7 @@ class Supervisor:
                     frozen = 0
                     continue
                 rekicks = 0
-                recovered = False
+                self._on_crash_attempts = 0  # runner is up → this down-streak is over
 
                 # (2) running but stalled → restart. Needs frozen PROGRESS (if a progress fn
                 #     is set) AND a truthy STALL_CHECK (if set); with neither, no stall detection.

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 
 from graph.sdk import supervise as sdk_supervise  # re-exported on the plugin SDK surface
-from graph.supervisor import Supervisor, supervise
+from graph.supervisor import RetryAfter, Supervisor, supervise
 
 
 def test_supervise_is_exported_on_the_sdk():
@@ -95,6 +95,109 @@ async def test_unrecoverable_crash_clears_want_running():
     assert sv.status()["want_running"] is False
     assert not sv.running()
     await sv.aclose()
+
+
+# ── on_crash bounded retry + RetryAfter (#1823) ───────────────────────────────
+
+
+async def test_default_one_shot_preserved_on_repeated_crashes():
+    """Backward-compat: with the default (max_attempts=1), on_crash still fires at most once
+    per down-streak even when the runner keeps re-crashing fast — then blind-re-kicks."""
+    on_crash_calls = 0
+
+    async def work():
+        raise ValueError("always boom")
+
+    def on_crash(_r):
+        nonlocal on_crash_calls
+        on_crash_calls += 1
+        return True  # handled → re-kick (but the runner keeps crashing)
+
+    sv = supervise(work, interval=0.02, breath=0.0, on_crash=on_crash)  # default max_attempts=1
+    sv.start()
+    await asyncio.sleep(0.2)  # many crash / re-kick cycles
+    assert on_crash_calls == 1  # one-shot latch preserved
+    assert sv.status()["want_running"] is True  # blind re-kick continues (historical behavior)
+    await sv.aclose()
+
+
+async def test_bounded_retry_reinvokes_on_crash_then_stops():
+    """max_attempts>1 re-invokes on_crash on each fast re-crash, up to the bound, then STOPS
+    (instead of the old unbounded blind re-kick)."""
+    on_crash_calls = 0
+
+    async def work():
+        raise ValueError("always boom")
+
+    def on_crash(_r):
+        nonlocal on_crash_calls
+        on_crash_calls += 1
+        return True
+
+    sv = supervise(work, interval=0.02, breath=0.0, on_crash=on_crash, on_crash_max_attempts=3)
+    sv.start()
+    await asyncio.sleep(0.3)
+    assert on_crash_calls == 3  # re-invoked on each re-crash, up to the bound
+    assert sv.status()["want_running"] is False  # exhausted → stopped, not a blind loop
+    assert not sv.running()
+    await sv.aclose()
+
+
+async def test_retry_after_polls_without_rekick_then_recovers():
+    """The SpaceTraders case: on_crash returns RetryAfter to poll a slow recovery — the
+    supervisor waits + re-invokes WITHOUT re-kicking, then re-kicks once on_crash returns True."""
+    work_calls = 0
+    seen = []  # (result, work_calls at the time) per on_crash invocation
+
+    async def work():
+        nonlocal work_calls
+        work_calls += 1
+        if work_calls == 1:
+            raise ValueError("boom")
+        await asyncio.sleep(0.5)  # the recovered run stays alive
+        return "ok"
+
+    def on_crash(result):
+        seen.append((result, work_calls))
+        if len(seen) < 3:
+            return RetryAfter(0.01)  # not fixed yet — poll again, no re-kick
+        return True  # recovered → re-kick
+
+    sv = supervise(work, interval=0.02, breath=0.0, on_crash=on_crash, on_crash_max_attempts=5)
+    sv.start()
+    await asyncio.sleep(0.25)
+    assert len(seen) == 3  # polled 3× (2× RetryAfter + 1× True)
+    assert [wc for (_r, wc) in seen] == [1, 1, 1]  # runner NOT re-kicked during polling
+    assert work_calls >= 2  # re-kicked only after True → work ran again
+    assert sv.running()  # recovered and alive
+    await sv.aclose()
+
+
+async def test_retry_after_exhausted_stops():
+    """RetryAfter forever, bounded by max_attempts → stop when the budget is spent."""
+    calls = 0
+
+    async def work():
+        raise ValueError("boom")
+
+    def on_crash(_r):
+        nonlocal calls
+        calls += 1
+        return RetryAfter(0.01)  # never recovers
+
+    sv = supervise(work, interval=0.02, breath=0.0, on_crash=on_crash, on_crash_max_attempts=2)
+    sv.start()
+    await asyncio.sleep(0.2)
+    assert calls == 2  # polled up to the bound
+    assert sv.status()["want_running"] is False  # exhausted → stop
+    await sv.aclose()
+
+
+def test_retry_after_exported_on_sdk():
+    from graph.sdk import RetryAfter as sdk_ra
+
+    assert sdk_ra is RetryAfter
+    assert RetryAfter(1.5).seconds == 1.5
 
 
 async def test_stall_is_detected_and_restarted():

--- a/uv.lock
+++ b/uv.lock
@@ -1539,7 +1539,7 @@ wheels = [
 
 [[package]]
 name = "protoagent"
-version = "0.84.0"
+version = "0.93.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["fastapi", "http-server", "sqlite"] },


### PR DESCRIPTION
Closes #1823.

## Spec (the design, agreed in the audit)

**Problem.** The plugin-SDK `supervise()` primitive calls `on_crash` **at most once per crash streak** — the `recovered` latch is set before the call and only reset when the runner is *observed running*. If the runner **re-crashes faster than the watchdog interval** (default 90 s) — e.g. an API that 503s until a backend rebuilds — it's never seen running, so `on_crash` stays latched and the supervisor just re-spawns a doomed runner every interval (unbounded, only `rekicks_warn`). Plugins work around it with a multi-minute **blocking** retry *inside* `on_crash`, which blocks the watchdog (no stall detection, no responsive stop) — spacetraders-plugin#52.

**Design — additive, opt-in, default byte-identical:**
- `on_crash` may return **`RetryAfter(seconds)`**: *"not fixed yet — wait and call me again."* The supervisor sleeps **in the watchdog** (observable via `status()`, cancelled by `aclose()`) and re-invokes `on_crash` **without re-kicking** (the fault isn't fixed, so a re-kick would just re-crash), up to `on_crash_max_attempts`.
- **`on_crash_max_attempts: int = 1`** — max `on_crash` calls per down-streak. Default `1` = the historical one-shot. `> 1` re-invokes on repeated crashes; when the budget is spent, a bounded (`>1`) supervisor **stops** instead of blind-looping. The counter resets when the runner is seen running.
- Return contract: `True` → re-kick · `False` / raise → stop · `RetryAfter(s)` → poll again after `s`.
- `RetryAfter` is re-exported on `graph.sdk`.

## Why this is low-risk (from the audit)
- **One host-free leaf** (`graph/supervisor.py`, only `asyncio`/`logging`/`dataclasses`) + the `graph.sdk` re-export. **No config field, no golden/roundtrip coupling, no core caller** (core uses the *separate* `graph/fleet/supervisor.py`).
- **`on_crash -> bool` and the default are byte-identical** — external consumers (spacetraders, careercoach) and forks are unaffected; only a plugin that *opts in* changes behavior. The existing exactly-once test passes untouched.

## Tests (9 existing + 5 new)
- **Backward-compat proof:** `test_default_one_shot_preserved_on_repeated_crashes` — default still fires `on_crash` once per streak then blind-re-kicks.
- Bounded retry re-invokes on each fast re-crash then **stops**.
- `RetryAfter` **polls without re-kicking** (asserts the runner isn't re-run between polls) then re-kicks on `True` and stays alive.
- `RetryAfter` exhausted → stop.
- `RetryAfter` exported on `graph.sdk`.

## Gates
- `ruff` ✅ · `lint-imports` 3/3 ✅ · supervisor + changelog tests green. (Local full suite runs via `uv run` since my `.venv` got reset mid-session; CI runs it with the proper env.)

Follow-up unblocked: spacetraders-plugin can delete its blocking `on_crash` retry loop and return `RetryAfter` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new retry signal for crash recovery, letting supervisors pause before trying again.
  * Expanded crash-handling settings so recovery attempts can be retried multiple times before stopping.

* **Bug Fixes**
  * Improved supervisor behavior during repeated crashes, including better handling of rapid failures and recovery retries.
  * Reset recovery state when a supervisor is started again, helping fresh restarts behave consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->