### PR TITLE
chore: release v0.93.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.93.1] - 2026-07-05
+
 ### Added
 - **Supervisor `on_crash` bounded retry — `RetryAfter` + `on_crash_max_attempts` (#1823).** The
   plugin-SDK `supervise()` primitive called `on_crash` **at most once per crash streak**, then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.93.0"
+version = "0.93.1"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "v0.93.1",
+    "date": "2026-07-05",
+    "changes": [
+      "Supervisor on_crash bounded retry — RetryAfter + on_crash_max_attempts (#1823)."
+    ]
+  },
+  {
     "version": "v0.93.0",
     "date": "2026-07-05",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.93.1`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.93.1 -m 'Release v0.93.1' && git push origin v0.93.1`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the package version to **0.93.1**.
* **Documentation**
  * Added a new release note entry for **v0.93.1** highlighting a supervisor retry update for crash handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->