### PR TITLE
feat(coding-agent): managed git for acp delegates (ADR 0076)

### DIFF
--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -209,8 +209,9 @@ fi
 
 Because the ACP child **inherits protoAgent's environment** (see above), `OPENAI_API_KEY`
 — the gateway key protoAgent already has — flows straight through, and so does anything
-else the coder needs from its shell (e.g. a `GH_TOKEN` so it can `git push` / `gh pr
-create` from its `workdir`). No second secret store.
+else the coder needs from its shell (e.g. a `GH_TOKEN` for `git push` / `gh pr create`
+from its `workdir` — run by the coder itself in the default mode, or by the framework's
+git harness under `manage_git: true`, §Managed git below). No second secret store.
 
 > The `workdir` still has to be a real, writable checkout of the repo the coder edits —
 > provision it however you like (bake a clone, or `git clone` it at entrypoint with a
@@ -242,22 +243,65 @@ done
 **2. Declare one coder per worktree** — same binary, distinct `workdir`:
 
 ```yaml
-coding_agent:
-  agents:
-    - { name: coder-1, command: proto, args: ["--acp"], workdir: /work/wt-1 }
-    - { name: coder-2, command: proto, args: ["--acp"], workdir: /work/wt-2 }
-    - { name: coder-3, command: proto, args: ["--acp"], workdir: /work/wt-3 }
+delegates:
+  - { name: coder-1, type: acp, command: proto, args: ["--acp"], workdir: /work/wt-1, manage_git: true }
+  - { name: coder-2, type: acp, command: proto, args: ["--acp"], workdir: /work/wt-2, manage_git: true }
+  - { name: coder-3, type: acp, command: proto, args: ["--acp"], workdir: /work/wt-3, manage_git: true }
 ```
 
-**3. Fan out.** The agent issues several `code_with(coder-N, …)` calls in one turn (the tool
-node runs a turn's tool calls concurrently), or several `delegate_to(…, background=True)`
-calls — each lands on a free coder in its own worktree. The pool size is the cap; extra work
-queues. Tell each coder to branch off `origin/main` (`git checkout -b <task> origin/main`) so
-parallel branches never share a checkout.
+**3. Fan out.** The agent issues several `delegate_to(coder-N, …)` calls in one turn (the
+tool node runs a turn's tool calls concurrently), or several `delegate_to(…,
+background=True)` calls — each lands on a free coder in its own worktree. The pool size is
+the cap; extra work queues.
 
 Two caveats worth planning for: worktrees don't share `node_modules`/build caches (install
 per-worktree, or share a package store), and two parallel PRs that touch the same file will
 conflict at *merge* time (normal parallel-dev friction — rebase the loser), not at build time.
+
+### Managed git: the framework owns branch/commit/push/PR (ADR 0076)
+
+By default the coder owns its own git lifecycle — fine for a single supervised coder in a
+disposable checkout. At pool scale it is the reliability ceiling: coders invent colliding
+branch names (linked worktrees refuse the same branch twice), report "done" without ever
+pushing, open duplicate PRs when one item is fanned to several coders, and `git add -A`
+their scratch into the diff. Every one of those is a *deterministic* step an LLM was asked
+to perform.
+
+`manage_git: true` on an `acp` delegate moves the whole lifecycle into the framework
+(`plugins/coding_agent/git_harness.py`); the coder is told to **edit files and run tests
+only**. Per dispatch, the harness:
+
+1. derives a stable **work-item id** — `delegate_to(…, item_id="issue-42")`, or a hash of
+   the query text when omitted — and **claims** it: a second dispatch of an in-flight item
+   (any coder) is refused instead of duplicated, and an already-open PR for the item's
+   branch short-circuits before the coder even runs;
+2. mints the branch deterministically (`<branch_prefix>/<slug>-<id7>`, prefix defaults to
+   the delegate name) and cuts it from **fresh `origin/<base_branch>`** — never local HEAD;
+3. after the coder finishes: refuses to commit on the base branch (work stays recoverable
+   in the worktree — no completion theater), scans the diff for secrets, commits on the
+   coder's behalf, rebases onto fresh base (a conflict is reported and pushed as-is, not
+   fatal), pushes with `--force-with-lease`, **verifies the remote SHA actually moved**,
+   and opens the PR idempotently (re-runs reuse the existing PR).
+
+The lifecycle is idempotent to a coder that did partial git anyway (its commits are
+adopted, not duplicated), and the run's outcome — branch, verified push, PR URL, or the
+exact reason nothing was published — is appended to the coder's reply.
+
+```yaml
+delegates:
+  - name: coder-1
+    type: acp
+    command: proto
+    args: ["--acp"]
+    workdir: /work/wt-1
+    manage_git: true       # framework-owned git lifecycle
+    base_branch: main      # branches cut from origin/<base>; PRs target it
+    # branch_prefix: wt-1  # optional; defaults to the delegate name
+```
+
+The PR step needs `gh` on PATH and a `GH_TOKEN`/`GITHUB_TOKEN` (the same container env as
+above). Without them the branch is still pushed and verified — the reply just reports the
+PR step's failure instead of a URL.
 
 ## How it works
 

--- a/plugins/coding_agent/git_harness.py
+++ b/plugins/coding_agent/git_harness.py
@@ -1,0 +1,508 @@
+"""Deterministic, framework-owned git lifecycle for managed acp delegates (ADR 0076).
+
+The coder edits files and runs tests; this harness owns everything that touches a
+branch, the remote, or the PR — the steps whose LLM ownership caused every observed
+reliability failure (never-pushed work, duplicate PRs, branch collisions, committed
+scratch). Ported from protoMaker's git workflow (source-verified in
+docs/plans/coding-agent-deterministic-git.md), reshaped onto ``tools/shell.run_command``
++ ``tools/gh_cli.run_gh``.
+
+Lifecycle (driven by ``AcpAdapter._dispatch_managed``):
+
+    claim(item_id)                      # in-flight dedup — atomic on the event loop
+    preflight_pr(...)                   # open PR already? return it, don't dispatch
+    prepare(...)                        # fetch base, branch off origin/<base>, hygiene
+    <coder runs, edit-only directive>
+    finish(...)                         # guard → scan → commit → rebase → push → PR
+    release(item_id)
+
+"Edit-only" is an instruction, not an assumption: ``finish`` is idempotent to the coder
+having done partial git itself (committed, or committed *and* pushed) — the three-tier
+probe adopts that work instead of failing or duplicating it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+
+from tools.gh_cli import run_gh
+from tools.shell import ShellResult, run_command
+
+log = logging.getLogger("protoagent.plugins.coding_agent")
+
+# ── deterministic identity ────────────────────────────────────────────────────
+
+
+def derive_item_id(task: str) -> str:
+    """Stable work-item id for a task with no caller-supplied one. Hashing the task
+    text means a naive fan-out of the *same* task to several coders converges on one
+    claim instead of N duplicate branches/PRs."""
+    return hashlib.sha1(task.strip().encode()).hexdigest()[:12]
+
+
+def _slugify(text: str, maxlen: int = 50) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.strip().lower()).strip("-")
+    return slug[:maxlen].rstrip("-") or "task"
+
+
+def mint_branch(prefix: str, task: str, item_id: str) -> str:
+    """``<prefix>/<slug>-<last7(item_id)>`` — deterministic, no LLM, collision-proof
+    via the id suffix (two items with the same title still get distinct branches)."""
+    clean_prefix = re.sub(r"[^a-z0-9-]+", "-", prefix.strip().lower()).strip("-") or "task"
+    first_line = next((ln for ln in task.strip().splitlines() if ln.strip()), "task")
+    return f"{clean_prefix}/{_slugify(first_line)}-{item_id[-7:]}"
+
+
+def title_from(task: str) -> str:
+    """PR/commit title: the task's first non-empty line, collapsed, capped."""
+    first_line = next((ln for ln in task.strip().splitlines() if ln.strip()), "automated change")
+    title = " ".join(first_line.split())
+    return title[:72].rstrip() if len(title) > 72 else title
+
+
+def edit_only_directive(branch: str) -> str:
+    """Appended to the coder's task in managed mode."""
+    return (
+        "\n\n[managed git] Edit files and run tests only. Do NOT run git commands — do not "
+        "branch, commit, push, or open a PR. The framework owns the git lifecycle: when you "
+        f"finish, it commits your work and publishes it on branch `{branch}`."
+    )
+
+
+# ── single-claim registry (in-flight dedup) ───────────────────────────────────
+#
+# Module-global so every dispatch path (foreground tool call, background job) shares
+# one registry. The check-and-set in ``claim`` is atomic because every caller is an
+# async coroutine on the one event loop and there is NO await between the read and
+# the write — protoMaker's exact trick. If a caller is ever sync/threaded, this needs
+# a real lock.
+
+_CLAIMS: dict[str, str] = {}
+
+
+def claim(item_id: str, owner: str) -> str | None:
+    """Claim ``item_id`` for ``owner``. Returns None on success, or the current
+    holder's name if the item is already in flight. No await between check and set."""
+    holder = _CLAIMS.get(item_id)
+    if holder is not None:
+        return holder
+    _CLAIMS[item_id] = owner
+    return None
+
+
+def release(item_id: str) -> None:
+    _CLAIMS.pop(item_id, None)
+
+
+# ── git plumbing ──────────────────────────────────────────────────────────────
+
+# Linked worktrees share one .git — parallel harness runs contend on its lock files.
+# Bounded backoff-retry is the documented cure (the alternative is spurious failures
+# under exactly the fan-out this feature exists for).
+_LOCK_MARKERS = ("index.lock", "config.lock", "cannot lock ref", "unable to create")
+
+# Committer identity injected when the environment has none (agent containers often
+# don't) — commits would otherwise fail outright.
+_FALLBACK_IDENTITY = {
+    "GIT_AUTHOR_NAME": "protoAgent",
+    "GIT_AUTHOR_EMAIL": "agent@protoagent.local",
+    "GIT_COMMITTER_NAME": "protoAgent",
+    "GIT_COMMITTER_EMAIL": "agent@protoagent.local",
+}
+
+# Scratch that must never reach a PR. Untracked scratch is excluded structurally
+# (info/exclude, seeded by prepare); this list also backs a staged-path sweep in case
+# the coder force-added any of it.
+_SCRATCH_DIRS = (".proto/", ".worktrees/", ".claude/", "node_modules/")
+
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "private key"),
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "AWS access key id"),
+    (re.compile(r"\bghp_[A-Za-z0-9]{36}\b"), "GitHub token"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{22,}\b"), "GitHub fine-grained token"),
+    (re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"), "Slack token"),
+    (re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b"), "Google API key"),
+]
+
+
+async def _git(workdir: str, *args: str, env: dict[str, str] | None = None, timeout: float = 60.0) -> ShellResult:
+    """Run one git command in ``workdir``, retrying on shared-.git lock contention."""
+    res = ShellResult(1, "", "", error="git never ran")
+    for attempt in range(3):
+        res = await run_command(["git", *args], cwd=workdir, env=env, timeout=timeout)
+        blob = f"{res.stderr} {res.error or ''}".lower()
+        if not res.ok and any(m in blob for m in _LOCK_MARKERS) and attempt < 2:
+            await asyncio.sleep(0.4 * (2**attempt))
+            continue
+        return res
+    return res
+
+
+async def _count(workdir: str, spec: str) -> int | None:
+    """``git rev-list --count <spec>`` → int, or None when unresolvable. None means
+    *unknown* — callers must not treat it as 0, or work gets stranded (protoMaker's
+    hard-learned rule)."""
+    res = await _git(workdir, "rev-list", "--count", spec)
+    if not res.ok:
+        return None
+    try:
+        return int(res.stdout.strip())
+    except ValueError:
+        return None
+
+
+async def _identity_env(workdir: str) -> dict[str, str] | None:
+    """Fallback committer identity iff the repo/environment has none configured."""
+    res = await _git(workdir, "config", "user.email")
+    if res.ok and res.stdout.strip():
+        return None
+    return dict(_FALLBACK_IDENTITY)
+
+
+async def _seed_exclude(workdir: str) -> None:
+    """Structurally exclude scratch dirs via info/exclude (shared across linked
+    worktrees — which is what we want). A pathspec denylist at ``git add`` time is
+    deliberately NOT used: protoMaker tried and removed it (conflicts with tracked
+    files under excluded dirs)."""
+    res = await _git(workdir, "rev-parse", "--git-path", "info/exclude")
+    if not res.ok:
+        return
+    path = res.stdout.strip()
+    if not os.path.isabs(path):
+        path = os.path.join(workdir, path)
+    try:
+        existing = ""
+        if os.path.exists(path):
+            with open(path, encoding="utf-8", errors="replace") as f:
+                existing = f.read()
+        missing = [d for d in _SCRATCH_DIRS if d not in existing]
+        if missing:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write("\n# managed-git scratch exclusions (ADR 0076)\n")
+                f.writelines(f"{d}\n" for d in missing)
+    except OSError as exc:  # noqa: PERF203 — exclusion is best-effort hygiene
+        log.warning("[git-harness] seeding info/exclude failed: %s", exc)
+
+
+def _scan_added_lines(diff_text: str) -> list[str]:
+    """Secret findings in the diff's ADDED lines, as ``<file>: <kind>`` strings."""
+    findings: list[str] = []
+    current = "?"
+    for line in diff_text.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:]
+            continue
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        for pattern, kind in _SECRET_PATTERNS:
+            if pattern.search(line):
+                finding = f"{current}: {kind}"
+                if finding not in findings:
+                    findings.append(finding)
+    return findings
+
+
+# ── pre-run: branch setup ─────────────────────────────────────────────────────
+
+
+@dataclass
+class PrepareResult:
+    error: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+
+async def prepare(workdir: str, *, base: str, branch: str) -> PrepareResult:
+    """Put the delegate's worktree on ``branch``, cut from fresh ``origin/<base>``.
+
+    Never branches off HEAD (a stale local base silently poisons every PR). A reused
+    branch that has real commits ahead of base (a prior partial run) is kept; one with
+    none is re-cut. Leftover uncommitted changes from a previous run are stashed —
+    preserved but kept out of this item's commit."""
+    out = PrepareResult()
+
+    fetch = await _git(workdir, "fetch", "origin", base, timeout=120)
+    if not fetch.ok:
+        # Non-fatal: proceed on the cached ref (protoMaker's behavior) — but say so.
+        out.notes.append(f"fetch origin/{base} failed ({(fetch.stderr or fetch.error or '?')[:120]}); using cached ref")
+
+    dirty = await _git(workdir, "status", "--porcelain")
+    if dirty.ok and dirty.stdout.strip():
+        stash = await _git(workdir, "stash", "push", "-u", "-m", f"managed-git leftovers before {branch}")
+        if stash.ok:
+            out.notes.append("stashed leftover uncommitted changes from a previous run (`git stash list` to recover)")
+        else:
+            out.error = f"worktree has leftover changes and stashing them failed: {(stash.stderr or stash.error or '?')[:200]}"
+            return out
+
+    exists = (await _git(workdir, "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}")).ok
+    keep = False
+    if exists:
+        ahead = await _count(workdir, f"origin/{base}..{branch}")
+        keep = ahead is None or ahead > 0  # unknown ⇒ keep — never discard possibly-real work
+    if keep:
+        co = await _git(workdir, "checkout", branch)
+        out.notes.append(f"reusing branch {branch} (has commits from a prior run)")
+    else:
+        co = await _git(workdir, "checkout", "-B", branch, f"origin/{base}")
+    if not co.ok:
+        blob = f"{co.stderr} {co.error or ''}"
+        if "already checked out" in blob or "already used by worktree" in blob:
+            out.error = (
+                f"branch {branch!r} is checked out in another worktree — another coder holds this "
+                "item's branch. One branch per worktree; wait for it or prune the stale worktree."
+            )
+        else:
+            out.error = f"checkout failed: {blob.strip()[:300]}"
+        return out
+
+    await _seed_exclude(workdir)
+    return out
+
+
+# ── post-run: commit → rebase → push → PR ─────────────────────────────────────
+
+
+@dataclass
+class GitOutcome:
+    branch: str
+    item_id: str
+    base: str
+    stranded_on_base: bool = False
+    no_changes: bool = False
+    coder_did_git: str = ""  # "" | "committed" | "pushed"
+    committed: bool = False
+    commit_sha: str = ""
+    rebase_conflicts: list[str] = field(default_factory=list)
+    pushed: bool = False
+    pushed_sha: str = ""
+    pr_url: str = ""
+    pr_state: str = ""  # "created" | "existing" | "skipped-no-commits" | ""
+    blocked_secrets: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    def render(self) -> str:
+        """Operator/LLM-visible summary block appended to the coder's reply."""
+        lines = [f"[managed git] item `{self.item_id}` on branch `{self.branch}` (base `{self.base}`)"]
+        if self.stranded_on_base:
+            lines.append(
+                f"- BLOCKED: the coder left HEAD on `{self.base}` — nothing was committed. The edits "
+                "are recoverable in the worktree. Do NOT report this item as done."
+            )
+        elif self.blocked_secrets:
+            lines.append("- BLOCKED: commit refused, possible secrets in the diff: " + "; ".join(self.blocked_secrets))
+        elif self.no_changes:
+            lines.append("- no changes to publish (clean tree, nothing ahead of base)")
+        else:
+            if self.coder_did_git:
+                lines.append(f"- adopted work the coder had already {self.coder_did_git}")
+            if self.commit_sha:
+                lines.append(f"- committed `{self.commit_sha[:10]}`")
+            if self.rebase_conflicts:
+                lines.append(
+                    "- rebase onto fresh base hit conflicts (pushed as-is; resolve at merge time): "
+                    + ", ".join(self.rebase_conflicts)
+                )
+            lines.append(
+                f"- pushed to origin (remote verified at `{self.pushed_sha[:10]}`)" if self.pushed else "- NOT pushed"
+            )
+            if self.pr_url:
+                lines.append(f"- PR ({self.pr_state}): {self.pr_url}")
+            elif self.pr_state == "skipped-no-commits":
+                lines.append("- PR skipped: branch has no commits ahead of base")
+        lines.extend(f"- note: {e}" for e in self.errors)
+        return "\n".join(lines)
+
+
+async def finish(workdir: str, *, base: str, branch: str, item_id: str, title: str) -> GitOutcome:
+    """The framework-owned tail of a managed run. Every step degrades gracefully —
+    a commit survives a failed push, a push survives a failed PR create — and errors
+    accumulate in the result instead of raising."""
+    out = GitOutcome(branch=branch, item_id=item_id, base=base)
+    env = await _identity_env(workdir)
+
+    # Isolation guard: never commit on the base branch. A distinct signal, not just a
+    # refusal — the caller must surface this as NOT done (protoMaker's strandedOnBase).
+    head = await _git(workdir, "rev-parse", "--abbrev-ref", "HEAD")
+    head_branch = head.stdout.strip() if head.ok else ""
+    if head_branch == base:
+        out.stranded_on_base = True
+        out.errors.append(f"work left uncommitted in {workdir} — recover or re-run")
+        return out
+    if head_branch and head_branch != branch:
+        # The coder moved HEAD to its own branch despite the directive. Publishing what
+        # it committed beats publishing an empty ref — adopt its branch, note the drift.
+        out.errors.append(f"coder moved HEAD to {head_branch!r}; publishing that branch instead of {branch!r}")
+        out.branch = branch = head_branch
+
+    # Stage everything; exclusion is structural (.gitignore + info/exclude), plus a
+    # belt-and-suspenders sweep for force-added scratch.
+    add = await _git(workdir, "add", "-A", timeout=120)
+    if not add.ok:
+        out.errors.append(f"git add failed: {(add.stderr or add.error or '?')[:200]}")
+    staged = await _git(workdir, "diff", "--cached", "--name-only")
+    if staged.ok:
+        scratch = [p for p in staged.stdout.splitlines() if any(p.startswith(d) for d in _SCRATCH_DIRS)]
+        for path in scratch:
+            await _git(workdir, "reset", "-q", "HEAD", "--", path)
+        if scratch:
+            out.errors.append(f"unstaged scratch paths: {', '.join(scratch[:5])}{'…' if len(scratch) > 5 else ''}")
+
+    # Secret scan on what would be committed — the harness commit is the one reliable
+    # interception point.
+    diff = await _git(workdir, "diff", "--cached", timeout=120)
+    if diff.ok:
+        found = _scan_added_lines(diff.stdout)
+        if found:
+            await _git(workdir, "reset", "-q")
+            out.blocked_secrets = found
+            return out
+
+    staged_check = await _git(workdir, "diff", "--cached", "--quiet")
+    have_staged = staged_check.error is None and staged_check.returncode != 0
+
+    if have_staged:
+        commit = await _git(workdir, "commit", "--no-verify", "-m", f"{title}\n\nItem ID: {item_id}", env=env)
+        if not commit.ok:
+            out.errors.append(f"commit failed: {(commit.stderr or commit.error or '?')[:300]}")
+            return out
+        out.committed = True
+    else:
+        # Clean tree — three-tier probe for git the coder did itself (edit-only is an
+        # instruction, not an invariant).
+        await _git(workdir, "fetch", "origin", branch)  # best-effort; remote may not exist yet
+        remote_exists = (await _git(workdir, "rev-parse", "--verify", "--quiet", f"origin/{branch}")).ok
+        local_ahead_base = await _count(workdir, f"origin/{base}..HEAD")
+        local_unpushed = await _count(workdir, f"origin/{branch}..HEAD") if remote_exists else local_ahead_base
+        remote_ahead_base = await _count(workdir, f"origin/{base}..origin/{branch}") if remote_exists else 0
+        if local_ahead_base and local_unpushed:
+            out.coder_did_git = "committed"
+            out.committed = True
+        elif remote_ahead_base:
+            out.coder_did_git = "pushed"
+            sha = await _git(workdir, "rev-parse", f"origin/{branch}")
+            out.pushed, out.pushed_sha = True, (sha.stdout.strip() if sha.ok else "")
+        else:
+            out.no_changes = True
+            return out
+
+    if out.committed and not out.pushed:
+        # Rebase on the freshest base, then push. A conflict is merge-time friction,
+        # not a failure: abort the rebase and push what we have, reporting the files.
+        lease = False
+        fetched = await _git(workdir, "fetch", "origin", base, timeout=120)
+        if fetched.ok:
+            rebase = await _git(workdir, "rebase", f"origin/{base}", env=env, timeout=180)
+            if rebase.ok:
+                lease = True
+            else:
+                if "conflict" in f"{rebase.stdout} {rebase.stderr}".lower():
+                    conflicted = await _git(workdir, "diff", "--name-only", "--diff-filter=U")
+                    out.rebase_conflicts = conflicted.stdout.split() if conflicted.ok else ["(unknown)"]
+                await _git(workdir, "rebase", "--abort")
+
+        push = await _push_with_retry(workdir, branch, lease)
+        head_sha = await _git(workdir, "rev-parse", "HEAD")
+        out.commit_sha = head_sha.stdout.strip() if head_sha.ok else ""
+        if not push.ok:
+            out.errors.append(f"push failed: {(push.stderr or push.error or '?')[:300]}")
+            return out
+        # Verify the remote actually has our HEAD — "committed locally" never counts
+        # as done (the industry's #1 false-success mode).
+        remote = await _git(workdir, "ls-remote", "origin", f"refs/heads/{branch}", timeout=60)
+        remote_sha = remote.stdout.split()[0] if remote.ok and remote.stdout.strip() else ""
+        if remote_sha and remote_sha == out.commit_sha:
+            out.pushed, out.pushed_sha = True, remote_sha
+        else:
+            out.errors.append(f"push not verified: remote is at {remote_sha[:10] or '(unknown)'}, local at {out.commit_sha[:10]}")
+            return out
+
+    if out.pushed:
+        await _open_pr(workdir, out, title=title)
+    return out
+
+
+async def _push_with_retry(workdir: str, branch: str, lease: bool) -> ShellResult:
+    """Push with bounded backoff. ``--force-with-lease`` only after a successful
+    rebase (rewritten history); never bare ``--force``."""
+    args = ["push", *(["--force-with-lease"] if lease else []), "-u", "origin", branch]
+    res = ShellResult(1, "", "", error="push never ran")
+    for attempt in range(3):
+        res = await _git(workdir, *args, timeout=120)
+        if res.ok:
+            return res
+        blob = f"{res.stdout} {res.stderr} {res.error or ''}".lower()
+        transient = any(m in blob for m in ("stale info", "cannot lock ref", "could not resolve host", "index.lock"))
+        if transient and attempt < 2:
+            await _git(workdir, "fetch", "origin", branch)
+            await asyncio.sleep(0.5 * (2**attempt))
+            continue
+        return res
+    return res
+
+
+# ── PR layer (idempotent) ─────────────────────────────────────────────────────
+
+
+async def preflight_pr(workdir: str, branch: str) -> str:
+    """URL of an already-open PR for ``branch``, or "". Run BEFORE dispatching the
+    coder: it catches restarts and the created-a-PR-but-crashed case across process
+    lifetimes, which the in-memory claim registry can't."""
+    rc, stdout, _ = await run_gh(
+        ["pr", "list", "--head", branch, "--state", "open", "--json", "url", "--limit", "1"],
+        cwd=workdir,
+    )
+    if rc == 0 and stdout.strip():
+        import json
+
+        try:
+            rows = json.loads(stdout)
+            if rows:
+                return str(rows[0].get("url", ""))
+        except ValueError:
+            pass
+    return ""
+
+
+async def _open_pr(workdir: str, out: GitOutcome, *, title: str) -> None:
+    """Create-or-reuse the PR for ``out.branch``. Idempotency layers: 0-commits-ahead
+    skip → open-PR pre-check → create → "already exists" recovery."""
+    ahead = await _count(workdir, f"origin/{out.base}..origin/{out.branch}")
+    if ahead == 0:
+        out.pr_state = "skipped-no-commits"
+        return
+    existing = await preflight_pr(workdir, out.branch)
+    if existing:
+        out.pr_url, out.pr_state = existing, "existing"
+        return
+    body = f"Automated change for item `{out.item_id}` (branch `{out.branch}`).\n\nPublished by the managed-git harness (ADR 0076)."
+    rc, stdout, stderr = await run_gh(
+        ["pr", "create", "--head", out.branch, "--base", out.base, "--title", title, "--body", body],
+        cwd=workdir,
+        timeout=60,
+    )
+    if rc == 0:
+        url = next((ln for ln in reversed(stdout.strip().splitlines()) if ln.startswith("http")), stdout.strip())
+        out.pr_url, out.pr_state = url, "created"
+        return
+    if "already exists" in stderr.lower():
+        rc2, stdout2, _ = await run_gh(
+            ["pr", "list", "--head", out.branch, "--state", "all", "--json", "url", "--limit", "1"],
+            cwd=workdir,
+        )
+        if rc2 == 0 and stdout2.strip():
+            import json
+
+            try:
+                rows = json.loads(stdout2)
+                if rows:
+                    out.pr_url, out.pr_state = str(rows[0].get("url", "")), "existing"
+                    return
+            except ValueError:
+                pass
+    out.errors.append(f"gh pr create failed: {stderr[:300] or '(no stderr)'}")

--- a/plugins/delegates/__init__.py
+++ b/plugins/delegates/__init__.py
@@ -34,6 +34,7 @@ def _build_delegate_to(registry: DelegateRegistry):
         target: str,
         query: str,
         background: bool = False,
+        item_id: str = "",
         state: Annotated[Any, InjectedState] = None,
     ) -> str:
         """Hand a question or task to one of your configured delegates and return its reply.
@@ -58,13 +59,17 @@ def _build_delegate_to(registry: DelegateRegistry):
                 does not see this conversation, so restate what it needs.
             background: run the delegation detached and get the reply back on
                 completion, instead of waiting inline (default False).
+            item_id: stable work-item id for a coding task on a managed-git coding
+                agent — one PR per id, and a second dispatch of an in-flight id is
+                refused instead of duplicating the work. Use the issue/board id when
+                there is one; leave empty to derive one from the query text.
         """
         if not str(query).strip():
             return "Error: `query` is empty — give the delegate something to do."
         if background:
-            return await _spawn_background_delegation(registry, target, query, state)
+            return await _spawn_background_delegation(registry, target, query, state, item_id=item_id)
         try:
-            return await registry.dispatch(target, query)
+            return await registry.dispatch(target, query, item_id=item_id.strip() or None)
         except DelegateError as exc:
             return f"Error: {exc}"
         except Exception as exc:  # noqa: BLE001 — surface as a tool error string
@@ -75,7 +80,9 @@ def _build_delegate_to(registry: DelegateRegistry):
     return delegate_to
 
 
-async def _spawn_background_delegation(registry: DelegateRegistry, target: str, query: str, state: Any) -> str:
+async def _spawn_background_delegation(
+    registry: DelegateRegistry, target: str, query: str, state: Any, *, item_id: str = ""
+) -> str:
     """Run a delegation as a detached background job (ADR 0050): return a handle now and
     drain the delegate's reply back into the spawning session on completion — the same
     durable store + concurrency cap + drain-on-next-turn notification that
@@ -96,7 +103,7 @@ async def _spawn_background_delegation(registry: DelegateRegistry, target: str, 
     except Exception:  # noqa: BLE001 — no runtime state (e.g. a unit test) → inline
         mgr = None
     if mgr is None:
-        return await registry.dispatch(target, query)
+        return await registry.dispatch(target, query, item_id=item_id.strip() or None)
 
     try:
         from tools.lg_tools import _session_id_from
@@ -108,7 +115,10 @@ async def _spawn_background_delegation(registry: DelegateRegistry, target: str, 
         session = ""
 
     async def _work() -> str:
-        return await registry.dispatch(target, query)
+        # item_id rides into the dispatch itself, so the managed-git claim/dedup
+        # applies identically to background and foreground fan-out (one registry,
+        # one event loop).
+        return await registry.dispatch(target, query, item_id=item_id.strip() or None)
 
     snippet = " ".join(query.split())[:80]
     job_id = await mgr.spawn_work(

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -86,6 +86,12 @@ class Delegate:
     allow_kinds: list[str] = field(default_factory=list)
     deny_kinds: list[str] = field(default_factory=list)
     confirm: bool = False
+    # acp managed git (ADR 0076): the framework owns branch/commit/push/PR; the
+    # coder edits files only. Off by default — non-worktree setups keep the old
+    # coder-owns-git mode.
+    manage_git: bool = False
+    base_branch: str = "main"
+    branch_prefix: str = ""  # empty ⇒ the delegate's name
 
 
 def _secret(raw: dict, value_key: str, env_key: str) -> str:
@@ -515,6 +521,29 @@ class AcpAdapter(Adapter):
                 help="Ask the operator before each call.",
             ),
             FieldSpec("timeout_s", "Timeout (s)", "number", default=600),
+            FieldSpec(
+                "manage_git",
+                "Managed git",
+                "select",
+                options=["false", "true"],
+                default="false",
+                help="Framework owns branch/commit/push/PR (ADR 0076); the coder only edits "
+                "files. Needs workdir to be a git checkout with an `origin` remote.",
+            ),
+            FieldSpec(
+                "base_branch",
+                "Base branch",
+                "text",
+                placeholder="main",
+                help="Managed git: branches are cut from fresh origin/<base> and PRs target it.",
+            ),
+            FieldSpec(
+                "branch_prefix",
+                "Branch prefix",
+                "text",
+                placeholder="(delegate name)",
+                help="Managed git: branch names are <prefix>/<slug>-<id7>. Empty ⇒ the delegate's name.",
+            ),
         ]
 
     def parse(self, raw: dict) -> Delegate:
@@ -543,6 +572,9 @@ class AcpAdapter(Adapter):
         d.allow_kinds = [str(k).lower() for k in (raw.get("allow_kinds") or [])]
         d.deny_kinds = [str(k).lower() for k in (raw.get("deny_kinds") or [])]
         d.confirm = str(raw.get("confirm", "")).strip().lower() in ("1", "true", "yes")
+        d.manage_git = str(raw.get("manage_git", "")).strip().lower() in ("1", "true", "yes")
+        d.base_branch = str(raw.get("base_branch") or "main").strip() or "main"
+        d.branch_prefix = str(raw.get("branch_prefix", "")).strip()
         return d
 
     @staticmethod
@@ -563,7 +595,12 @@ class AcpAdapter(Adapter):
             "deny_kinds": d.deny_kinds,
         }
 
-    async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
+    async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None, item_id: str | None = None) -> str:
+        if d.manage_git:
+            return await self._dispatch_managed(d, query, timeout=timeout, item_id=item_id)
+        return await self._prompt(d, query, timeout=timeout)
+
+    async def _prompt(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
         # Reuse the ADR 0024 ACP client + by-kind permission policy.
         from plugins.coding_agent import _client_for, _drop_client, _make_permission
         from plugins.coding_agent.acp_client import AcpError
@@ -584,6 +621,41 @@ class AcpAdapter(Adapter):
             raise
         except AcpError as exc:
             raise DelegateError(str(exc))
+
+    async def _dispatch_managed(
+        self, d: Delegate, query: str, *, timeout: float | None = None, item_id: str | None = None
+    ) -> str:
+        """Managed-git dispatch (ADR 0076): claim → PR pre-flight → branch setup →
+        edit-only coder run → framework-owned commit/rebase/push/PR. The claim dedups
+        in-flight duplicates (fan-out of one item); the PR pre-flight dedups across
+        restarts. On a coder failure the worktree keeps its edits and a re-run's
+        idempotent lifecycle adopts them."""
+        from plugins.coding_agent import git_harness as harness
+
+        iid = (item_id or "").strip() or harness.derive_item_id(query)
+        branch = harness.mint_branch(d.branch_prefix or d.name, query, iid)
+        holder = harness.claim(iid, d.name)
+        if holder is not None:
+            return (
+                f"Item `{iid}` is already being built by {holder!r} (branch `{branch}`) — not "
+                "dispatching a duplicate. Wait for the in-flight run instead of re-fanning this item."
+            )
+        try:
+            workdir = os.path.expanduser(d.workdir)
+            existing = await harness.preflight_pr(workdir, branch)
+            if existing:
+                return f"An open PR already exists for item `{iid}` (branch `{branch}`): {existing} — not dispatching a duplicate."
+            prep = await harness.prepare(workdir, base=d.base_branch, branch=branch)
+            if prep.error:
+                return f"Error: managed-git setup for {d.name!r} failed: {prep.error}"
+            reply = await self._prompt(d, query + harness.edit_only_directive(branch), timeout=timeout)
+            outcome = await harness.finish(
+                workdir, base=d.base_branch, branch=branch, item_id=iid, title=harness.title_from(query)
+            )
+            notes = "".join(f"\n- note: {n}" for n in prep.notes)
+            return f"{reply}\n\n{outcome.render()}{notes}"
+        finally:
+            harness.release(iid)
 
     async def teardown(self, d: Delegate) -> bool:
         """Evict + terminate the cached ACP subprocess for this delegate.

--- a/plugins/delegates/registry.py
+++ b/plugins/delegates/registry.py
@@ -63,9 +63,12 @@ class DelegateRegistry:
             for d in self._items.values()
         ]
 
-    async def dispatch(self, name: str, query: str) -> str:
+    async def dispatch(self, name: str, query: str, *, item_id: str | None = None) -> str:
         d = self._items.get(name)
         if d is None:
             raise DelegateError(f"unknown delegate {name!r}. Configured: {', '.join(self._items) or '(none)'}.")
         adapter = ADAPTERS[d.type]
+        if d.type == "acp":
+            # Only the acp adapter understands work-item identity (managed git, ADR 0076).
+            return await adapter.dispatch(d, query, item_id=item_id)
         return await adapter.dispatch(d, query)

--- a/tests/test_delegates_plugin.py
+++ b/tests/test_delegates_plugin.py
@@ -68,6 +68,24 @@ def test_acp_parse_ok_and_requires_command_workdir():
         ADAPTERS["acp"].parse({"name": "x", "type": "acp", "command": "proto"})  # no workdir
 
 
+def test_acp_parse_manage_git_fields():
+    # Managed git (ADR 0076): off by default; fields parse with sane fallbacks.
+    d = ADAPTERS["acp"].parse({"name": "c", "type": "acp", "command": "proto", "workdir": "/tmp"})
+    assert d.manage_git is False and d.base_branch == "main" and d.branch_prefix == ""
+    d = ADAPTERS["acp"].parse(
+        {
+            "name": "c",
+            "type": "acp",
+            "command": "proto",
+            "workdir": "/tmp",
+            "manage_git": "true",
+            "base_branch": "  develop ",
+            "branch_prefix": "wt-1",
+        }
+    )
+    assert d.manage_git is True and d.base_branch == "develop" and d.branch_prefix == "wt-1"
+
+
 def test_acp_parse_claude_code_alias():
     # `claude-code` is a convenience alias for the claude-agent-acp adapter (#1116):
     # the operator's intuitive name maps to the real binary, with no launch args.
@@ -304,11 +322,11 @@ async def test_delegate_to_background_falls_back_inline_without_manager(monkeypa
     assert out == "dispatched:quick q"
 
 
-async def _fake_dispatch(self, name, query):
+async def _fake_dispatch(self, name, query, *, item_id=None):
     return f"dispatched:{query}"
 
 
-async def _unexpected_dispatch(self, name, query):
+async def _unexpected_dispatch(self, name, query, *, item_id=None):
     raise AssertionError("dispatch must not run inline when a background job is spawned")
 
 

--- a/tests/test_git_harness.py
+++ b/tests/test_git_harness.py
@@ -1,0 +1,312 @@
+"""Managed-git harness (ADR 0076) — real-git lifecycle tests + claim/dedup.
+
+Follows the repo's real-subprocess style (tests/test_shell.py): a real ``git init``
+repo in tmp_path with a bare local "origin", so branch/commit/push behavior is
+exercised for real. Only the ``gh`` PR layer is faked (monkeypatched ``run_gh``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from plugins.coding_agent import git_harness as harness
+from tools.shell import run_command
+
+
+async def _git(cwd, *args) -> str:
+    res = await run_command(["git", *args], cwd=str(cwd))
+    assert res.ok, f"git {' '.join(args)}: {res.stderr or res.error}"
+    return res.stdout
+
+
+@pytest.fixture
+async def repo(tmp_path):
+    """A work clone with a local bare origin, one pushed commit on main."""
+    origin = tmp_path / "origin.git"
+    work = tmp_path / "work"
+    assert (await run_command(["git", "init", "--bare", str(origin)])).ok
+    assert (await run_command(["git", "clone", str(origin), str(work)])).ok
+    await _git(work, "config", "user.email", "test@example.com")
+    await _git(work, "config", "user.name", "Test")
+    (work / "README.md").write_text("hello\n")
+    await _git(work, "add", "-A")
+    await _git(work, "commit", "-m", "init")
+    await _git(work, "branch", "-M", "main")
+    await _git(work, "push", "-u", "origin", "main")
+    return work
+
+
+def _fake_gh(monkeypatch, responses: dict[str, tuple[int, str, str]]) -> list[list[str]]:
+    """Fake ``run_gh`` keyed on the first two args ('pr list' / 'pr create')."""
+    calls: list[list[str]] = []
+
+    async def fake(args, timeout=30, cwd=None):
+        calls.append(list(args))
+        return responses.get(" ".join(args[:2]), (1, "", "no fake response"))
+
+    monkeypatch.setattr(harness, "run_gh", fake)
+    return calls
+
+
+# ── deterministic identity ────────────────────────────────────────────────────
+
+
+def test_mint_branch_deterministic_and_unique():
+    a = harness.mint_branch("proto-1", "Fix the flaky VRAM chart", "abc123def456")
+    assert a == harness.mint_branch("proto-1", "Fix the flaky VRAM chart", "abc123def456")
+    assert a == "proto-1/fix-the-flaky-vram-chart-3def456"
+    # Same title, different item ⇒ different branch (the id suffix is the collision-proofing).
+    b = harness.mint_branch("proto-1", "Fix the flaky VRAM chart", "zzz999zzz999")
+    assert a != b
+
+
+def test_mint_branch_survives_hostile_input():
+    branch = harness.mint_branch("Proto 1!", "  Émojis 🎉 & spaces:\nsecond line ignored", "abc123def456")
+    prefix, _, slug = branch.partition("/")
+    assert prefix == "proto-1"
+    assert slug.endswith("-3def456")
+    assert " " not in branch and ":" not in branch
+    # Empty everything still yields a valid ref.
+    assert harness.mint_branch("", "", "abc123def456") == "task/task-3def456"
+
+
+def test_derive_item_id_stable_and_whitespace_insensitive():
+    assert harness.derive_item_id("do the thing") == harness.derive_item_id("  do the thing  \n")
+    assert len(harness.derive_item_id("x")) == 12
+
+
+def test_title_from_caps_and_collapses():
+    assert harness.title_from("  Fix   the\tthing  \nrest is body") == "Fix the thing"
+    assert len(harness.title_from("x" * 200)) <= 72
+
+
+# ── claim registry ────────────────────────────────────────────────────────────
+
+
+def test_claim_and_release():
+    assert harness.claim("item-1", "coder-a") is None
+    assert harness.claim("item-1", "coder-b") == "coder-a"
+    harness.release("item-1")
+    assert harness.claim("item-1", "coder-b") is None
+    harness.release("item-1")
+    harness.release("item-1")  # idempotent
+
+
+async def test_claim_dedups_concurrent_fanout():
+    got: list[str | None] = []
+
+    async def worker(name: str):
+        holder = harness.claim("item-fan", name)
+        got.append(holder)
+        if holder is None:
+            await asyncio.sleep(0.02)  # hold the claim while the others arrive
+            harness.release("item-fan")
+
+    await asyncio.gather(*(worker(f"c{i}") for i in range(4)))
+    assert got.count(None) == 1  # exactly one dispatch wins
+
+
+# ── prepare ───────────────────────────────────────────────────────────────────
+
+
+async def test_prepare_branches_off_origin_not_local_head(repo):
+    # Diverge LOCAL main with an unpushed commit — the branch must not inherit it.
+    (repo / "local-only.txt").write_text("x\n")
+    await _git(repo, "add", "-A")
+    await _git(repo, "commit", "-m", "local drift")
+    drift_sha = await _git(repo, "rev-parse", "HEAD")
+
+    prep = await harness.prepare(str(repo), base="main", branch="t/task-abc1234")
+    assert prep.error is None
+    assert await _git(repo, "rev-parse", "--abbrev-ref", "HEAD") == "t/task-abc1234"
+    res = await run_command(["git", "merge-base", "--is-ancestor", drift_sha, "HEAD"], cwd=str(repo))
+    assert res.returncode != 0  # the local-drift commit is NOT on the new branch
+
+
+async def test_prepare_stashes_leftovers_and_seeds_exclude(repo):
+    (repo / "leftover.txt").write_text("stranded work\n")
+    prep = await harness.prepare(str(repo), base="main", branch="t/clean-abc1234")
+    assert prep.error is None
+    assert any("stashed leftover" in n for n in prep.notes)
+    assert (await _git(repo, "status", "--porcelain")) == ""
+    assert "leftover" in (await _git(repo, "stash", "list"))
+    exclude = await _git(repo, "rev-parse", "--git-path", "info/exclude")
+    path = repo / exclude if not exclude.startswith("/") else exclude
+    assert ".proto/" in open(path).read()
+
+
+async def test_prepare_keeps_branch_with_prior_commits(repo):
+    await harness.prepare(str(repo), base="main", branch="t/keep-abc1234")
+    (repo / "work.txt").write_text("prior run\n")
+    await _git(repo, "add", "-A")
+    await _git(repo, "commit", "-m", "prior partial run")
+    sha = await _git(repo, "rev-parse", "HEAD")
+    await _git(repo, "checkout", "main")
+
+    prep = await harness.prepare(str(repo), base="main", branch="t/keep-abc1234")
+    assert prep.error is None
+    assert await _git(repo, "rev-parse", "HEAD") == sha  # not re-cut — prior work kept
+
+
+# ── finish ────────────────────────────────────────────────────────────────────
+
+
+async def test_finish_commits_pushes_and_opens_pr(repo, monkeypatch):
+    calls = _fake_gh(
+        monkeypatch,
+        {"pr list": (0, "[]", ""), "pr create": (0, "https://github.com/x/y/pull/7", "")},
+    )
+    await harness.prepare(str(repo), base="main", branch="t/feat-abc1234")
+    (repo / "feature.txt").write_text("new\n")
+    (repo / ".proto").mkdir()
+    (repo / ".proto" / "scratch.md").write_text("coder scratch\n")  # excluded structurally
+
+    out = await harness.finish(str(repo), base="main", branch="t/feat-abc1234", item_id="abc1234", title="Add feature")
+    assert out.committed and out.pushed
+    assert out.pushed_sha == out.commit_sha
+    assert out.pr_url.endswith("/pull/7") and out.pr_state == "created"
+    # Remote really has the commit, and scratch never reached it.
+    remote_sha = (await _git(repo, "ls-remote", "origin", "refs/heads/t/feat-abc1234")).split()[0]
+    assert remote_sha == out.commit_sha
+    files = await _git(repo, "diff", "--name-only", "origin/main..HEAD")
+    assert "feature.txt" in files and ".proto/scratch.md" not in files
+    assert any(a[:2] == ["pr", "create"] for a in calls)
+    assert "Item ID: abc1234" in (await _git(repo, "log", "-1", "--format=%B"))
+
+
+async def test_finish_no_changes_is_honest(repo, monkeypatch):
+    _fake_gh(monkeypatch, {"pr list": (0, "[]", "")})
+    await harness.prepare(str(repo), base="main", branch="t/noop-abc1234")
+    out = await harness.finish(str(repo), base="main", branch="t/noop-abc1234", item_id="abc1234", title="Nothing")
+    assert out.no_changes and not out.committed and not out.pushed and not out.pr_url
+    assert "no changes" in out.render()
+
+
+async def test_finish_adopts_coder_commit(repo, monkeypatch):
+    _fake_gh(monkeypatch, {"pr list": (0, "[]", ""), "pr create": (0, "https://github.com/x/y/pull/8", "")})
+    await harness.prepare(str(repo), base="main", branch="t/adopt-abc1234")
+    (repo / "coder.txt").write_text("coder did git itself\n")
+    await _git(repo, "add", "-A")
+    await _git(repo, "commit", "-m", "coder's own commit")
+
+    out = await harness.finish(str(repo), base="main", branch="t/adopt-abc1234", item_id="abc1234", title="Adopt")
+    assert out.coder_did_git == "committed"
+    assert out.pushed and out.pr_url.endswith("/pull/8")
+
+
+async def test_finish_stranded_on_base_refuses(repo, monkeypatch):
+    _fake_gh(monkeypatch, {"pr list": (0, "[]", "")})
+    await harness.prepare(str(repo), base="main", branch="t/stray-abc1234")
+    await _git(repo, "checkout", "main")
+    (repo / "oops.txt").write_text("edited on main\n")
+
+    out = await harness.finish(str(repo), base="main", branch="t/stray-abc1234", item_id="abc1234", title="Stray")
+    assert out.stranded_on_base and not out.committed and not out.pushed
+    assert "BLOCKED" in out.render()
+    # Nothing was committed to main; the work is still there, uncommitted.
+    assert (await _git(repo, "rev-list", "--count", "origin/main..main")) == "0"
+    assert "oops.txt" in (await _git(repo, "status", "--porcelain"))
+
+
+async def test_finish_blocks_secrets(repo, monkeypatch):
+    _fake_gh(monkeypatch, {"pr list": (0, "[]", "")})
+    await harness.prepare(str(repo), base="main", branch="t/leak-abc1234")
+    (repo / "config.py").write_text('AWS_KEY = "AKIA' + "ABCDEFGHIJKLMNOP" + '"\n')
+
+    out = await harness.finish(str(repo), base="main", branch="t/leak-abc1234", item_id="abc1234", title="Leak")
+    assert out.blocked_secrets and not out.committed and not out.pushed
+    assert "config.py" in out.blocked_secrets[0]
+    assert (await _git(repo, "rev-list", "--count", "origin/main..HEAD")) == "0"
+
+
+async def test_finish_reuses_existing_pr(repo, monkeypatch):
+    _fake_gh(monkeypatch, {"pr list": (0, '[{"url": "https://github.com/x/y/pull/3"}]', "")})
+    await harness.prepare(str(repo), base="main", branch="t/reuse-abc1234")
+    (repo / "again.txt").write_text("re-run\n")
+
+    out = await harness.finish(str(repo), base="main", branch="t/reuse-abc1234", item_id="abc1234", title="Re-run")
+    assert out.pushed
+    assert out.pr_url.endswith("/pull/3") and out.pr_state == "existing"
+
+
+# ── managed dispatch (adapter integration) ────────────────────────────────────
+
+
+def _managed_delegate(repo, name="coder-1"):
+    from plugins.delegates.adapters import Delegate
+
+    return Delegate(name=name, type="acp", command="fake", workdir=str(repo), manage_git=True, base_branch="main")
+
+
+async def test_managed_dispatch_end_to_end(repo, monkeypatch):
+    from plugins.delegates.adapters import AcpAdapter
+
+    _fake_gh(monkeypatch, {"pr list": (0, "[]", ""), "pr create": (0, "https://github.com/x/y/pull/9", "")})
+    seen_queries: list[str] = []
+
+    async def fake_prompt(self, d, query, *, timeout=None):
+        seen_queries.append(query)
+        (repo / "built.txt").write_text("done\n")
+        return "I made the change and ran the tests."
+
+    monkeypatch.setattr(AcpAdapter, "_prompt", fake_prompt)
+    reply = await AcpAdapter().dispatch(_managed_delegate(repo), "Add the built file", item_id="item-42")
+
+    assert "I made the change" in reply
+    assert "pull/9" in reply and "[managed git]" in reply
+    assert "Do NOT run git commands" in seen_queries[0]  # edit-only directive reached the coder
+    branch = await _git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    assert branch == "coder-1/add-the-built-file-item-42"
+    assert harness.claim("item-42", "probe") is None  # claim was released
+    harness.release("item-42")
+
+
+async def test_managed_dispatch_dedups_inflight_item(repo, monkeypatch):
+    from plugins.delegates.adapters import AcpAdapter
+
+    _fake_gh(monkeypatch, {"pr list": (0, "[]", ""), "pr create": (0, "https://github.com/x/y/pull/10", "")})
+
+    async def slow_prompt(self, d, query, *, timeout=None):
+        (repo / "slow.txt").write_text("done\n")
+        await asyncio.sleep(0.05)
+        return "built it"
+
+    monkeypatch.setattr(AcpAdapter, "_prompt", slow_prompt)
+    adapter = AcpAdapter()
+    task = "One item fanned to two coders"
+    a, b = await asyncio.gather(
+        adapter.dispatch(_managed_delegate(repo, "coder-1"), task),
+        adapter.dispatch(_managed_delegate(repo, "coder-2"), task),  # same task ⇒ same derived item_id
+    )
+    replies = sorted([a, b])
+    assert sum("already being built" in r for r in replies) == 1
+    assert sum("[managed git]" in r for r in replies) == 1
+
+
+async def test_managed_dispatch_preflight_returns_existing_pr(repo, monkeypatch):
+    from plugins.delegates.adapters import AcpAdapter
+
+    _fake_gh(monkeypatch, {"pr list": (0, '[{"url": "https://github.com/x/y/pull/11"}]', "")})
+
+    async def must_not_run(self, d, query, *, timeout=None):
+        raise AssertionError("coder must not be dispatched when an open PR exists")
+
+    monkeypatch.setattr(AcpAdapter, "_prompt", must_not_run)
+    reply = await AcpAdapter().dispatch(_managed_delegate(repo), "Anything", item_id="item-43")
+    assert "pull/11" in reply and "already exists" in reply
+
+
+async def test_unmanaged_dispatch_untouched(repo, monkeypatch):
+    """manage_git=False keeps the old path — no branch, no git, no directive."""
+    from plugins.delegates.adapters import AcpAdapter, Delegate
+
+    async def fake_prompt(self, d, query, *, timeout=None):
+        return f"plain: {query}"
+
+    monkeypatch.setattr(AcpAdapter, "_prompt", fake_prompt)
+    d = Delegate(name="c", type="acp", command="fake", workdir=str(repo))
+    reply = await AcpAdapter().dispatch(d, "just a task")
+    assert reply == "plain: just a task"
+    assert await _git(repo, "rev-parse", "--abbrev-ref", "HEAD") == "main"

--- a/tools/gh_cli.py
+++ b/tools/gh_cli.py
@@ -25,11 +25,12 @@ def _resolve_token() -> str | None:
     return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or None
 
 
-async def run_gh(args: list[str], timeout: int = _COMMAND_TIMEOUT) -> tuple[int, str, str]:
+async def run_gh(args: list[str], timeout: int = _COMMAND_TIMEOUT, cwd: str | None = None) -> tuple[int, str, str]:
     """Run a ``gh`` command, returning ``(returncode, stdout, stderr)``.
 
     Times out (killing the process), and reports a clean error when ``gh``
-    isn't installed instead of raising.
+    isn't installed instead of raising. ``cwd`` scopes repo-relative commands
+    (``gh pr …``) to a checkout, the way ``gh`` resolves the target repo.
     """
     env = os.environ.copy()
     token = _resolve_token()
@@ -44,6 +45,7 @@ async def run_gh(args: list[str], timeout: int = _COMMAND_TIMEOUT) -> tuple[int,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
+            cwd=cwd,
         )
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         return (


### PR DESCRIPTION
Implements phases 1–3 of [ADR 0076](https://github.com/protoLabsAI/protoAgent/pull/1845): an opt-in `manage_git` mode on `acp` delegates where the coder only edits files and a deterministic harness owns branch/commit/rebase/push/PR.

**Why:** every reliability failure observed running a multi-coder worktree pool traces to the LLM owning a deterministic git step — branch collisions, "done" without a push, duplicate PRs on fan-out, scratch in the diff. Industry consensus (Copilot coding agent, Devin, Aider, Cursor, Jules) keeps remote-touching git in the harness; duplicate PRs are the #1 empirical agent-PR rejection cause (23%, arXiv 2601.15195).

**What:**
- `plugins/coding_agent/git_harness.py` — deterministic branch minting (`<prefix>/<slug>-<id7>`, no LLM), branch cut from fresh `origin/<base>` (never HEAD), isolation guard (`stranded_on_base`), secret scan before commit, commit-on-behalf idempotent to partial coder git (adopts committed / already-pushed work), rebase with conflict-tolerant push, `--force-with-lease` + lock-contention retry + **remote-SHA verification**, idempotent `gh pr create`.
- Single-claim registry on `item_id` (event-loop-atomic; `delegate_to` gains the arg, hash-of-query default) + open-PR pre-flight — in-flight and cross-restart dedup.
- `Delegate`/`FieldSpec`/`parse` additions: `manage_git` (default **off** — existing delegates untouched), `base_branch`, `branch_prefix`.
- `run_gh` grows `cwd`; guide gains the managed-git section and drops the retired `code_with` YAML.

**Verification:** new real-git test suite (tmp repos with a bare origin, `gh` faked): happy path with remote-SHA assertion, no-changes honesty, coder-did-git adoption, stranded-on-base refusal, secret block, PR reuse, concurrent fan-out dedup (exactly one dispatch), preflight short-circuit, unmanaged path unchanged. `ruff`, `lint-imports`, full `pytest` (3279 passed), and `live_smoke` all green locally.

Follow-ups per the plan: P4 roxy wiring + band-aid removal (fork-local), P6 hot-file defer / foundation gating / worktree locks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)