### PR TITLE
fix(coding-agent): harden the managed-git harness (review findings from #1846)

### DIFF
--- a/plugins/coder/generate.py
+++ b/plugins/coder/generate.py
@@ -88,11 +88,15 @@ def make_delegate_generator(delegate_name: str, *, solution_name: str = "solutio
                 f"(an openai model endpoint, or an acp coder). Available: {available}"
             )
         prompt = _prompt(task, solution_name=solution_name, feedback=feedback)
+        # raw=True: the reply is candidate CODE for the ladder to select from, not a
+        # change to publish — bypass a manage_git delegate's branch/commit/PR lifecycle
+        # (ADR 0076), which would otherwise open a real PR per best-of-k attempt and
+        # dedup attempts 2..k into "PR already exists" refusal strings.
         if d.type in _STATEFUL_TYPES:
             async with _lock_for(delegate_name):  # serialize concurrent best-of-k on one session
-                reply = await reg.dispatch(delegate_name, prompt)
+                reply = await reg.dispatch(delegate_name, prompt, raw=True)
         else:
-            reply = await reg.dispatch(delegate_name, prompt)
+            reply = await reg.dispatch(delegate_name, prompt, raw=True)
         return extract_code(reply)
 
     return generate

--- a/plugins/coding_agent/git_harness.py
+++ b/plugins/coding_agent/git_harness.py
@@ -25,11 +25,13 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import logging
 import os
 import re
 from dataclasses import dataclass, field
 
+from graph.middleware.redaction import PATTERNS as _REDACTION_PATTERNS
 from tools.gh_cli import run_gh
 from tools.shell import ShellResult, run_command
 
@@ -120,27 +122,36 @@ _FALLBACK_IDENTITY = {
 # the coder force-added any of it.
 _SCRATCH_DIRS = (".proto/", ".worktrees/", ".claude/", "node_modules/")
 
+# Reuse the maintained token-shape patterns from the audit-log redactor — one place
+# to harden when providers change token formats. Only the token-SHAPED patterns:
+# the redactor's contextual ones (bearer_token, generic_api_key, env_var_assignment,
+# client_secret) match ordinary code (`API_KEY = os.environ[...]`) and would
+# false-positive-block legitimate commits.
+_TOKEN_PATTERN_NAMES = (
+    "openai_key",
+    "google_oauth",
+    "google_api_key",
+    "github_token",
+    "slack_token",
+    "aws_access_key",
+    "discord_token",
+)
 _SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"), "private key"),
-    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "AWS access key id"),
-    (re.compile(r"\bghp_[A-Za-z0-9]{36}\b"), "GitHub token"),
-    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{22,}\b"), "GitHub fine-grained token"),
-    (re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"), "Slack token"),
-    (re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b"), "Google API key"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{22,}\b"), "github fine-grained token"),
+    *((_REDACTION_PATTERNS[n], n.replace("_", " ")) for n in _TOKEN_PATTERN_NAMES if n in _REDACTION_PATTERNS),
 ]
 
 
 async def _git(workdir: str, *args: str, env: dict[str, str] | None = None, timeout: float = 60.0) -> ShellResult:
     """Run one git command in ``workdir``, retrying on shared-.git lock contention."""
-    res = ShellResult(1, "", "", error="git never ran")
-    for attempt in range(3):
+    for attempt in range(2):
         res = await run_command(["git", *args], cwd=workdir, env=env, timeout=timeout)
         blob = f"{res.stderr} {res.error or ''}".lower()
-        if not res.ok and any(m in blob for m in _LOCK_MARKERS) and attempt < 2:
-            await asyncio.sleep(0.4 * (2**attempt))
-            continue
-        return res
-    return res
+        if res.ok or not any(m in blob for m in _LOCK_MARKERS):
+            return res
+        await asyncio.sleep(0.4 * (2**attempt))
+    return await run_command(["git", *args], cwd=workdir, env=env, timeout=timeout)
 
 
 async def _count(workdir: str, spec: str) -> int | None:
@@ -274,6 +285,7 @@ class GitOutcome:
     item_id: str
     base: str
     stranded_on_base: bool = False
+    blocked_reason: str = ""  # non-base refusal (detached HEAD, unresolvable base, …)
     no_changes: bool = False
     coder_did_git: str = ""  # "" | "committed" | "pushed"
     committed: bool = False
@@ -294,6 +306,8 @@ class GitOutcome:
                 f"- BLOCKED: the coder left HEAD on `{self.base}` — nothing was committed. The edits "
                 "are recoverable in the worktree. Do NOT report this item as done."
             )
+        elif self.blocked_reason:
+            lines.append(f"- BLOCKED: {self.blocked_reason} Do NOT report this item as done.")
         elif self.blocked_secrets:
             lines.append("- BLOCKED: commit refused, possible secrets in the diff: " + "; ".join(self.blocked_secrets))
         elif self.no_changes:
@@ -334,6 +348,13 @@ async def finish(workdir: str, *, base: str, branch: str, item_id: str, title: s
         out.stranded_on_base = True
         out.errors.append(f"work left uncommitted in {workdir} — recover or re-run")
         return out
+    if head_branch == "HEAD" or not head_branch:
+        # Detached HEAD (a crashed rebase/bisect, or the coder checked out a sha) —
+        # `--abbrev-ref` returns the literal string "HEAD". Publishing would push a
+        # branch named "HEAD"; refuse and leave the work recoverable instead.
+        out.blocked_reason = "the worktree is in detached-HEAD state — nothing was committed or pushed."
+        out.errors.append(f"work (if any) left in {workdir} — reattach the branch and re-run")
+        return out
     if head_branch and head_branch != branch:
         # The coder moved HEAD to its own branch despite the directive. Publishing what
         # it committed beats publishing an empty ref — adopt its branch, note the drift.
@@ -354,7 +375,8 @@ async def finish(workdir: str, *, base: str, branch: str, item_id: str, title: s
             out.errors.append(f"unstaged scratch paths: {', '.join(scratch[:5])}{'…' if len(scratch) > 5 else ''}")
 
     # Secret scan on what would be committed — the harness commit is the one reliable
-    # interception point.
+    # interception point. The same diff text answers "is anything staged?" (its
+    # emptiness), so no separate `--quiet` probe.
     diff = await _git(workdir, "diff", "--cached", timeout=120)
     if diff.ok:
         found = _scan_added_lines(diff.stdout)
@@ -362,9 +384,13 @@ async def finish(workdir: str, *, base: str, branch: str, item_id: str, title: s
             await _git(workdir, "reset", "-q")
             out.blocked_secrets = found
             return out
-
-    staged_check = await _git(workdir, "diff", "--cached", "--quiet")
-    have_staged = staged_check.error is None and staged_check.returncode != 0
+        have_staged = bool(diff.stdout.strip())
+    else:
+        # Diff unreadable — fall back to the exit-code probe. `--quiet` exits 1 for
+        # "staged changes present"; any OTHER nonzero (128 = corrupt index, …) is an
+        # error, not a yes.
+        staged_check = await _git(workdir, "diff", "--cached", "--quiet")
+        have_staged = staged_check.error is None and staged_check.returncode == 1
 
     if have_staged:
         commit = await _git(workdir, "commit", "--no-verify", "-m", f"{title}\n\nItem ID: {item_id}", env=env)
@@ -378,15 +404,27 @@ async def finish(workdir: str, *, base: str, branch: str, item_id: str, title: s
         await _git(workdir, "fetch", "origin", branch)  # best-effort; remote may not exist yet
         remote_exists = (await _git(workdir, "rev-parse", "--verify", "--quiet", f"origin/{branch}")).ok
         local_ahead_base = await _count(workdir, f"origin/{base}..HEAD")
-        local_unpushed = await _count(workdir, f"origin/{branch}..HEAD") if remote_exists else local_ahead_base
-        remote_ahead_base = await _count(workdir, f"origin/{base}..origin/{branch}") if remote_exists else 0
-        if local_ahead_base and local_unpushed:
+        if local_ahead_base is None:
+            # _count contract: None = UNKNOWN (origin/<base> unresolvable), never 0.
+            # Claiming no_changes here would strand committed work behind an honest-
+            # looking "nothing to publish" — refuse loudly instead.
+            out.blocked_reason = f"origin/{base} is unresolvable — cannot tell whether the coder committed work."
+            out.errors.append(f"fetch origin/{base} and re-run; work (if any) is intact in {workdir}")
+            return out
+        local_unpushed = await _count(workdir, f"origin/{branch}..HEAD") if remote_exists else None
+        remote_ahead_base = (await _count(workdir, f"origin/{base}..origin/{branch}") or 0) if remote_exists else 0
+        if local_ahead_base and (local_unpushed is None or local_unpushed):
+            # Unknown unpushed-count ⇒ assume unpushed: re-pushing is idempotent,
+            # stranding is not.
             out.coder_did_git = "committed"
             out.committed = True
         elif remote_ahead_base:
-            out.coder_did_git = "pushed"
             sha = await _git(workdir, "rev-parse", f"origin/{branch}")
-            out.pushed, out.pushed_sha = True, (sha.stdout.strip() if sha.ok else "")
+            if not (sha.ok and sha.stdout.strip()):
+                out.blocked_reason = f"origin/{branch} is ahead of base but its sha is unresolvable."
+                return out
+            out.coder_did_git = "pushed"
+            out.pushed, out.pushed_sha = True, sha.stdout.strip()
         else:
             out.no_changes = True
             return out
@@ -410,7 +448,14 @@ async def finish(workdir: str, *, base: str, branch: str, item_id: str, title: s
         head_sha = await _git(workdir, "rev-parse", "HEAD")
         out.commit_sha = head_sha.stdout.strip() if head_sha.ok else ""
         if not push.ok:
-            out.errors.append(f"push failed: {(push.stderr or push.error or '?')[:300]}")
+            blob = f"{push.stdout} {push.stderr}".lower()
+            if "stale info" in blob or "rejected" in blob:
+                out.errors.append(
+                    f"push refused: the remote branch moved since our fetch (a concurrent writer?) — "
+                    f"not overwriting it. Inspect origin/{branch} and re-run."
+                )
+            else:
+                out.errors.append(f"push failed: {(push.stderr or push.error or '?')[:300]}")
             return out
         # Verify the remote actually has our HEAD — "committed locally" never counts
         # as done (the industry's #1 false-success mode).
@@ -428,38 +473,39 @@ async def finish(workdir: str, *, base: str, branch: str, item_id: str, title: s
 
 
 async def _push_with_retry(workdir: str, branch: str, lease: bool) -> ShellResult:
-    """Push with bounded backoff. ``--force-with-lease`` only after a successful
-    rebase (rewritten history); never bare ``--force``."""
+    """Push with bounded backoff on infrastructure failures. ``--force-with-lease``
+    only after a successful rebase (rewritten history); never bare ``--force``.
+
+    A lease REJECTION ("stale info") is deliberately NOT retried: fetching the branch
+    and re-pushing would move the lease baseline to the concurrent writer's tip and
+    the retry would silently overwrite their commits — the exact accident the lease
+    exists to prevent. It surfaces as a push failure for the operator to resolve."""
     args = ["push", *(["--force-with-lease"] if lease else []), "-u", "origin", branch]
-    res = ShellResult(1, "", "", error="push never ran")
-    for attempt in range(3):
+    for attempt in range(2):
         res = await _git(workdir, *args, timeout=120)
         if res.ok:
             return res
         blob = f"{res.stdout} {res.stderr} {res.error or ''}".lower()
-        transient = any(m in blob for m in ("stale info", "cannot lock ref", "could not resolve host", "index.lock"))
-        if transient and attempt < 2:
-            await _git(workdir, "fetch", "origin", branch)
-            await asyncio.sleep(0.5 * (2**attempt))
-            continue
-        return res
-    return res
+        transient = any(
+            m in blob for m in ("cannot lock ref", "could not resolve host", "unable to access", "connection")
+        )
+        if not transient:
+            return res
+        await asyncio.sleep(0.5 * (2**attempt))
+    return await _git(workdir, *args, timeout=120)
 
 
 # ── PR layer (idempotent) ─────────────────────────────────────────────────────
 
 
-async def preflight_pr(workdir: str, branch: str) -> str:
-    """URL of an already-open PR for ``branch``, or "". Run BEFORE dispatching the
-    coder: it catches restarts and the created-a-PR-but-crashed case across process
-    lifetimes, which the in-memory claim registry can't."""
+async def _pr_url_for(workdir: str, branch: str, *, state: str) -> str:
+    """URL of the newest PR for ``branch`` in ``state`` (gh's open/closed/merged/all),
+    or ""."""
     rc, stdout, _ = await run_gh(
-        ["pr", "list", "--head", branch, "--state", "open", "--json", "url", "--limit", "1"],
+        ["pr", "list", "--head", branch, "--state", state, "--json", "url", "--limit", "1"],
         cwd=workdir,
     )
     if rc == 0 and stdout.strip():
-        import json
-
         try:
             rows = json.loads(stdout)
             if rows:
@@ -467,6 +513,13 @@ async def preflight_pr(workdir: str, branch: str) -> str:
         except ValueError:
             pass
     return ""
+
+
+async def preflight_pr(workdir: str, branch: str) -> str:
+    """URL of an already-open PR for ``branch``, or "". Run BEFORE dispatching the
+    coder: it catches restarts and the created-a-PR-but-crashed case across process
+    lifetimes, which the in-memory claim registry can't."""
+    return await _pr_url_for(workdir, branch, state="open")
 
 
 async def _open_pr(workdir: str, out: GitOutcome, *, title: str) -> None:
@@ -491,18 +544,8 @@ async def _open_pr(workdir: str, out: GitOutcome, *, title: str) -> None:
         out.pr_url, out.pr_state = url, "created"
         return
     if "already exists" in stderr.lower():
-        rc2, stdout2, _ = await run_gh(
-            ["pr", "list", "--head", out.branch, "--state", "all", "--json", "url", "--limit", "1"],
-            cwd=workdir,
-        )
-        if rc2 == 0 and stdout2.strip():
-            import json
-
-            try:
-                rows = json.loads(stdout2)
-                if rows:
-                    out.pr_url, out.pr_state = str(rows[0].get("url", "")), "existing"
-                    return
-            except ValueError:
-                pass
+        url = await _pr_url_for(workdir, out.branch, state="all")
+        if url:
+            out.pr_url, out.pr_state = url, "existing"
+            return
     out.errors.append(f"gh pr create failed: {stderr[:300] or '(no stderr)'}")

--- a/plugins/delegates/__init__.py
+++ b/plugins/delegates/__init__.py
@@ -66,10 +66,14 @@ def _build_delegate_to(registry: DelegateRegistry):
         """
         if not str(query).strip():
             return "Error: `query` is empty — give the delegate something to do."
+        # Normalize identity ONCE at the tool boundary: whitespace-padded ids must not
+        # hash/claim differently from their trimmed twin (that would silently defeat
+        # the one-PR-per-item dedup).
+        item_id = str(item_id or "").strip()
         if background:
             return await _spawn_background_delegation(registry, target, query, state, item_id=item_id)
         try:
-            return await registry.dispatch(target, query, item_id=item_id.strip() or None)
+            return await registry.dispatch(target, query, item_id=item_id or None)
         except DelegateError as exc:
             return f"Error: {exc}"
         except Exception as exc:  # noqa: BLE001 — surface as a tool error string
@@ -103,7 +107,7 @@ async def _spawn_background_delegation(
     except Exception:  # noqa: BLE001 — no runtime state (e.g. a unit test) → inline
         mgr = None
     if mgr is None:
-        return await registry.dispatch(target, query, item_id=item_id.strip() or None)
+        return await registry.dispatch(target, query, item_id=item_id or None)
 
     try:
         from tools.lg_tools import _session_id_from
@@ -118,7 +122,7 @@ async def _spawn_background_delegation(
         # item_id rides into the dispatch itself, so the managed-git claim/dedup
         # applies identically to background and foreground fan-out (one registry,
         # one event loop).
-        return await registry.dispatch(target, query, item_id=item_id.strip() or None)
+        return await registry.dispatch(target, query, item_id=item_id or None)
 
     snippet = " ".join(query.split())[:80]
     job_id = await mgr.spawn_work(

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -120,7 +120,12 @@ class Adapter:
     def parse(self, raw: dict) -> Delegate:
         raise NotImplementedError
 
-    async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
+    async def dispatch(
+        self, d: Delegate, query: str, *, timeout: float | None = None, item_id: str | None = None
+    ) -> str:
+        """Dispatch ``query`` to ``d``. ``item_id`` is the work-item identity used by
+        adapters that manage a git lifecycle (acp, ADR 0076); identity-less adapters
+        accept and ignore it, so the registry can forward it uniformly."""
         raise NotImplementedError
 
     async def probe(self, d: Delegate) -> dict:
@@ -258,7 +263,9 @@ class A2aAdapter(Adapter):
             d.poll_timeout_s = 300.0
         return d
 
-    async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
+    async def dispatch(
+        self, d: Delegate, query: str, *, timeout: float | None = None, item_id: str | None = None
+    ) -> str:
         import time
 
         import httpx
@@ -437,7 +444,9 @@ class OpenAiAdapter(Adapter):
             d.temperature = 0.4
         return d
 
-    async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
+    async def dispatch(
+        self, d: Delegate, query: str, *, timeout: float | None = None, item_id: str | None = None
+    ) -> str:
         import httpx
 
         messages = []

--- a/plugins/delegates/registry.py
+++ b/plugins/delegates/registry.py
@@ -63,12 +63,19 @@ class DelegateRegistry:
             for d in self._items.values()
         ]
 
-    async def dispatch(self, name: str, query: str, *, item_id: str | None = None) -> str:
+    async def dispatch(self, name: str, query: str, *, item_id: str | None = None, raw: bool = False) -> str:
+        """Dispatch ``query`` to the named delegate.
+
+        ``item_id`` is the work-item identity for adapters that manage a git
+        lifecycle (ADR 0076); identity-less adapters ignore it. ``raw=True`` bypasses
+        the managed-git lifecycle for programmatic callers that consume the reply as
+        DATA (e.g. the coder ladder's candidate generation, ADR 0064) — no branch, no
+        commit, no PR, no claim; just the coder's text."""
         d = self._items.get(name)
         if d is None:
             raise DelegateError(f"unknown delegate {name!r}. Configured: {', '.join(self._items) or '(none)'}.")
-        adapter = ADAPTERS[d.type]
-        if d.type == "acp":
-            # Only the acp adapter understands work-item identity (managed git, ADR 0076).
-            return await adapter.dispatch(d, query, item_id=item_id)
-        return await adapter.dispatch(d, query)
+        if raw and d.manage_git:
+            import dataclasses
+
+            d = dataclasses.replace(d, manage_git=False)
+        return await ADAPTERS[d.type].dispatch(d, query, item_id=item_id)

--- a/tests/test_git_harness.py
+++ b/tests/test_git_harness.py
@@ -221,6 +221,86 @@ async def test_finish_blocks_secrets(repo, monkeypatch):
     assert (await _git(repo, "rev-list", "--count", "origin/main..HEAD")) == "0"
 
 
+async def test_finish_detached_head_refuses(repo, monkeypatch):
+    _fake_gh(monkeypatch, {"pr list": (0, "[]", "")})
+    await harness.prepare(str(repo), base="main", branch="t/detach-abc1234")
+    await _git(repo, "checkout", "--detach")
+    (repo / "adrift.txt").write_text("edited while detached\n")
+
+    out = await harness.finish(str(repo), base="main", branch="t/detach-abc1234", item_id="abc1234", title="Adrift")
+    assert out.blocked_reason and "detached" in out.blocked_reason
+    assert not out.committed and not out.pushed
+    assert "BLOCKED" in out.render()
+    # No branch literally named HEAD was minted or pushed.
+    res = await run_command(["git", "rev-parse", "--verify", "refs/heads/HEAD"], cwd=str(repo))
+    assert res.returncode != 0
+
+
+async def test_finish_unresolvable_base_blocks_instead_of_no_changes(repo, monkeypatch):
+    """_count contract: None = unknown, never 0 — committed work must not be
+    reported as 'no changes to publish'."""
+    _fake_gh(monkeypatch, {"pr list": (0, "[]", "")})
+    await harness.prepare(str(repo), base="main", branch="t/ghost-abc1234")
+    (repo / "real-work.txt").write_text("committed by the coder\n")
+    await _git(repo, "add", "-A")
+    await _git(repo, "commit", "-m", "coder work")
+
+    out = await harness.finish(str(repo), base="ghost", branch="t/ghost-abc1234", item_id="abc1234", title="Ghost")
+    assert not out.no_changes
+    assert out.blocked_reason and "unresolvable" in out.blocked_reason
+    assert not out.pushed
+
+
+async def test_push_lease_rejection_never_clobbers_concurrent_writer(repo, tmp_path, monkeypatch):
+    """A lease rejection must surface as a failure — never fetch-and-force over a
+    concurrent writer's commits."""
+    _fake_gh(monkeypatch, {"pr list": (0, "[]", "")})
+    branch = "t/race-abc1234"
+    await harness.prepare(str(repo), base="main", branch=branch)
+    (repo / "ours.txt").write_text("our work\n")
+
+    # A concurrent writer pushes to the same branch first, from a second clone.
+    other = tmp_path / "other"
+    origin_url = (await _git(repo, "remote", "get-url", "origin")).strip()
+    assert (await run_command(["git", "clone", origin_url, str(other)])).ok
+    await _git(other, "config", "user.email", "rival@example.com")
+    await _git(other, "config", "user.name", "Rival")
+    await _git(other, "checkout", "-b", branch, "origin/main")
+    (other / "theirs.txt").write_text("their work\n")
+    await _git(other, "add", "-A")
+    await _git(other, "commit", "-m", "concurrent work")
+    await _git(other, "push", "-u", "origin", branch)
+    their_sha = await _git(other, "rev-parse", "HEAD")
+
+    out = await harness.finish(str(repo), base="main", branch=branch, item_id="abc1234", title="Race")
+    assert not out.pushed
+    assert any("refused" in e or "failed" in e for e in out.errors)
+    # The concurrent writer's commit survived on the remote.
+    remote_sha = (await _git(repo, "ls-remote", "origin", f"refs/heads/{branch}")).split()[0]
+    assert remote_sha == their_sha
+
+
+async def test_registry_raw_dispatch_bypasses_managed_git(repo, monkeypatch):
+    """The coder ladder (ADR 0064) consumes replies as candidate code — raw=True must
+    skip branch/commit/PR and the claim."""
+    from plugins.delegates.adapters import AcpAdapter
+    from plugins.delegates.registry import DelegateRegistry
+
+    async def fake_prompt(self, d, query, *, timeout=None):
+        return "```python\nprint('candidate')\n```"
+
+    monkeypatch.setattr(AcpAdapter, "_prompt", fake_prompt)
+    reg = DelegateRegistry(
+        [{"name": "c1", "type": "acp", "command": "fake", "workdir": str(repo), "manage_git": "true"}]
+    )
+    reply = await reg.dispatch("c1", "same prompt", raw=True)
+    assert "candidate" in reply and "[managed git]" not in reply
+    assert await _git(repo, "rev-parse", "--abbrev-ref", "HEAD") == "main"  # no branch minted
+    # And a second identical raw dispatch is NOT deduped away (best-of-k stays k).
+    reply2 = await reg.dispatch("c1", "same prompt", raw=True)
+    assert "candidate" in reply2 and "already being built" not in reply2
+
+
 async def test_finish_reuses_existing_pr(repo, monkeypatch):
     _fake_gh(monkeypatch, {"pr list": (0, '[{"url": "https://github.com/x/y/pull/3"}]', "")})
     await harness.prepare(str(repo), base="main", branch="t/reuse-abc1234")


### PR DESCRIPTION
High-effort self-review of #1846 (8 finder angles) surfaced these; #1846 auto-merged mid-review, so the fixes land as a follow-up.

**Correctness**
1. **Coder-plugin collision (cross-file):** `plugins/coder` best-of-k fires k identical prompts at its delegate; through a `manage_git` acp delegate, attempt 1 opened a real PR and attempts 2..k collapsed into "already being built/PR exists" refusal strings that `extract_code` would parse as candidates. `generate()` now dispatches `raw=True` (new `registry.dispatch` kwarg): reply-as-data, no branch/PR/claim.
2. **Lease clobber:** on a `--force-with-lease` rejection the retry loop fetched the branch and retried — which resets the lease baseline to the concurrent writer's tip and silently overwrites their commits (the exact accident the lease prevents). Lease rejections now surface as a push refusal; only infrastructure failures retry. Test pushes from a real second clone and asserts the rival's commit survives.
3. **Detached HEAD** adopted literal `HEAD` as a branch → now a distinct BLOCKED outcome.
4. **`_count` None contract:** unresolvable `origin/<base>` in the clean-tree probe read as "no changes to publish", stranding committed coder work → now BLOCKED with the reason.
5. **Empty-sha verified push** and **`--quiet` exit-128** edge cases closed.

**Reuse/altitude**
- Secret scan now reuses the token-shape patterns from `graph/middleware/redaction.py` (adds OpenAI/ya29/Discord coverage; contextual patterns excluded — they match ordinary code).
- `item_id` moved onto the base `Adapter.dispatch` signature (registry type-switch removed); normalized once at the `delegate_to` boundary; `_pr_url_for` dedupes the gh JSON parsing.

Full suite green locally (3283 passed), ruff + lint-imports clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delegated generation can now return raw candidate code directly, without going through the usual managed publish flow.

* **Bug Fixes**
  * Improved handling of managed-git finishes in edge cases like detached worktrees, unresolved bases, and remote push conflicts.
  * Delegate item identifiers are now handled more consistently across foreground and background runs, reducing duplicate work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->