### PR TITLE
fix(fleet): spawned members run open on loopback — don't inherit the hub's A2A_AUTH_TOKEN

### DIFF
--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -188,6 +188,16 @@ def start(ident: str) -> dict:
 
         env, argv = manager.run_exec(wid, ["--ui", "none"])
         full_env = {**os.environ, **env}
+        # A hub-spawned member binds loopback and is reached in-process — the fleet proxy
+        # attaches the hub's own token, and the portfolio PM treats a local board as
+        # tokenless. But the child inherits the hub's INBOUND ``A2A_AUTH_TOKEN`` here, which
+        # would make it REQUIRE a bearer that a token-free local dispatch never sends → 401
+        # (a spawned team is unreachable by its own PM). So a spawned member runs OPEN on
+        # loopback unless its own workspace env set a token explicitly. Loopback-only, so
+        # open is safe; ``PROTOAGENT_ALLOW_OPEN`` covers the case it binds a non-loopback host.
+        if "A2A_AUTH_TOKEN" not in env:
+            full_env.pop("A2A_AUTH_TOKEN", None)
+            full_env.setdefault("PROTOAGENT_ALLOW_OPEN", "1")
         log_path = _log_path(ws)
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_offset = log_path.stat().st_size if log_path.exists() else 0

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -661,3 +661,62 @@ def test_host_entry_member_flag(fleet, monkeypatch):
     monkeypatch.setattr(manager, "is_workspace_member", lambda: True)
     host = next(a for a in supervisor.status() if a.get("host"))
     assert host["member"] is True
+
+
+def _env_capturing_fleet(tmp_path, monkeypatch):
+    """Like the ``fleet`` fixture but captures the env passed to Popen, so a test can
+    assert what the spawned child inherits."""
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    alive: set[int] = set()
+    captured: dict = {}
+    monkeypatch.setattr(supervisor, "_alive", lambda pid: int(pid) in alive if pid else False)
+
+    class FakeProc:
+        returncode = None
+
+        def __init__(self, *a, **k):
+            self.pid = 99001
+            alive.add(99001)
+            captured["env"] = k.get("env", {})
+
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
+    monkeypatch.setattr(supervisor, "_is_our_agent", lambda pid: True)
+    monkeypatch.setattr(supervisor, "_port_listening", lambda port, timeout=0.25: True)
+    return captured
+
+
+def test_spawned_member_runs_open_on_loopback(tmp_path, monkeypatch):
+    """A hub-spawned member must NOT inherit the hub's inbound A2A_AUTH_TOKEN — else it
+    would require a bearer that a token-free local dispatch (the portfolio PM) never sends,
+    making a spawned team unreachable by its own PM (the 401). It runs open on loopback."""
+    captured = _env_capturing_fleet(tmp_path, monkeypatch)
+    monkeypatch.setenv("A2A_AUTH_TOKEN", "hub-inbound-secret")
+    manager.create("beta", port=7891)
+
+    supervisor.start("beta")
+
+    assert "A2A_AUTH_TOKEN" not in captured["env"]  # stripped
+    assert captured["env"].get("PROTOAGENT_ALLOW_OPEN") == "1"
+
+
+def test_spawned_member_keeps_explicit_workspace_token(tmp_path, monkeypatch):
+    """If the workspace's OWN run_exec env sets A2A_AUTH_TOKEN, that's an explicit per-team
+    token and must be preserved (only the INHERITED hub token is stripped)."""
+    captured = _env_capturing_fleet(tmp_path, monkeypatch)
+    monkeypatch.setenv("A2A_AUTH_TOKEN", "hub-inbound-secret")
+    manager.create("gamma", port=7892)
+
+    real_run_exec = manager.run_exec
+
+    def run_exec_with_token(wid, extra):
+        env, argv = real_run_exec(wid, extra)
+        env["A2A_AUTH_TOKEN"] = "team-own-token"
+        return env, argv
+
+    monkeypatch.setattr(supervisor.manager, "run_exec", run_exec_with_token)
+    supervisor.start("gamma")
+
+    assert captured["env"].get("A2A_AUTH_TOKEN") == "team-own-token"  # explicit token wins


### PR DESCRIPTION
## The bug

A hub-spawned fleet member — e.g. a **portfolio PM's spun-up Lead Engineer team** — binds loopback and is reached in-process: the fleet proxy attaches the hub's own token, and the `portfolio` plugin treats a local board as **tokenless** (dispatches with no bearer).

But `supervisor.start` merged the hub's full `os.environ` into the child (`full_env = {**os.environ, **env}`), so the child **inherited the hub's inbound `A2A_AUTH_TOKEN`** and began **requiring** a bearer that the token-free local dispatch never sends → **401**. Net effect: a spawned team is unreachable by the very PM that spawned it (surfaced standing up a portfolio Portfolio Manager whose `portfolio_spinup_team` team returned 401 on every board read/dispatch).

## The fix

Strip the inherited `A2A_AUTH_TOKEN` for spawned members — loopback-only, so open is safe; `PROTOAGENT_ALLOW_OPEN` covers a non-loopback bind. An **explicit per-team token** set in the workspace's own `run_exec` env is preserved — only the *inherited* hub token is dropped.

## Tests

Two regression tests: (1) a spawned member with a hub `A2A_AUTH_TOKEN` set spawns with it stripped + `PROTOAGENT_ALLOW_OPEN=1`; (2) an explicit workspace token survives. Full `test_fleet_supervisor.py` green (35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace agent startup so it no longer inherits an unintended auth token from the host environment.
  * Allowed spawned agents to bind locally without requiring a bearer token when the workspace does not provide one.
  * Preserved an explicitly configured workspace token when one is set.

* **Tests**
  * Added coverage for spawned-agent environment handling to verify token stripping and token preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->