### PR TITLE
feat(craft): adr-authoring skill — the house ADR/plan-doc conventions

### DIFF
--- a/plugins/craft/protoagent.plugin.yaml
+++ b/plugins/craft/protoagent.plugin.yaml
@@ -1,17 +1,18 @@
 id: craft
 name: Craft
-version: 0.1.0
+version: 0.2.0
 # user_only skills (withheld from agent retrieval, slash-only) landed 2026-06;
 # first host release carrying them is 0.85.0.
 min_protoagent_version: "0.85.0"
 description: >-
-  Engineering rituals as user-only slash commands: /grill (relentless plan
-  interview), /standup (operational status report), /code-review (two-axis
-  Standards vs Spec review), /writing-skills (the skill-authoring discipline) —
-  plus a skill_writer subagent that drafts SKILL.md skills to that discipline.
-  Prompt-only: no tools, routes, network, or filesystem access. The grilling,
-  code-review, and skill-authoring material is adapted from mattpocock/skills
-  (MIT).
+  Engineering rituals as skills: /grill (relentless plan interview), /standup
+  (operational status report), /code-review (adversarial review-workflow
+  driver, ADR 0077), /writing-skills (the skill-authoring discipline), and
+  adr-authoring (the house ADR/plan-doc conventions — agent-retrievable, so
+  agent-authored ADRs meet the bar) — plus a skill_writer subagent that drafts
+  SKILL.md skills to that discipline. Prompt-only: no tools, routes, network,
+  or filesystem access. The grilling, code-review, and skill-authoring
+  material is adapted from mattpocock/skills (MIT).
 # First-party and ON by default, like artifact/notes/docs — pure prompt content,
 # nothing to trust. Turn it off per-instance with `plugins: { disabled: [craft] }`.
 enabled: true

--- a/plugins/craft/skills/adr-authoring/SKILL.md
+++ b/plugins/craft/skills/adr-authoring/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: adr-authoring
+description: >-
+  Use this when writing, drafting, or updating an Architecture Decision Record
+  (ADR) or a plan document for this repo — e.g. "write an ADR for X", "record
+  this decision", "author the ADR for this design", "draft the plan doc".
+  Covers the house MADR shape, numbering, the index row, the docs-nav
+  regeneration step, and the VitePress traps that fail the docs build.
+---
+
+# Authoring ADRs (and plan docs)
+
+An ADR that doesn't pass the docs build or drifts from the house shape costs a
+review round-trip. This is the checklist that makes an agent-authored ADR land
+first try.
+
+## 1. Number and file
+
+- Next number = highest existing `docs/adr/NNNN-*.md` + 1, zero-padded to 4.
+  Check right before opening the PR — another PR may have taken your number.
+- Filename: `docs/adr/NNNN-short-kebab-slug.md`. Never renumber or delete a
+  merged ADR — supersede it (new ADR, and flip the old one's Status to
+  `Superseded by [NNNN](./NNNN-….md)`).
+
+## 2. The house MADR shape
+
+```markdown
+# NNNN — Title: what is decided, not the topic area
+
+- Status: Proposed            ← Proposed | Accepted | Superseded by NNNN
+- Date: YYYY-MM-DD
+- Builds on: ADR 00XX (one-line why), ADR 00YY (…)   ← the lineage, load-bearing
+- Plan: [`docs/plans/<slug>.md`](../plans/<slug>.md)  ← if a plan doc exists
+
+## Context
+## Decision
+## Consequences
+```
+
+- **Builds on** is not decoration — reviewers navigate the decision graph
+  through it. Cite the ADRs whose machinery you extend or constrain, each with
+  a clause saying *how* it relates.
+- **Decision** carries labeled sub-decisions (`**D1 — Name.**` …) when there is
+  more than one; consumers cite "ADR NNNN D3" from code comments.
+- **Consequences** includes the honest costs and the revisit trigger, not just
+  benefits.
+- Write in the repo's voice: dense, specific, mechanism-first. Name files,
+  fields, and functions in backticks. No filler sections (no empty
+  "Alternatives considered" — fold real alternatives into Context or Decision).
+
+## 3. The index row
+
+Add one row to the table in `docs/adr/index.md`, after the previous highest:
+
+```markdown
+| [NNNN](./NNNN-slug.md) | Title — a summary dense enough to decide "do I need to read this?" from the index alone | Proposed |
+```
+
+- **One physical line** — never wrap the row.
+- Escape any `|` inside the summary as `\|`.
+
+## 4. Regenerate the docs nav
+
+```
+python scripts/gen_docs_nav.py
+```
+
+ADRs are enumerated from the filesystem into `plugins/docs/nav.json`, and
+`tests/test_docs_plugin.py` fails CI when the committed file is stale. A new
+ADR file without a nav regen is a red build. Commit the regenerated
+`plugins/docs/nav.json` with the ADR.
+
+## 5. VitePress traps (each has failed a real build)
+
+- **Every relative link must resolve within this PR.** The dead-link check
+  fails the build on a link to a file that isn't on main *and* isn't added by
+  your PR — a plan doc still sitting in an unmerged PR is a dead link until it
+  merges. Either merge the target first or hold the link until it exists.
+- Relative links from `docs/adr/` go up one level: `../plans/<slug>.md`,
+  `../guides/<slug>.md`. Link the `.md` path (VitePress rewrites it).
+- **No wrapped code spans**: a backtick span broken across lines renders as
+  literal backticks and can break table rows.
+- Bare `<angle-bracket>` tokens outside code spans are parsed as HTML tags and
+  can blank out the rest of the page — backtick them.
+
+## 6. Plan docs (`docs/plans/`)
+
+Same discipline, different genre: a plan is *phased work* (milestones, sizes,
+dependency spine, accept criteria per milestone), where an ADR is *one
+decision*. Plans live at `docs/plans/<slug>.md`, get linked from the ADRs they
+produced (`- Plan:` header line) and link back to the ADRs they cite. A plan
+that changes a decision doesn't edit the ADR's Decision section — it spawns a
+new ADR.
+
+## 7. Verify before the PR
+
+```
+python scripts/gen_docs_nav.py --check   # nav in sync
+npm run docs:build                       # dead links + markdown traps
+python -m pytest tests/test_docs_plugin.py -q
+```
+
+`npm run docs:build` is the one that catches the link/markdown traps — run it
+even for a "one-line" ADR edit.

--- a/tests/test_craft_plugin.py
+++ b/tests/test_craft_plugin.py
@@ -20,6 +20,11 @@ ROOT = Path("plugins/craft")
 
 EXPECTED_SLASHES = {"grill", "standup", "code-review", "writing-skills"}
 
+# Agent-retrievable bundled skills (no user_only/slash): guidance the AGENT pulls
+# while doing the work — adr-authoring exists precisely so agent-authored ADRs
+# meet the house bar (plan M3), so hiding it from retrieval would defeat it.
+EXPECTED_AGENT_SKILLS = {"adr-authoring"}
+
 
 def _skill_files() -> list[Path]:
     return sorted(ROOT.glob("skills/*/SKILL.md"))
@@ -54,20 +59,27 @@ def test_register_contributes_skills_and_subagent():
 
 def test_bundled_skills_are_loader_valid_and_user_only():
     files = _skill_files()
-    assert len(files) == 4, f"expected 4 bundled skills, found {[str(f) for f in files]}"
+    expected_count = len(EXPECTED_SLASHES) + len(EXPECTED_AGENT_SKILLS)
+    assert len(files) == expected_count, f"unexpected bundled skills: {[str(f) for f in files]}"
 
     seen = {}
+    agent_skills = set()
     for path in files:
         artifact = parse_skill_md(path)
         assert artifact is not None, f"{path} failed to parse"
+        assert artifact.prompt_template, f"{path} has an empty body"
+        if artifact.name in EXPECTED_AGENT_SKILLS:
+            assert not artifact.user_only, f"{path} must be agent-retrievable"
+            agent_skills.add(artifact.name)
+            continue
         assert artifact.user_only, f"{path} must be user_only (slash-only rituals)"
         assert artifact.user_facing, f"{path}: user_only implies user_facing"
         assert artifact.slash, f"{path} must pin an explicit slash token"
-        assert artifact.prompt_template, f"{path} has an empty body"
         seen[artifact.slash] = artifact.name
 
     assert set(seen) == EXPECTED_SLASHES
-    assert len(seen) == len(files), "slash tokens must be unique"
+    assert agent_skills == EXPECTED_AGENT_SKILLS
+    assert len(seen) == len(files) - len(agent_skills), "slash tokens must be unique"
 
 
 def test_slash_tokens_not_shadowed_by_core_subagents():


### PR DESCRIPTION
M3 of the codified-delivery-loop plan (`docs/plans/codified-delivery-loop.md`). The decompose antagonist already checks "cites ADRs"; this skill is what makes agent-authored ADRs actually meet the bar.

## What ships

- `plugins/craft/skills/adr-authoring/SKILL.md` — **agent-retrievable** (not `user_only`: the point is that an agent pulls it *while* authoring). Encodes:
  - numbering + supersede-never-delete, the MADR house shape (Builds-on lineage as the decision graph, `**D1 —**` labeled decisions, honest Consequences with revisit triggers)
  - the `docs/adr/index.md` row discipline (one physical line, escaped pipes, index-decidable summary)
  - the `scripts/gen_docs_nav.py` regen step that `test_docs_plugin.py` enforces
  - the VitePress traps that have each failed a real build — including the one that failed **this program's own M1 CI an hour ago** (relative link to a plan doc sitting in an unmerged PR = dead link)
  - plan-doc conventions (`docs/plans/`): plan = phased work, ADR = one decision
  - the pre-PR verify trio: `gen_docs_nav.py --check` / `npm run docs:build` / `pytest tests/test_docs_plugin.py`
- Craft manifest → 0.2.0, description updated
- `test_craft_plugin.py` pins the new two-tier contract: 4 user-only slash rituals + 1 agent-retrievable skill

## Verification

Full suite **3285 passed**, `npm run docs:build` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the available Craft skills to include engineering rituals and architecture decision record authoring.
  * Added guidance for creating ADRs and related planning documents.

* **Documentation**
  * Clarified how skills should behave and what conventions to follow when writing them.
  * Added build and verification steps to help keep docs and related outputs consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->