### PR TITLE
feat(workflows): due-diligence workflow — codebase-grounded adopt/build/defer verdicts

### DIFF
--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -263,6 +263,63 @@ Output the report directly.""",
 )
 
 
+# ── Due-diligence workflow role ───────────────────────────────────────────────
+# The gather angle deep-research never had: what does OUR code already do about
+# the thing being evaluated? Used by the `due-diligence` workflow in parallel
+# with external research; the synthesis weighs BOTH before an adopt/build/defer
+# verdict. Read-only by construction (fs read tools + github read tools).
+
+CODEBASE_MAPPER_CONFIG = SubagentConfig(
+    name="codebase-mapper",
+    description=(
+        "Maps how the registered codebase(s) relate to a question under "
+        "evaluation: existing implementations, integration points, constraints "
+        "(deps, patterns, ADRs), and the size of the build-vs-adopt gap. "
+        "Read-only. Used by the due-diligence workflow as the internal-evidence "
+        "gather stage."
+    ),
+    system_prompt="""You are protoAgent's codebase-mapper. Given a question under
+due diligence ("should we adopt X / build Y / change Z?"), you produce the
+INTERNAL half of the evidence: what the code that would be affected actually
+looks like today. External research is someone else's job — never search the
+web; read code.
+
+Procedure:
+1. ``list_projects`` to see the registered codebases; pick the relevant one(s)
+   from the question/context. For a library/repo being EVALUATED (not
+   registered locally), read it over ``github_repo_contents`` /
+   ``github_read_file`` instead.
+2. Locate the touchpoints: ``search_files``/``find_files`` for the domain terms,
+   then ``read_file`` the hits that matter. Check the repo's ADRs/docs for
+   PRIOR decisions on this ground — a due-diligence answer that contradicts an
+   accepted ADR must say so explicitly.
+3. Map, with file:line citations:
+   - **Current state** — what exists that does (or approximates) the thing.
+   - **Integration points** — where an adoption would plug in; which contracts
+     it must honor.
+   - **Constraints** — deps it must coexist with, patterns/ADRs it must follow,
+     tests that pin current behavior.
+   - **Gap** — what building it ourselves would actually take vs adopting.
+
+Report only what you READ — no recommendations, no external claims; flag
+anything you could not locate as unknown rather than guessing. Keep it tight
+(~400 words + citations). Hard stop at max_turns: return the partial map,
+marked partial.""",
+    tools=[
+        "current_time",
+        "list_projects",
+        "list_dir",
+        "read_file",
+        "find_files",
+        "search_files",
+        "github_read_file",
+        "github_repo_contents",
+        "memory_recall",
+    ],
+    max_turns=25,
+)
+
+
 # ── Code-review workflow roles (ADR 0077) ─────────────────────────────────────
 # The finder/synthesizer stages of the `code-review` workflow. Like the
 # deep-research roles, they are separate agents so nobody grades their own
@@ -502,6 +559,7 @@ SUBAGENT_REGISTRY: dict[str, SubagentConfig] = {
     "antagonist": ANTAGONIST_CONFIG,
     "verifier": VERIFIER_CONFIG,
     "synthesizer": SYNTHESIZER_CONFIG,
+    "codebase-mapper": CODEBASE_MAPPER_CONFIG,
     "review-finder": REVIEW_FINDER_CONFIG,
     "review-synthesizer": REVIEW_SYNTHESIZER_CONFIG,
     "dream": DREAM_CONFIG,

--- a/plugins/craft/protoagent.plugin.yaml
+++ b/plugins/craft/protoagent.plugin.yaml
@@ -1,16 +1,17 @@
 id: craft
 name: Craft
-version: 0.2.0
+version: 0.3.0
 # user_only skills (withheld from agent retrieval, slash-only) landed 2026-06;
 # first host release carrying them is 0.85.0.
 min_protoagent_version: "0.85.0"
 description: >-
   Engineering rituals as skills: /grill (relentless plan interview), /standup
   (operational status report), /code-review (adversarial review-workflow
-  driver, ADR 0077), /writing-skills (the skill-authoring discipline), and
-  adr-authoring (the house ADR/plan-doc conventions — agent-retrievable, so
-  agent-authored ADRs meet the bar) — plus a skill_writer subagent that drafts
-  SKILL.md skills to that discipline. Prompt-only: no tools, routes, network,
+  driver, ADR 0077), /due-diligence (adopt/build/defer verdict via the
+  due-diligence workflow), /writing-skills (the skill-authoring discipline),
+  and adr-authoring (the house ADR/plan-doc conventions — agent-retrievable,
+  so agent-authored ADRs meet the bar) — plus a skill_writer subagent that
+  drafts SKILL.md skills to that discipline. Prompt-only: no tools, routes, network,
   or filesystem access. The grilling, code-review, and skill-authoring
   material is adapted from mattpocock/skills (MIT).
 # First-party and ON by default, like artifact/notes/docs — pure prompt content,

--- a/plugins/craft/skills/due-diligence/SKILL.md
+++ b/plugins/craft/skills/due-diligence/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: due-diligence
+description: >-
+  /due-diligence — validate a technology or architecture choice with the
+  due-diligence workflow: codebase map + external research in parallel,
+  antagonist + claim verification, and a cited adopt/build/defer verdict.
+user_only: true
+slash: due-diligence
+---
+
+# Due Diligence — evidence before commitment
+
+Drive the `due-diligence` workflow (plan M2): a codebase-mapper reads what our
+code already does about the question while a researcher gathers the external
+evidence; an antagonist steelmans the opposing case and a verifier checks the
+load-bearing claims; the synthesis is a verdict document that ends in
+**adopt / build / defer** with conditions. You scope the question, run it, and
+present the verdict — you do not research inline.
+
+## 1. Scope the question
+
+A DD run on a vague question wastes six subagent stages. Before running,
+sharpen it to the shape "should we <adopt X | build Y | change Z> for
+<purpose>?" —
+
+- If the user named a technology but not the job, ask for the job ("evaluate
+  Redis" → for what — cache, queue, session store?).
+- If alternatives matter, name them in the question ("…vs keeping SQLite").
+- Capture scope hints for the mapper in `context`: which project (registry
+  name), which subsystems/dirs the decision touches, any ADR the user knows
+  is relevant.
+
+One clarifying exchange at most — then run with the best question you have.
+
+## 2. Run the workflow
+
+```
+run_workflow("due-diligence", {"question": "<sharpened question>", "context": "<scope hints or omit>"})
+```
+
+Five subagent stages (two parallel pairs + synthesis) — tell the user it's
+running and that it reads their registered code as part of the evidence.
+
+## 3. Present the verdict
+
+Lead with the verdict block (**adopt / build / defer** + rationale +
+conditions + revisit trigger) — it is the deliverable; the evidence sections
+back it. Keep the antagonist's strongest surviving counterpoint visible even
+when the verdict goes the other way. If the verdict is `defer`, make the
+conditions actionable (what to prove, how). Offer the natural follow-ups:
+save the document to notes/memory, or — when the verdict implies a decision
+worth recording — draft the ADR (the `adr-authoring` skill has the house
+conventions).

--- a/plugins/workflows/recipes/due-diligence.yaml
+++ b/plugins/workflows/recipes/due-diligence.yaml
@@ -1,0 +1,121 @@
+# Due diligence with adversarial review (delivery-loop plan M2). A re-authoring
+# of deep-research for DECISIONS about code: the same adversarial spine
+# (gather → antagonist ∥ verify → synthesis), plus the gather angle research
+# never had — a codebase map of what our own code already does about the thing
+# being evaluated. The synthesis is a verdict document, not a survey: it must
+# end on adopt / build / defer with conditions.
+#
+#   run_workflow("due-diligence", {"question": "Should we adopt X for Y?"})
+#   run_workflow("due-diligence", {"question": "…", "context": "affects graph/ + the a2a_impl surface"})
+#
+# Callable headlessly — the board DESIGN gate (plan M6) runs it on large/
+# architectural features before mark_ready.
+name: due-diligence
+description: >-
+  Evidence-based validation of a technology/architecture choice — codebase map
+  and external research in parallel, then antagonist and claim-verifier in
+  parallel, then a cited synthesis ending in an explicit adopt/build/defer
+  verdict with conditions.
+version: 1
+inputs:
+  - name: question
+    description: The decision under diligence ("should we adopt/build/change …?").
+    required: true
+  - name: context
+    description: Optional scope hints — which project/repo/subsystems are affected.
+    default: ""
+steps:
+  - id: map_codebase
+    subagent: codebase-mapper
+    prompt: |
+      Map the internal evidence for this due-diligence question (context:
+      {{inputs.context}}):
+
+      {{inputs.question}}
+
+      Current state, integration points, constraints (deps/patterns/ADRs —
+      cite prior decisions on this ground), and the build-vs-adopt gap, with
+      file citations. Internal evidence only.
+
+  - id: research
+    subagent: researcher
+    prompt: |
+      Research the EXTERNAL evidence for this due-diligence question (depth:
+      deep):
+
+      {{inputs.question}}
+
+      Cover: the leading options and their maturity/maintenance reality,
+      adoption + community health, known failure modes and practitioner
+      criticism (seek community/code sources — HN, Reddit, GitHub issues — not
+      just marketing), migration/integration cost signals, and credible
+      alternatives including "do nothing". Numbered citations.
+
+  - id: antagonist
+    subagent: antagonist
+    depends_on: [map_codebase, research]
+    prompt: |
+      Adversarially review this due-diligence evidence on:
+      "{{inputs.question}}". Steelman the strongest case AGAINST the direction
+      the evidence leans, attack unsupported claims, and hunt disconfirming
+      evidence (failed adoptions, "considered harmful", maintainer burnout,
+      lock-in stories). Also attack the INTERNAL evidence: does the codebase
+      map actually support the integration story, or is it thinner than it
+      reads?
+
+      ## Codebase map (internal)
+      {{steps.map_codebase.output}}
+
+      ## External research
+      {{steps.research.output}}
+
+  - id: verify
+    subagent: verifier
+    depends_on: [map_codebase, research]
+    prompt: |
+      Verify the material claims in this due-diligence evidence on
+      "{{inputs.question}}" — the ones the verdict would hinge on (maturity,
+      maintenance, compatibility, performance, licensing). Check external
+      claims against sources; where an internal claim cites a file, spot-check
+      it if you can. Verification table + the line for the synthesizer.
+
+      ## Codebase map (internal)
+      {{steps.map_codebase.output}}
+
+      ## External research
+      {{steps.research.output}}
+
+  - id: synthesize
+    subagent: synthesizer
+    depends_on: [map_codebase, research, antagonist, verify]
+    prompt: |
+      Write the due-diligence verdict document for: {{inputs.question}}
+
+      This is a DECISION document, not a survey. Structure:
+      - Bottom line first, then the evidence (internal + external, numbered
+        [N] citations carried through), a "## Counterpoints & risks" section
+        that answers the antagonist, and dropped/qualified claims per the
+        verifier.
+      - End with an explicit verdict block:
+
+        **Verdict: adopt | build | defer**
+        - Rationale: (2-4 lines, hedged by what survived adversarial review)
+        - Conditions: (what must hold / be proven for this verdict; what would
+          flip it)
+        - Revisit when: (the concrete trigger)
+
+      An "it depends" answer is a **defer** with sharp conditions — never omit
+      the verdict block. Earned Confidence per the usual rules.
+
+      ## Codebase map (internal)
+      {{steps.map_codebase.output}}
+
+      ## External research
+      {{steps.research.output}}
+
+      ## Opposition memo (antagonist)
+      {{steps.antagonist.output}}
+
+      ## Claim verification (verifier)
+      {{steps.verify.output}}
+output: "{{steps.synthesize.output}}"

--- a/tests/test_craft_plugin.py
+++ b/tests/test_craft_plugin.py
@@ -18,7 +18,7 @@ from graph.skills.loader import parse_skill_md
 
 ROOT = Path("plugins/craft")
 
-EXPECTED_SLASHES = {"grill", "standup", "code-review", "writing-skills"}
+EXPECTED_SLASHES = {"grill", "standup", "code-review", "writing-skills", "due-diligence"}
 
 # Agent-retrievable bundled skills (no user_only/slash): guidance the AGENT pulls
 # while doing the work — adr-authoring exists precisely so agent-authored ADRs

--- a/tests/test_due_diligence_workflow.py
+++ b/tests/test_due_diligence_workflow.py
@@ -1,0 +1,72 @@
+"""The due-diligence workflow + the codebase-mapper role (plan M2) — mirrors
+tests/test_deep_research.py: the recipe validates against the shipped registry,
+the new gather role reads code (not the web), and the synthesis is contractually
+a verdict document."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from graph.subagents.config import SUBAGENT_REGISTRY
+from plugins.workflows.engine import validate_recipe
+
+RECIPE_PATH = Path(__file__).parent.parent / "plugins" / "workflows" / "recipes" / "due-diligence.yaml"
+
+
+def _recipe() -> dict:
+    return yaml.safe_load(RECIPE_PATH.read_text())
+
+
+# ── the codebase-mapper role ──────────────────────────────────────────────────
+
+
+def test_codebase_mapper_registered():
+    assert "codebase-mapper" in SUBAGENT_REGISTRY
+
+
+def test_codebase_mapper_reads_code_not_the_web():
+    tools = SUBAGENT_REGISTRY["codebase-mapper"].tools
+    assert "read_file" in tools and "search_files" in tools and "list_projects" in tools
+    assert "github_read_file" in tools  # unregistered/candidate repos read over gh
+    assert "web_search" not in tools and "fetch_url" not in tools  # external evidence is the researcher's lane
+
+
+def test_codebase_mapper_is_read_only():
+    tools = SUBAGENT_REGISTRY["codebase-mapper"].tools
+    assert "write_file" not in tools and "edit_file" not in tools and "run_command" not in tools
+
+
+# ── the recipe ────────────────────────────────────────────────────────────────
+
+
+def test_recipe_validates_against_shipped_registry():
+    assert validate_recipe(_recipe(), known_subagents=set(SUBAGENT_REGISTRY)) == []
+
+
+def test_recipe_shape_gather_parallel_then_adversarial_parallel_then_verdict():
+    steps = {s["id"]: s for s in _recipe()["steps"]}
+    # Gather: codebase map ∥ external research (no deps on either).
+    assert steps["map_codebase"]["subagent"] == "codebase-mapper"
+    assert not steps["map_codebase"].get("depends_on")
+    assert steps["research"]["subagent"] == "researcher"
+    assert not steps["research"].get("depends_on")
+    # Adversarial: antagonist ∥ verifier, both over BOTH gather outputs.
+    for sid in ("antagonist", "verify"):
+        assert sorted(steps[sid]["depends_on"]) == ["map_codebase", "research"]
+    assert steps["antagonist"]["subagent"] == "antagonist"
+    assert steps["verify"]["subagent"] == "verifier"
+    # Synthesis sees everything.
+    assert sorted(steps["synthesize"]["depends_on"]) == ["antagonist", "map_codebase", "research", "verify"]
+
+
+def test_synthesis_prompt_carries_the_verdict_contract():
+    steps = {s["id"]: s for s in _recipe()["steps"]}
+    prompt = steps["synthesize"]["prompt"]
+    assert "adopt | build | defer" in prompt
+    assert "Conditions:" in prompt and "Revisit when:" in prompt
+
+
+def test_recipe_output_is_the_synthesis():
+    assert _recipe()["output"].strip() == "{{steps.synthesize.output}}"


### PR DESCRIPTION
M2 of the codified-delivery-loop plan (`docs/plans/codified-delivery-loop.md`). ~90% a re-authoring of `deep-research.yaml` — same adversarial spine, pointed at decisions about code.

## What ships

- **`codebase-mapper` role** (F2.1) — the missing gather angle: reads what the registered codebase(s) already do about the question. Read-only by construction: fs read tools (`list_projects`/`list_dir`/`read_file`/`find_files`/`search_files`) + github read tools for unregistered/candidate repos; **no web tools** (external evidence is the researcher's lane), no writes, no shell. Cites files; flags prior ADRs on the same ground.
- **`due-diligence.yaml`** (F2.2) — `map_codebase ∥ research → antagonist ∥ verify → synthesize`. The antagonist is told to attack the *internal* evidence too (is the integration story thinner than it reads?). The synthesis is contractually a **verdict document**: it must end in `**Verdict: adopt | build | defer**` + rationale + conditions + revisit trigger — "it depends" is a defer with sharp conditions.
- **`/due-diligence` craft skill** (F2.3) — scope the question to "should we <adopt X | build Y | change Z> for <purpose>?" (one clarifying exchange max), `run_workflow`, present verdict-first; offers the `adr-authoring` skill as the natural follow-up when the verdict implies a decision worth recording. Craft → 0.3.0.

## Verification

8 new tests: role registration, read-only + no-web tool assertions, recipe validation against the shipped registry, DAG shape (two parallel pairs), verdict contract pinned in the synthesis prompt. Full suite **3311 passed**, ruff + lint-imports clean.

Headless consumer: the board DESIGN gate (plan M6) runs this on large/architectural features before `mark_ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)