### PR TITLE
fix(managed-git): infer branch/PR name from the task, dedup on the item id

### DIFF
--- a/plugins/coding_agent/git_harness.py
+++ b/plugins/coding_agent/git_harness.py
@@ -61,10 +61,61 @@ def mint_branch(prefix: str, task: str, item_id: str) -> str:
 
 
 def title_from(task: str) -> str:
-    """PR/commit title: the task's first non-empty line, collapsed, capped."""
+    """PR/commit title: the task's first non-empty line, collapsed, capped. The
+    deterministic fallback for ``infer_title`` — fine when the caller's first line IS the
+    intent, wrong when the task is wrapped in a coder preamble (see ``infer_title``)."""
     first_line = next((ln for ln in task.strip().splitlines() if ln.strip()), "automated change")
     title = " ".join(first_line.split())
     return title[:72].rstrip() if len(title) > 72 else title
+
+
+_TITLE_PROMPT = (
+    "You write ONE conventional-commit title summarizing the coding task below "
+    "(e.g. `fix: guard null user`, `feat: add compare view`, `chore: bump deps`). "
+    "Output ONLY the title: one line, no quotes, no body, <= 70 chars. IGNORE any "
+    "boilerplate wrapped around the task — 'you are implementing one feature', "
+    "working-directory notes, git/tooling rules; title the ACTUAL change the task asks for."
+)
+
+
+async def infer_title(task: str, config=None) -> str | None:
+    """Infer a concise conventional-commit title from a task via the cheap aux model, so
+    the branch slug + PR title describe the WORK — not whatever boilerplate preamble a
+    caller wrapped the task in (project_board's coder prompt starts "You are implementing
+    ONE feature in this repository…", which the naive first-line heuristic slugged into the
+    branch/title). Best-effort: returns None on any failure so callers fall back to the
+    deterministic ``title_from``. Uniqueness never depends on this — the branch's ``-<id7>``
+    item-id suffix is what dedups (``preflight_pr``), so an inferred slug is free to vary."""
+    task = (task or "").strip()
+    if not task:
+        return None
+    try:
+        from langchain_core.messages import HumanMessage, SystemMessage
+
+        from graph.agent import _resolve_aux_model
+        from graph.llm import create_llm
+
+        if config is None:
+            from runtime.state import STATE
+
+            config = getattr(STATE, "graph_config", None)
+        if config is None:
+            return None
+        llm = create_llm(config, model_name=_resolve_aux_model(config, ""))
+        resp = await llm.ainvoke(
+            [SystemMessage(content=_TITLE_PROMPT), HumanMessage(content=task[:4000])]
+        )
+        raw = str(getattr(resp, "content", "") or "").strip()
+        # Reject a chatty reply BEFORE collapsing whitespace (join-on-split would hide the
+        # newline) — a real title is one short line; anything multi-line/long is the model
+        # ignoring "one line", so fall back rather than slug a paragraph into a branch.
+        if not raw or "\n" in raw or len(raw) > 100:
+            return None
+        title = " ".join(raw.split()).strip("\"'`").strip()
+        return title[:72].rstrip() or None
+    except Exception:  # noqa: BLE001 — inference is best-effort; the deterministic fallback covers it
+        log.debug("[managed-git] title inference failed; using deterministic first-line", exc_info=True)
+        return None
 
 
 def edit_only_directive(branch: str) -> str:
@@ -515,11 +566,32 @@ async def _pr_url_for(workdir: str, branch: str, *, state: str) -> str:
     return ""
 
 
-async def preflight_pr(workdir: str, branch: str) -> str:
-    """URL of an already-open PR for ``branch``, or "". Run BEFORE dispatching the
-    coder: it catches restarts and the created-a-PR-but-crashed case across process
-    lifetimes, which the in-memory claim registry can't."""
-    return await _pr_url_for(workdir, branch, state="open")
+async def _pr_url_by_item(workdir: str, item_id: str, *, state: str) -> str:
+    """URL of a PR whose head branch carries this item's ``-<id7>`` suffix, or "".
+    Dedup keys on the STABLE item id, not the (possibly inferred, run-to-run varying)
+    slug — so a re-run that names the branch differently still finds the prior PR."""
+    suffix = f"-{item_id[-7:]}"
+    rc, stdout, _ = await run_gh(
+        ["pr", "list", "--state", state, "--json", "url,headRefName", "--limit", "50"],
+        cwd=workdir,
+    )
+    if rc == 0 and stdout.strip():
+        try:
+            for row in json.loads(stdout):
+                if str(row.get("headRefName", "")).endswith(suffix):
+                    return str(row.get("url", ""))
+        except ValueError:
+            pass
+    return ""
+
+
+async def preflight_pr(workdir: str, item_id: str) -> str:
+    """URL of an already-open PR for this ITEM (matched by its stable ``-<id7>`` branch
+    suffix), or "". Run BEFORE dispatching the coder: it catches restarts and the
+    created-a-PR-but-crashed case across process lifetimes, which the in-memory claim
+    registry can't — and keying on the item id (not the slug) makes it robust even when
+    the slug was inferred differently on the re-run."""
+    return await _pr_url_by_item(workdir, item_id, state="open")
 
 
 async def _open_pr(workdir: str, out: GitOutcome, *, title: str) -> None:
@@ -529,7 +601,7 @@ async def _open_pr(workdir: str, out: GitOutcome, *, title: str) -> None:
     if ahead == 0:
         out.pr_state = "skipped-no-commits"
         return
-    existing = await preflight_pr(workdir, out.branch)
+    existing = await preflight_pr(workdir, out.item_id)
     if existing:
         out.pr_url, out.pr_state = existing, "existing"
         return

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -642,7 +642,12 @@ class AcpAdapter(Adapter):
         from plugins.coding_agent import git_harness as harness
 
         iid = (item_id or "").strip() or harness.derive_item_id(query)
-        branch = harness.mint_branch(d.branch_prefix or d.name, query, iid)
+        # Name the work, not the wrapper: infer a conventional-commit title from the task
+        # (project_board wraps features in a coder preamble whose first line is boilerplate,
+        # which the deterministic first-line slug would otherwise bake into the branch/PR).
+        # Best-effort — falls back to the deterministic title. Uniqueness is the id suffix.
+        title = (await harness.infer_title(query)) or harness.title_from(query)
+        branch = harness.mint_branch(d.branch_prefix or d.name, title, iid)
         holder = harness.claim(iid, d.name)
         if holder is not None:
             return (
@@ -651,7 +656,7 @@ class AcpAdapter(Adapter):
             )
         try:
             workdir = os.path.expanduser(d.workdir)
-            existing = await harness.preflight_pr(workdir, branch)
+            existing = await harness.preflight_pr(workdir, iid)
             if existing:
                 return f"An open PR already exists for item `{iid}` (branch `{branch}`): {existing} — not dispatching a duplicate."
             prep = await harness.prepare(workdir, base=d.base_branch, branch=branch)
@@ -659,7 +664,7 @@ class AcpAdapter(Adapter):
                 return f"Error: managed-git setup for {d.name!r} failed: {prep.error}"
             reply = await self._prompt(d, query + harness.edit_only_directive(branch), timeout=timeout)
             outcome = await harness.finish(
-                workdir, base=d.base_branch, branch=branch, item_id=iid, title=harness.title_from(query)
+                workdir, base=d.base_branch, branch=branch, item_id=iid, title=title
             )
             notes = "".join(f"\n- note: {n}" for n in prep.notes)
             return f"{reply}\n\n{outcome.render()}{notes}"

--- a/tests/test_git_harness.py
+++ b/tests/test_git_harness.py
@@ -302,7 +302,8 @@ async def test_registry_raw_dispatch_bypasses_managed_git(repo, monkeypatch):
 
 
 async def test_finish_reuses_existing_pr(repo, monkeypatch):
-    _fake_gh(monkeypatch, {"pr list": (0, '[{"url": "https://github.com/x/y/pull/3"}]', "")})
+    # dedup matches the item's -<id7> suffix, so the open PR must carry it on its head branch.
+    _fake_gh(monkeypatch, {"pr list": (0, '[{"url": "https://github.com/x/y/pull/3", "headRefName": "t/reuse-abc1234"}]', "")})
     await harness.prepare(str(repo), base="main", branch="t/reuse-abc1234")
     (repo / "again.txt").write_text("re-run\n")
 
@@ -368,7 +369,9 @@ async def test_managed_dispatch_dedups_inflight_item(repo, monkeypatch):
 async def test_managed_dispatch_preflight_returns_existing_pr(repo, monkeypatch):
     from plugins.delegates.adapters import AcpAdapter
 
-    _fake_gh(monkeypatch, {"pr list": (0, '[{"url": "https://github.com/x/y/pull/11"}]', "")})
+    # An open PR whose head branch carries item-43's suffix — a DIFFERENT slug than this
+    # run would mint, proving dedup keys on the item id, not the slug.
+    _fake_gh(monkeypatch, {"pr list": (0, '[{"url": "https://github.com/x/y/pull/11", "headRefName": "coder-1/some-other-slug-item-43"}]', "")})
 
     async def must_not_run(self, d, query, *, timeout=None):
         raise AssertionError("coder must not be dispatched when an open PR exists")
@@ -390,3 +393,67 @@ async def test_unmanaged_dispatch_untouched(repo, monkeypatch):
     reply = await AcpAdapter().dispatch(d, "just a task")
     assert reply == "plain: just a task"
     assert await _git(repo, "rev-parse", "--abbrev-ref", "HEAD") == "main"
+
+
+# ── name inference + item-id-suffix dedup (ADR 0076 follow-up) ─────────────────
+
+
+async def test_preflight_pr_matches_by_item_id_suffix(repo, monkeypatch):
+    """Dedup keys on the stable `-<id7>` item suffix, NOT the slug — so an open PR is
+    found even if the re-run's inferred slug differs from the original."""
+    iid = "abc123def456"  # 12-char id (like derive_item_id); last7 -> "3def456"
+    prs = [
+        {"url": "https://gh/pr/1", "headRefName": "proto/some-other-work-9999999"},
+        {"url": "https://gh/pr/2", "headRefName": "proto/a-totally-different-slug-3def456"},
+    ]
+    import json as _json
+
+    _fake_gh(monkeypatch, {"pr list": (0, _json.dumps(prs), "")})
+    assert await harness.preflight_pr(str(repo), iid) == "https://gh/pr/2"
+
+    # No branch carrying this item's suffix -> no match (fresh dispatch proceeds).
+    _fake_gh(monkeypatch, {"pr list": (0, _json.dumps(prs[:1]), "")})
+    assert await harness.preflight_pr(str(repo), iid) == ""
+
+
+async def test_infer_title_falls_back_to_none_without_model():
+    """No config + no runtime STATE -> None, so the caller uses the deterministic title."""
+    assert await harness.infer_title("fix the thing", config=None) in (None,)  # STATE absent in unit ctx
+
+
+async def test_infer_title_cleans_model_output(monkeypatch):
+    """A chatty/quoted model reply is collapsed to one capped line; the coder preamble
+    the task is wrapped in must NOT end up in the title (the model is told to ignore it)."""
+    import graph.agent
+    import graph.llm
+
+    class _Msg:
+        def __init__(self, c):
+            self.content = c
+
+    class _LLM:
+        async def ainvoke(self, _msgs):
+            return _Msg('  "fix: guard null user"  ')
+
+    monkeypatch.setattr(graph.agent, "_resolve_aux_model", lambda cfg, x: "aux")
+    monkeypatch.setattr(graph.llm, "create_llm", lambda cfg, model_name=None: _LLM())
+
+    task = "You are implementing ONE feature in this repository.\n\nActually: guard the null user."
+    assert await harness.infer_title(task, config={}) == "fix: guard null user"
+
+
+async def test_infer_title_rejects_multiline_reply(monkeypatch):
+    """A model that ignores 'one line' is rejected (fall back), not slugged into a branch."""
+    import graph.agent
+    import graph.llm
+
+    class _Msg:
+        content = "fix: a thing\nand a whole paragraph of explanation that should never be a branch name"
+
+    class _LLM:
+        async def ainvoke(self, _msgs):
+            return _Msg()
+
+    monkeypatch.setattr(graph.agent, "_resolve_aux_model", lambda cfg, x: "aux")
+    monkeypatch.setattr(graph.llm, "create_llm", lambda cfg, model_name=None: _LLM())
+    assert await harness.infer_title("do the thing", config={}) is None


### PR DESCRIPTION
## The bug (caught by a live smoke test)

A roxy → protoContent managed-git dispatch opened **PR #422** on protoContent with branch `proto/you-are-implementing-one-feature-in-this-repositor-fb77326` and a matching title. The *diff was correct* (one-line change) — but the **name was garbage**.

Root cause: `mint_branch`/`title_from` slug the task's **first non-empty line**. That's right when a caller's first line is the intent, but `project_board` wraps every feature in a coder preamble — `"You are implementing ONE feature in this repository. Your working directory is…"` — so the preamble got slugged into the branch + PR title.

## Fix

- **`infer_title()`** — a best-effort step that summarizes the task into a one-line conventional-commit title via the cheap **aux model** (`_resolve_aux_model` → `routing.aux_model`, falling back to the main model when unset — the `conversation_harvest` pattern), told to ignore the coder-preamble boilerplate. Falls back to the deterministic `title_from` on any failure.
- **Dedup keys on the item id, not the slug.** Since an inferred slug can vary run-to-run, `preflight_pr` now matches an open PR by the stable `-<id7>` **item-id suffix** on its head branch (was: exact `--head <branch>`). A re-run that names the branch differently still finds the prior PR — preserving the cross-restart no-duplicate guarantee. Uniqueness was always the id suffix, never the slug.

## Tests

New: `infer_title` output-cleaning, multiline/no-model fallback, suffix-based `preflight_pr`. Updated the two existing dedup tests to carry `headRefName`. Full `test_git_harness` + `test_delegates_plugin` green (63); ruff clean.

Follow-up to #1846/#1847 (ADR 0076). Surfaced standing up the roxy Portfolio Manager fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Branch and pull request titles can now be inferred automatically from the task, with a safe fallback when inference is unavailable.

* **Bug Fixes**
  * Pull request reuse now matches on a stable item-based identifier, reducing duplicate PRs when branch naming differs.
  * Existing PR detection is more reliable during managed dispatch and finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->