### PR TITLE
fix(sdk): run_subagent defaults extra_tools to the host's plugin + MCP tools

### DIFF
--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -67,8 +67,17 @@ async def run_subagent(
     Pulls the config + knowledge store + scheduler from runtime state, so a plugin
     tool only supplies the subagent + prompt. This is the capability the workflows
     plugin's engine injects as its per-step ``run_step``.
+
+    ``extra_tools`` defaults to the host's plugin + MCP tools (the same set the
+    lead graph and the console fan-out expose) — a subagent whose allowlist names
+    a plugin tool (the review-finder's ``github_pr_diff``, a finance backtester)
+    must see it here too, or every SDK-driven workflow step silently degrades to
+    "No tools available". Pass an explicit list (even ``[]``) to override.
     """
     from graph.agent import run_manual_subagent
+
+    if extra_tools is None:
+        extra_tools = list(getattr(STATE, "plugin_tools", None) or []) + list(getattr(STATE, "mcp_tools", None) or [])
 
     return await run_manual_subagent(
         STATE.graph_config,

--- a/tests/test_sdk_subagent_tools.py
+++ b/tests/test_sdk_subagent_tools.py
@@ -1,0 +1,52 @@
+"""sdk.run_subagent must expose the host's plugin + MCP tools by default.
+
+The workflows engine drives every recipe step through sdk.run_subagent with no
+extra_tools argument. Roles whose allowlists name PLUGIN tools (review-finder's
+github_pr_diff, ADR 0077) resolved to "No tools available" because the SDK
+didn't forward STATE.plugin_tools — caught live by the code-review acceptance
+run. These pin the default + the explicit-override escape hatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graph import sdk
+from runtime.state import STATE
+
+
+@pytest.fixture()
+def capture(monkeypatch):
+    """Stub run_manual_subagent and record the kwargs the SDK forwards."""
+    calls = {}
+
+    async def fake_run(config, knowledge_store=None, scheduler=None, **kw):
+        calls.update(kw)
+        return "ok"
+
+    import graph.agent as agent_mod
+
+    monkeypatch.setattr(agent_mod, "run_manual_subagent", fake_run)
+    monkeypatch.setattr(STATE, "graph_config", object(), raising=False)
+    return calls
+
+
+async def test_defaults_to_plugin_and_mcp_tools(monkeypatch, capture):
+    plugin_tool, mcp_tool = object(), object()
+    monkeypatch.setattr(STATE, "plugin_tools", [plugin_tool], raising=False)
+    monkeypatch.setattr(STATE, "mcp_tools", [mcp_tool], raising=False)
+    await sdk.run_subagent("researcher", "p", description="d")
+    assert capture["extra_tools"] == [plugin_tool, mcp_tool]
+
+
+async def test_explicit_empty_list_disables_the_default(monkeypatch, capture):
+    monkeypatch.setattr(STATE, "plugin_tools", [object()], raising=False)
+    await sdk.run_subagent("researcher", "p", description="d", extra_tools=[])
+    assert capture["extra_tools"] == []
+
+
+async def test_tolerates_missing_state_fields(monkeypatch, capture):
+    monkeypatch.setattr(STATE, "plugin_tools", None, raising=False)
+    monkeypatch.setattr(STATE, "mcp_tools", None, raising=False)
+    await sdk.run_subagent("researcher", "p", description="d")
+    assert capture["extra_tools"] == []

--- a/uv.lock
+++ b/uv.lock
@@ -1539,7 +1539,7 @@ wheels = [
 
 [[package]]
 name = "protoagent"
-version = "0.93.0"
+version = "0.93.1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["fastapi", "http-server", "sqlite"] },


### PR DESCRIPTION
Found by M1's live acceptance run: `run_workflow("code-review", {pr: 1847})` on a dev instance returned a structurally perfect report whose four finder steps all said **"No tools available for subagent 'review-finder'"** — the workflows engine drives steps through `sdk.run_subagent`, which never forwarded `STATE.plugin_tools`/`STATE.mcp_tools`, so any role allowlisting plugin tools silently no-ops.

Fix: default `extra_tools` to the same plugin+MCP set the lead graph (`server/agent_init.py`) and console fan-out (`operator_api/console_handlers.py`) already expose. Explicit `extra_tools` (including `[]`) still overrides.

3 new tests (default, explicit-empty override, missing STATE fields). Full suite **3314 passed**; ruff + lint-imports clean.

Unblocks the ADR 0077 review pipeline (and the board review gate that consumes it, projectBoard v0.30.0+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)