### PR TITLE
fix(review): review-finder turn budget 15 → 25

### DIFF
--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -362,7 +362,10 @@ manufacture findings to look busy.
 
 Hard stop at max_turns: return what you have (partial findings beat none).""",
     tools=["github_pr_diff", "github_get_commit_diff", "github_read_file", "github_get_pr"],
-    max_turns=15,
+    # 25, not 15: on the first live acceptance run (PR #1847, a 6-file diff) two of
+    # four finders hit the 15-turn recursion limit mid-read — a finder that re-fetches
+    # a truncated diff and reads 2-3 surrounding files legitimately spends ~20 turns.
+    max_turns=25,
     # Per-invocation review verdicts are context-specific — never distill to a skill.
     allow_skill_emission=False,
 )


### PR DESCRIPTION
From the M1 live acceptance run (`run_workflow("code-review", {pr: 1847})` on a dev instance @ main): the pipeline worked end-to-end — 4 deduped, evidence-backed, `parse_findings`-parseable findings, including a real major on `git_harness.py` — but **two of four finders starved at the 15-turn recursion limit** on a 6-file diff. Reading a truncated diff twice plus 2-3 surrounding files is ~20 legitimate turns. Bump to 25 (the codebase-mapper's budget, same read-heavy shape).

Also observed on the run, not fixed here: the final report step sometimes re-emits findings without the verifier's `verdict` field (prompt adherence; findings still parse — verdicts remain visible in the verify step's output). Worth a prompt tweak if it recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)