### PR TITLE
feat(review): noise ledger + Gap semantics + delta re-reviews (ADR 0078 Phase A1)

### DIFF
--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -216,7 +216,10 @@ claim against the code — does the quoted evidence exist, and does it show the
 claimed defect? Return the SAME findings array (fenced ```json), each item
 annotated with "verdict": "confirmed" | "refuted" | "uncertain" and a one-line
 "note" saying why. Do not add new findings; do not drop any — verdicts do the
-filtering downstream.
+filtering downstream. Grounding rule: "confirmed" means YOU re-read the code
+and saw the defect. A claim you could not re-verify (the file fetch failed, a
+cross-repo reference you can't reach, CI you can't see) is verdict "uncertain"
+with note "gap: unverified — <why>" — never confirmed on plausibility alone.
 Hard stop at max_turns.""",
     # The github read tools serve the code-review verify pass; they resolve only
     # when the github plugin is enabled (missing tool names are skipped) and are
@@ -355,8 +358,32 @@ Procedure:
    `major` is a real bug or regression, `minor` is a correctness-adjacent flaw,
    `nit` is style your angle explicitly owns (else skip nits).
 
+OUT OF SCOPE — these never become findings (a review is only as trusted as its
+signal-to-noise ratio; below-the-bar findings train authors to ignore the panel):
+- Style/formatting the repo's linter or formatter already owns (spacing, import
+  order, quote style, line length).
+- Theoretical risks behind preconditions that cannot occur (an attacker who
+  already holds the keys; an input the type system forbids).
+- Subjective preference dressed as defect ("I'd have used a map here") when the
+  code is correct and readable as written.
+- Anything about code you did not actually read — no fetched file/hunk, no finding.
+- Points the PR's own description or an already-resolved review thread covers.
+
+GAPS are not findings: when a claim depends on something you could not verify
+(a cross-repo path, a file the tools couldn't fetch, CI you can't see), state it
+in your prose as `Gap: unverified — <what and why>` and leave it OUT of the JSON
+array. Never convert an unverified assumption into a blocker/major. Report only
+findings you'd stake >80% confidence on; consolidate same-defect duplicates into
+one entry.
+
 A clean diff from your angle is a GOOD result — return the empty array; never
 manufacture findings to look busy.
+
+When the task's `## Prior findings` section contains findings (not "none"),
+this is a DELTA re-review: check which prior findings are now fixed (drop
+them), carry forward the still-open ones you can re-evidence against the
+CURRENT diff, and only then look for new defects in your angle. Do not
+re-litigate a prior finding whose verdict was `refuted`.
 
 {FINDINGS_CONTRACT}
 
@@ -389,8 +416,12 @@ verdict-annotated list). You produce ONE canonical findings block.
   severity by how load-bearing the file is. Re-grade severity when a finder
   plainly over- or under-called it; you see the whole picture, they saw a lane.
 - **Drop:** findings with no evidence, findings about code the diff doesn't
-  touch, and (on a final pass) findings the verifier marked "refuted". Keep
-  "uncertain" ones, marked as such.
+  touch, findings in the panel's out-of-scope ledger that slipped through
+  (linter-owned style, theoretical risks behind impossible preconditions,
+  subjective preference on correct code, points a resolved thread already
+  settled), and (on a final pass) findings the verifier marked "refuted". Keep
+  "uncertain" ones, marked as such. A finder's `Gap:` prose lines are NOT
+  findings — surface them in your brief as gaps, never in the array.
 - **Never add** a finding of your own — you synthesize the panel, you are not on it.
 
 {FINDINGS_CONTRACT}

--- a/plugins/workflows/recipes/code-review.yaml
+++ b/plugins/workflows/recipes/code-review.yaml
@@ -25,6 +25,13 @@ inputs:
   - name: repo
     description: Repository as owner/name (omit to use the configured default repo).
     default: ""
+  - name: prior_findings
+    description: >-
+      Findings JSON from a previous review of this PR (optional). When present,
+      finders run a DELTA re-review: drop what's fixed, carry forward what's
+      still open, then look for new defects. GitHub-native review memory
+      (ADR 0078 D5) — the caller recalls, the panel re-evaluates.
+    default: "(none — first review of this PR)"
 steps:
   - id: find_correctness
     subagent: review-finder
@@ -34,6 +41,9 @@ steps:
       off-by-ones, broken edge cases, error-handling gaps, races, wrong
       conditionals, unhandled None/empty/failure paths — does this code do what
       it claims under all inputs it will actually see?
+
+      ## Prior findings
+      {{inputs.prior_findings}}
 
   - id: find_removed_behavior
     subagent: review-finder
@@ -45,6 +55,9 @@ steps:
       conditions, deleted call sites, semantics changed without the callers
       changing. Regressions hide on the minus side of the diff.
 
+      ## Prior findings
+      {{inputs.prior_findings}}
+
   - id: find_crossfile
     subagent: review-finder
     prompt: |
@@ -54,6 +67,9 @@ steps:
       consumers, config keys renamed on one side only, docs/tests contradicting
       the new behavior. Use github_read_file on the files the diff touches
       indirectly — this angle is exactly the one a hunk-by-hunk read misses.
+
+      ## Prior findings
+      {{inputs.prior_findings}}
 
   - id: find_conventions
     subagent: review-finder
@@ -65,6 +81,9 @@ steps:
       lies, duplicated logic, dead/debug code left in, missing or weakened
       tests for changed behavior, secrets or scratch files in the diff.
       Severity honestly — most convention findings are minor/nit.
+
+      ## Prior findings
+      {{inputs.prior_findings}}
 
   - id: synthesize
     subagent: review-synthesizer

--- a/tests/test_code_review_workflow.py
+++ b/tests/test_code_review_workflow.py
@@ -74,3 +74,36 @@ def test_recipe_shape_four_finders_then_synthesize_verify_report():
 
 def test_recipe_output_is_the_final_report():
     assert _recipe()["output"].strip() == "{{steps.report.output}}"
+
+
+# ── the noise ledger + delta re-review (ADR 0078 Phase A1) ────────────────────
+
+
+def test_finder_carries_the_noise_ledger_and_gap_rule():
+    p = SUBAGENT_REGISTRY["review-finder"].system_prompt
+    assert "OUT OF SCOPE" in p and "linter or formatter already owns" in p
+    assert "Gap: unverified" in p  # unverifiable claims are Gaps, never severities
+    assert "80% confidence" in p
+    assert "DELTA re-review" in p
+
+
+def test_verifier_grounding_rule_never_confirms_on_plausibility():
+    p = SUBAGENT_REGISTRY["verifier"].system_prompt
+    assert "gap: unverified" in p
+    assert "never confirmed on plausibility alone" in p
+
+
+def test_synthesizer_filters_ledger_slippage_and_gap_lines():
+    p = SUBAGENT_REGISTRY["review-synthesizer"].system_prompt
+    assert "out-of-scope ledger" in p
+    assert "never in the array" in p  # Gap prose lines stay out of the findings JSON
+
+
+def test_recipe_declares_prior_findings_and_threads_it_into_every_finder():
+    r = _recipe()
+    prior = next(i for i in r["inputs"] if i["name"] == "prior_findings")
+    assert prior["default"].startswith("(none")  # empty state is explicit, not a blank section
+    finders = [s for s in r["steps"] if s["subagent"] == "review-finder"]
+    assert len(finders) == 4
+    for s in finders:
+        assert "{{inputs.prior_findings}}" in s["prompt"], s["id"]


### PR DESCRIPTION
Phase A1 of the QA review takeover (#1859): Quinn's signal-to-noise discipline ported into the ADR 0077 panel.

- **Finder**: out-of-scope ledger + `Gap: unverified` rule (a claim you couldn't verify is prose, never a blocker) + >80% bar + consolidation + delta re-review off `## Prior findings`.
- **Verifier**: `confirmed` requires re-read evidence — unreachable references go `uncertain`/`gap`, never confirmed on plausibility.
- **Synthesizer**: filters ledger slippage; Gap lines stay out of the findings array.
- **Recipe**: `prior_findings` input with an explicit `(none — first review)` default (a blank section must not masquerade as a delta pass), threaded into all four finders.

Consumers unchanged — the board gate and craft skill pick up delta re-reviews when they start passing `prior_findings` (Phase A2, next PR).

4 new test pins · full suite **3322 passed** · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)