### PR TITLE
fix(review): keep verify-pass verdicts through the report re-parse

### DIFF
--- a/graph/review/findings.py
+++ b/graph/review/findings.py
@@ -171,15 +171,25 @@ def parse_findings(text: str) -> list[Finding]:
 
     Picks the candidate JSON array with the most finding-shaped items (models
     sometimes echo an earlier step's list before their own — the fuller list is
-    the deliverable; ties → the LAST one, the reply's conclusion). An explicit
-    empty array parses as [] (a clean review), as does text with no array at all
-    — callers that must distinguish should check for the fence themselves.
+    the deliverable). Among arrays of EQUAL length, the one carrying the most
+    verdicts wins — the verify pass annotates the same findings with
+    confirmed/refuted/uncertain, and the final report often reprints the plain
+    (verdict-less) list alongside it; a bare last-wins tie-break would drop the
+    computed verdicts from the rendered report depending on print order. Genuine
+    ties (same length, same verdict count) → the LAST one, the reply's
+    conclusion. An explicit empty array parses as [] (a clean review), as does
+    text with no array at all — callers that must distinguish should check for
+    the fence themselves.
     """
     best: list[Finding] = []
+    best_key = (-1, -1)
     for arr in _candidate_arrays(text):
         findings = [f for item in arr if isinstance(item, dict) and (f := _coerce(item))]
-        if len(findings) >= len(best):
-            best = findings
+        # (finding count, verdict count): count picks the deliverable, verdict
+        # count keeps the verify pass's annotations on an equal-length tie.
+        key = (len(findings), sum(1 for f in findings if f.verdict))
+        if key >= best_key:
+            best, best_key = findings, key
     return best
 
 

--- a/tests/test_review_findings.py
+++ b/tests/test_review_findings.py
@@ -50,6 +50,19 @@ def test_parse_prefers_the_fuller_array():
     assert len(parse_findings(text)) == 2
 
 
+def test_parse_keeps_verdicts_when_a_plain_copy_is_reprinted_last():
+    # The verify pass annotates the findings; the final report reprints the plain
+    # (verdict-less) list AFTER the annotated one. Both are the same length, so a
+    # bare last-wins tie-break would surface the plain copy and drop the computed
+    # verdicts from the rendered report. The richer (verdict-bearing) list wins.
+    annotated = json.dumps([{**_ITEM, "verdict": "confirmed", "note": "reproduced"}])
+    plain = json.dumps([_ITEM])
+    text = f"Verifier said:\n```json\n{annotated}\n```\nFinal list:\n```json\n{plain}\n```"
+    found = parse_findings(text)
+    assert len(found) == 1
+    assert found[0].verdict == "confirmed"
+
+
 def test_parse_empty_array_and_no_array_return_empty():
     assert parse_findings("Clean review.\n```json\n[]\n```") == []
     assert parse_findings("No JSON here at all.") == []


### PR DESCRIPTION
## Problem

The review-report rendering re-parses the findings JSON out of the final pass's prose (`parse_findings`) before `render_findings_markdown`. When the verify pass has annotated findings with verdicts (confirmed/refuted/uncertain) and the final report reprints the plain, verdict-less copy of the same list alongside the annotated one, both candidate arrays are the **same length**. The old `len(findings) >= len(best)` last-wins tie-break then surfaced whichever list printed last — so depending on model output order, the computed verdicts were **intermittently dropped** from the rendered report.

## Fix

Break equal-length ties by verdict count: candidate key becomes `(len(findings), verdict_count)`. Finding count still dominates (the "fuller list is the deliverable" rule is unchanged); among equal-length arrays the verdict-bearing one wins; genuine ties (same length, same verdict count) still fall through to the last array via `>=`.

Adds a regression test (`test_parse_keeps_verdicts_when_a_plain_copy_is_reprinted_last`).

## Verification

All 11 tests in `tests/test_review_findings.py` pass (project `.venv`, Python 3.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)