### PR TITLE
docs(plan): qa takeover — dual-layer posture, CodeRabbit shadow, protoPatch as a panel member

### DIFF
--- a/docs/plans/qa-review-takeover.md
+++ b/docs/plans/qa-review-takeover.md
@@ -11,10 +11,18 @@
 
 ## Objective
 
-protoAgent-native agents take over Quinn's fleet-review role: auto-review every PR,
-post formal verdicts, promote to merge deterministically — while keeping our structural
+protoAgent-native agents grow into the fleet's review role: auto-review every PR, post
+formal verdicts, promote to merge deterministically — while keeping our structural
 advantages (adversarial panel, parseable findings, closed fix loop) and adopting every
 guard Quinn's production history paid for.
+
+**Posture (operator decision 2026-07-06): dual-layer for an extended period, not a
+cutover race.** Two independent formal reviewers on the same PR is a feature — Quinn's
+fast single pass + our deep panel catch different things, and branch protection can
+require both. Retiring Quinn (or CodeRabbit) is a per-repo decision the comparison data
+earns much later. The eval benchmarks our findings against BOTH incumbents: Quinn's
+verdicts AND CodeRabbit's review threads on the same PRs (CodeRabbit is already a
+required check fleet-wide — its threads are a third dataset, free).
 
 ## The harvest (what her scar tissue taught, by issue number)
 
@@ -72,6 +80,26 @@ message); self-review guard (author == token identity ⇒ refuse). Write-gated l
 **Accept:** unit tests prove a blocking verdict is impossible against pending CI and
 against the agent's own PR.
 
+**B2 — protoPatch as a first-class panel member** `protoAgent` + `pr-reviewer-plugin` [M]
+protoPatch (our `clawpatch` CLI, npm-published, protolabs/smart via gateway) is a big
+part of Quinn's strength — the cross-file/systemic engine a diff pass can't match. It
+joins OUR pipeline as a **fifth, non-LLM finder**, not an optional garnish:
+- A `protopatch_review` tool: resolve head+base SHAs server-side from the PR (never
+  model-provided refs), maintain a content-addressed shallow checkout at the head
+  (`--filter=blob:none`, TTL + prune — port CheckoutCache's model), run
+  `clawpatch ci --provider gateway --json --since <baseSha>` with a per-repo state dir
+  and a hard time budget (her 300s → clean timeout, review proceeds without it).
+- Map its JSON findings into the ADR 0077 schema (severity/category/file:line/evidence
+  carry over cleanly) and feed them into the synthesize step alongside the four LLM
+  finders — so protoPatch findings get the same dedup + independent verify + noise
+  filtering as everything else. That composition is an edge Quinn doesn't have: her
+  clawpatch findings go straight into her verdict; ours survive an adversarial verify.
+- Recipe: the full-panel variant gains a `find_structural` step behind the structural
+  trigger; the lite variant skips it.
+**Accept:** on a structural-trigger PR the final findings block contains verified
+protoPatch-sourced findings (category preserved, source attributed), and a protoPatch
+timeout degrades to the four-finder review with a Gap noted.
+
 **C — the reviewer machinery** `pr-reviewer-plugin` (new) [L]
 Webhook route (HMAC) → chokepoint (30s cooldown per repo/PR/SHA, in-flight map, typed
 drops) → dispatch: structural trigger picks full-panel vs lite recipe; run via
@@ -85,19 +113,27 @@ verdict mix, per-finding resolution — ws-91a answered).
 **Accept:** an end-to-end dry run on a test repo: webhook → review → COMMENT → CI green
 → deterministic APPROVE → auto-merge armed, with every drop/skip typed and logged.
 
-**D — the agent + shadow mode → cutover** `qaEngineer` bundle (new) [M]
-Bundle pins + archetype + persona port + `shadow_mode: true` (COMMENT-only, no
-promotion). Deploy alongside Quinn on the same repos; compare N weeks of findings vs
-her verdicts + CodeRabbit threads + merge outcomes, using her own eval metrics as the
-bar (respect the 44.7s-median question: measure where the multi-step panel earns its
-latency vs her single pass; the lite recipe is the lever). Per-repo cutover: flip
-`shadow_mode: false`, retire Quinn's dispatch for that repo, keep protoPatch as a
-finding source throughout.
-**Accept:** shadow report shows ≥ her catch-rate with acceptable noise on ≥2 repos;
-one repo fully cut over with zero silent merges.
+**D — the agent: shadow → second formal layer** `qaEngineer` bundle (new) [M]
+Bundle pins + archetype + persona port. Three stages, each gated on data:
+1. **Shadow** (`shadow_mode: true`): COMMENT-only on the same PRs Quinn and CodeRabbit
+   review. The eval compares all three streams per PR — findings we caught that they
+   didn't, theirs we missed, noise each layer added — plus merge outcomes, with Quinn's
+   own eval metrics as the floor (and respect her 44.7s median: measure where the panel
+   earns its latency; the lite recipe is the lever).
+2. **Second formal layer** — the standing posture "for a bit" (operator, 2026-07-06):
+   our reviewer posts real verdicts ALONGSIDE Quinn, two independent reviews per PR
+   with different failure modes, both feeding branch protection. Approve-on-green
+   promotion stays single-owner (Quinn's) until explicitly handed over per-repo — two
+   promoters racing is how double-merges happen.
+3. **Per-repo retirement** (much later, data-earned): where the comparison shows our
+   layer dominating on catch-rate + noise, retire Quinn's dispatch — or the CodeRabbit
+   seat — for that repo. No program-level cutover date.
+**Accept (stages 1-2):** a three-way comparison report over ≥2 repos / ≥2 weeks;
+dual-layer running with zero silent merges and no duplicate-promotion incidents.
 
 ## Parked / explicit non-goals
-- Rebuilding protoPatch (call the existing CLI/service; it's model-agnostic via gateway).
+- Rebuilding protoPatch's engine (B2 CALLS the existing CLI — the work is integration +
+  checkout mechanics, never a rewrite).
 - The Qdrant learning loop — only wire retrieval WITH a consumer in the same phase
   (her write-only flywheel is the anti-lesson); our KG-lessons path is the substrate.
 - bug_triage / security_triage skills — same harvest pattern, separate program.


### PR DESCRIPTION
Three operator course-corrections to the ADR 0078 plan:

1. **Dual-layer is the posture, not a transition cost.** Phase D: shadow → **second formal layer** (our verdicts alongside Quinn's; approve-on-green promotion stays single-owner per repo — two promoters racing is how double-merges happen) → per-repo retirement only when the data earns it. No cutover date.
2. **Shadow CodeRabbit too.** The comparison is three-way: our findings vs Quinn's verdicts vs CodeRabbit's threads on the same PRs — CodeRabbit is already a required check fleet-wide, so the dataset is free.
3. **protoPatch is first-class (new Phase B2).** `protopatch_review` tool — server-resolved head/base SHAs, CheckoutCache-model shallow checkouts, `clawpatch ci --provider gateway --json --since <base>`, hard time budget — findings mapped into ADR 0077 schema and fed into the panel as a **fifth, non-LLM finder**, subject to the same dedup + adversarial verify as the LLM finders (an edge Quinn's direct-to-verdict wiring doesn't have).

🤖 Generated with [Claude Code](https://claude.com/claude-code)