### PR TITLE
feat(review): source attribution on findings — non-LLM panel members (ADR 0078 B2)

### DIFF
--- a/graph/review/findings.py
+++ b/graph/review/findings.py
@@ -60,7 +60,13 @@ Rules: `line` is the NEW-file line number (0 if not line-anchored). `claim` stat
 a defect, not a description of the code. `evidence` must quote or concretely
 reference the diff — a finding you cannot evidence does not go in the list. No
 findings → an empty array `[]`. Prose around the fence is fine (your reasoning);
-the fenced array is the deliverable."""
+the fenced array is the deliverable.
+
+Items may additionally carry a `source` field naming the engine that produced
+the finding (e.g. `"protopatch"` for the structural analysis pass; absent means
+an LLM panel finder). When an input finding carries `source`, preserve it
+verbatim on that finding through every merge/verify/report pass — never strip
+it, never invent one."""
 
 
 @dataclass
@@ -71,15 +77,15 @@ class Finding:
     category: str = ""
     claim: str = ""
     evidence: str = ""
+    source: str = ""  # producing engine ("protopatch", …); "" = an LLM panel finder
     verdict: str = ""  # "" until a verify pass sets confirmed/refuted/uncertain
     note: str = field(default="")  # verifier's one-line justification, optional
 
     def to_dict(self) -> dict:
         d = asdict(self)
-        if not d["verdict"]:
-            d.pop("verdict")
-        if not d["note"]:
-            d.pop("note")
+        for optional in ("source", "verdict", "note"):
+            if not d[optional]:
+                d.pop(optional)
         return d
 
 
@@ -106,6 +112,7 @@ def _coerce(item: dict) -> Finding | None:
         category=str(item.get("category") or "").strip().lower(),
         claim=claim,
         evidence=str(item.get("evidence") or "").strip(),
+        source=str(item.get("source") or "").strip().lower(),
         verdict=verdict,
         note=str(item.get("note") or "").strip(),
     )
@@ -210,7 +217,8 @@ def render_findings_markdown(findings: list[Finding], *, title: str = "Review fi
         for f in by_sev[sev]:
             loc = f"`{f.file}:{f.line}`" if f.file and f.line else (f"`{f.file}`" if f.file else "(no file)")
             verdict = f" — **{f.verdict}**" if f.verdict else ""
-            cat = f" _[{f.category}]_" if f.category else ""
+            tag = " · ".join(x for x in (f.category, f.source) if x)
+            cat = f" _[{tag}]_" if tag else ""
             lines.append(f"- {loc}{cat}{verdict}: {f.claim}")
             if f.evidence:
                 lines.append(f"  - evidence: {f.evidence}")

--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -216,7 +216,8 @@ claim against the code — does the quoted evidence exist, and does it show the
 claimed defect? Return the SAME findings array (fenced ```json), each item
 annotated with "verdict": "confirmed" | "refuted" | "uncertain" and a one-line
 "note" saying why. Do not add new findings; do not drop any — verdicts do the
-filtering downstream. Grounding rule: "confirmed" means YOU re-read the code
+filtering downstream. Preserve every field an item came with (including
+"source" — tool-sourced findings get the same skeptical verify, not a pass). Grounding rule: "confirmed" means YOU re-read the code
 and saw the defect. A claim you could not re-verify (the file fetch failed, a
 cross-repo reference you can't reach, CI you can't see) is verdict "uncertain"
 with note "gap: unverified — <why>" — never confirmed on plausibility alone.
@@ -412,6 +413,13 @@ verdict-annotated list). You produce ONE canonical findings block.
   defect are ONE finding — keep the clearer claim, the stronger evidence, and
   the HIGHER severity. Note angle agreement in the claim when it strengthens it
   ("flagged by both correctness and cross-file review").
+- **Tool-sourced findings are full panel members.** A findings list may come
+  from a non-LLM engine (its items carry a `source` field, e.g. "protopatch").
+  Merge, dedup, re-grade, and drop them by exactly the same rules as the LLM
+  finders' — no deference, no discount. When a tool-sourced finding merges with
+  an LLM finding, the survivor keeps the `source` field (agreement across
+  engines is strong evidence — note it in the claim). Preserve `source` on
+  every item that has one; never invent it on one that doesn't.
 - **Rank:** order the array blocker → major → minor → nit, and within a
   severity by how load-bearing the file is. Re-grade severity when a finder
   plainly over- or under-called it; you see the whole picture, they saw a lane.

--- a/tests/test_review_findings.py
+++ b/tests/test_review_findings.py
@@ -100,10 +100,31 @@ def test_contract_snippet_names_every_schema_field():
         assert f'"{field_name}"' in FINDINGS_CONTRACT
 
 
+def test_contract_documents_source_preservation():
+    assert "`source`" in FINDINGS_CONTRACT and "protopatch" in FINDINGS_CONTRACT
+
+
 def test_to_dict_round_trips_through_parse():
     f = Finding(file="a.py", line=3, severity="blocker", category="security", claim="X", evidence="Y")
     [back] = parse_findings(json.dumps([f.to_dict()]))
     assert back == f
+
+
+def test_source_round_trips_and_is_omitted_when_empty():
+    f = Finding(file="a.py", line=3, severity="major", category="bug", claim="X", evidence="Y", source="protopatch")
+    d = f.to_dict()
+    assert d["source"] == "protopatch"
+    [back] = parse_findings(json.dumps([d]))
+    assert back == f
+    # An LLM panel finding has no source — the key stays out of the dict.
+    assert "source" not in Finding(claim="X").to_dict()
+
+
+def test_source_is_normalized_and_defaults_empty():
+    [f] = parse_findings(json.dumps([{**_ITEM, "source": "  ProtoPatch "}]))
+    assert f.source == "protopatch"
+    [g] = parse_findings(json.dumps([_ITEM]))
+    assert g.source == ""
 
 
 # ── render: the human-facing report ───────────────────────────────────────────
@@ -121,3 +142,10 @@ def test_render_groups_by_severity_and_shows_verdicts():
 
 def test_render_empty_says_clean():
     assert "clean" in render_findings_markdown([]).lower()
+
+
+def test_render_shows_source_alongside_category():
+    md = render_findings_markdown(
+        [Finding(file="a.py", line=1, severity="major", category="concurrency", claim="Race.", source="protopatch")]
+    )
+    assert "_[concurrency · protopatch]_" in md

--- a/uv.lock
+++ b/uv.lock
@@ -1539,7 +1539,7 @@ wheels = [
 
 [[package]]
 name = "protoagent"
-version = "0.93.1"
+version = "0.94.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["fastapi", "http-server", "sqlite"] },


### PR DESCRIPTION
## What

Core half of **ADR 0078 Phase B2** (protoPatch as a first-class fifth panel member):

- `Finding` gains an optional `source` field naming the producing engine (`"protopatch"`; empty = LLM panel finder). Coerced (lowercased/stripped), omitted from `to_dict()` when empty, round-trips through `parse_findings`.
- `FINDINGS_CONTRACT` documents the rule once: a finding that arrives with `source` keeps it verbatim through every merge/verify/report pass — never stripped, never invented.
- `review-synthesizer` prompt: tool-sourced findings are full panel members — same dedup/re-grade/drop rules, no deference; a cross-engine merge keeps the attribution (agreement across engines strengthens the claim).
- `verifier` prompt: preserve every input field including `source`; tool-sourced findings get the same skeptical verify, not a pass.
- `render_findings_markdown` shows the source next to the category (`_[concurrency · protopatch]_`).

## Why

B2's acceptance criterion is "the final findings block contains verified protoPatch-sourced findings (category preserved, **source attributed**)" — the contract had no attribution field. The plugin side (checkout cache + `protopatch_review` tool + `structural-finder` + five-finder recipe) lands in the new pr-reviewer-plugin next.

## Tests

- `ruff check .`, `lint-imports`: clean
- `pytest tests/ -q`: 3327 passed, 5 skipped
- `scripts/live_smoke.py`: passed
- New: contract mentions `source`; round-trip with/without source; normalization; rendering

Refs: ADR 0078, docs/plans/qa-review-takeover.md (Phase B2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)