### PR TITLE
docs(changelog): findings source attribution entry for #1864

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Findings `source` attribution — non-LLM panel members (ADR 0078 B2, #1864).** The ADR 0077
+  `Finding` schema gains an optional `source` field naming the producing engine (e.g.
+  `"protopatch"`; empty = an LLM panel finder), preserved through parse/`to_dict` round-trips and
+  shown in the markdown rendering. `FINDINGS_CONTRACT` pins the preserve-verbatim rule; the
+  review-synthesizer treats tool-sourced findings as full panel members (same dedup/re-grade/drop
+  rules, cross-engine merges keep the attribution) and the verifier applies the same skeptical
+  verify to them. Enables the pr-reviewer plugin's protoPatch structural finder to join the
+  review panel with its findings attributed end-to-end.
+
 ## [0.94.0] - 2026-07-06
 
 ## [0.93.1] - 2026-07-05


### PR DESCRIPTION
Adds the missed [Unreleased] CHANGELOG entry for #1864 (findings `source` attribution, ADR 0078 B2) ahead of cutting v0.95.0 — the pr-reviewer-plugin pins `min_protoagent_version: 0.95.0` on this contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)