### PR TITLE
chore: release v0.95.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.95.0] - 2026-07-06
+
 ### Added
 - **Findings `source` attribution — non-LLM panel members (ADR 0078 B2, #1864).** The ADR 0077
   `Finding` schema gains an optional `source` field naming the producing engine (e.g.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.94.0"
+version = "0.95.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "v0.95.0",
+    "date": "2026-07-06",
+    "changes": [
+      "Findings source attribution — non-LLM panel members."
+    ]
+  },
+  {
     "version": "v0.93.1",
     "date": "2026-07-05",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.95.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.95.0 -m 'Release v0.95.0' && git push origin v0.95.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **0.95.0**.
  * Added a new release note entry for **v0.95.0** with the latest update highlighted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->