### PR TITLE
fix(workflows): installed-plugin recipe dirs resolve lazily (ADR 0027 bundle promise)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Installed-plugin workflow recipes were silently invisible (#1867).** The in-tree `workflows`
+  plugin scanned recipe dirs eagerly at register time — before instance-installed plugins had
+  loaded — so a git-installed plugin's `workflows/` dir (the ADR 0027 bundle promise) never
+  reached the registry, at boot or reload. The registry now resolves lazily (rebuilt when the
+  plugin-dir set changes) behind a live proxy on `STATE.workflow_registry`, so boot ordering,
+  `enable_plugin` hot installs, and config reloads all pick up plugin recipes.
+
 ## [0.95.0] - 2026-07-06
 
 ### Added

--- a/plugins/workflows/__init__.py
+++ b/plugins/workflows/__init__.py
@@ -84,18 +84,39 @@ async def _safe(cb: Callable[[dict], Awaitable[None]], event: dict) -> None:
 
 
 def register(registry: Any) -> None:
-    # Other enabled plugins' recipe dirs are collected on the shared registry (ADR 0027).
-    reg = _build_registry(getattr(registry, "workflow_dirs", None))
+    # Other plugins' recipe dirs are NOT knowable here: every plugin gets its own
+    # PluginRegistry, and this in-tree plugin registers before the instance-installed
+    # ones, so the accumulated dir list (STATE.plugin_workflow_dirs) is only complete
+    # AFTER the full load — an eager scan would permanently miss every git-installed
+    # plugin's workflows/ dir (the ADR 0027 bundle promise). Resolve lazily instead:
+    # every access goes through _reg(), which rebuilds the WorkflowRegistry whenever
+    # the plugin-dir set changed (first use after boot, hot install, config reload).
+    # Rescanning a handful of YAML files is cheap; staleness here is silent data loss.
+    from runtime.state import STATE
+
+    _cache: dict[str, Any] = {"dirs": None, "reg": None}
+
+    def _reg() -> WorkflowRegistry:
+        dirs = tuple(str(d) for d in (getattr(STATE, "plugin_workflow_dirs", None) or ()))
+        if _cache["reg"] is None or dirs != _cache["dirs"]:
+            _cache["dirs"] = dirs
+            _cache["reg"] = _build_registry(list(dirs))
+        return _cache["reg"]
+
+    class _LiveRegistry:
+        """What STATE.workflow_registry publishes — a thin proxy so consumers that
+        grabbed it once (chat slash-command, console) always see the current scan."""
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(_reg(), name)
 
     # Publish the registry + a runner onto runtime state so core surfaces that predate
     # the plugin (the chat `/<recipe>` slash-command) can use workflows WITHOUT importing
     # this plugin — both are None when the plugin is disabled, which gates those paths.
-    from runtime.state import STATE
-
     async def _run(name: str, inputs: dict | None = None, on_step=None) -> dict:
-        return await _execute(reg, name, inputs or {}, on_step)
+        return await _execute(_reg(), name, inputs or {}, on_step)
 
-    STATE.workflow_registry = reg
+    STATE.workflow_registry = _LiveRegistry()
     STATE.workflow_run = _run
 
     @tool
@@ -111,7 +132,7 @@ def register(registry: Any) -> None:
             inputs: Mapping of the workflow's declared inputs to values.
         """
         if not name.strip():
-            summaries = reg.list()
+            summaries = _reg().list()
             if not summaries:
                 return "No workflows are available."
             lines = ["Available workflows:"]
@@ -120,7 +141,7 @@ def register(registry: Any) -> None:
                 lines.append(f"- {s['name']}: {s['description']} (inputs: {', '.join(req) or 'none required'})")
             return "\n".join(lines)
         try:
-            result = await _execute(reg, name, inputs or {})
+            result = await _execute(_reg(), name, inputs or {})
         except ValueError as exc:
             return f"Workflow {name!r}: {exc}"
         return result["output"]
@@ -155,7 +176,7 @@ def register(registry: Any) -> None:
         if errs:
             return "Cannot save — the workflow is invalid: " + "; ".join(errs)
         try:
-            path = reg.save(recipe)
+            path = _reg().save(recipe)
         except Exception as exc:  # noqa: BLE001 — readable tool error
             return f"Error saving workflow: {exc}"
         return f"Saved workflow {name!r} ({len(steps)} step(s)) to {path}. Run it with run_workflow({name!r}, ...)."
@@ -170,12 +191,12 @@ def register(registry: Any) -> None:
 
     @router.get("/list")
     async def _list() -> dict:
-        return {"workflows": reg.list()}
+        return {"workflows": _reg().list()}
 
     @router.post("/{name}/run")
-    async def _run(name: str, body: dict = Body(default={})) -> dict:
+    async def _run_route(name: str, body: dict = Body(default={})) -> dict:
         try:
-            return await _execute(reg, name, (body or {}).get("inputs") or {})
+            return await _execute(_reg(), name, (body or {}).get("inputs") or {})
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -184,11 +205,11 @@ def register(registry: Any) -> None:
         errs = validate_recipe(body, known_subagents=sdk.subagent_types())
         if errs:
             raise HTTPException(status_code=400, detail="invalid recipe: " + "; ".join(errs))
-        path = reg.save(body)
+        path = _reg().save(body)
         return {"saved": True, "name": body.get("name"), "path": path}
 
     @router.delete("/{name}")
     async def _delete(name: str) -> dict:
-        return {"deleted": reg.delete(name)}
+        return {"deleted": _reg().delete(name)}
 
     registry.register_router(router, prefix="/api/plugins/workflows")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -175,3 +175,51 @@ def test_registry_loads_and_lists(tmp_path):
     assert reg.names() == ["wf"]
     assert reg.get("wf")["description"] == "d"
     assert reg.list()[0]["name"] == "wf"
+
+
+def test_register_sees_plugin_workflow_dirs_added_after_load(tmp_path, monkeypatch):
+    """Installed-plugin recipe dirs are only complete on STATE.plugin_workflow_dirs
+    AFTER the full plugin load — the workflows plugin registers earlier (in-tree
+    plugins load first), so an eager scan would permanently miss them (the ADR 0027
+    bundle promise). The registry must resolve lazily: a dir that lands on STATE
+    after register() shows up on the next access, without a reload."""
+    from types import SimpleNamespace
+
+    import plugins.workflows as wf
+    import runtime.state as rs
+
+    writable = tmp_path / "writable"
+    monkeypatch.setattr(wf.sdk, "config", lambda: SimpleNamespace(workflow_dir=str(writable)))
+    monkeypatch.setattr(wf.sdk, "subagent_types", lambda: {"researcher"})
+    monkeypatch.setattr(rs.STATE, "workflow_registry", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "workflow_run", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "plugin_workflow_dirs", [], raising=False)
+
+    class _Reg:
+        workflow_dirs: list = []
+
+        def register_tools(self, tools):
+            pass
+
+        def register_workflow_dir(self, d):
+            pass
+
+        def register_router(self, router, prefix=None):
+            pass
+
+    wf.register(_Reg())
+    baseline = {s["name"] for s in rs.STATE.workflow_registry.list()}
+    assert "late" not in baseline
+
+    # A git-installed plugin's workflows/ dir lands on STATE after this plugin loaded.
+    late_dir = tmp_path / "late-plugin" / "workflows"
+    late_dir.mkdir(parents=True)
+    (late_dir / "late.yaml").write_text(
+        "name: late\ndescription: from an installed plugin\nsteps:\n"
+        "  - id: a\n    subagent: researcher\n    prompt: p\n",
+        encoding="utf-8",
+    )
+    rs.STATE.plugin_workflow_dirs = [str(late_dir)]
+
+    names = {s["name"] for s in rs.STATE.workflow_registry.list()}
+    assert "late" in names  # no reload, no re-register — the proxy rescanned

--- a/uv.lock
+++ b/uv.lock
@@ -1539,7 +1539,7 @@ wheels = [
 
 [[package]]
 name = "protoagent"
-version = "0.94.0"
+version = "0.95.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["fastapi", "http-server", "sqlite"] },


### PR DESCRIPTION
## What

A git-installed plugin's `workflows/` recipes never reached the workflow registry: each plugin gets its own `PluginRegistry`, and the in-tree `workflows` plugin registers before instance-installed plugins — so its eager scan ran before `STATE.plugin_workflow_dirs` was complete, at boot *and* on reload. The ADR 0027 "installing a repo pulls in the whole bundle" promise held for skills (consumed post-load) but silently not for workflows.

Now the plugin resolves its `WorkflowRegistry` lazily through `_reg()` — rebuilt whenever the plugin-dir set changes — and `STATE.workflow_registry` publishes a thin `__getattr__` proxy so consumers that grabbed the handle once (chat `/<recipe>`, console Studio) always see the current scan. Boot ordering, `enable_plugin` hot installs, and config reloads all pick up new dirs with no re-registration.

Found live: wiring pr-reviewer-plugin's `code-review-structural` recipe (ADR 0078 B2) — the plugin loaded (tool + subagent registered, dir discovered) but the recipe never appeared in `/api/plugins/workflows/list`.

## Tests

- New: `test_register_sees_plugin_workflow_dirs_added_after_load` — a dir landing on STATE after `register()` shows up on the next access, no reload.
- `pytest tests/ -q`: 3328 passed, 5 skipped; `ruff` + `lint-imports` clean.

## CHANGELOG

Added under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)