### PR TITLE
fix(review): the report pass carries verify verdicts into the final findings JSON

### DIFF
--- a/plugins/workflows/recipes/code-review.yaml
+++ b/plugins/workflows/recipes/code-review.yaml
@@ -126,7 +126,9 @@ steps:
       ones marked as such, re-rank, and produce the deliverable: the prose
       brief first (overall risk, fix-first item, what the panel disagreed on,
       what verification changed), then the canonical fenced findings JSON as
-      the FINAL block of your reply.
+      the FINAL block of your reply. Carry every surviving finding's `verdict`
+      and `note` fields into that final JSON verbatim — a reprint that drops
+      them erases the verify pass for downstream parsers.
 
       {{steps.verify.output}}
 output: "{{steps.report.output}}"


### PR DESCRIPTION
On the live B2 acceptance run (code-review-structural over a seeded fixture PR) the verify step confirmed all 8 findings, but the report step's final reprint dropped every `verdict`/`note` field — so the verify pass is invisible to anything parsing the recipe output. The #1861 parse tie-break only preserves verdicts when the report happens to echo the annotated list alongside its own; this makes the carry an explicit instruction in the report prompt instead of luck.

Same line added to the pr-reviewer-plugin's structural recipe separately.

Tests: recipe/workflow suites pass (26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)