### PR TITLE
docs: ADR 0078 Accepted — the QA review takeover program executed

### DIFF
--- a/docs/adr/0078-fleet-pr-review-qa-tier.md
+++ b/docs/adr/0078-fleet-pr-review-qa-tier.md
@@ -1,6 +1,8 @@
 # 0078 — Fleet PR review as a protoAgent tier: harvest Quinn, keep the panel
 
-- Status: Proposed
+- Status: Accepted (2026-07-06 — Phases A/B/B2/C shipped and accepted live; D built,
+  shadow data collection is the standing posture; stage-2/3 promotion stays a per-repo
+  operator decision earned by the three-way eval)
 - Date: 2026-07-06
 - Builds on: ADR 0077 (the adversarial review workflow + findings convention — the
   engine this operationalizes), ADR 0025 (delegates spine), ADR 0042 (bundle

--- a/docs/plans/qa-review-takeover.md
+++ b/docs/plans/qa-review-takeover.md
@@ -1,7 +1,9 @@
 # QA review takeover — harvest Quinn, ship a QA-engineer tier
 
 - Date: 2026-07-06
-- Status: Active (Phase A in flight)
+- Status: Executed (all phases shipped 2026-07-06; ADR 0078 Accepted. Standing:
+  shadow-mode data collection toward the D stage-1 three-way report; stage-2/3
+  promotion is per-repo and operator-gated)
 - ADR: [`0078`](../adr/0078-fleet-pr-review-qa-tier.md)
 - Predecessor program: [`codified-delivery-loop.md`](./codified-delivery-loop.md) (M1/M5
   built the review engine this program operationalizes)
@@ -114,7 +116,22 @@ joins OUR pipeline as a **fifth, non-LLM finder**, not an optional garnish:
 protoPatch-sourced findings (category preserved, source attributed), and a protoPatch
 timeout degrades to the four-finder review with a Gap noted.
 
-**C — the reviewer machinery** `pr-reviewer-plugin` (new) [L]
+**C — the reviewer machinery** `pr-reviewer-plugin` [L, SHIPPED 2026-07-06]
+Shipped as pr-reviewer-plugin v0.2.0/v0.2.1 (PRs #3/#5). Acceptance passed live on
+the dev instance: HMAC webhook (bad sig 403, unconfigured secret fails closed),
+typed drops observed live (`bad-signature`, `pr-not-eligible` ×closed+draft,
+`in-flight`) with the rest unit-pinned, structural trigger computed server-side
+("4 files changed (> 3)" → structural recipe; empty reasons → lite), FAIL verdict
+posted with the machine marker, unchanged-head reaffirm in one API call, verify
+verdicts+notes carried into the posted body, and the full green path on a scratch
+repo: review → PASS (56.1s lite — at Quinn's latency floor) → the 3-minute sweep
+promoted autonomously (APPROVE + native auto-merge armed, base=main only). Two live
+lessons folded in: Quinn's org-wide seat preempted promotion on protoLabsAI repos
+BOTH times — the single-owner rule (`promotion_owner: false` default) is not
+theoretical — and an honest WARN initially held promotion forever, so v0.2.1
+restored her exact semantics (latest clear PASS/WARN verdict promotes on green;
+latest FAIL holds).
+<details><summary>Original scope (as planned)</summary>
 Webhook route (HMAC) → chokepoint (30s cooldown per repo/PR/SHA, in-flight map, typed
 drops) → dispatch: structural trigger picks full-panel vs lite recipe; run via
 `STATE.workflow_run`; verdict mapping (findings → PASS/WARN/FAIL → review action);
@@ -126,8 +143,17 @@ every unknown); prior-review recall off the posted verdict body; protoPatch clie
 verdict mix, per-finding resolution — ws-91a answered).
 **Accept:** an end-to-end dry run on a test repo: webhook → review → COMMENT → CI green
 → deterministic APPROVE → auto-merge armed, with every drop/skip typed and logged.
+</details>
 
-**D — the agent: shadow → second formal layer** `qaEngineer` bundle (new) [M]
+**D — the agent: shadow → second formal layer** `qaEngineer` bundle [M, BUILT 2026-07-06 — shadow data collection is the standing stage]
+Shipped as the qaEngineer bundle v0.1.0 (github-plugin v0.2.0 + pr-reviewer-plugin
+pinned; archetype "QA Engineer"; persona "Vera" ported from quinn.yaml — verdict
+system, three-layer verification, 80% bar, self-restriction, shadow discipline;
+`shadow_mode: true` default). Bundle install verified end-to-end (members pinned at
+release tags, builtin recognized, config suggestions printed). Stage-1 acceptance
+(the ≥2-repo/≥2-week three-way report) is calendar-gated data collection — the eval
+substrate ships in the plugin (`GET /api/plugins/pr-reviewer/eval` + three-way
+rows); stages 2-3 remain per-repo operator decisions the data earns.
 Bundle pins + archetype + persona port. Three stages, each gated on data:
 1. **Shadow** (`shadow_mode: true`): COMMENT-only on the same PRs Quinn and CodeRabbit
    review. The eval compares all three streams per PR — findings we caught that they


### PR DESCRIPTION
Flips ADR 0078 Proposed→Accepted and marks the plan Executed. All phases shipped 2026-07-06:

- **A** (panel hardening + fail-closed gate), **B** (guarded verdict tools, github-plugin v0.2.0 — now also tagged), **B2** (protoPatch as the fifth panel finder, core v0.95.0 + pr-reviewer-plugin v0.1.0) — previously landed.
- **C** (pr-reviewer-plugin v0.2.0/v0.2.1): webhook+HMAC ingress, typed-drop chokepoint, server-side structural trigger, fail-closed exhaustion, verdict mapping, approve-on-green + 3-min sweep, telemetry+eval. **Acceptance passed live**: full chain webhook → panel review → COMMENT verdict (marker + carried verify verdicts) → CI green → sweep autonomously APPROVEd + armed native auto-merge → merged. Eval over the dry run: 5/5 completion, PASS/WARN/FAIL all exercised, lite p50 57.7s (Quinn's 44.7s floor in sight; structural 413s), zero exhaustions, every drop/hold typed (`bad-signature`, `pr-not-eligible`, `in-flight`, `no-clear-verdict`, `checks-failed`, `stale-head`, `not-promotion-owner`).
- **D** (qaEngineer bundle v0.1.0): pins + archetype + the Vera persona (Quinn's verdict system/three-layer verification/self-restriction), `shadow_mode: true` default; bundle install verified end-to-end. Stage-1's three-way report is standing data collection; stages 2–3 remain per-repo operator decisions.

Live lessons already folded in: Quinn's org-wide seat preempted promotion on protoLabsAI repos both times (the single-owner default is not theoretical); an honest WARN initially blocked promotion forever → v0.2.1 restored her exact non-blocking-WARN semantics; GitHub's own 422 on self-approval independently enforces the reviewer≠author topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release planning documents to reflect that the work is now accepted and executed.
  * Clarified which phases are live, which are built, and the current status for later rollout stages.
  * Added date-stamped acceptance notes and more concrete progress details for the review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->