### PR TITLE
fix(a2a): serve the classic v0.3 vocabulary — enable_v0_3_compat on /a2a (#1854)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A2A producer tasks GC'd while pending at turn end (#1713).** a2a-sdk 1.1.0's turn
+  teardown drops the last strong reference to the still-pending `producer:<task_id>` asyncio
+  task without cancelling or awaiting it, so cyclic GC destroys it — `ERROR asyncio Task was
+  destroyed but it is pending!` at `ActiveTask._run_producer`, 103× in production logs,
+  clustering at turn completions (upstream a2aproject/a2a-python#1123). Until the SDK fix
+  ships, the A2A mount now swaps in `OwnedProducerActiveTaskRegistry` (`a2a_impl/registry.py`):
+  its cleanup path owns the producer/consumer tasks for their lifetime — strong-referenced and
+  awaited (short grace to flush) or cancelled+awaited before the `ActiveTask` is dropped, so
+  pending work completes or fails loudly instead of being silently destroyed. Degrades to a
+  logged warning + stock behavior if an a2a-sdk upgrade moves the internals.
+- **Classic A2A `message/send` got `-32601 Method not found` (#1854).** a2a-sdk 1.1.0 renamed the
+  JSON-RPC methods; every v0.3-vocabulary client (the fleet's delegate spine, documented curl
+  examples) hit Method-not-found on `/a2a`. The route now mounts with `enable_v0_3_compat=True`,
+  serving both vocabularies on the same endpoint, and the live smoke pins the compat adapter so a
+  future SDK bump can't silently drop it. Found live on the v0.95.0 local test pass.
 - **Installed-plugin workflow recipes were silently invisible (#1867).** The in-tree `workflows`
   plugin scanned recipe dirs eagerly at register time — before instance-installed plugins had
   loaded — so a git-installed plugin's `workflows/` dir (the ADR 0027 bundle promise) never

--- a/a2a_impl/registry.py
+++ b/a2a_impl/registry.py
@@ -1,0 +1,164 @@
+"""Owned-lifetime ActiveTaskRegistry — retires producer/consumer tasks at turn teardown (#1713).
+
+Upstream bug (a2a-sdk 1.1.0, reported as a2aproject/a2a-python#1121 / #1123): at the end
+of a turn the SDK's ``ActiveTask`` teardown drops the last external strong reference to
+the still-*pending* ``producer:<task_id>`` asyncio task without cancelling or awaiting it:
+
+1. On the terminal event the consumer sets ``_is_finished`` and shuts the request queue
+   while the producer is still pending (``active_task.py:299-306``).
+2. The producer wakes into its ``finally`` and parks at
+   ``await self._event_queue_subscribers.close(immediate=False)`` (``active_task.py:566``
+   — the exact line in the production tracebacks), an await the SDK itself documents as
+   a deadlock risk when unconsumed events remain (``event_queue_v2.py:214-217``).
+3. The consumer's ``finally`` drops the refcount to 0 and fires ``_on_cleanup`` →
+   ``ActiveTaskRegistry._remove_task`` pops the ``ActiveTask`` from the registry dict —
+   the only external strong reference — *without* touching ``_producer_task``.
+4. The pending producer is now reachable only through the reference island
+   ``ActiveTask._producer_task ↔ producer-coro.self``; cyclic GC collects it →
+   ``ERROR asyncio Task was destroyed but it is pending!`` (103× in production logs,
+   clustering at turn completions).
+
+The real fix belongs upstream (strong-ref + cancel/await the producer in the SDK's own
+teardown). Until that ships, this module contains it from the host side: a registry
+subclass whose cleanup path *owns* the ActiveTask's background tasks for their full
+lifetime — it holds a strong reference, gives the producer a short grace period to flush
+naturally, then cancels and awaits it, so pending work either completes or fails loudly
+(a logged warning) instead of being silently destroyed by the garbage collector.
+
+This intentionally reaches into a2a-sdk private attributes (``_producer_task``,
+``_consumer_task``, ``_active_task_registry``) — there is no public seam: protoAgent
+supplies only the ``AgentExecutor``, and the producer task is created inside
+``ActiveTask.start()``. Every access is guarded so an SDK upgrade that moves the
+internals degrades to a logged warning + stock behavior, never a crash. Re-verify (and
+ideally delete this module) when bumping past a2a-sdk 1.1.0 — see the upstream issues.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from a2a.server.agent_execution.active_task_registry import ActiveTaskRegistry
+
+if TYPE_CHECKING:
+    from a2a.server.agent_execution.active_task import ActiveTask
+
+log = logging.getLogger(__name__)
+
+# How long a pending producer/consumer gets to finish naturally before we cancel it.
+# The common case (task merely not yet resumed when the last reference dropped) resolves
+# in one loop iteration; the grace only matters when the final queue-join genuinely
+# hangs, and then we *want* the deterministic cancel.
+FLUSH_GRACE_S = 0.5
+# Upper bound on waiting for a cancelled task to unwind before we warn and move on.
+CANCEL_WAIT_S = 5.0
+
+
+class OwnedProducerActiveTaskRegistry(ActiveTaskRegistry):
+    """ActiveTaskRegistry that retires an ActiveTask's background tasks before
+    dropping the last strong reference to them (#1713).
+
+    The stock ``_on_active_task_cleanup`` schedules only ``_remove_task(task_id)``;
+    this override schedules retire-then-remove, strong-ref'd in the registry's own
+    ``_cleanup_tasks`` set (the same pattern the SDK already uses for the cleanup
+    tasks themselves), with the ActiveTask kept alive by the coroutine's closure
+    until its producer/consumer are done.
+    """
+
+    def _on_active_task_cleanup(self, active_task: ActiveTask) -> None:
+        task = asyncio.create_task(
+            self._retire_and_remove(active_task),
+            name=f"a2a-retire:{active_task.task_id}",
+        )
+        self._cleanup_tasks.add(task)
+        task.add_done_callback(self._cleanup_tasks.discard)
+
+    async def _retire_and_remove(self, active_task: ActiveTask) -> None:
+        """Retire the producer/consumer tasks, then remove the ActiveTask.
+
+        Removal always happens (even if retirement itself errors) so a defect here
+        can never leak ActiveTasks in the registry — worst case we degrade to the
+        stock drop-without-await behavior for that one task, with a logged error.
+        """
+        try:
+            for attr in ("_producer_task", "_consumer_task"):
+                bg = getattr(active_task, attr, None)
+                if isinstance(bg, asyncio.Task):
+                    await self._retire(bg, active_task.task_id)
+        except Exception:  # pragma: no cover — defensive: never block removal
+            log.exception(
+                "[a2a] retiring background tasks for task %s failed", active_task.task_id
+            )
+        await self._remove_task(active_task.task_id)
+
+    @staticmethod
+    async def _retire(bg: asyncio.Task, task_id: str) -> None:
+        """Await ``bg`` briefly so in-flight frames can flush; cancel+await if stuck."""
+        if not bg.done():
+            _, pending = await asyncio.wait({bg}, timeout=FLUSH_GRACE_S)
+            if pending:
+                log.debug(
+                    "[a2a] %s still pending %.1fs after task %s teardown; cancelling",
+                    bg.get_name(),
+                    FLUSH_GRACE_S,
+                    task_id,
+                )
+                bg.cancel()
+                _, pending = await asyncio.wait({bg}, timeout=CANCEL_WAIT_S)
+                if pending:  # pragma: no cover — nothing in the SDK shields cancel
+                    log.warning(
+                        "[a2a] %s for task %s did not stop within %.1fs of cancel; "
+                        "leaving it referenced in the cleanup task",
+                        bg.get_name(),
+                        task_id,
+                        CANCEL_WAIT_S,
+                    )
+                    # Keep a strong reference until it does finish, so it still
+                    # can't be GC'd pending.
+                    await asyncio.wait({bg})
+                    return
+        if bg.cancelled():
+            return
+        exc = bg.exception()
+        if exc is not None:
+            # The SDK's producer/consumer normally swallow their own errors; anything
+            # surfacing here would previously have been silently destroyed with the
+            # task. Fail loudly instead.
+            log.warning(
+                "[a2a] %s for task %s finished with an unhandled error at teardown: %r",
+                bg.get_name(),
+                task_id,
+                exc,
+            )
+
+
+def harden_active_task_registry(handler: object) -> bool:
+    """Swap ``handler._active_task_registry`` for the owned-producer subclass.
+
+    Called at mount time, before the handler serves any request, so the stock
+    registry being replaced is guaranteed empty. Returns ``True`` on success;
+    on any surprise (an a2a-sdk upgrade moving the internals) it logs a warning
+    and leaves the stock registry in place — never raises.
+    """
+    try:
+        current = getattr(handler, "_active_task_registry", None)
+        if not isinstance(current, ActiveTaskRegistry):
+            raise TypeError(
+                f"handler._active_task_registry is {type(current).__name__}, "
+                "expected ActiveTaskRegistry"
+            )
+        handler._active_task_registry = OwnedProducerActiveTaskRegistry(  # type: ignore[attr-defined]
+            agent_executor=current._agent_executor,
+            task_store=current._task_store,
+            push_sender=current._push_sender,
+        )
+    except Exception:
+        log.warning(
+            "[a2a] could not install the owned-producer task registry; falling back to "
+            "the stock a2a-sdk registry (producer tasks may be GC'd while pending at "
+            "turn end — #1713). Did an a2a-sdk upgrade move the internals?",
+            exc_info=True,
+        )
+        return False
+    return True

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -152,6 +152,38 @@ def main() -> int:
         terminal = "COMPLETED" in raw or "live smoke ok" in raw or '"artifact' in raw.lower()
         assert terminal, f"no terminal/answer frame; first 600 chars: {raw[:600]!r}"
         print("ok: A2A SendStreamingMessage turn decoded + reached a terminal frame")
+
+        # Classic v0.3 vocabulary on the SAME endpoint (#1854): a2a-sdk 1.1.0
+        # renamed the JSON-RPC methods, and without enable_v0_3_compat the whole
+        # fleet's `message/send` clients got -32601. Pin that the compat adapter
+        # stays mounted — the method must DISPATCH (any real turn outcome is
+        # fine; a -32601 error means the adapter fell off).
+        legacy = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": "smoke-v03",
+                "method": "message/send",
+                "params": {
+                    "message": {
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": "ping"}],
+                        "messageId": "m2",
+                        "contextId": "smoke-v03",
+                    }
+                },
+            }
+        ).encode()
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{agent_port}/a2a",
+            data=legacy,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=60) as r:
+            legacy_raw = r.read().decode("utf-8", "replace")
+        assert "-32601" not in legacy_raw and "Method not found" not in legacy_raw, (
+            f"classic message/send got Method-not-found — v0.3 compat is off (#1854): {legacy_raw[:300]!r}"
+        )
+        print("ok: classic v0.3 message/send still dispatches (compat adapter mounted)")
         print("\nLIVE SMOKE PASSED ✓")
         return 0
     except Exception as e:  # noqa: BLE001 — smoke must report, not traceback-crash

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -776,6 +776,7 @@ def _main():
 
     from a2a_impl import auth
     from a2a_impl.executor import ProtoAgentExecutor, set_progress_hook, set_terminal_hook
+    from a2a_impl.registry import harden_active_task_registry
     from a2a_impl.stores import (
         build_a2a_stores,
         build_push_sender,
@@ -885,15 +886,26 @@ def _main():
         push_config_store=push_config_store,
         push_sender=build_push_sender(push_config_store, _a2a_push_client),
     )
+    # a2a-sdk 1.1.0 GC's a turn's still-pending `producer:<task_id>` task at teardown
+    # (upstream a2a-python#1123; #1713) — 'Task was destroyed but it is pending!' at
+    # every turn completion under load. Swap in a registry whose cleanup owns the
+    # producer/consumer tasks for their lifetime: strong-ref'd and awaited (grace to
+    # flush) or cancelled+awaited before the last reference drops. Remove once the
+    # SDK ships the fix and the pin moves past 1.1.0 (see a2a_impl/registry.py).
+    harden_active_task_registry(a2a_request_handler)
     add_a2a_routes_to_fastapi(
         fastapi_app,
         # ``agent_card_routes`` (server.a2a) serves the same well-known card as
         # a2a-sdk's ``create_agent_card_routes`` plus a proto-free protocolVersion
         # hint, so a delegating peer can pre-check version compatibility (ADR 0051).
         agent_card_routes=agent_card_routes(a2a_card),
-        jsonrpc_routes=create_jsonrpc_routes(a2a_request_handler, rpc_url="/a2a"),
+        # enable_v0_3_compat: a2a-sdk 1.1.0 renamed the JSON-RPC methods; without the
+        # compat adapter every classic client (`message/send` — the fleet's delegate
+        # spine, our own docs' curl examples) gets -32601 Method not found (#1854).
+        # Both vocabularies serve on the same endpoint until the fleet migrates.
+        jsonrpc_routes=create_jsonrpc_routes(a2a_request_handler, rpc_url="/a2a", enable_v0_3_compat=True),
     )
-    log.info("[a2a] a2a-sdk routes mounted (JSON-RPC at /a2a, card at /.well-known/agent-card.json)")
+    log.info("[a2a] a2a-sdk routes mounted (JSON-RPC at /a2a + v0.3 compat, card at /.well-known/agent-card.json)")
 
     # --- Prometheus metrics -------------------------------------------------
     if metrics.is_enabled():

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -38,6 +38,7 @@ from google.protobuf.json_format import MessageToDict
 
 import protolabs_a2a as pa
 from a2a_impl.executor import _CONTEXT_MIME, ProtoAgentExecutor, TurnOutcome, set_terminal_hook
+from a2a_impl.registry import OwnedProducerActiveTaskRegistry, harden_active_task_registry
 
 A2A_HEADERS = {"A2A-Version": "1.0"}
 
@@ -194,7 +195,12 @@ def _build_app(stream_fn, *, bearer=None, api_key="", allowed_origins=None, task
         agent_card=card,
         push_config_store=InMemoryPushNotificationConfigStore(),
     )
+    # Mirror production wiring (#1713): every test turn runs through the
+    # owned-producer registry, exactly like server/__init__.py mounts it.
+    assert harden_active_task_registry(handler)
+    _HANDLERS.append(handler)
     app = FastAPI()
+    app.state.a2a_handler = handler
     if bearer is not None or api_key or allowed_origins is not None:
         from a2a_impl import auth
 
@@ -249,6 +255,29 @@ def _clear_terminal_hook():
     set_terminal_hook(None)
     yield
     set_terminal_hook(None)
+
+
+# Handlers built by _build_app during the current test — drained at teardown so
+# their retire-then-remove cleanup tasks (#1713) finish inside the test's event
+# loop instead of being destroyed pending when pytest closes it.
+_HANDLERS: list = []
+
+
+@pytest.fixture(autouse=True)
+def _fast_retire(monkeypatch):
+    """Shrink the producer flush grace so teardown drains stay fast in tests."""
+    monkeypatch.setattr("a2a_impl.registry.FLUSH_GRACE_S", 0.02)
+
+
+@pytest.fixture(autouse=True)
+async def _drain_a2a_cleanup():
+    yield
+    for handler in _HANDLERS:
+        reg = getattr(handler, "_active_task_registry", None)
+        tasks = set(getattr(reg, "_cleanup_tasks", ()) or ())
+        if tasks:
+            await asyncio.wait(tasks, timeout=5)
+    _HANDLERS.clear()
 
 
 @pytest.mark.asyncio
@@ -938,3 +967,138 @@ def test_extract_image_parts_empty_when_no_message():
     from a2a_impl.executor import _extract_image_parts
 
     assert _extract_image_parts(_t.SimpleNamespace(message=None)) == []
+
+
+# ── a2a_impl.registry: producer-task ownership at turn teardown (#1713) ───────
+# a2a-sdk 1.1.0's ActiveTask teardown drops the last strong reference to the
+# still-pending `producer:<task_id>` task without cancelling or awaiting it, so
+# cyclic GC destroys it ("Task was destroyed but it is pending!"). The hardened
+# registry must own the producer/consumer tasks for their lifetime: awaited
+# (grace to flush) or cancelled+awaited before the ActiveTask is dropped.
+
+
+def _hardened_registry() -> OwnedProducerActiveTaskRegistry:
+    from a2a.server.tasks import InMemoryTaskStore as _Store
+
+    return OwnedProducerActiveTaskRegistry(agent_executor=None, task_store=_Store())
+
+
+async def test_harden_swaps_registry_preserving_wiring():
+    async def stream(text, ctx, *, resume=False, caller_trace=None, **kwargs):
+        yield ("done", "ok")
+
+    app = _build_app(stream)
+    handler = app.state.a2a_handler
+    reg = handler._active_task_registry
+    assert isinstance(reg, OwnedProducerActiveTaskRegistry)
+    # Same executor/store the stock registry was built with — only the cleanup
+    # behavior changes.
+    assert reg._agent_executor is handler.agent_executor
+    assert reg._task_store is handler.task_store
+
+
+def test_harden_degrades_gracefully_on_moved_internals():
+    """If an a2a-sdk upgrade moves _active_task_registry, hardening must warn and
+    no-op — never crash the mount."""
+
+    class _NotAHandler:
+        pass
+
+    assert harden_active_task_registry(_NotAHandler()) is False
+
+
+async def test_cleanup_retires_stuck_producer_instead_of_dropping_it():
+    """A producer parked forever (the active_task.py:566 close-join hang) is
+    cancelled and awaited by the cleanup path — not left pending for the GC."""
+    import types as _t
+
+    reg = _hardened_registry()
+    hang = asyncio.Event()
+
+    async def _stuck():
+        await hang.wait()
+
+    async def _done():
+        return None
+
+    stub = _t.SimpleNamespace(
+        task_id="t-1713",
+        _producer_task=asyncio.create_task(_stuck(), name="producer:t-1713"),
+        _consumer_task=asyncio.create_task(_done(), name="consumer:t-1713"),
+    )
+    reg._active_tasks["t-1713"] = stub
+
+    reg._on_active_task_cleanup(stub)
+
+    async with asyncio.timeout(10):
+        while reg._cleanup_tasks or "t-1713" in reg._active_tasks:
+            await asyncio.sleep(0.005)
+
+    assert stub._producer_task.done()
+    assert stub._producer_task.cancelled()  # stuck → cancelled+awaited, not dropped
+    assert stub._consumer_task.done()
+    assert await reg.get("t-1713") is None  # still removed from the registry
+
+
+async def test_cleanup_lets_flushing_producer_finish_without_cancel():
+    """A producer that completes within the grace window flushes naturally —
+    awaited to completion, never cancelled."""
+    import types as _t
+
+    reg = _hardened_registry()
+    flushed = asyncio.Event()
+
+    async def _flushing():
+        await asyncio.sleep(0)  # one loop iteration, like a completing queue-join
+        flushed.set()
+
+    stub = _t.SimpleNamespace(
+        task_id="t-flush",
+        _producer_task=asyncio.create_task(_flushing(), name="producer:t-flush"),
+        _consumer_task=None,  # start()-failure path leaves these unset — must not crash
+    )
+    reg._active_tasks["t-flush"] = stub
+
+    reg._on_active_task_cleanup(stub)
+
+    async with asyncio.timeout(10):
+        while reg._cleanup_tasks or "t-flush" in reg._active_tasks:
+            await asyncio.sleep(0.005)
+
+    assert flushed.is_set()
+    assert stub._producer_task.done()
+    assert not stub._producer_task.cancelled()
+
+
+async def test_turn_teardown_retires_real_producer_task(monkeypatch):
+    """End-to-end through the real SDK: after a SendMessage turn completes, the
+    ActiveTask's producer/consumer tasks are done (retired) by the time the
+    registry drops it — the exact guarantee whose absence caused #1713."""
+    retired = []
+    orig = OwnedProducerActiveTaskRegistry._retire_and_remove
+
+    async def spy(self, active_task):
+        await orig(self, active_task)
+        retired.append(active_task)
+
+    monkeypatch.setattr(OwnedProducerActiveTaskRegistry, "_retire_and_remove", spy)
+
+    async def stream(text, ctx, *, resume=False, caller_trace=None, **kwargs):
+        yield ("text", "hello ")
+        yield ("done", "hello world")
+
+    app = _build_app(stream)
+    reg = app.state.a2a_handler._active_task_registry
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://t") as c:
+        task = (await _send_msg(c)).json()["result"]["task"]
+        final = await _poll_terminal(c, task["id"])
+        assert final["status"]["state"] == "TASK_STATE_COMPLETED"
+
+    # Wait for the turn's retire-then-remove cleanup to run.
+    async with asyncio.timeout(10):
+        while not retired or reg._cleanup_tasks or reg._active_tasks:
+            await asyncio.sleep(0.005)
+
+    for active in retired:
+        assert active._producer_task is not None and active._producer_task.done()
+        assert active._consumer_task is not None and active._consumer_task.done()


### PR DESCRIPTION
Closes #1854. a2a-sdk 1.1.0 renamed the JSON-RPC methods, so every v0.3-vocabulary client (`message/send` — fleet delegate spine, documented curl examples) got `-32601` on `/a2a`. One flag (`enable_v0_3_compat=True` on `create_jsonrpc_routes`) mounts the SDK's compat adapter — both vocabularies on the same endpoint.

**Live-verified** on the local v0.95.0 test pass (where the bug bit the first real turn): classic `message/send` → `state: completed`. The live smoke gate now probes the classic method so an SDK bump can't silently drop the adapter.

Full suite green; changelog entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)