### PR TITLE
fix(artifact): re-theme the sandboxed frame live on app-theme switch (#1872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   examples) hit Method-not-found on `/a2a`. The route now mounts with `enable_v0_3_compat=True`,
   serving both vocabularies on the same endpoint, and the live smoke pins the compat adapter so a
   future SDK bump can't silently drop it. Found live on the v0.95.0 local test pass.
+- **Artifact panel kept the stale palette after an app-theme switch (#1872).** The artifact
+  shell bakes the `--pl-*` tokens into the sandboxed frame as literal colors at render time, so
+  a later theme toggle re-skinned the console but not the artifact. The shell now observes the
+  plugin-kit's token rewrite on the root element and pushes fresh tokens into the frame, where
+  the injected shim applies them in place — no re-render, so interactive artifact state survives.
 - **Installed-plugin workflow recipes were silently invisible (#1867).** The in-tree `workflows`
   plugin scanned recipe dirs eagerly at register time — before instance-installed plugins had
   loaded — so a git-installed plugin's `workflows/` dir (the ADR 0027 bundle promise) never

--- a/plugins/artifact/__init__.py
+++ b/plugins/artifact/__init__.py
@@ -813,7 +813,17 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
   // works from the sandbox; the shell validates e.source and calls the bearer-gated
   // endpoint. ask() rejects if the operator hasn't enabled it (ARTIFACT_ASK_ENABLED).
   var SHIM = '<script>(function(){var s=0,w={};'
-    + 'window.addEventListener("message",function(e){var m=e.data||{};if(m.type!=="protoArtifact:result")return;'
+    + 'window.addEventListener("message",function(e){var m=e.data||{};'
+    // Live re-theme (#1872): base() bakes the tokens in as literals at render time,
+    // so a later app-theme switch left the frame in the stale palette. The shell
+    // pushes fresh tokens; update :root + html/body in place (no re-render, so
+    // interactive artifact state survives).
+    + 'if(m.type==="protoArtifact:theme"&&m.tokens){var st=document.documentElement.style;'
+    + 'for(var k in m.tokens){if(k.indexOf("--pl-")===0)st.setProperty(k,String(m.tokens[k]));}'
+    + 'var bg=m.tokens["--pl-color-bg"],fg=m.tokens["--pl-color-fg"];'
+    + 'if(bg){st.background=bg;if(document.body)document.body.style.background=bg;}'
+    + 'if(fg&&document.body)document.body.style.color=fg;return;}'
+    + 'if(m.type!=="protoArtifact:result")return;'
     + 'var p=w[m.id];if(!p)return;delete w[m.id];m.error?p.reject(new Error(m.error)):p.resolve(m.text);});'
     + 'window.protoArtifact={ask:function(prompt){return new Promise(function(res,rej){var id=++s;w[id]={resolve:res,reject:rej};'
     + 'parent.postMessage({type:"protoArtifact:ask",id:id,prompt:String(prompt)},"*");'
@@ -1016,6 +1026,23 @@ _SHELL_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
     var key=a.id+"@"+vi;  // re-srcdoc only when the shown version actually changes
     if(key!==lastRendered){ lastRendered=key; renderingId=a.id; renderingVer=vi+1; $frame.srcdoc=srcdoc(a.kind, v.code); $frame.style.display="block"; }
   }
+
+  // Live re-theme (#1872): base() bakes the theme tokens into the srcdoc as literal
+  // colors, so an app-theme switch after render left the artifact in the stale
+  // palette. The DS plugin-kit re-themes THIS page by rewriting the --pl-* tokens on
+  // the root element; observe that and push the fresh tokens into the frame (the
+  // SHIM applies them in place — no re-srcdoc, so interactive artifact state survives).
+  function pushTheme(){
+    if(!$frame || !$frame.contentWindow || $frame.style.display==="none") return;
+    var cs=getComputedStyle(document.documentElement);
+    function tok(n,d){ return (cs.getPropertyValue(n)||d).trim(); }
+    var tokens={"--pl-color-bg":tok("--pl-color-bg","#0a0a0c"),"--pl-color-fg":tok("--pl-color-fg","#ededed"),
+                "--pl-color-accent":tok("--pl-color-accent","#9b87f2"),"--pl-color-border":tok("--pl-color-border","rgba(255,255,255,.08)")};
+    try{ $frame.contentWindow.postMessage({type:"protoArtifact:theme",tokens:tokens},"*"); }catch(_){}
+  }
+  new MutationObserver(pushTheme).observe(document.documentElement,{attributes:true,attributeFilter:["style","class","data-theme"]});
+  // A theme switch can race a render — re-push once the fresh srcdoc has loaded.
+  $frame.addEventListener("load", pushTheme);
 
   $art.addEventListener("change", function(e){
     selId=e.target.value; selVer=null; followNewest=(selId===(curId||(arts[0]&&arts[0].id)));

--- a/tests/test_artifact_plugin.py
+++ b/tests/test_artifact_plugin.py
@@ -745,3 +745,18 @@ def test_check_artifact_waits_for_a_live_render(monkeypatch, tmp_path):
     art._write_store(store)
     art._LAST_POLL_TS = 0
     assert "rendered cleanly" in art.check_artifact.invoke({"artifact_id": aid})
+
+
+def test_live_theme_repush_is_wired(monkeypatch, tmp_path):
+    """App-theme switches re-theme the NESTED artifact frame in place (#1872): base()
+    bakes tokens in as literals at render time, so without a push the frame kept the
+    stale palette. The shell observes the kit's token rewrite on the root element and
+    postMessages fresh tokens; the SHIM applies them without a re-srcdoc (interactive
+    artifact state survives)."""
+    html = _load(monkeypatch, tmp_path)._SHELL_HTML
+    # frame side: the SHIM handles the theme message and updates :root vars in place.
+    assert 'protoArtifact:theme' in html
+    assert 'st.setProperty(k,String(m.tokens[k]))' in html
+    # shell side: observe the kit re-theme + re-push after a fresh srcdoc load.
+    assert "new MutationObserver(pushTheme).observe(document.documentElement" in html
+    assert '$frame.addEventListener("load", pushTheme)' in html


### PR DESCRIPTION
Closes #1872. Root cause: the artifact shell's `base()` reads the `--pl-*` theme tokens at render time and bakes them into the sandboxed frame's srcdoc as literal colors — first paint is correct, but an app-theme switch re-skins only the console (the DS plugin-kit rewrites tokens on the root element) while the nested frame keeps its captured palette.

Fix: the shell observes the kit's token rewrite (MutationObserver on the root element) and pushes fresh tokens into the frame over the existing postMessage channel; the injected SHIM applies them to `:root` + html/body **in place** — no re-srcdoc, so interactive artifact state survives the toggle. Race with an in-flight render covered by re-pushing on frame `load`.

Found on the v0.95.0 local test pass (static trace of the reported mechanism; the reporter's description matches exactly). Test pins both halves of the wiring. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)