### PR TITLE
chore: release v0.95.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.95.1] - 2026-07-07
+
 ### Fixed
 - **A2A producer tasks GC'd while pending at turn end (#1713).** a2a-sdk 1.1.0's turn
   teardown drops the last strong reference to the still-pending `producer:<task_id>` asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.95.0"
+version = "0.95.1"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "v0.95.1",
+    "date": "2026-07-07",
+    "changes": [
+      "A2A producer tasks GC'd while pending at turn end (#1713).",
+      "Classic A2A message/send got -32601 Method not found (#1854).",
+      "Artifact panel kept the stale palette after an app-theme switch (#1872).",
+      "Installed-plugin workflow recipes were silently invisible (#1867)."
+    ]
+  },
+  {
     "version": "v0.95.0",
     "date": "2026-07-06",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.95.1`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.95.1 -m 'Release v0.95.1' && git push origin v0.95.1`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).