### PR TITLE
fix(subagents): salvage partial output at the recursion limit — max_turns is a budget, not a bomb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A subagent hitting `max_turns` failed its whole delegation (GRAPH_RECURSION_LIMIT).** Every
+  subagent prompt promises "hard stop at max_turns: return what you have," but the runner's
+  `ainvoke` raised at the recursion limit and lost the run — seen live when one review-finder
+  reading one file too many exhausted an entire ADR 0078 shadow panel. The runner now streams
+  values and salvages the partial transcript with an explicit hard-stop marker (`Gap`, never a
+  fabricated verdict); genuine failures still raise. The review-finder budget also moves 25→40
+  (protoContent-sized cross-file reads legitimately exceed 25).
+
 ## [0.95.1] - 2026-07-07
 
 ### Fixed

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -334,10 +334,25 @@ async def _run_subagent(
         sub_run_config["metadata"] = {"parent_task_id": parent_task_id}
 
     try:
-        result = await subagent.ainvoke(
-            {"messages": [{"role": "user", "content": prompt}]},
-            config=sub_run_config,
-        )
+        # Stream values (not ainvoke) so the last state survives a recursion-limit
+        # stop: every subagent prompt promises "hard stop at max_turns: return what
+        # you have", but ainvoke() RAISES GraphRecursionError and loses the run —
+        # a finder that read one file too many failed its whole panel step (seen
+        # live: ADR 0078 shadow reviews on protoContent, GRAPH_RECURSION_LIMIT).
+        # max_turns is a budget, not a bomb: on the limit, salvage the transcript.
+        from langgraph.errors import GraphRecursionError
+
+        result: dict[str, Any] = {}
+        hard_stop = False
+        try:
+            async for state in subagent.astream(
+                {"messages": [{"role": "user", "content": prompt}]},
+                config=sub_run_config,
+                stream_mode="values",
+            ):
+                result = state
+        except GraphRecursionError:
+            hard_stop = True
 
         messages = result.get("messages", [])
 
@@ -353,11 +368,21 @@ async def _run_subagent(
                 break
 
         if body is None:
+            if hard_stop:
+                return (
+                    f"[{subagent_type} hard-stopped at max_turns: {description}] -- no salvageable "
+                    "output; treat this lane as a Gap, not a verdict."
+                )
             return f"[{subagent_type} completed: {description}] -- no output produced."
 
         if truncate is not None and len(body) > truncate:
             body = body[:truncate] + f"\n\n…[truncated to {truncate} chars]"
 
+        if hard_stop:
+            return (
+                f"[{subagent_type} hard-stopped at max_turns: {description} — PARTIAL output; "
+                f"unverified remainder is a Gap]\n\n{body}"
+            )
         return f"[{subagent_type} completed: {description}]\n\n{body}"
     except Exception as e:
         # Surface a hard subagent failure as a tool ERROR (X) rather than a green

--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -390,10 +390,11 @@ re-litigate a prior finding whose verdict was `refuted`.
 
 Hard stop at max_turns: return what you have (partial findings beat none).""",
     tools=["github_pr_diff", "github_get_commit_diff", "github_read_file", "github_get_pr"],
-    # 25, not 15: on the first live acceptance run (PR #1847, a 6-file diff) two of
-    # four finders hit the 15-turn recursion limit mid-read — a finder that re-fetches
-    # a truncated diff and reads 2-3 surrounding files legitimately spends ~20 turns.
-    max_turns=25,
+    # 40: bumped twice on live evidence — 15→25 (#1858: a 6-file protoAgent diff),
+    # 25→40 (ADR 0078 shadow reviews on protoContent hit 25 mid-read). The limit is
+    # now a soft budget (run_subagent salvages partial output at the recursion
+    # limit), so headroom costs nothing when unused.
+    max_turns=40,
     # Per-invocation review verdicts are context-specific — never distill to a skill.
     allow_skill_emission=False,
 )

--- a/tests/test_subagent_max_turns_partial.py
+++ b/tests/test_subagent_max_turns_partial.py
@@ -1,0 +1,92 @@
+"""max_turns is a budget, not a bomb (#1879-class): a subagent that hits the
+recursion limit returns its PARTIAL transcript with a hard-stop marker instead of
+raising SubagentError — the contract every subagent prompt already promises
+("hard stop at max_turns: return what you have"). Seen live: an ADR 0078 shadow
+review on protoContent lost a whole panel to one finder reading one file too many."""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage
+from langgraph.errors import GraphRecursionError
+
+import graph.agent as agent_mod
+from graph.config import LangGraphConfig
+from graph.subagents.config import SUBAGENT_REGISTRY, SubagentConfig
+
+
+class _FakeSubagent:
+    """astream yields one values-state carrying a partial AIMessage, then hits
+    the recursion limit — the shape of a finder mid-investigation."""
+
+    def __init__(self, states, raise_after=True):
+        self._states = states
+        self._raise = raise_after
+
+    async def astream(self, _inputs, config=None, stream_mode=None):
+        assert stream_mode == "values"
+        for s in self._states:
+            yield s
+        if self._raise:
+            raise GraphRecursionError("Recursion limit of 40 reached without hitting a stop condition.")
+
+
+@pytest.fixture
+def stubbed(monkeypatch):
+    cfg = SubagentConfig(name="stub", description="d", system_prompt="p", tools=["current_time"], max_turns=40)
+    monkeypatch.setitem(SUBAGENT_REGISTRY, "stub", cfg)
+    monkeypatch.setattr(agent_mod, "_subagent_tools", lambda *_a, **_k: [object()])
+    monkeypatch.setattr(agent_mod, "create_llm", lambda *_a, **_k: object())
+    monkeypatch.setattr(agent_mod, "build_subagent_prompt", lambda *_a, **_k: "sys")
+    return cfg
+
+
+async def _run(monkeypatch, fake):
+    monkeypatch.setattr(agent_mod, "create_agent", lambda **_k: fake)
+    return await agent_mod._run_subagent(
+        config=LangGraphConfig(),
+        tool_map={},
+        available_subagents="stub",
+        description="review lane",
+        prompt="go",
+        subagent_type="stub",
+    )
+
+
+async def test_recursion_limit_salvages_partial_output(monkeypatch, stubbed):
+    fake = _FakeSubagent([{"messages": [AIMessage(content="Partial findings so far: A and B.")]}])
+    out = await _run(monkeypatch, fake)
+    assert "hard-stopped at max_turns" in out and "PARTIAL" in out
+    assert "Partial findings so far: A and B." in out  # the transcript survived
+
+
+async def test_recursion_limit_with_no_output_is_an_explicit_gap(monkeypatch, stubbed):
+    fake = _FakeSubagent([{"messages": []}])
+    out = await _run(monkeypatch, fake)
+    assert "hard-stopped at max_turns" in out and "Gap" in out
+    assert not out.startswith("Error")
+
+
+async def test_clean_completion_is_unchanged(monkeypatch, stubbed):
+    fake = _FakeSubagent([{"messages": [AIMessage(content="All done.")]}], raise_after=False)
+    out = await _run(monkeypatch, fake)
+    assert out.startswith("[stub completed: review lane]")
+    assert "All done." in out
+
+
+async def test_other_failures_still_raise_subagent_error(monkeypatch, stubbed):
+    class _Boom:
+        async def astream(self, *_a, **_k):
+            raise RuntimeError("model exploded")
+            yield  # pragma: no cover
+
+    monkeypatch.setattr(agent_mod, "create_agent", lambda **_k: _Boom())
+    with pytest.raises(agent_mod.SubagentError):
+        await agent_mod._run_subagent(
+            config=LangGraphConfig(),
+            tool_map={},
+            available_subagents="stub",
+            description="review lane",
+            prompt="go",
+            subagent_type="stub",
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -1539,7 +1539,7 @@ wheels = [
 
 [[package]]
 name = "protoagent"
-version = "0.95.0"
+version = "0.95.1"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["fastapi", "http-server", "sqlite"] },


### PR DESCRIPTION
Found live on Vera's first shadow backfill: protoContent#434's panel exhausted because ONE finder hit `GRAPH_RECURSION_LIMIT` mid-read (nondeterministic — `find_crossfile` first run, `find_correctness` on the re-run). The prompts promise 'hard stop at max_turns: return what you have,' but `ainvoke` raises and loses the transcript, so the fail-closed exhaustion gate (correctly) voided the whole review.

- `_run_subagent` now streams `values`, keeps the last state, and on `GraphRecursionError` returns the partial transcript prefixed `[<type> hard-stopped at max_turns … PARTIAL output; unverified remainder is a Gap]` — no salvageable output becomes an explicit Gap line. Genuine failures still raise `SubagentError`.
- review-finder `max_turns` 25→40 (third data point: protoContent's cross-file reads; headroom is free now that the limit degrades).

4 new tests (salvage, empty-salvage Gap, unchanged clean path, non-recursion failures still raise); full suite 3338 green; changelog entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)