### PR TITLE
feat(tracing): fleet-wide distributed traces — one Langfuse trace per cross-agent flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Fleet-wide distributed Langfuse tracing.** A hub→member delegation now renders as ONE
+  Langfuse trace instead of disconnected per-agent fragments. Four seams: (1) `trace_session`
+  JOINS a caller's trace when the inbound A2A metadata carries `a2a.trace` ids (Langfuse
+  `trace_context`; malformed ids degrade to a fresh trace), (2) the a2a delegate adapter now
+  SENDS `a2a.trace` (`traceId`/`spanId`) on outbound `SendMessage` when a trace is active —
+  via the new `tracing.current_trace_context()` helper, (3) the new `TraceContextMiddleware`
+  stamps `existing_trace_id`/`parent_observation_id`/`generation_name` onto each gateway LLM
+  call's `extra_body.metadata`, so the LiteLLM gateway's own Langfuse callback lands its
+  generations (with token/cost detail) inside the agent's trace, and (4) `_run_subagent` wraps
+  each delegation in a `subagent:<type>` boundary span (`tracing.trace_span`) so subagent
+  tool/LLM observations nest under one node — without touching the max_turns salvage path.
+  The server shutdown hook now also flushes buffered observations so spans survive process
+  exit. Everything is a no-op when Langfuse isn't configured.
+
 ### Fixed
 - **A subagent hitting `max_turns` failed its whole delegation (GRAPH_RECURSION_LIMIT).** Every
   subagent prompt promises "hard stop at max_turns: return what you have," but the runner's

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -75,6 +75,17 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
         )
     )
 
+    # Fleet tracing: stamp the active Langfuse trace context onto each gateway
+    # LLM call (extra_body.metadata existing_trace_id/parent_observation_id) so
+    # the gateway's own Langfuse callback lands its generations in OUR trace.
+    # Inside ModelOverride (it must stamp the ACTUAL per-tab model) and inside
+    # PromptCache (whose locked [ModelOverride, PromptCache] wrapper order and
+    # caching decisions stay untouched — this only copies extra_body). No-op
+    # when tracing is disabled.
+    from graph.middleware.trace_context import TraceContextMiddleware
+
+    middleware.append(TraceContextMiddleware())
+
     # Enforcement gate first (outermost) so disallowed/rate-limited tool
     # calls are blocked before any execution. Opt-in via config.
     if config.enforcement_enabled and (config.enforcement_disallowed_tools or config.enforcement_rate_limits):
@@ -303,7 +314,11 @@ async def _run_subagent(
     # cover them too — not just the lead agent. Mirror the lead's gate so a disallowed/
     # rate-limited tool is blocked inside a delegation. (Per-instance limiter: each
     # subagent run gets its own window — a per-delegation cap, not a shared budget.)
-    sub_middleware = [AuditMiddleware()]
+    # TraceContextMiddleware mirrors the lead chain too: the subagent's gateway LLM
+    # calls join the SAME Langfuse trace (nested under the subagent boundary span).
+    from graph.middleware.trace_context import TraceContextMiddleware
+
+    sub_middleware = [TraceContextMiddleware(), AuditMiddleware()]
     if getattr(config, "enforcement_enabled", False) and (
         config.enforcement_disallowed_tools or config.enforcement_rate_limits
     ):
@@ -342,17 +357,28 @@ async def _run_subagent(
         # max_turns is a budget, not a bomb: on the limit, salvage the transcript.
         from langgraph.errors import GraphRecursionError
 
+        from observability import tracing
+
         result: dict[str, Any] = {}
         hard_stop = False
-        try:
-            async for state in subagent.astream(
-                {"messages": [{"role": "user", "content": prompt}]},
-                config=sub_run_config,
-                stream_mode="values",
-            ):
-                result = state
-        except GraphRecursionError:
-            hard_stop = True
+        # Boundary span (fleet tracing): the subagent's tool/LLM observations
+        # nest under one `subagent:<type>` node in the current trace instead of
+        # scattering across the session span. No-op when tracing is disabled;
+        # exceptions (incl. GraphRecursionError salvage) pass through unchanged.
+        with tracing.trace_span(
+            f"subagent:{subagent_type}",
+            metadata={"description": description, "parent_task_id": parent_task_id or ""},
+            as_type="agent",
+        ):
+            try:
+                async for state in subagent.astream(
+                    {"messages": [{"role": "user", "content": prompt}]},
+                    config=sub_run_config,
+                    stream_mode="values",
+                ):
+                    result = state
+            except GraphRecursionError:
+                hard_stop = True
 
         messages = result.get("messages", [])
 

--- a/graph/middleware/trace_context.py
+++ b/graph/middleware/trace_context.py
@@ -1,0 +1,74 @@
+"""TraceContextMiddleware — join gateway LLM generations to the active Langfuse trace.
+
+The LiteLLM gateway runs its own Langfuse success/failure callback in the SAME
+Langfuse project, so every model call already produces a generation — but in a
+SEPARATE trace with no link back to the agent turn that made it. LiteLLM's
+Langfuse integration honors request ``metadata`` keys for exactly this:
+
+- ``existing_trace_id``       → the generation lands in that trace (verified in
+  litellm 1.83.10 ``integrations/langfuse/langfuse.py`` — popped from clean
+  metadata and used as the trace id)
+- ``parent_observation_id``   → nests it under that observation
+- ``generation_name``         → names the generation
+
+The proxy reads ``metadata`` from the request body (``add_litellm_data_to_request``
+merges it into litellm_params for any key; only ``user_api_key_*``-prefixed keys,
+``tags``, and ``_pipeline_managed_guardrails`` are stripped), so an
+OpenAI-compatible client delivers it via ``extra_body``.
+
+Trace ids are PER-TURN (and the current span is per-CALL), so a static
+``extra_body`` on the compiled model can't carry them. This middleware sits at
+the ``wrap_model_call`` boundary — the only seam that sees every model call,
+including per-tab overridden models — and stamps a fresh trace context onto a
+cheap ``model_copy`` of the request's model right before the call.
+
+No-op (one function call returning None) when tracing is disabled or no trace
+is active, and for models without an ``extra_body`` slot (e.g. ACP aux models).
+Never raises — a tracing failure must not break a turn.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from langchain.agents.middleware import AgentMiddleware
+
+log = logging.getLogger(__name__)
+
+
+class TraceContextMiddleware(AgentMiddleware):
+    """Stamp the current Langfuse trace context onto each gateway LLM call."""
+
+    def _with_trace(self, request):
+        try:
+            from observability import tracing
+
+            ctx = tracing.current_trace_context()
+            if not ctx:
+                return request
+            model = getattr(request, "model", None)
+            # Only OpenAI-compatible clients carry extra_body; anything else
+            # (ACP aux models, fakes) is left untouched.
+            if model is None or not hasattr(model, "extra_body"):
+                return request
+            meta = {
+                "existing_trace_id": ctx["trace_id"],
+                "generation_name": f"{os.environ.get('AGENT_NAME', 'protoagent')}-turn",
+            }
+            if ctx.get("span_id"):
+                meta["parent_observation_id"] = ctx["span_id"]
+            extra_body = dict(getattr(model, "extra_body", None) or {})
+            merged_meta = dict(extra_body.get("metadata") or {})
+            merged_meta.update(meta)
+            extra_body["metadata"] = merged_meta
+            return request.override(model=model.model_copy(update={"extra_body": extra_body}))
+        except Exception:  # noqa: BLE001 — tracing must never break a model call
+            log.debug("[trace-context] could not stamp trace context", exc_info=True)
+            return request
+
+    def wrap_model_call(self, request, handler):
+        return handler(self._with_trace(request))
+
+    async def awrap_model_call(self, request, handler):
+        return await handler(self._with_trace(request))

--- a/observability/tracing.py
+++ b/observability/tracing.py
@@ -40,10 +40,17 @@ import contextlib
 import contextvars
 import logging
 import os
-from typing import Any, AsyncIterator
+import re
+from typing import Any, AsyncIterator, Iterator
 
 _langfuse = None
 _enabled = False
+
+# W3C/OTel id shapes (what Langfuse v3+/v4 uses on the wire). A caller's ids
+# must match these to be JOINable — anything else falls back to a fresh trace
+# rather than crashing the turn or poisoning the SDK with a bogus context.
+_TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_SPAN_ID_RE = re.compile(r"^[0-9a-f]{16}$")
 
 
 # Silence the harmless "Failed to detach context" error emitted by
@@ -117,6 +124,57 @@ def current_session_id() -> str:
     return _session_id_ctx.get()
 
 
+def current_trace_context() -> dict | None:
+    """The active trace context as ``{"trace_id": ..., "span_id": ...}``, or None.
+
+    Used to PROPAGATE the trace across process boundaries — outbound A2A
+    dispatches attach it as ``a2a.trace`` metadata (the receiver's
+    ``trace_session`` joins it via ``trace_context``), and the gateway
+    trace-join middleware stamps it onto LLM request metadata so LiteLLM's
+    Langfuse callback lands generations in the SAME trace.
+
+    ``span_id`` is the current observation (present only when the SDK exposes
+    one); ``trace_id`` alone is still a valid, joinable context. Returns None
+    when tracing is disabled or no trace is active — callers skip propagation.
+    """
+    if not _enabled or _langfuse is None:
+        return None
+    trace_id = ""
+    try:
+        trace_id = _langfuse.get_current_trace_id() or ""
+    except Exception:  # noqa: BLE001 — propagation is best-effort
+        pass
+    trace_id = trace_id or _trace_id_ctx.get()
+    if not trace_id:
+        return None
+    ctx: dict = {"trace_id": trace_id}
+    try:
+        span_id = _langfuse.get_current_observation_id()
+        if span_id:
+            ctx["span_id"] = span_id
+    except Exception:  # noqa: BLE001
+        pass
+    return ctx
+
+
+def _caller_trace_context(metadata: dict | None) -> dict | None:
+    """Build a Langfuse ``trace_context`` from ``caller_trace_id`` /
+    ``caller_span_id`` metadata (the ids an A2A caller sent as ``a2a.trace``).
+
+    Malformed ids → None (fresh trace) — never let a bad caller id crash a
+    turn or feed the SDK an invalid W3C context."""
+    if not metadata:
+        return None
+    trace_id = str(metadata.get("caller_trace_id") or "").strip().lower()
+    if not _TRACE_ID_RE.match(trace_id):
+        return None
+    ctx: dict = {"trace_id": trace_id}
+    span_id = str(metadata.get("caller_span_id") or "").strip().lower()
+    if _SPAN_ID_RE.match(span_id):
+        ctx["parent_span_id"] = span_id
+    return ctx
+
+
 @contextlib.asynccontextmanager
 async def trace_session(
     session_id: str,
@@ -143,6 +201,13 @@ async def trace_session(
     ``session_id`` is threaded into both the metadata and the Langfuse
     contextvar so audit records created inside the scope can be cross-
     referenced to the trace.
+
+    Fleet tracing: when ``metadata`` carries ``caller_trace_id`` (and
+    optionally ``caller_span_id``) — the ids an upstream agent sent as
+    ``a2a.trace`` — the session span JOINS that trace via Langfuse's
+    ``trace_context`` instead of opening a fresh one, so a hub→member
+    delegation renders as ONE distributed trace. The ids are still stamped
+    into the span metadata; malformed ids degrade to a fresh trace.
     """
     # Always set session_id so AuditMiddleware can read it even when
     # Langfuse is disabled.
@@ -166,7 +231,9 @@ async def trace_session(
     ctx = None
     token = None
     try:
+        trace_context = _caller_trace_context(metadata)
         ctx = _langfuse.start_as_current_observation(
+            trace_context=trace_context,
             name=name,
             metadata={
                 **(metadata or {}),
@@ -175,7 +242,13 @@ async def trace_session(
             },
         )
         span = ctx.__enter__()
-        trace_id = getattr(span, "trace_id", "") or getattr(span, "id", "")
+        # Joined session: the span reports the CALLER's trace id — that's what
+        # audit records and downstream propagation must carry.
+        trace_id = (
+            getattr(span, "trace_id", "")
+            or (trace_context or {}).get("trace_id", "")
+            or getattr(span, "id", "")
+        )
         token = _trace_id_ctx.set(trace_id)
         yield span
     except Exception as e:
@@ -195,6 +268,50 @@ async def trace_session(
             try:
                 ctx.__exit__(None, None, None)
             except Exception:
+                pass
+
+
+@contextlib.contextmanager
+def trace_span(
+    name: str,
+    metadata: dict | None = None,
+    as_type: str = "span",
+) -> Iterator[Any]:
+    """Open a child observation in the CURRENT trace for the duration of the block.
+
+    Used for boundary spans — e.g. ``subagent:<type>`` around a subagent run so
+    the subagent's tool/LLM observations nest under one node instead of
+    scattering across the session span. Nests under whatever observation is
+    current (the ``trace_session`` root, or an outer ``trace_span``).
+
+    Contract mirrors ``trace_session``: the block ALWAYS runs; when tracing is
+    disabled or the SDK errors on setup, it yields None and proceeds. A body
+    exception propagates unchanged (the span still closes) — tracing never
+    alters control flow.
+    """
+    if not _enabled or _langfuse is None:
+        yield None
+        return
+
+    ctx = None
+    span = None
+    try:
+        ctx = _langfuse.start_as_current_observation(
+            name=name,
+            as_type=as_type,
+            metadata=metadata or {},
+        )
+        span = ctx.__enter__()
+    except Exception as e:  # noqa: BLE001 — never fail the wrapped work for tracing
+        print(f"[tracing] trace_span({name}) error: {e}")
+        ctx = None
+    try:
+        yield span
+    finally:
+        if ctx is not None:
+            try:
+                ctx.__exit__(None, None, None)
+            except Exception:  # noqa: BLE001
                 pass
 
 

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -320,6 +320,33 @@ class A2aAdapter(Adapter):
             return data.get("result") or {}
 
         poll_timeout = d.poll_timeout_s if d.poll_timeout_s and d.poll_timeout_s > 0 else 300.0
+        # Fleet tracing: when this dispatch runs inside a traced turn, hand the
+        # peer our Langfuse trace context as ``a2a.trace`` metadata — the shape
+        # a2a_impl/executor._extract_caller_trace reads on the receiving side
+        # (camelCase traceId/spanId, threaded into trace_session as
+        # caller_trace_id/caller_span_id → the peer JOINS our trace). Attached at
+        # BOTH request level (preferred by the receiver's metadata merge) and
+        # message level (fallback for peers whose SDK drops request metadata).
+        # Absent when tracing is off — the request is byte-identical to before.
+        send_params: dict = {
+            "message": {
+                "role": "ROLE_USER",
+                "parts": [{"text": query}],
+                "messageId": str(uuid.uuid4()),
+            }
+        }
+        try:
+            from observability import tracing
+
+            tctx = tracing.current_trace_context()
+        except Exception:  # noqa: BLE001 — tracing must never break a dispatch
+            tctx = None
+        if tctx:
+            wire = {"traceId": tctx["trace_id"]}
+            if tctx.get("span_id"):
+                wire["spanId"] = tctx["span_id"]
+            send_params["metadata"] = {"a2a.trace": wire}
+            send_params["message"]["metadata"] = {"a2a.trace": wire}
         # A2A 1.0 (a2a-sdk >=1.0): JSON-RPC `SendMessage` / `GetTask`, the ROLE_USER
         # enum, and a `result.task` envelope. (`message/send` + lowercase `user` is
         # the v0.3 legacy dialect, which 1.0 servers reject with -32601.)
@@ -333,17 +360,7 @@ class A2aAdapter(Adapter):
         # poll loop, which returns quickly regardless. An explicit ``timeout`` still overrides.
         read_budget = timeout if timeout is not None else poll_timeout
         async with httpx.AsyncClient(timeout=httpx.Timeout(read_budget, connect=10.0)) as client:
-            result = await _rpc(
-                client,
-                "SendMessage",
-                {
-                    "message": {
-                        "role": "ROLE_USER",
-                        "parts": [{"text": query}],
-                        "messageId": str(uuid.uuid4()),
-                    }
-                },
-            )
+            result = await _rpc(client, "SendMessage", send_params)
             text = _extract_text(result)
             if text:
                 return text

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -698,6 +698,14 @@ def _main():
             await _a2a_push_client.aclose()
         except Exception:
             log.exception("[a2a] push client close failed")
+        # Flush buffered Langfuse observations LAST (after every surface above
+        # has stopped emitting) so in-flight spans survive process exit instead
+        # of dying in the SDK's batch buffer. Off the loop — flush() blocks on
+        # the exporter. Best-effort, like everything else in this hook.
+        try:
+            await asyncio.to_thread(tracing.flush)
+        except Exception:  # noqa: BLE001 — shutdown teardown is best-effort
+            log.exception("[tracing] flush on shutdown failed")
 
     # Chat / goal / health / OpenAI-compat HTTP surface. Extracted to
     # operator_api/chat_routes.py (ADR 0023 phase 3); ``ui`` is passed in

--- a/tests/test_delegate_a2a_robustness.py
+++ b/tests/test_delegate_a2a_robustness.py
@@ -185,3 +185,87 @@ def test_explicit_timeout_overrides_read_budget(patched):
 
     assert asyncio.run(A.dispatch(d, "hi", timeout=25)) == "ok"
     assert cap["timeout"].read == 25.0
+
+
+# ── fleet tracing: outbound a2a.trace propagation ──────────────────────────────
+
+
+class _BodyCaptureClient(_FakeClient):
+    """A _FakeClient that also records every posted JSON-RPC body."""
+
+    bodies: list  # class attr replaced per-install
+
+    async def post(self, url, json=None, headers=None):
+        type(self).bodies.append(json)
+        return await super().post(url, json=json, headers=headers)
+
+
+def _install_capture_client(monkeypatch, **kw):
+    class _C(_BodyCaptureClient):
+        bodies = []
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **client_kw: _C(**kw, **client_kw))
+    return _C.bodies
+
+
+_TID = "a" * 32
+_SID = "b" * 16
+
+# Patch the SAME module object dispatch resolves via `from observability import
+# tracing` (the package attribute — stable even if a sibling test swapped the
+# sys.modules entry).
+from observability import tracing as _tracing  # noqa: E402
+
+
+def test_dispatch_attaches_a2a_trace_when_tracing_active(patched):
+    """When a traced turn dispatches to a peer, the SendMessage carries our
+    Langfuse trace context as ``a2a.trace`` metadata — camelCase traceId/spanId,
+    the exact shape a2a_impl/executor._extract_caller_trace reads — at BOTH
+    request level (preferred) and message level (fallback)."""
+    patched.setattr(_tracing, "current_trace_context", lambda: {"trace_id": _TID, "span_id": _SID})
+    patched.setattr("tools.a2a_parse._extract_text", lambda result, *a, **k: "pong" if result else "")
+    bodies = _install_capture_client(patched, send_resp=_Resp({"jsonrpc": "2.0", "result": {"text": "pong"}}))
+
+    assert asyncio.run(A.dispatch(_parse(), "ping")) == "pong"
+
+    send = next(b for b in bodies if b.get("method") == "SendMessage")
+    wire = {"traceId": _TID, "spanId": _SID}
+    assert send["params"]["metadata"] == {"a2a.trace": wire}
+    assert send["params"]["message"]["metadata"] == {"a2a.trace": wire}
+
+
+def test_dispatch_attaches_trace_id_only_when_no_current_span(patched):
+    patched.setattr(_tracing, "current_trace_context", lambda: {"trace_id": _TID})
+    patched.setattr("tools.a2a_parse._extract_text", lambda result, *a, **k: "pong" if result else "")
+    bodies = _install_capture_client(patched, send_resp=_Resp({"jsonrpc": "2.0", "result": {"text": "pong"}}))
+
+    assert asyncio.run(A.dispatch(_parse(), "ping")) == "pong"
+
+    send = next(b for b in bodies if b.get("method") == "SendMessage")
+    assert send["params"]["metadata"] == {"a2a.trace": {"traceId": _TID}}
+
+
+def test_dispatch_sends_no_trace_metadata_when_tracing_inactive(patched):
+    """Tracing off ⇒ the request is unchanged — no metadata keys at all."""
+    patched.setattr(_tracing, "current_trace_context", lambda: None)
+    patched.setattr("tools.a2a_parse._extract_text", lambda result, *a, **k: "pong" if result else "")
+    bodies = _install_capture_client(patched, send_resp=_Resp({"jsonrpc": "2.0", "result": {"text": "pong"}}))
+
+    assert asyncio.run(A.dispatch(_parse(), "ping")) == "pong"
+
+    send = next(b for b in bodies if b.get("method") == "SendMessage")
+    assert "metadata" not in send["params"]
+    assert "metadata" not in send["params"]["message"]
+
+
+def test_dispatch_survives_tracing_helper_blowup(patched):
+    """A tracing failure must never break a dispatch."""
+
+    def _boom():
+        raise RuntimeError("tracing exploded")
+
+    patched.setattr(_tracing, "current_trace_context", _boom)
+    patched.setattr("tools.a2a_parse._extract_text", lambda result, *a, **k: "pong" if result else "")
+    _install_capture_client(patched, send_resp=_Resp({"jsonrpc": "2.0", "result": {"text": "pong"}}))
+
+    assert asyncio.run(A.dispatch(_parse(), "ping")) == "pong"

--- a/tests/test_subagent_trace_span.py
+++ b/tests/test_subagent_trace_span.py
@@ -1,0 +1,134 @@
+"""Fleet tracing: `_run_subagent` wraps its execution in a `subagent:<type>`
+boundary observation so the subagent's tool/LLM spans nest under one node in
+the current Langfuse trace — WITHOUT regressing the #1879 salvage contract
+(GraphRecursionError → partial output) or the SubagentError contract, and as a
+strict no-op when tracing is disabled."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage
+from langgraph.errors import GraphRecursionError
+
+import graph.agent as agent_mod
+from graph.config import LangGraphConfig
+from graph.subagents.config import SUBAGENT_REGISTRY, SubagentConfig
+from observability import tracing
+
+
+class _FakeSubagent:
+    def __init__(self, states, raise_after=False):
+        self._states = states
+        self._raise = raise_after
+
+    async def astream(self, _inputs, config=None, stream_mode=None):
+        assert stream_mode == "values"
+        for s in self._states:
+            yield s
+        if self._raise:
+            raise GraphRecursionError("Recursion limit of 40 reached without hitting a stop condition.")
+
+
+@pytest.fixture
+def stubbed(monkeypatch):
+    cfg = SubagentConfig(name="stub", description="d", system_prompt="p", tools=["current_time"], max_turns=40)
+    monkeypatch.setitem(SUBAGENT_REGISTRY, "stub", cfg)
+    monkeypatch.setattr(agent_mod, "_subagent_tools", lambda *_a, **_k: [object()])
+    monkeypatch.setattr(agent_mod, "create_llm", lambda *_a, **_k: object())
+    monkeypatch.setattr(agent_mod, "build_subagent_prompt", lambda *_a, **_k: "sys")
+    return cfg
+
+
+@pytest.fixture
+def fake_langfuse(monkeypatch):
+    """Enable the REAL tracing module with a fake Langfuse client (the module
+    object `_run_subagent` resolves via `from observability import tracing`)."""
+    fake = MagicMock()
+    span = MagicMock()
+    span.trace_id = "trace-abc"
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=span)
+    cm.__exit__ = MagicMock(return_value=None)
+    fake.start_as_current_observation.return_value = cm
+    monkeypatch.setattr(tracing, "_langfuse", fake)
+    monkeypatch.setattr(tracing, "_enabled", True)
+    return fake
+
+
+async def _run(monkeypatch, fake_agent):
+    monkeypatch.setattr(agent_mod, "create_agent", lambda **_k: fake_agent)
+    return await agent_mod._run_subagent(
+        config=LangGraphConfig(),
+        tool_map={},
+        available_subagents="stub",
+        description="review lane",
+        prompt="go",
+        subagent_type="stub",
+        parent_task_id="call-7",
+    )
+
+
+async def test_subagent_run_is_wrapped_in_boundary_span(monkeypatch, stubbed, fake_langfuse):
+    out = await _run(monkeypatch, _FakeSubagent([{"messages": [AIMessage(content="done.")]}]))
+    assert out.startswith("[stub completed: review lane]")
+
+    fake_langfuse.start_as_current_observation.assert_called_once()
+    kwargs = fake_langfuse.start_as_current_observation.call_args.kwargs
+    assert kwargs["name"] == "subagent:stub"
+    assert kwargs["as_type"] == "agent"
+    assert kwargs["metadata"]["description"] == "review lane"
+    assert kwargs["metadata"]["parent_task_id"] == "call-7"
+    cm = fake_langfuse.start_as_current_observation.return_value
+    cm.__enter__.assert_called_once()
+    cm.__exit__.assert_called_once()
+
+
+async def test_salvage_path_survives_boundary_span(monkeypatch, stubbed, fake_langfuse):
+    """The #1879 contract holds under tracing: recursion-limit stop still
+    salvages the partial transcript, and the boundary span still closes."""
+    fake = _FakeSubagent([{"messages": [AIMessage(content="Partial findings so far.")]}], raise_after=True)
+    out = await _run(monkeypatch, fake)
+    assert "hard-stopped at max_turns" in out and "PARTIAL" in out
+    assert "Partial findings so far." in out
+    cm = fake_langfuse.start_as_current_observation.return_value
+    cm.__exit__.assert_called_once()
+
+
+async def test_subagent_error_contract_survives_boundary_span(monkeypatch, stubbed, fake_langfuse):
+    class _Boom:
+        async def astream(self, *_a, **_k):
+            raise RuntimeError("model exploded")
+            yield  # pragma: no cover
+
+    monkeypatch.setattr(agent_mod, "create_agent", lambda **_k: _Boom())
+    with pytest.raises(agent_mod.SubagentError):
+        await agent_mod._run_subagent(
+            config=LangGraphConfig(),
+            tool_map={},
+            available_subagents="stub",
+            description="review lane",
+            prompt="go",
+            subagent_type="stub",
+        )
+    # the span was opened AND closed despite the hard failure
+    cm = fake_langfuse.start_as_current_observation.return_value
+    cm.__exit__.assert_called_once()
+
+
+async def test_tracing_disabled_is_a_noop(monkeypatch, stubbed):
+    """No Langfuse ⇒ no span calls, identical output."""
+    monkeypatch.setattr(tracing, "_langfuse", None)
+    monkeypatch.setattr(tracing, "_enabled", False)
+    out = await _run(monkeypatch, _FakeSubagent([{"messages": [AIMessage(content="done.")]}]))
+    assert out.startswith("[stub completed: review lane]")
+
+
+async def test_langfuse_setup_failure_never_breaks_the_run(monkeypatch, stubbed):
+    fake = MagicMock()
+    fake.start_as_current_observation.side_effect = RuntimeError("langfuse down")
+    monkeypatch.setattr(tracing, "_langfuse", fake)
+    monkeypatch.setattr(tracing, "_enabled", True)
+    out = await _run(monkeypatch, _FakeSubagent([{"messages": [AIMessage(content="done.")]}]))
+    assert out.startswith("[stub completed: review lane]")

--- a/tests/test_trace_context_middleware.py
+++ b/tests/test_trace_context_middleware.py
@@ -1,0 +1,138 @@
+"""TraceContextMiddleware — per-call Langfuse trace join for gateway LLM calls.
+
+The LiteLLM gateway's own Langfuse callback honors request-body ``metadata``
+keys ``existing_trace_id`` / ``parent_observation_id`` / ``generation_name``
+(verified against litellm 1.83.10). This middleware stamps them onto a copy of
+the request's model via ``extra_body`` at the ``wrap_model_call`` boundary —
+fresh ids per call, no-op when tracing is inactive, never raises.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.middleware.trace_context import TraceContextMiddleware
+from observability import tracing
+
+_TID = "a" * 32
+_SID = "b" * 16
+
+
+class _FakeModel:
+    """Pydantic-shaped stand-in: has an extra_body slot + model_copy(update=...)."""
+
+    def __init__(self, extra_body=None):
+        self.extra_body = extra_body
+
+    def model_copy(self, update=None):
+        clone = _FakeModel(self.extra_body)
+        for k, v in (update or {}).items():
+            setattr(clone, k, v)
+        return clone
+
+
+class _FakeRequest:
+    def __init__(self, model):
+        self.model = model
+
+    def override(self, model=None):
+        return _FakeRequest(model)
+
+
+@pytest.fixture
+def mw():
+    return TraceContextMiddleware()
+
+
+def _set_ctx(monkeypatch, ctx):
+    monkeypatch.setattr(tracing, "current_trace_context", lambda: ctx)
+
+
+def test_stamps_trace_metadata_onto_model_copy(monkeypatch, mw):
+    _set_ctx(monkeypatch, {"trace_id": _TID, "span_id": _SID})
+    monkeypatch.setenv("AGENT_NAME", "vera")
+    req = _FakeRequest(_FakeModel())
+
+    out = mw._with_trace(req)
+
+    assert out is not req  # overridden
+    meta = out.model.extra_body["metadata"]
+    assert meta["existing_trace_id"] == _TID
+    assert meta["parent_observation_id"] == _SID
+    assert meta["generation_name"] == "vera-turn"
+
+
+def test_trace_id_only_omits_parent_observation(monkeypatch, mw):
+    _set_ctx(monkeypatch, {"trace_id": _TID})
+    out = mw._with_trace(_FakeRequest(_FakeModel()))
+    meta = out.model.extra_body["metadata"]
+    assert meta["existing_trace_id"] == _TID
+    assert "parent_observation_id" not in meta
+
+
+def test_merges_with_existing_extra_body_without_mutating_original(monkeypatch, mw):
+    """A gateway model may already carry extra_body (top_k, thinking, …) — the
+    stamp must merge, and the ORIGINAL model must stay untouched (it's shared
+    across turns via the compiled graph / middleware caches)."""
+    _set_ctx(monkeypatch, {"trace_id": _TID})
+    original = _FakeModel({"top_k": 20, "metadata": {"custom": "keep"}})
+    out = mw._with_trace(_FakeRequest(original))
+
+    assert out.model.extra_body["top_k"] == 20
+    assert out.model.extra_body["metadata"]["custom"] == "keep"
+    assert out.model.extra_body["metadata"]["existing_trace_id"] == _TID
+    # original untouched
+    assert original.extra_body == {"top_k": 20, "metadata": {"custom": "keep"}}
+
+
+def test_noop_when_tracing_inactive(monkeypatch, mw):
+    _set_ctx(monkeypatch, None)
+    req = _FakeRequest(_FakeModel())
+    assert mw._with_trace(req) is req
+
+
+def test_noop_for_models_without_extra_body(monkeypatch, mw):
+    """ACP aux models (and fakes) have no extra_body slot — leave them alone."""
+    _set_ctx(monkeypatch, {"trace_id": _TID})
+    req = _FakeRequest(object())
+    assert mw._with_trace(req) is req
+
+
+def test_tracing_blowup_never_breaks_the_model_call(monkeypatch, mw):
+    def _boom():
+        raise RuntimeError("otel misery")
+
+    monkeypatch.setattr(tracing, "current_trace_context", _boom)
+    req = _FakeRequest(_FakeModel())
+    assert mw._with_trace(req) is req
+
+
+def test_real_chatopenai_payload_carries_the_stamp(monkeypatch, mw):
+    """End-to-end through the REAL client class: the stamped copy's request
+    payload includes extra_body.metadata — i.e. the gateway will actually see
+    existing_trace_id on the wire."""
+    from langchain_openai import ChatOpenAI
+
+    _set_ctx(monkeypatch, {"trace_id": _TID, "span_id": _SID})
+    model = ChatOpenAI(api_key="x", model="gw/model", extra_body={"top_k": 20})
+    out = mw._with_trace(_FakeRequest(model))
+
+    payload = out.model._get_request_payload([("human", "hi")])
+    meta = payload["extra_body"]["metadata"]
+    assert meta["existing_trace_id"] == _TID
+    assert meta["parent_observation_id"] == _SID
+    assert payload["extra_body"]["top_k"] == 20
+    # the shared original stays clean
+    assert model.extra_body == {"top_k": 20}
+
+
+async def test_awrap_model_call_passes_stamped_request_to_handler(monkeypatch, mw):
+    _set_ctx(monkeypatch, {"trace_id": _TID})
+    seen = {}
+
+    async def handler(request):
+        seen["req"] = request
+        return "resp"
+
+    assert await mw.awrap_model_call(_FakeRequest(_FakeModel()), handler) == "resp"
+    assert seen["req"].model.extra_body["metadata"]["existing_trace_id"] == _TID

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -225,6 +225,194 @@ def test_score_current_trace_delegates_to_client():
     )
 
 
+# ── Fleet tracing: caller trace join (a2a.trace → trace_context) ─────────────
+
+_TID = "a" * 32  # valid W3C trace id (32 hex)
+_SID = "b" * 16  # valid W3C span id (16 hex)
+
+
+@pytest.mark.asyncio
+async def test_trace_session_joins_caller_trace_context():
+    """When metadata carries caller_trace_id/caller_span_id (the a2a.trace ids
+    an upstream agent sent), the session span JOINS that trace via Langfuse's
+    trace_context — and current_trace_id() reports the JOINED id so audit
+    records + downstream propagation carry the fleet trace."""
+    tracing = _reload_tracing()
+    fake, span, _child = _enable_with_fake_client(tracing)
+    span.trace_id = _TID  # the SDK reports the joined trace id on the span
+
+    async with tracing.trace_session(
+        "s-1", name="a2a-stream", metadata={"caller_trace_id": _TID, "caller_span_id": _SID}
+    ):
+        assert tracing.current_trace_id() == _TID
+
+    kwargs = fake.start_as_current_observation.call_args.kwargs
+    assert kwargs["trace_context"] == {"trace_id": _TID, "parent_span_id": _SID}
+    # The metadata stamping is KEPT (operators cross-reference by it too)
+    assert kwargs["metadata"]["caller_trace_id"] == _TID
+    assert kwargs["metadata"]["caller_span_id"] == _SID
+
+
+@pytest.mark.asyncio
+async def test_trace_session_join_without_span_id_still_joins_trace():
+    tracing = _reload_tracing()
+    fake, _span, _child = _enable_with_fake_client(tracing)
+
+    async with tracing.trace_session("s-1", metadata={"caller_trace_id": _TID}):
+        pass
+
+    kwargs = fake.start_as_current_observation.call_args.kwargs
+    assert kwargs["trace_context"] == {"trace_id": _TID}
+
+
+@pytest.mark.asyncio
+async def test_trace_session_malformed_caller_ids_fall_back_to_fresh_trace():
+    """Malformed caller ids must never crash a turn or feed the SDK a bogus
+    W3C context — the session degrades to a fresh trace."""
+    tracing = _reload_tracing()
+    fake, _span, _child = _enable_with_fake_client(tracing)
+
+    async with tracing.trace_session(
+        "s-1", metadata={"caller_trace_id": "not-a-trace-id", "caller_span_id": "zz"}
+    ) as span:
+        assert span is not None  # the session still traces — freshly
+        assert tracing.current_trace_id() == "trace-abc"
+
+    kwargs = fake.start_as_current_observation.call_args.kwargs
+    assert kwargs["trace_context"] is None
+
+
+@pytest.mark.asyncio
+async def test_trace_session_join_with_malformed_span_id_keeps_trace_id_only():
+    tracing = _reload_tracing()
+    fake, _span, _child = _enable_with_fake_client(tracing)
+
+    async with tracing.trace_session("s-1", metadata={"caller_trace_id": _TID, "caller_span_id": "junk"}):
+        pass
+
+    kwargs = fake.start_as_current_observation.call_args.kwargs
+    assert kwargs["trace_context"] == {"trace_id": _TID}
+
+
+# ── current_trace_context (outbound propagation helper) ──────────────────────
+
+
+def test_disabled_current_trace_context_is_none():
+    tracing = _reload_tracing()
+    assert tracing.current_trace_context() is None
+
+
+def test_current_trace_context_shape_from_sdk():
+    tracing = _reload_tracing()
+    fake, _span, _child = _enable_with_fake_client(tracing)
+    fake.get_current_trace_id.return_value = _TID
+    fake.get_current_observation_id.return_value = _SID
+    assert tracing.current_trace_context() == {"trace_id": _TID, "span_id": _SID}
+
+
+def test_current_trace_context_without_current_span_has_trace_id_only():
+    tracing = _reload_tracing()
+    fake, _span, _child = _enable_with_fake_client(tracing)
+    fake.get_current_trace_id.return_value = _TID
+    fake.get_current_observation_id.return_value = None
+    assert tracing.current_trace_context() == {"trace_id": _TID}
+
+
+def test_current_trace_context_none_when_no_active_trace():
+    tracing = _reload_tracing()
+    fake, _span, _child = _enable_with_fake_client(tracing)
+    fake.get_current_trace_id.return_value = None
+    fake.get_current_observation_id.return_value = None
+    assert tracing.current_trace_context() is None
+
+
+def test_current_trace_context_falls_back_to_contextvar_when_sdk_errors():
+    tracing = _reload_tracing()
+    fake, _span, _child = _enable_with_fake_client(tracing)
+    fake.get_current_trace_id.side_effect = RuntimeError("otel misery")
+    fake.get_current_observation_id.side_effect = RuntimeError("otel misery")
+    token = tracing._trace_id_ctx.set(_TID)
+    try:
+        assert tracing.current_trace_context() == {"trace_id": _TID}
+    finally:
+        tracing._trace_id_ctx.reset(token)
+
+
+# ── trace_span (boundary spans, e.g. subagent:<type>) ────────────────────────
+
+
+def test_disabled_trace_span_is_noop():
+    tracing = _reload_tracing()
+    with tracing.trace_span("subagent:worker") as span:
+        assert span is None
+
+
+def test_trace_span_opens_and_closes_child_observation():
+    tracing = _reload_tracing()
+    fake, span, _child = _enable_with_fake_client(tracing)
+
+    with tracing.trace_span("subagent:worker", metadata={"description": "d"}, as_type="agent") as s:
+        assert s is span
+
+    kwargs = fake.start_as_current_observation.call_args.kwargs
+    assert kwargs["name"] == "subagent:worker"
+    assert kwargs["as_type"] == "agent"
+    assert kwargs["metadata"] == {"description": "d"}
+    cm = fake.start_as_current_observation.return_value
+    cm.__enter__.assert_called_once()
+    cm.__exit__.assert_called_once()
+
+
+def test_trace_span_body_exception_propagates_but_span_closes():
+    tracing = _reload_tracing()
+    fake, _span, _child = _enable_with_fake_client(tracing)
+
+    with pytest.raises(RuntimeError):
+        with tracing.trace_span("subagent:worker"):
+            raise RuntimeError("subagent exploded")
+
+    cm = fake.start_as_current_observation.return_value
+    cm.__exit__.assert_called_once()
+
+
+def test_trace_span_sdk_error_yields_none_and_body_runs():
+    tracing = _reload_tracing()
+    fake = MagicMock()
+    fake.start_as_current_observation.side_effect = RuntimeError("langfuse down")
+    tracing._langfuse = fake
+    tracing._enabled = True
+
+    ran = False
+    with tracing.trace_span("subagent:worker") as span:
+        assert span is None
+        ran = True
+    assert ran
+
+
+# ── shutdown flush wiring ─────────────────────────────────────────────────────
+
+
+def test_flush_delegates_to_client_and_swallows_errors():
+    tracing = _reload_tracing()
+    fake, _span, _child = _enable_with_fake_client(tracing)
+    tracing.flush()
+    fake.flush.assert_called_once()
+    fake.flush.side_effect = RuntimeError("exporter down")
+    tracing.flush()  # must not raise
+
+
+def test_server_shutdown_hook_flushes_tracing():
+    """Wiring lock: the server shutdown hook must flush buffered observations
+    so spans survive process exit (server/__init__.py is only importable inside
+    a full boot, so we lock the source contract)."""
+    from pathlib import Path
+
+    src = (Path(__file__).parents[1] / "server" / "__init__.py").read_text()
+    hook = src.split('@fastapi_app.on_event("shutdown")', 1)[1]
+    hook = hook.split("register_chat_routes", 1)[0]  # the hook body ends before route registration
+    assert "tracing.flush" in hook, "shutdown hook no longer flushes Langfuse tracing"
+
+
 def test_no_legacy_shims_exist():
     """Greenfield guarantee — start_trace / end_trace / trace_llm_call were
     removed. Their return would silently break the nesting contract by


### PR DESCRIPTION
The fleet already reports to ONE Langfuse project (jon/roxy/frank/gateway + newly vera/ava), but every hop filed its own disconnected trace. This makes a cross-fleet flow a single tree:

1. **Callee joins the caller's trace** — `trace_session` passes `trace_context={trace_id, parent_span_id}` (langfuse 4.7.1) when `a2a.trace` metadata arrives, instead of only stashing the ids in span metadata. W3C-shape validated; malformed → fresh trace, never a crashed turn.
2. **Caller finally sends `a2a.trace`** — the delegates A2A adapter attaches `{traceId, spanId}` (camelCase — matching what `server/chat.py` reads) at request + message level via new `tracing.current_trace_context()`. The receiver half existed since ADR 0006; this closes the loop.
3. **Gateway generations nest into the agent trace** — new `TraceContextMiddleware` stamps `extra_body.metadata = {existing_trace_id, parent_observation_id, generation_name}` per model call (lead + subagent chains); litellm 1.83.10's Langfuse callback honors those keys (verified against the actual wheel: `litellm_pre_call_utils` passes them through for any key tier). Fixes the audit's "no LLM spans" gap using the gateway callback that already reports.
4. **`subagent:<type>` boundary spans** — Vera's five panel lanes (and every `task()` delegation) become readable branches; recursion-limit salvage + SubagentError contracts locked by tests.
5. **Flush on shutdown** — buffered spans survive process exit.

Result: `ava → jon (A2A) → jon's subagents → gateway generations` is one trace; a Vera panel shows five finder branches with tools + generations nested where they belong.

34 new tests across tracing/delegates/subagent/middleware; full suite 3370 green; live smoke green; changelog entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end trace propagation across agent runs, subagents, and outbound message dispatches.
  * Improved tracing support for request/response boundaries and shutdown-time flushing.

* **Bug Fixes**
  * Tracing failures now safely fall back without breaking model calls or message dispatch.
  * Subagent execution and recursion-limit handling remain reliable even when tracing is enabled.
  * Better handling for missing or partial trace information, including trace-only propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->