### PR TITLE
fleet: agents load their OWN SOUL/persona, not the hub placeholder

### DIFF
--- a/graph/prompts.py
+++ b/graph/prompts.py
@@ -54,11 +54,28 @@ def build_system_prompt(
     """
     parts = []
 
-    # 1. Identity — prefer the runtime workspace (entrypoint.sh copies
-    # config/SOUL.md to /sandbox/SOUL.md at container start). Fall back
-    # to the repo source so local `python -m server` runs without a
-    # /sandbox mount still pick up persona edits made via the drawer.
-    soul = _read_file(f"{workspace}/SOUL.md")
+    # 1. Identity — the instance's OWN persona. Prefer the canonical live SOUL:
+    # ``instance_paths().soul_path`` = ``<instance_root>/config/SOUL.md`` — the path
+    # ``config_io.read_soul``/``write_soul`` use and the persona drawer edits, and
+    # PROTOAGENT_HOME-aware. This is what makes a FLEET MEMBER load ITS OWN persona:
+    # a member is spawned directly by the supervisor (not via entrypoint.sh, which
+    # only the primary runs to copy config/SOUL.md → /sandbox/SOUL.md), and it
+    # inherits the hub's default ``workspace`` (/sandbox), so the legacy
+    # ``{workspace}/SOUL.md`` read below resolved the HUB's file — a placeholder for
+    # the member — leaving it with NO identity (it then collapses onto whatever the
+    # injected team context foregrounds — the hub agent). Reading the instance's own
+    # config/SOUL.md fixes members and also gives the primary its real persona
+    # regardless of the entrypoint copy. Fall back to the legacy runtime copy
+    # (``{workspace}/SOUL.md``), then the repo/bundle default.
+    soul = ""
+    try:
+        from infra.paths import instance_paths
+
+        soul = _read_file(instance_paths().soul_path)
+    except Exception:  # noqa: BLE001 — path resolution must never break prompt building
+        soul = ""
+    if not soul:
+        soul = _read_file(f"{workspace}/SOUL.md")
     if not soul:
         soul = _read_file(Path(__file__).parent.parent / "config" / "SOUL.md")
     if soul:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,48 @@
+"""System-prompt SOUL resolution — a fleet member must load ITS OWN persona.
+
+Regression guard for the member-identity bug: ``build_system_prompt`` used to read
+``{workspace}/SOUL.md`` with ``workspace`` defaulting to the hub root ``/sandbox``. A
+fleet member (spawned directly by the supervisor, not via entrypoint.sh) inherited that
+default and so loaded the HUB's SOUL file — a placeholder for the member — leaving it with
+no identity. The fix reads the instance's canonical ``config/SOUL.md``
+(``instance_paths().soul_path``, PROTOAGENT_HOME-aware) first.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graph.prompts import build_system_prompt
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_member_loads_own_config_soul_over_hub_workspace(monkeypatch, tmp_path):
+    """The instance's own config/SOUL.md wins over the (hub-default) {workspace}/SOUL.md."""
+    home = tmp_path / "member"
+    _write(home / "config" / "SOUL.md", "# Identity\nI am Matt, the design-system engineer.")
+    monkeypatch.setenv("PROTOAGENT_HOME", str(home))
+    # The hub's default workspace carries a DIFFERENT (placeholder) SOUL.
+    hub = tmp_path / "hub"
+    _write(hub / "SOUL.md", "# Soul\nReplace this file.")
+
+    prompt = build_system_prompt(workspace=str(hub), include_subagents=False)
+
+    assert "I am Matt, the design-system engineer." in prompt
+    assert "Replace this file." not in prompt
+
+
+def test_falls_back_to_workspace_soul_when_no_instance_soul(monkeypatch, tmp_path):
+    """Backward-compat: with no instance config/SOUL.md, the legacy {workspace}/SOUL.md is used."""
+    home = tmp_path / "member"
+    (home / "config").mkdir(parents=True)  # instance root exists but no SOUL.md
+    monkeypatch.setenv("PROTOAGENT_HOME", str(home))
+    hub = tmp_path / "hub"
+    _write(hub / "SOUL.md", "# Identity\nLegacy runtime persona.")
+
+    prompt = build_system_prompt(workspace=str(hub), include_subagents=False)
+
+    assert "Legacy runtime persona." in prompt


### PR DESCRIPTION
## The bug

`graph/prompts.py::build_system_prompt()` read the persona from `{workspace}/SOUL.md`, with `workspace` **defaulting to the hub root `/sandbox`** — relying on `entrypoint.sh` having copied `config/SOUL.md → /sandbox/SOUL.md` at container start.

Only the **primary** agent runs that entrypoint. A **fleet member** ([ADR 0042](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0042-fleet-supervisor-unified-console.md)) is spawned *directly* by the supervisor and inherits the hub's default `workspace`, so it read the **hub's** SOUL file — a placeholder for the member — and ran with **no identity**.

### How it surfaced

A design-system fleet member (`matt`, 0 own-knowledge chunks) answered *"Who are you?"* as **"jon — GTM strategist & team lead"** — reciting the shared `team-charter.md` verbatim. With no persona loaded and nothing in its own knowledge to compensate, the member collapsed onto whatever the injected team context foregrounded (the lead is named first in the charter). Across probes it drifted between jon / matt / cindi. Both the primary *and* members were in fact running on the bundle placeholder — the primary just masks it with rich own-knowledge + card.

## The fix

Resolve the instance's **canonical** live SOUL first: `instance_paths().soul_path` = `<instance_root>/config/SOUL.md` — the path `config_io.read_soul`/`write_soul` already use (and the persona drawer edits), and `PROTOAGENT_HOME`-aware. Each process now loads **its own** persona. The legacy `{workspace}/SOUL.md` and the repo/bundle default remain as ordered fallbacks, so nothing regresses; the primary also gets its real persona regardless of the entrypoint copy.

### Verified live

Hot-patched into a running hub + restarted the member — it now answers **"Matt — frontend engineering, design system, accessibility"** consistently across fresh threads, zero cross-member bleed.

## Tests

`tests/test_prompts.py` — a member's `config/SOUL.md` wins over a hub-default `{workspace}/SOUL.md`; falls back to `{workspace}/SOUL.md` when the instance has none. Soul/prompt suites green (21 passed).

## Note

Complements #1881 (fleet members self-advertise their A2A tenant URL). Both are "a fleet member is its own identity" — this one is the persona; #1881 is the discoverable address. Independent code paths; both should land before the next hub rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The app now prefers the instance-specific `SOUL.md` persona when building prompts, instead of always using the workspace copy.
  * If the instance persona is unavailable or cannot be loaded, it safely falls back to the workspace version without breaking prompt creation.

* **Tests**
  * Added regression coverage for instance-specific persona loading.
  * Added a fallback test to confirm the workspace persona is still used when no instance file exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->