### PR TITLE
fix(plugins): silence routine hot-reload router re-mount, keep real dup warning

### DIFF
--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -1353,23 +1353,38 @@ def _mount_plugin_routers(routers: list[dict]) -> None:
         return
     from graph.plugins.registry import _prefix_conforms
 
+    # Every call re-passes the full live router list (boot AND each reload rebuilds
+    # it from scratch), so most "key already in plugin_router_keys" hits are just
+    # the routine hot-reload no-op — not a misconfiguration. Only warn when the
+    # SAME key shows up twice within THIS call: that's a plugin genuinely handing
+    # us two distinct routers for one prefix (the projectBoard /board 404 case).
+    seen_this_call: set[tuple[str, str]] = set()
     for r in routers:
         plugin_id = r.get("plugin_id", "")
         prefix = r.get("prefix") or ""
         key = (plugin_id, prefix)
         if key in STATE.plugin_router_keys:
-            # A plugin registered a SECOND router at the SAME prefix — the first
-            # already won the slot, so this one is silently dropped and its routes
-            # never serve (projectBoard's /board 404'd for exactly this reason).
-            # Mount distinct prefixes for distinct route groups (e.g. a public
-            # /plugins/<id> view router + a gated /api/plugins/<id> data router).
-            log.warning(
-                "[plugins] %s registered a second router at prefix %s — dropped "
-                "(its routes won't be served; mount each router at a distinct prefix)",
-                plugin_id,
-                prefix or "/",
-            )
+            if key in seen_this_call:
+                # A plugin registered a SECOND router at the SAME prefix — the first
+                # already won the slot, so this one is silently dropped and its routes
+                # never serve (projectBoard's /board 404'd for exactly this reason).
+                # Mount distinct prefixes for distinct route groups (e.g. a public
+                # /plugins/<id> view router + a gated /api/plugins/<id> data router).
+                log.warning(
+                    "[plugins] %s registered a second router at prefix %s — dropped "
+                    "(its routes won't be served; mount each router at a distinct prefix)",
+                    plugin_id,
+                    prefix or "/",
+                )
+            else:
+                seen_this_call.add(key)
+                log.debug(
+                    "[plugins] %s: router at %s already mounted — hot-reload no-op",
+                    plugin_id,
+                    prefix or "/",
+                )
             continue
+        seen_this_call.add(key)
         # Warn for non-conforming prefixes (#870 plugin prefix enforcement).
         # The two canonical prefixes are /plugins/<id>/... (public view) and
         # /api/plugins/<id>/... (bearer-gated data router) — the documented

--- a/tests/test_plugin_route_hotmount.py
+++ b/tests/test_plugin_route_hotmount.py
@@ -63,6 +63,22 @@ def test_remount_skipped_new_added(app):
     assert STATE.plugin_router_keys == {("a", "/api/a"), ("b", "/api/b")}
 
 
+def test_remount_is_silent_no_op(app, caplog):
+    # #1878: re-passing the SAME router on a reload (the routine case — every
+    # reload rebuilds the full router list from scratch) must NOT warn. Only a
+    # genuine intra-batch duplicate (two distinct routers, one prefix) should.
+    first = {"plugin_id": "a", "router": _router("a"), "prefix": "/api/a"}
+    _mount_plugin_routers([first])
+
+    with caplog.at_level("WARNING", logger="server.agent_init"):
+        _mount_plugin_routers([first])
+    assert "registered a second router" not in caplog.text
+
+    with caplog.at_level("WARNING", logger="server.agent_init"):
+        _mount_plugin_routers([first, {"plugin_id": "a", "router": _router("a2"), "prefix": "/api/a"}])
+    assert "registered a second router" in caplog.text
+
+
 def test_view_route_resolves_after_enable(app):
     # The P0 fix: enabling a view-contributing plugin hot-mounts the router that serves
     # its view page — so /api/plugins/<id>/view 200s immediately, no restart, no 404.


### PR DESCRIPTION
## What

`_mount_plugin_routers` (`server/agent_init.py`) is called at boot **and** on every config reload, always with the plugin bundle's full, freshly-rebuilt router list — that's intentional, it's how hot-mounting a newly-enabled plugin's routes works without a restart. But the "this key is already mounted" branch treated every re-pass as a misconfiguration and logged at `WARNING`:

```
[plugins] <id> registered a second router at prefix /plugins/<id> — dropped (its routes won't be served; ...)
```

So on **every reload**, **every** route-bearing plugin logged this — reading like an outage during incident triage, even though the original boot-time mount kept serving the whole time (verified in the issue: the pr-reviewer webhook kept recording telemetry after the warnings fired).

## Fix

Distinguish the two cases that were sharing one code path:

- **Cross-call re-mount** (the routine case — a reload rebuilds the same router list and re-passes it): now logs at `DEBUG` as a hot-reload no-op.
- **Intra-batch collision** (a plugin genuinely hands us two *distinct* routers for the same prefix in one pass — the original #870 / projectBoard `/board` 404 case): still logs the `WARNING`, unchanged.

This is done with a small `seen_this_call` set scoped to each call, so the diagnostic value of the original warning (catching a real per-prefix collision) is preserved — it just no longer fires for steady-state reloads.

Scope note (documented, not fixed here): a plugin whose router factory closes over live config still won't get its **new** router mounted on reload — FastAPI has no route-removal API, so unmount+remount (the "correct semantics" option in the issue) is a bigger lift than this de-scare. Left for a follow-up if a plugin actually needs that.

## Testing
- Added `test_remount_is_silent_no_op` to `tests/test_plugin_route_hotmount.py`: re-passing the same router logs no warning; a genuine same-call duplicate still does.
- `uv run pytest tests/test_plugin_route_hotmount.py tests/test_plugin_routes.py tests/test_a2a_auth.py -q` → 104 passed.
- `uv run ruff check` on both changed files → clean.

Fixes #1878

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin router hot-reload behavior so previously mounted routes no longer trigger unnecessary warnings.
  - True duplicate routes added in the same reload cycle still raise a warning and are skipped.
- **Tests**
  - Added coverage to verify silent remounts on reload and warning behavior for genuine duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->