### PR TITLE
fix(fleet): set spawned member's own AGENT_NAME instead of inheriting the hub's

### DIFF
--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -213,6 +213,17 @@ def start(ident: str) -> dict:
             hub_public_url = (os.environ.get("A2A_PUBLIC_URL") or "").strip().rstrip("/")
             if hub_public_url:
                 full_env["A2A_PUBLIC_URL"] = f"{hub_public_url}/agents/{wid}"
+        # AGENT_NAME namespaces several subsystems that read os.environ directly rather
+        # than the resolved config identity: Prometheus metric prefixes
+        # (observability/metrics.py), trace tags (observability/tracing.py,
+        # graph/middleware/trace_context.py), scheduler storage
+        # (scheduler/local.py — a real collision risk when members share a storage
+        # path), and the ``<AGENT_NAME>_API_KEY`` lookup (server/agent_init.py,
+        # evals/client.py). full_env otherwise inherits the hub's AGENT_NAME from
+        # os.environ, so a member runs every one of those under the HUB's name. An
+        # explicit per-workspace value still wins (mirrors the pair above).
+        if "AGENT_NAME" not in env:
+            full_env["AGENT_NAME"] = name
         log_path = _log_path(ws)
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_offset = log_path.stat().st_size if log_path.exists() else 0

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -777,3 +777,36 @@ def test_member_tenant_url_respects_explicit_workspace_override(tmp_path, monkey
     supervisor.start("zeta")
 
     assert captured["env"]["A2A_PUBLIC_URL"] == "http://custom:9999/base"  # explicit wins
+
+
+def test_spawned_member_gets_own_agent_name(tmp_path, monkeypatch):
+    """A hub-spawned member must NOT inherit the hub's AGENT_NAME — else it runs under the
+    hub's name in every AGENT_NAME-namespaced subsystem (metrics prefix, trace tags,
+    scheduler storage, ``<AGENT_NAME>_API_KEY`` lookups). It gets its own workspace name."""
+    captured = _env_capturing_fleet(tmp_path, monkeypatch)
+    monkeypatch.setenv("AGENT_NAME", "jon")
+    manager.create("theta", port=7897)
+
+    supervisor.start("theta")
+
+    assert captured["env"]["AGENT_NAME"] == "theta"
+
+
+def test_spawned_member_agent_name_respects_explicit_workspace_override(tmp_path, monkeypatch):
+    """If the workspace's own run_exec env sets AGENT_NAME, that explicit value is kept
+    (mirrors the A2A_AUTH_TOKEN / A2A_PUBLIC_URL override rule)."""
+    captured = _env_capturing_fleet(tmp_path, monkeypatch)
+    monkeypatch.setenv("AGENT_NAME", "jon")
+    manager.create("iota", port=7898)
+
+    real_run_exec = manager.run_exec
+
+    def run_exec_with_name(wid, extra):
+        env, argv = real_run_exec(wid, extra)
+        env["AGENT_NAME"] = "custom-name"
+        return env, argv
+
+    monkeypatch.setattr(supervisor.manager, "run_exec", run_exec_with_name)
+    supervisor.start("iota")
+
+    assert captured["env"]["AGENT_NAME"] == "custom-name"  # explicit wins


### PR DESCRIPTION
## What

A hub-spawned fleet member inherits the **hub's** `AGENT_NAME` env var instead of running under its own identity.

## Why

`graph/fleet/supervisor.py::start()` builds the child process env as `full_env = {**os.environ, **env}`. `env` comes from `workspaces.manager.run_exec()`, which sets `PROTOAGENT_HOME` and `PROTOAGENT_INSTANCE` — but never `AGENT_NAME`. So `full_env` silently falls through to the hub's own `AGENT_NAME` from `os.environ`.

`agent_name()` resolves from config first, so a member's persona/card were already correct — this is **not** the "member answers as the hub" bug. But the raw `AGENT_NAME` env var leaks directly into subsystems that read `os.environ` instead of the resolved identity:

- `observability/metrics.py` — Prometheus metric prefix (e.g. a member logs `prefix=jon_` when it isn't jon)
- `observability/tracing.py` / `graph/middleware/trace_context.py` — trace tags carry the hub's name
- `scheduler/local.py` / `scheduler/__init__.py` — scheduler storage is namespaced by `AGENT_NAME`, so a member's scheduled jobs can land in the **hub's** namespace when they share a storage path (a real collision risk)
- `server/__init__.py` / `server/agent_init.py` / `evals/client.py` — `<AGENT_NAME.upper()>_API_KEY` env lookups resolve to the hub's key var for the member

This is the third of a sibling series fixing the same "member inherits hub identity env" bug class in `supervisor.start()`'s child-env-building code:
- #1881 fixed `A2A_PUBLIC_URL` inheritance (agent-card tenant URL)
- #1882 fixed SOUL/persona loading

## Fix

Mirrors #1881's exact pattern: at spawn, set the child's `AGENT_NAME` to the member's own workspace display name (the same `name` `_stamp_identity` already writes into the member's own `identity.name`), instead of leaving it to inherit from `os.environ`. An explicit per-workspace override (a future `run_exec` env entry) still wins, same override rule as the `A2A_AUTH_TOKEN` and `A2A_PUBLIC_URL` blocks right above it.

## Testing

- `uv run pytest tests/test_fleet_supervisor.py -q` — 41 passed (39 existing + 2 new regression tests: a member gets its own `AGENT_NAME` instead of the hub's; an explicit per-workspace override still wins)
- `uv run pytest tests/test_fleet_proxy_ws.py tests/test_fleet_reap.py tests/test_fleet_routes.py tests/test_ops_fleet.py tests/test_prompts.py tests/test_workspaces.py -q` — 53 passed (other fleet/workspace-adjacent suites, unaffected)
- `uv run ruff check graph/fleet/supervisor.py tests/test_fleet_supervisor.py` — clean

Fixes #1883

🤖 Generated with [Claude Code](https://claude.com/claude-code)