### PR TITLE
fix(knowledge): retrigger the agent when a background ingest job completes

### DIFF
--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -1061,6 +1061,37 @@ def _build_inbox_store(config):
         return None
 
 
+def _on_work_terminal(job) -> None:
+    """Deliver a deterministic ``spawn_work`` job's completion (``knowledge_ingest``,
+    ``delegate_to``) the SAME way the A2A terminal hook delivers a subagent-turn job
+    (``server.a2a._handle_background_terminal``, ADR 0050 Phase 2 / ADR 0070 D1):
+    push-resume the job's ORIGIN session when the D1 guards allow it (not disabled,
+    not canceled, has a real chat origin, not incognito), so the origin agent runs a
+    turn there and briefs the operator; fall back to the Activity-thread idle-wake
+    otherwise. Module-level (not a nested closure) so it's independently testable.
+
+    Before this, a ``spawn_work`` job only ever fired the Activity-thread wake — never
+    a turn in the chat session that actually requested it — so a promise like
+    ``knowledge_ingest``'s "I'll report back when it's ready" never fired (#1840).
+    Lazy import keeps the manager off ``server`` and avoids a server.a2a ↔ agent_init
+    import cycle. Best-effort — never raises into the manager's terminal callback."""
+    try:
+        from server.a2a import (
+            _background_wake_enabled,
+            _should_auto_resume,
+            _spawn_background_resume,
+            _spawn_background_wake,
+        )
+
+        mgr = getattr(STATE, "background_mgr", None)
+        if mgr is not None and _should_auto_resume(job):
+            _spawn_background_resume(mgr, job)
+        elif _background_wake_enabled():
+            _spawn_background_wake(job)
+    except Exception:  # noqa: BLE001 — the wake/resume is best-effort
+        log.exception("[background] work-job terminal hook failed for %s", getattr(job, "id", "?"))
+
+
 def _build_background_manager(config):
     """Background subagent manager (ADR 0050). Fires detached jobs as self-POSTed A2A
     turns, so it derives the invoke URL + auth exactly like ``_build_scheduler`` (so a
@@ -1106,18 +1137,6 @@ def _build_background_manager(config):
         publish = _event_bus.publish
     except Exception:  # noqa: BLE001
         publish = None
-
-    def _on_work_terminal(job) -> None:
-        """Give a deterministic ``spawn_work`` job the SAME idle-wake the A2A terminal
-        hook gives a subagent-turn job (ADR 0050 Phase 2). Lazy import keeps the
-        manager off ``server`` and avoids a server.a2a ↔ agent_init cycle."""
-        try:
-            from server.a2a import _background_wake_enabled, _spawn_background_wake
-
-            if _background_wake_enabled():
-                _spawn_background_wake(job)
-        except Exception:  # noqa: BLE001 — the wake is best-effort
-            log.exception("[background] work-job terminal hook failed for %s", getattr(job, "id", "?"))
 
     try:
         return BackgroundManager(

--- a/tests/test_background_results.py
+++ b/tests/test_background_results.py
@@ -84,6 +84,18 @@ async def _settle_bg_tasks() -> None:
         await asyncio.sleep(0.01)
 
 
+async def _settle_work_job(store: BackgroundStore, job_id: str, tries: int = 400):
+    """Poll a ``spawn_work`` job (mirrors tests/test_background_work.py) until it
+    leaves ``running`` — a work job settles synchronously inside its own task, no
+    self-POST round trip to wait on."""
+    for _ in range(tries):
+        j = store.get(job_id)
+        if j is not None and j.status != "running":
+            return j
+        await asyncio.sleep(0.005)
+    raise AssertionError(f"job {job_id} never settled")
+
+
 def _outcome(job_id: str, state: str = "completed", text: str = "the report"):
     from a2a_impl.executor import TurnOutcome
 
@@ -469,6 +481,117 @@ class TestReportIndexing:
 
         assert trust_tier("background_report") == 2
         assert trust_label("background_report") == "agent"
+
+
+# ── #1840: spawn_work jobs (knowledge_ingest, delegate_to) push-resume too ────
+
+
+class TestWorkJobTerminalResume:
+    """``spawn_work`` (``knowledge_ingest``'s background path, ``delegate_to``) settles
+    through ``BackgroundManager._run_work`` -> its ``on_terminal`` hook
+    (``server.agent_init._on_work_terminal``) -- a DIFFERENT completion path than the
+    A2A terminal hook covered by ``TestTerminalHookResume`` (that one only fires for
+    ``spawn`` subagent-TURN jobs). Before #1840, ``_on_work_terminal`` only ever fired
+    the Activity-thread idle-wake, never the ADR 0070 D1 push-resume into the ORIGIN
+    chat session -- so ``knowledge_ingest``'s "I'll report back when it's ready"
+    promise never produced a follow-up turn. These mirror TestTerminalHookResume's
+    checks for this second completion path."""
+
+    def _wire(self, tmp_path, monkeypatch):
+        import server.a2a as a2a
+        from runtime.state import STATE
+        from server import agent_init
+
+        mgr = BackgroundManager(
+            agent_name="a",
+            invoke_url="http://127.0.0.1:7870",
+            store=_store(tmp_path),
+            on_terminal=agent_init._on_work_terminal,
+        )
+        monkeypatch.setattr(STATE, "background_mgr", mgr, raising=False)
+        resumes: list = []
+        wakes: list = []
+        monkeypatch.setattr(a2a, "_spawn_background_resume", lambda _mgr, job: resumes.append(job.id))
+        monkeypatch.setattr(a2a, "_spawn_background_wake", lambda job: wakes.append(job.id))
+        return mgr, resumes, wakes
+
+    async def test_ingest_completion_pushes_resume_into_origin_session(self, tmp_path, monkeypatch, hook_env):
+        """The #1840 repro: a knowledge_ingest background job finishing must push a
+        retrigger into the ORIGIN chat session, not just the Activity-thread wake."""
+        mgr, resumes, wakes = self._wire(tmp_path, monkeypatch)
+
+        async def work():
+            return "Ingested 'YouTube video' (youtube, 20490 chars) -> 18 chunk(s) in 'general'."
+
+        job_id = await mgr.spawn_work(
+            origin_session="chat-42", kind="ingest", description="Ingest YouTube video", work=work
+        )
+        job = await _settle_work_job(mgr.store, job_id)
+
+        assert job.status == "completed"
+        assert resumes == [job_id]
+        assert wakes == []  # the resume turn IS the reaction -- never both
+
+    async def test_disabled_config_falls_back_to_wake(self, tmp_path, monkeypatch, hook_env):
+        from graph.config import LangGraphConfig
+        from runtime.state import STATE
+
+        mgr, resumes, wakes = self._wire(tmp_path, monkeypatch)
+        monkeypatch.setattr(STATE, "graph_config", LangGraphConfig(background_auto_resume=False), raising=False)
+
+        async def work():
+            return "done"
+
+        job_id = await mgr.spawn_work(origin_session="chat-42", kind="ingest", description="Ingest x", work=work)
+        await _settle_work_job(mgr.store, job_id)
+
+        assert resumes == []
+        assert wakes == [job_id]
+
+    async def test_background_origin_never_resumes(self, tmp_path, monkeypatch, hook_env):
+        """No resume chains: a spawn_work job spawned from a background turn (e.g. a
+        subagent that itself calls knowledge_ingest) must not nudge the worker context."""
+        mgr, resumes, wakes = self._wire(tmp_path, monkeypatch)
+
+        async def work():
+            return "done"
+
+        job_id = await mgr.spawn_work(
+            origin_session="background:bg-parentparent", kind="ingest", description="chained", work=work
+        )
+        await _settle_work_job(mgr.store, job_id)
+
+        assert resumes == []
+        assert wakes == [job_id]
+
+    async def test_incognito_origin_never_resumes(self, tmp_path, monkeypatch, hook_env):
+        mgr, resumes, wakes = self._wire(tmp_path, monkeypatch)
+
+        async def work():
+            return "done"
+
+        job_id = await mgr.spawn_work(
+            origin_session="chat-42", kind="ingest", description="d", work=work, origin_incognito=True
+        )
+        await _settle_work_job(mgr.store, job_id)
+
+        assert resumes == []
+
+    async def test_delegate_to_background_completion_also_resumes(self, tmp_path, monkeypatch, hook_env):
+        """The same ``spawn_work`` completion path backs ``delegate_to``'s background
+        dispatch (plugins/delegates) -- the fix isn't ingest-specific."""
+        mgr, resumes, wakes = self._wire(tmp_path, monkeypatch)
+
+        async def work():
+            return "delegate replied"
+
+        job_id = await mgr.spawn_work(
+            origin_session="chat-7", kind="delegate", description="delegate -> foo: bar", work=work
+        )
+        await _settle_work_job(mgr.store, job_id)
+
+        assert resumes == [job_id]
+        assert wakes == []
 
 
 # ── D2: the drain notification's pointer line ────────────────────────────────


### PR DESCRIPTION
## What

`knowledge_ingest`'s background path (ADR 0050 `spawn_work` — any network fetch or
media transcription) never retriggered the agent in the originating conversation
once the job finished, even though `knowledge_ingest`'s own docstring promises
"you're notified when it finishes indexing" and the agent tells the operator
"I'll report back."

## Why (the broken promise + repro)

Per #1840: ask the agent to ingest a slow source (e.g. a YouTube video) →
`knowledge_ingest` returns a background job id and the agent says it'll report
back → the job completes and indexes successfully (visible in logs, and the
content is searchable via `memory_recall`) → **no follow-up turn ever fires** —
the operator is left hanging.

Root cause: `knowledge_ingest`'s background jobs run through
`BackgroundManager.spawn_work` → `_run_work`, which settles via an `on_terminal`
callback — a **different** completion path than `spawn()`-based subagent-turn
jobs, which settle via the A2A terminal hook
(`server/a2a.py::_handle_background_terminal`). That hook already does the ADR
0070 D1 push-resume (nudges the job's `origin_session` so the agent runs a turn
there and briefs the operator), falling back to the ADR 0050 Phase 2
Activity-thread wake only when the resume doesn't apply. But
`server/agent_init.py::_on_work_terminal` (the `spawn_work` completion hook,
previously a nested closure inside `_build_background_manager`) only ever did
the Activity-thread wake — it never made the push-resume decision at all. So a
`spawn_work` completion could wake the Activity feed but never retrigger the
actual chat session the operator was sitting in.

## Fix (what plumbing was reused)

No new plumbing — the origin session was already carried on every `spawn_work`
job row (`origin_session=_session_id_from(state)`), and the ADR 0070 push-resume
mechanism (`BackgroundManager.resume_origin` / `server.a2a._spawn_background_resume`
+ `_should_auto_resume`) already existed and already worked for `spawn()` jobs.

- Pulled `_on_work_terminal` out of `_build_background_manager`'s closure to a
  module-level function in `server/agent_init.py` (behavior-preserving refactor,
  needed so it's independently testable).
- Gave it the same D1 delivery decision `_handle_background_terminal` makes:
  push-resume the origin session via `_spawn_background_resume` when
  `_should_auto_resume(job)` allows it (feature on, not canceled, has a real chat
  origin, not incognito); fall back to the Activity-thread wake otherwise.

This also fixes the same broken promise for `delegate_to`'s background dispatch
(`plugins/delegates`), which shares the same `spawn_work` completion path.

Scope: only `server/agent_init.py` (the hook) changed — `background/manager.py`
and the reactive-inbox/ADR 0003 machinery are untouched, since the missing piece
was purely in how the `spawn_work` completion hook decided to notify.

## Testing

Added `tests/test_background_results.py::TestWorkJobTerminalResume`, mirroring
the existing `TestTerminalHookResume` checks (which cover the `spawn()` path) for
this second (`spawn_work`) completion path:
- a completed ingest-kind job push-resumes the origin session, not just the wake
- `background.auto_resume: false` restores the Activity wake
- a chained background-origin job never resumes (no resume chains)
- an incognito origin never resumes
- `delegate_to`'s background dispatch gets the same fix (not ingest-specific)

```
uv run pytest tests/test_background_results.py tests/test_background_work.py \
  tests/test_background.py tests/test_knowledge_ingest_tool.py \
  tests/test_delegates_plugin.py -q
# 154 passed

uv run ruff check server/agent_init.py tests/test_background_results.py
# All checks passed!

lint-imports
# Contracts: 3 kept, 0 broken.
```

Fixes #1840