### PR TITLE
fix(config): default filesystem.allow_run OFF on the headless UI tier

### DIFF
--- a/graph/config.py
+++ b/graph/config.py
@@ -141,6 +141,21 @@ def _env_default(name: str, default, cast=str):
         return default
 
 
+def _default_filesystem_allow_run() -> bool:
+    """Tier-aware app-default for ``filesystem.allow_run`` (#1849). ``run_command``
+    is HITL-gated (``run_requires_approval``) — safe when an operator is watching to
+    approve each call, but on a headless/A2A-only instance there's no one to click
+    approve, so the pending ``interrupt()`` checkpoints the turn forever and every
+    later message queues behind it. Default stays ON for an interactive tier
+    (someone's presumably watching); default OFF for the 'none' (headless) UI tier.
+    Reads ``PROTOAGENT_UI`` directly rather than via ``_env_default`` because this is
+    a derived boolean, not a passthrough value — ``server/__init__`` mirrors the
+    FINAL resolved tier there once, whether it came from ``--ui``, ``PROTOAGENT_UI``,
+    or the deprecated ``--headless`` alias. An explicit ``filesystem.allow_run`` in
+    config always wins over this default regardless of tier."""
+    return os.environ.get("PROTOAGENT_UI", "").strip().lower() != "none"
+
+
 def _host_scoped_fields():
     """The host-scoped (ADR 0047 ``scope=="host"``) settings fields — the single
     source for both the host-layer filter and the shadow check, so they can't drift."""
@@ -759,11 +774,15 @@ class LangGraphConfig:
     # under the workspace root (``..``/symlink escapes refused). A capable, safe
     # first run: the agent can actually work with files, but only inside the fence.
     # ``projects`` entries: ``{name, path, write: true|false}`` register extra dirs.
-    # ``allow_run`` adds the dual-use ``run_command`` power tool. ON by default
-    # now that it's gated: run_command (like execute_code) is fenced cwd but
-    # arbitrary argv (not a real sandbox), so each call pauses for HITL approval
-    # (``run_requires_approval``) — the operator sees the command + approves. A
-    # fork can drop the gate inside a hardened container / trusted autonomous run.
+    # ``allow_run`` adds the dual-use ``run_command`` power tool. Gated: run_command
+    # (like execute_code) is fenced cwd but arbitrary argv (not a real sandbox), so
+    # each call pauses for HITL approval (``run_requires_approval``) — the operator
+    # sees the command + approves. This dataclass default (True) is what a directly
+    # constructed config gets; ``from_dict``/``from_yaml`` resolve an UNSET value
+    # through ``_default_filesystem_allow_run()`` instead, which flips to False on a
+    # headless instance — no operator means a pending approval wedges the turn
+    # forever (#1849). Explicit config always wins either way. A fork can also drop
+    # the approval gate itself inside a hardened container / trusted autonomous run.
     filesystem_enabled: bool = True
     filesystem_allow_run: bool = True
     filesystem_run_requires_approval: bool = True
@@ -1059,7 +1078,7 @@ class LangGraphConfig:
             operator_allowed_dirs=list(operator.get("allowed_dirs", []) or []),
             operator_project_dir=str(operator.get("project_dir", "") or ""),
             filesystem_enabled=data.get("filesystem", {}).get("enabled", cls.filesystem_enabled),
-            filesystem_allow_run=data.get("filesystem", {}).get("allow_run", cls.filesystem_allow_run),
+            filesystem_allow_run=data.get("filesystem", {}).get("allow_run", _default_filesystem_allow_run()),
             filesystem_run_requires_approval=data.get("filesystem", {}).get(
                 "run_requires_approval", cls.filesystem_run_requires_approval
             ),

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -377,6 +377,10 @@ def _main():
     if ui == "full":  # the Gradio tier was removed; 'full' is now an alias for console.
         log.warning("--ui full / PROTOAGENT_UI=full is deprecated (the Gradio UI was removed) — using console.")
         ui = "console"
+    # Mirror the FINAL resolved tier into the env: graph/config.py's tier-aware
+    # defaults (e.g. filesystem.allow_run, #1849) read PROTOAGENT_UI directly, and
+    # need this value whether it came from --ui, PROTOAGENT_UI, or --headless.
+    os.environ["PROTOAGENT_UI"] = ui
 
     # `--setup` one-shot: complete setup headlessly and exit.
     if args.setup:

--- a/tests/test_settings_cascade.py
+++ b/tests/test_settings_cascade.py
@@ -557,3 +557,37 @@ def test_d8_manager_port_base_reads_live_config(monkeypatch):
 
     monkeypatch.setattr(rs.STATE, "graph_config", _Cfg(), raising=False)
     assert manager._port_base() == 8200
+
+
+# ── #1849: filesystem.allow_run defaults OFF on the headless UI tier ───────────
+# run_command's HITL approval gate assumes an operator is watching to approve it;
+# on a headless (PROTOAGENT_UI=none) instance there's no one to approve, so a
+# pending interrupt() wedges the turn forever. The UNSET default is now tier-aware
+# (resolved from PROTOAGENT_UI, mirrored there by server/__init__ from --ui); an
+# explicit ``filesystem.allow_run`` in config always wins regardless of tier.
+
+
+def _ui_env_clear(monkeypatch):
+    monkeypatch.delenv("PROTOAGENT_UI", raising=False)
+
+
+def test_allow_run_defaults_true_on_interactive_tier(monkeypatch):
+    _ui_env_clear(monkeypatch)
+    assert LangGraphConfig.from_dict({}).filesystem_allow_run is True
+
+
+def test_allow_run_defaults_false_on_headless_tier(monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_UI", "none")
+    assert LangGraphConfig.from_dict({}).filesystem_allow_run is False
+
+
+def test_allow_run_explicit_true_wins_on_headless_tier(monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_UI", "none")
+    cfg = LangGraphConfig.from_dict({"filesystem": {"allow_run": True}})
+    assert cfg.filesystem_allow_run is True
+
+
+def test_allow_run_explicit_false_wins_on_interactive_tier(monkeypatch):
+    _ui_env_clear(monkeypatch)
+    cfg = LangGraphConfig.from_dict({"filesystem": {"allow_run": False}})
+    assert cfg.filesystem_allow_run is False


### PR DESCRIPTION
## What

`run_command`'s HITL approval gate (`filesystem_run_requires_approval`, `tools/fs_tools.py`) assumes an operator is watching to approve each call — that's a fair assumption for an interactive console/desktop session, and the existing comment in `graph/config.py` says as much. But on a **headless** (`--ui none`) or A2A-only instance, there's no one to click approve: the pending `interrupt()` checkpoints the turn forever, and every later message queues behind it. Concrete incident: a Portfolio Manager bundle (A2A-only, no console) deadlocked on its first `run_command` call for exactly this reason.

## Why not just flip the global default

The issue as filed asks to flip `filesystem_allow_run`'s default straight to `False`. I looked at implementing that (Option A in the triage) and pushed back on it: it would silently take `run_command` away from **every existing interactive install too** — the exact population the current code comment says it's already safe for (HITL-approved, operator watching). That's a real regression, not just a footgun fix.

## Fix (Option B from the triage)

Make the **unset** default tier-aware instead of touching the static default:

- `graph/config.py`: new `_default_filesystem_allow_run()` resolves `False` when `PROTOAGENT_UI` is `"none"` (headless), `True` otherwise. Used as the `from_dict`/`from_yaml` fallback for an unset `filesystem.allow_run` — an **explicit** value in config always wins over this, regardless of tier.
- `server/__init__.py`: mirrors the *final* resolved `ui` tier into `os.environ["PROTOAGENT_UI"]` right after resolution, so this reflects the real tier whether it came from `--ui`, the `PROTOAGENT_UI` env var, or the deprecated `--headless` alias.
- This also protects fleet members for free: `graph/fleet/supervisor.py` already spawns members with `--ui none`, so a member now gets the safe default without any change to the supervisor. Same for eval-sweep runs (`evals/sweep.py` already sets `PROTOAGENT_UI=none`).

## Testing

- Added 4 tests to `tests/test_settings_cascade.py` (`test_allow_run_defaults_true_on_interactive_tier`, `_defaults_false_on_headless_tier`, `_explicit_true_wins_on_headless_tier`, `_explicit_false_wins_on_interactive_tier`).
- `uv run pytest tests/test_settings_cascade.py tests/test_config_roundtrip.py tests/test_fs_tools.py tests/test_tools_disabled.py -q` → 93 passed. The golden `FROM_YAML_EXAMPLE_FIELDS["filesystem_allow_run"] = True` in `test_config_roundtrip.py` is unaffected (that test never sets `PROTOAGENT_UI=none`, same convention as the other env-fallback fields it already covers, e.g. `bind_host`).
- `uv run ruff check` on changed files → clean.

Fixes #1849

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default behavior for file system run access to better match the selected UI tier, including headless setups.
  * Ensured the app consistently applies the final UI mode during startup, so related settings resolve correctly.
  * Explicitly configured file system run settings now take precedence over the default in all supported modes.

* **Tests**
  * Added coverage for the new tier-aware default behavior and override handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->