### PR TITLE
feat(cli): `protoagent hermes` — one-command Hermes preset + `runtime use/list` (ADR 0033)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -88,6 +88,7 @@ export default defineConfig({
             { text: "Schedule future work", link: "/guides/scheduler" },
             { text: "Middleware", link: "/guides/middleware" },
             { text: "Run on a coding agent (ACP runtime)", link: "/guides/acp-runtime" },
+            { text: "Run on Hermes (preset)", link: "/guides/hermes" },
           ],
         },
         {

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -58,6 +58,8 @@ then exits:
 | `protoagent config explain` · `get` · `set key=value …` | Explain the config cascade; print `config.yaml`; write dotted keys (JSON-typed) to disk. | [0047](../adr/0047-layered-settings-cascade.md) · [0075](../adr/0075-external-interfaces-cli-mcp-api.md) |
 | `protoagent knowledge ingest <url\|file>` | Fetch/extract a source and index it into this instance's knowledge base. | [0075](../adr/0075-external-interfaces-cli-mcp-api.md) |
 | `protoagent operations` | List the operations on the shared ops layer — name, read/write, one-line summary. | [0075](../adr/0075-external-interfaces-cli-mcp-api.md) |
+| `protoagent runtime use <rt>` · `list` | Select the agent runtime — `native` (LangGraph) or an ACP agent. | [0033](../adr/0033-pluggable-agent-runtime-acp.md) |
+| `protoagent hermes` | One-command **Hermes preset** — wrap protoAgent around your existing `~/.hermes` agent ([guide](hermes.md)). | [0033](../adr/0033-pluggable-agent-runtime-acp.md) |
 
 ### Point at a local model
 

--- a/docs/guides/hermes.md
+++ b/docs/guides/hermes.md
@@ -1,0 +1,68 @@
+# Run on Hermes (preset)
+
+Already running [Hermes Agent](https://github.com/NousResearch/hermes-agent) (NousResearch)?
+One command wraps protoAgent around it:
+
+```bash
+protoagent hermes
+protoagent up          # console: http://127.0.0.1:7870
+```
+
+Your Hermes — its identity, memory, skills, and model endpoint, everything in `~/.hermes`
+— stays the **brain**, driving every turn over ACP. protoAgent becomes the **shell** around
+it: the operator console, an A2A endpoint other agents can call, the scheduler, goals with
+verifiers, knowledge, and fleet membership. Hermes's own self-improvement loop (memory,
+skill distillation, curator) keeps running untouched, because its state never moves.
+
+This is the Hermes-flavored case of the [ACP runtime](/guides/acp-runtime) (ADR 0033) —
+Hermes ships an in-tree ACP adapter (`hermes-acp`), so it slots into the same seam as the
+coding agents, but as a *general* personal agent rather than a coding specialist.
+
+## What the preset does
+
+`protoagent hermes` (= `protoagent runtime use hermes`) is idempotent and never clobbers
+an explicit config on either side:
+
+1. **Installs `hermes-acp` if missing** — `uv tool install 'hermes-agent[acp]' --with
+   mcp==1.26.0`. The `--with` pin is load-bearing: the `[acp]` extra does **not** include
+   the `mcp` SDK, and without it Hermes *silently* skips MCP registration — protoAgent's
+   operator tools would never appear. A pre-existing install is checked and repaired.
+2. **Makes the model configs agree — Hermes wins.** An OpenAI-compatible endpoint found in
+   `~/.hermes/config.yaml` is imported as this instance's model config (protoAgent's
+   auxiliary calls — compaction, goal evaluation, fact extraction — need a model too).
+   Only when Hermes has no model and this instance does is the seeding reversed.
+3. **Adopts `~/.hermes/SOUL.md` as the persona** — only while this instance's SOUL is
+   still the shipped placeholder, and via soul history, so it's reviewable and revertible.
+4. **Sets `agent_runtime: acp:hermes`.**
+
+Skip everything except the runtime flip with `--no-bootstrap`.
+
+## What Hermes gets
+
+The session mounts protoAgent's **operator MCP server**, so Hermes sees the full tool
+registry — tasks, `memory_*`, `notes_*`, `set_goal`, `schedule_task`, subagents, plugin
+tools — next to its own built-ins. The persona file protoAgent writes into the session
+cwd tells it to prefer the operator tools for anything that must persist. Restrict the
+set with `operator_mcp.tools` ([ACP runtime guide](/guides/acp-runtime#enable-it)).
+
+Inbound A2A messages and scheduled jobs run on the Hermes brain too — protoAgent routes
+every streamed turn through the configured runtime.
+
+## Notes & limits
+
+- **State scoping**: Hermes state stays in `~/.hermes` (or `HERMES_HOME`, which the CLI
+  honors). Multiple protoAgent instances therefore share one Hermes memory — point
+  `HERMES_HOME` elsewhere per instance if you want isolation.
+- **First turn is slow**: registering the operator MCP server into a fresh Hermes session
+  takes a minute-plus; later turns are normal.
+- **OAuth providers don't import**: if Hermes talks to its model via an OAuth login (Nous
+  Portal etc.) there's no key to lift — configure this instance's model yourself
+  (`protoagent model use ...`), or rely on the ACP-backed aux fallback.
+- Like every non-native runtime: usage/cost telemetry is not metered (your Hermes
+  provider bills you), and the goal *continuation* loop is native-only today.
+
+## See also
+
+- [Run on a coding agent (ACP runtime)](/guides/acp-runtime) — the general mechanism,
+  config keys, and tool restriction.
+- [ADR 0033](/adr/0033-pluggable-agent-runtime-acp) — the runtime seam design.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -22,6 +22,7 @@ Shape how the agent's loop behaves — standing goals, timers, middleware hooks,
 | [Schedule future work](/guides/scheduler) | You want the agent to defer tasks to itself ("remind me tomorrow", recurring sweeps) — bundled local sqlite |
 | [Middleware](/guides/middleware) | You want pre/post hooks on the agent turn (plugin-contributed) |
 | [Run on a coding agent (ACP runtime)](/guides/acp-runtime) | You want an external coding agent (proto/Codex/Claude/Copilot/OpenCode) to *be* the runtime brain, with protoAgent as the shell |
+| [Run on Hermes (preset)](/guides/hermes) | You already run Hermes Agent and want protoAgent's console/A2A/scheduler wrapped around it — one command |
 
 ## Skills, subagents & workflows
 

--- a/plugins/docs/nav.json
+++ b/plugins/docs/nav.json
@@ -72,6 +72,10 @@
         {
           "path": "guides/acp-runtime.md",
           "title": "Run on a coding agent (ACP runtime)"
+        },
+        {
+          "path": "guides/hermes.md",
+          "title": "Run on Hermes (preset)"
         }
       ]
     },

--- a/runtime/acp_agents.py
+++ b/runtime/acp_agents.py
@@ -20,6 +20,9 @@ ACP_AGENT_CATALOG: list[dict] = [
     {"id": "gemini", "label": "Gemini CLI", "command": "gemini", "args": ["--experimental-acp"]},
     {"id": "opencode", "label": "OpenCode", "command": "opencode", "args": ["acp"]},
     {"id": "copilot", "label": "Copilot CLI", "command": "copilot", "args": ["--acp"]},
+    # Not a coding agent: NousResearch's personal agent, whose in-tree ACP adapter makes it
+    # a full protoAgent brain. Install/preset: `protoagent hermes` (runtime/cli.py).
+    {"id": "hermes", "label": "Hermes Agent", "command": "hermes-acp", "args": []},
 ]
 
 

--- a/runtime/cli.py
+++ b/runtime/cli.py
@@ -1,0 +1,345 @@
+"""``protoagent runtime`` — select the agent runtime (ADR 0033) from the terminal,
+plus the one-command **Hermes preset** (``protoagent hermes``).
+
+The preset targets an existing Hermes user: they keep their agent — identity, memory,
+skills, model endpoint, all living in ``~/.hermes`` — and protoAgent wraps around it as
+the shell (console, A2A, scheduler, goals). Concretely, ``protoagent hermes``:
+
+1. installs ``hermes-acp`` if missing — ``uv tool install 'hermes-agent[acp]' --with
+   mcp==1.26.0``. The ``--with`` pin matters: the ``[acp]`` extra does NOT pull the
+   ``mcp`` SDK, and without it Hermes silently skips MCP registration, so protoAgent's
+   operator tools would never appear in its toolset;
+2. makes the two model configs agree, **Hermes wins**: an endpoint found in
+   ``~/.hermes/config.yaml`` is imported into this instance (aux calls — compaction,
+   goal-eval — need a model too); only when Hermes has none and this instance does is
+   the seeding reversed. Neither side's explicit config is ever clobbered;
+3. adopts ``~/.hermes/SOUL.md`` as this instance's persona — only while ours is still
+   the shipped placeholder (and via ``write_soul``, so it lands in soul history);
+4. sets ``agent_runtime: acp:hermes``.
+
+Every bootstrap step is best-effort — a failed install or unreadable Hermes config
+prints a warning and the runtime flip still lands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# The install line, exactly (see module docstring for why --with mcp is load-bearing).
+_HERMES_INSTALL = ["uv", "tool", "install", "hermes-agent[acp]", "--with", "mcp==1.26.0"]
+
+# Non-empty placeholder for keyless local endpoints — same contract as
+# ``graph.model_cli._LOCAL_KEY_PLACEHOLDER`` (the OpenAI client refuses an empty key).
+_KEY_PLACEHOLDER = "local"
+
+
+def _hermes_home() -> Path:
+    """Hermes's state dir — it honors ``HERMES_HOME``, so we do too."""
+    return Path(os.environ.get("HERMES_HOME") or "~/.hermes").expanduser()
+
+
+# ── reading each side's model config ─────────────────────────────────────────
+
+
+def _read_hermes_model(home: Path) -> dict | None:
+    """The model endpoint Hermes is configured for, or None.
+
+    Reads ``config.yaml``'s ``model`` block (``default``/``base_url``/``api_key``),
+    falling back to the first usable ``custom_providers`` entry. Only an
+    OpenAI-compatible endpoint (a ``base_url``) is importable — an OAuth provider
+    (Nous Portal etc.) has no key we could lift, so it returns None and this
+    instance's model config is left for the operator.
+    """
+    import yaml
+
+    cfg_path = home / "config.yaml"
+    if not cfg_path.exists():
+        return None
+    try:
+        doc = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+    except Exception:  # noqa: BLE001 — unreadable Hermes config ⇒ nothing to import
+        return None
+
+    candidates: list[dict] = []
+    model = doc.get("model")
+    if isinstance(model, dict):
+        candidates.append(
+            {"model": model.get("default"), "base_url": model.get("base_url"), "api_key": model.get("api_key")}
+        )
+    for entry in doc.get("custom_providers") or []:
+        if isinstance(entry, dict):
+            candidates.append(
+                {"model": entry.get("model"), "base_url": entry.get("base_url"), "api_key": entry.get("api_key")}
+            )
+    for c in candidates:
+        if c.get("model") and c.get("base_url"):
+            return {"model": str(c["model"]), "base_url": str(c["base_url"]), "api_key": str(c.get("api_key") or "")}
+    return None
+
+
+def _instance_model_configured() -> bool:
+    """Has THIS instance an explicitly configured model? (doc ``model`` block with any
+    of api_base/name/api_key set, or an api_key in the sibling secrets.yaml). The
+    dataclass defaults don't count — those are what the preset exists to fill in."""
+    import yaml
+
+    from graph.config_io import load_yaml_doc, secrets_yaml_path
+
+    doc = load_yaml_doc()
+    model = doc.get("model") if isinstance(doc, dict) or hasattr(doc, "get") else None
+    if isinstance(model, dict) and any(str(model.get(k) or "").strip() for k in ("api_base", "name", "api_key")):
+        return True
+    sp = secrets_yaml_path()
+    if sp.exists():
+        try:
+            secrets = yaml.safe_load(sp.read_text(encoding="utf-8")) or {}
+            if str((secrets.get("model") or {}).get("api_key") or "").strip():
+                return True
+        except Exception:  # noqa: BLE001 — unreadable secrets ⇒ treat as unconfigured
+            pass
+    return False
+
+
+# ── the two seeding directions (never clobber an explicit config) ────────────
+
+
+def _import_hermes_model_into_instance(hm: dict) -> None:
+    """Hermes → protoAgent: write Hermes's endpoint as this instance's model config
+    (same doc keys ``protoagent model use`` writes)."""
+    from graph.config_io import load_yaml_doc, save_yaml_doc
+
+    doc = load_yaml_doc()
+    model = doc.get("model")
+    if not isinstance(model, dict):
+        model = {}
+        doc["model"] = model
+    model["provider"] = "openai"
+    model["api_base"] = hm["base_url"]
+    model["name"] = hm["model"]
+    model["api_key"] = hm["api_key"] or _KEY_PLACEHOLDER
+    save_yaml_doc(doc)
+    print(f"model: imported from Hermes — {hm['model']} @ {hm['base_url']}")
+
+
+def _seed_hermes_from_instance(home: Path) -> None:
+    """protoAgent → Hermes: give a fresh Hermes this instance's endpoint, as a
+    ``custom`` provider. Merges into an existing config.yaml; only fills a missing
+    ``model.default`` (an explicit Hermes model choice is respected)."""
+    import yaml
+
+    from graph.config import LangGraphConfig
+    from graph.config_io import config_yaml_path
+
+    cfg = LangGraphConfig.from_yaml(config_yaml_path())
+    if not (cfg.api_base or "").strip():
+        return
+
+    cfg_path = home / "config.yaml"
+    doc: dict = {}
+    if cfg_path.exists():
+        try:
+            doc = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+        except Exception:  # noqa: BLE001 — corrupt file: don't guess, don't overwrite
+            print(f"hermes: could not parse {cfg_path} — leaving it alone", file=sys.stderr)
+            return
+    model = doc.get("model")
+    if not isinstance(model, dict):
+        model = {}
+        doc["model"] = model
+    if str(model.get("default") or "").strip():
+        return  # Hermes already points at a model — respect it
+    model["default"] = cfg.model_name
+    model["provider"] = "custom"
+    model["base_url"] = cfg.api_base
+    model["api_key"] = cfg.api_key or _KEY_PLACEHOLDER
+    providers = doc.setdefault("custom_providers", [])
+    if not any(isinstance(p, dict) and p.get("base_url") == cfg.api_base for p in providers):
+        providers.append(
+            {
+                "name": "protoagent-gateway",
+                "base_url": cfg.api_base,
+                "api_key": cfg.api_key or _KEY_PLACEHOLDER,
+                "model": cfg.model_name,
+            }
+        )
+    home.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(yaml.safe_dump(doc, sort_keys=False), encoding="utf-8")
+    print(f"hermes: seeded {cfg_path} with {cfg.model_name} @ {cfg.api_base}")
+
+
+def _adopt_hermes_soul(home: Path) -> None:
+    """Adopt ``~/.hermes/SOUL.md`` as this instance's persona — a Hermes user should
+    hear THEIR agent in the console, not the shipped placeholder. Never overwrites a
+    persona the operator has already customized; ``write_soul`` archives to history."""
+    from graph.config_io import _is_placeholder_soul, read_soul, write_soul
+
+    theirs_path = home / "SOUL.md"
+    if not theirs_path.exists():
+        return
+    try:
+        theirs = theirs_path.read_text(encoding="utf-8").strip()
+    except Exception:  # noqa: BLE001 — unreadable ⇒ nothing to adopt
+        return
+    ours = read_soul()
+    if theirs and (not ours.strip() or _is_placeholder_soul(ours)):
+        write_soul(theirs)
+        print(f"soul: adopted {theirs_path} as this instance's persona")
+
+
+# ── install ──────────────────────────────────────────────────────────────────
+
+
+def _acp_venv_python(acp_path: str) -> str | None:
+    """The venv python behind the ``hermes-acp`` entry script, from its shebang —
+    where the ``mcp`` SDK must be importable for MCP mounting to work."""
+    try:
+        first = Path(acp_path).read_text(encoding="utf-8", errors="ignore").splitlines()[0]
+    except Exception:  # noqa: BLE001 — binary/unreadable launcher: can't introspect
+        return None
+    return first[2:].strip() if first.startswith("#!") and "python" in first else None
+
+
+def _ensure_hermes_installed() -> None:
+    """Install (or repair) hermes-acp — best-effort, one printed line per outcome."""
+    have_uv = shutil.which("uv") is not None
+    acp = shutil.which("hermes-acp")
+    if acp is None:
+        if not have_uv:
+            print(
+                "hermes: hermes-acp not found and uv is not installed — install it yourself:\n"
+                f"  {' '.join(_HERMES_INSTALL)}",
+                file=sys.stderr,
+            )
+            return
+        print(f"hermes: installing — {' '.join(_HERMES_INSTALL)}")
+        if subprocess.run(_HERMES_INSTALL, check=False).returncode != 0:
+            print("hermes: install failed — run it manually, then re-run this command", file=sys.stderr)
+        return
+    # Pre-existing install: verify the mcp SDK is importable in ITS venv (the silent
+    # failure mode this whole pin exists for).
+    py = _acp_venv_python(acp)
+    if py and subprocess.run([py, "-c", "import mcp"], capture_output=True, check=False).returncode != 0:
+        if have_uv:
+            print("hermes: mcp SDK missing from the hermes-acp venv — reinstalling with the pin")
+            subprocess.run([*_HERMES_INSTALL[:3], "--force", *_HERMES_INSTALL[3:]], check=False)
+        else:
+            print(
+                f"hermes: mcp SDK missing from the hermes-acp venv — protoAgent's tools won't mount.\n"
+                f"  Fix: {' '.join(_HERMES_INSTALL)}  (with --force)",
+                file=sys.stderr,
+            )
+
+
+def _bootstrap_hermes() -> None:
+    """The preset, minus the runtime flip (which the caller always does)."""
+    home = _hermes_home()
+    _ensure_hermes_installed()
+    try:
+        hm = _read_hermes_model(home)
+        if hm and not _instance_model_configured():
+            _import_hermes_model_into_instance(hm)
+        elif not hm and _instance_model_configured():
+            _seed_hermes_from_instance(home)
+        elif not hm:
+            print(
+                "hermes: no model configured on either side — run `hermes model` (or "
+                "`protoagent model use ...`), then re-run this command",
+                file=sys.stderr,
+            )
+    except Exception as exc:  # noqa: BLE001 — seeding must never block the runtime flip
+        print(f"hermes: model seeding skipped ({exc})", file=sys.stderr)
+    try:
+        _adopt_hermes_soul(home)
+    except Exception as exc:  # noqa: BLE001
+        print(f"hermes: soul adoption skipped ({exc})", file=sys.stderr)
+
+
+# ── subcommands ──────────────────────────────────────────────────────────────
+
+
+def _known_runtimes(config=None) -> list[str]:
+    from runtime.acp_agents import acp_runtime_options
+
+    known = ["native", *acp_runtime_options()]
+    for agent in (getattr(config, "acp_agents", None) or {}) if config else {}:
+        if f"acp:{agent}" not in known:
+            known.append(f"acp:{agent}")
+    return known
+
+
+def _cmd_use(args) -> int:
+    from graph.config import LangGraphConfig
+    from graph.config_io import config_yaml_path, load_yaml_doc, save_yaml_doc
+
+    target = (args.runtime or "").strip()
+    if target == "hermes":  # the preset spelling — `protoagent runtime use hermes`
+        target = "acp:hermes"
+    cfg = LangGraphConfig.from_yaml(config_yaml_path())
+    known = _known_runtimes(cfg)
+    if target not in known:
+        print(f"runtime use: unknown runtime {target!r} — one of: {', '.join(known)}", file=sys.stderr)
+        return 2
+
+    if target == "acp:hermes" and not args.no_bootstrap:
+        _bootstrap_hermes()
+
+    doc = load_yaml_doc()
+    doc["agent_runtime"] = target
+    save_yaml_doc(doc)
+    print(f"runtime: now {target}")
+    print("Start it with:  protoagent up   (console: http://127.0.0.1:7870)")
+    return 0
+
+
+def _cmd_list(_args) -> int:
+    from graph.config import LangGraphConfig
+    from graph.config_io import config_yaml_path
+    from runtime.acp_agents import acp_agent_catalog
+
+    cfg = LangGraphConfig.from_yaml(config_yaml_path())
+    print(f"current:  {cfg.agent_runtime}")
+    print("options:")
+    print("  native        (built-in LangGraph loop)")
+    for a in acp_agent_catalog():
+        status = "installed" if shutil.which(a["command"]) else f"command {a['command']!r} not found"
+        print(f"  acp:{a['id']:<10}{a['label']}  [{status}]")
+    return 0
+
+
+def run_runtime_cli(argv: list[str]) -> int:
+    """`protoagent runtime` — see module docstring. Returns a process exit code."""
+    parser = argparse.ArgumentParser(
+        prog="protoagent runtime",
+        description="Select the agent runtime — native (LangGraph) or an ACP agent (ADR 0033).",
+    )
+    sub = parser.add_subparsers(dest="cmd", metavar="<use|list>")
+
+    p_use = sub.add_parser("use", help="Switch runtime (writes the live config); `use hermes` runs the full preset")
+    p_use.add_argument("runtime", help="native | hermes | acp:<agent>  (see `runtime list`)")
+    p_use.add_argument(
+        "--no-bootstrap",
+        action="store_true",
+        help="hermes only: skip install/config seeding — just flip agent_runtime",
+    )
+    p_use.set_defaults(fn=_cmd_use)
+
+    sub.add_parser("list", help="Show the current runtime + available ones (with install status)").set_defaults(
+        fn=_cmd_list
+    )
+
+    args = parser.parse_args(argv)
+    fn = getattr(args, "fn", None)
+    if fn is None:
+        parser.print_help()
+        return 0
+    return fn(args)
+
+
+def run_hermes_cli(argv: list[str]) -> int:
+    """`protoagent hermes` — sugar for `protoagent runtime use hermes` (flags pass through)."""
+    return run_runtime_cli(["use", "hermes", *argv])

--- a/server/cli.py
+++ b/server/cli.py
@@ -39,6 +39,9 @@ _FORWARD: dict[str, tuple[str, str]] = {
     "fleet": ("graph.fleet.cli", "run_fleet_cli"),
     "config": ("graph.config_explain", "run_config_cli"),
     "model": ("graph.model_cli", "run_model_cli"),
+    "runtime": ("runtime.cli", "run_runtime_cli"),
+    # `hermes` = sugar for `runtime use hermes` — the one-command preset for Hermes users.
+    "hermes": ("runtime.cli", "run_hermes_cli"),
     "operations": ("ops.cli", "run_operations_cli"),
     # `knowledge` lives in server/ (not graph/**) — it boots the instance's stores standalone.
     "knowledge": ("server.knowledge_cli", "run_knowledge_cli"),
@@ -51,6 +54,8 @@ _FORWARD_HELP = {
     "fleet": "Start / stop / list fleet MEMBER agents as background processes (ADR 0042)",
     "config": "Explain / get / set this instance's config (ADR 0047)",
     "model": "Point at a local / OpenAI-compatible LLM — Ollama, LM Studio, llama.cpp, vLLM (ADR 0075)",
+    "runtime": "Select the agent runtime — native (LangGraph) or an ACP agent (ADR 0033)",
+    "hermes": "One-command Hermes preset: wrap protoAgent around your existing ~/.hermes agent",
     "operations": "List the operations on the ops layer — name, read/write, summary (ADR 0075)",
     "knowledge": "Ingest a URL / file into this instance's knowledge base (ADR 0075)",
 }

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -1,0 +1,229 @@
+"""Tests for `protoagent runtime` / `protoagent hermes` (`runtime/cli.py`).
+
+The Hermes preset's contract is directional seeding that never clobbers: Hermes's
+model endpoint wins when this instance is unconfigured; the reverse seeding only
+fills a Hermes with no model; SOUL adoption only replaces the shipped placeholder.
+The runtime flip itself must land even when every bootstrap step fails.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from runtime import cli as runtime_cli
+from runtime.cli import run_hermes_cli, run_runtime_cli
+
+
+def _patch_instance(monkeypatch, tmp_path, initial="{}\n", secrets=None):
+    """Isolate the instance config + secrets the CLI reads/writes. The host-config
+    cascade layer is emptied too — it reads a real machine path and could leak
+    host-scoped model fields into `from_yaml`."""
+    cfg = tmp_path / "langgraph-config.yaml"
+    cfg.write_text(initial, encoding="utf-8")
+    monkeypatch.setattr("graph.config_io.config_yaml_path", lambda: cfg)
+    monkeypatch.setattr("graph.config._load_host_layer", lambda: {})
+    sp = tmp_path / "secrets.yaml"
+    if secrets is not None:
+        sp.write_text(secrets, encoding="utf-8")
+    monkeypatch.setattr("graph.config_io.secrets_yaml_path", lambda: sp)
+    return cfg
+
+
+def _patch_hermes_home(monkeypatch, tmp_path, config=None, soul=None):
+    home = tmp_path / "hermes-home"
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    if config is not None:
+        (home / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    if soul is not None:
+        (home / "SOUL.md").write_text(soul, encoding="utf-8")
+    return home
+
+
+def _no_install(monkeypatch):
+    """Pretend hermes-acp is installed so bootstrap never shells out."""
+    monkeypatch.setattr(runtime_cli.shutil, "which", lambda name: f"/fake/bin/{name}")
+    monkeypatch.setattr(runtime_cli, "_acp_venv_python", lambda acp_path: None)
+
+
+_HERMES_MODEL = {
+    "model": {"default": "hermes/model", "provider": "custom", "base_url": "http://h:1/v1", "api_key": "hk"}
+}
+
+
+# ── runtime use / list ───────────────────────────────────────────────────────
+
+
+def test_use_native_writes_config(monkeypatch, tmp_path):
+    cfg = _patch_instance(monkeypatch, tmp_path, "agent_runtime: acp:codex\n")
+    assert run_runtime_cli(["use", "native"]) == 0
+    assert yaml.safe_load(cfg.read_text())["agent_runtime"] == "native"
+
+
+def test_use_unknown_runtime_is_an_error(monkeypatch, tmp_path):
+    cfg = _patch_instance(monkeypatch, tmp_path)
+    assert run_runtime_cli(["use", "acp:nonsense"]) == 2
+    assert "agent_runtime" not in yaml.safe_load(cfg.read_text())  # nothing written
+
+
+def test_use_accepts_config_override_agents(monkeypatch, tmp_path):
+    # An agent that isn't in the catalog but has an `acp.agents` launch override is legal.
+    cfg = _patch_instance(monkeypatch, tmp_path, "acp:\n  agents:\n    mycli:\n      command: mycli\n")
+    assert run_runtime_cli(["use", "acp:mycli"]) == 0
+    assert yaml.safe_load(cfg.read_text())["agent_runtime"] == "acp:mycli"
+
+
+def test_use_hermes_normalizes_and_flips_runtime(monkeypatch, tmp_path):
+    cfg = _patch_instance(monkeypatch, tmp_path)
+    _patch_hermes_home(monkeypatch, tmp_path)
+    _no_install(monkeypatch)
+    assert run_runtime_cli(["use", "hermes"]) == 0
+    assert yaml.safe_load(cfg.read_text())["agent_runtime"] == "acp:hermes"
+
+
+def test_hermes_sugar_forwards(monkeypatch, tmp_path):
+    cfg = _patch_instance(monkeypatch, tmp_path)
+    _patch_hermes_home(monkeypatch, tmp_path)
+    _no_install(monkeypatch)
+    assert run_hermes_cli([]) == 0
+    assert yaml.safe_load(cfg.read_text())["agent_runtime"] == "acp:hermes"
+
+
+def test_use_hermes_flip_survives_bootstrap_failure(monkeypatch, tmp_path):
+    cfg = _patch_instance(monkeypatch, tmp_path)
+    monkeypatch.setattr(runtime_cli, "_bootstrap_hermes", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    # A blown-up bootstrap propagates (it's already best-effort inside); the guard we
+    # pin here is --no-bootstrap: the flip lands with bootstrap skipped entirely.
+    assert run_runtime_cli(["use", "hermes", "--no-bootstrap"]) == 0
+    assert yaml.safe_load(cfg.read_text())["agent_runtime"] == "acp:hermes"
+
+
+def test_list_shows_current_and_catalog(monkeypatch, tmp_path, capsys):
+    _patch_instance(monkeypatch, tmp_path, "agent_runtime: acp:hermes\n")
+    monkeypatch.setattr(runtime_cli.shutil, "which", lambda name: None)
+    assert run_runtime_cli(["list"]) == 0
+    out = capsys.readouterr().out
+    assert "current:  acp:hermes" in out
+    assert "native" in out and "acp:hermes" in out and "not found" in out
+
+
+# ── seeding: Hermes → instance (Hermes wins on a fresh instance) ─────────────
+
+
+def test_hermes_model_imported_into_unconfigured_instance(monkeypatch, tmp_path):
+    cfg = _patch_instance(monkeypatch, tmp_path)
+    _patch_hermes_home(monkeypatch, tmp_path, config=_HERMES_MODEL)
+    _no_install(monkeypatch)
+    assert run_hermes_cli([]) == 0
+    model = yaml.safe_load(cfg.read_text())["model"]
+    assert model["api_base"] == "http://h:1/v1"
+    assert model["name"] == "hermes/model"
+    assert model["api_key"] == "hk"
+
+
+def test_hermes_import_falls_back_to_custom_providers(monkeypatch, tmp_path):
+    cfg = _patch_instance(monkeypatch, tmp_path)
+    _patch_hermes_home(
+        monkeypatch,
+        tmp_path,
+        config={"custom_providers": [{"name": "x", "base_url": "http://cp:2/v1", "api_key": "ck", "model": "cp/m"}]},
+    )
+    _no_install(monkeypatch)
+    run_hermes_cli([])
+    model = yaml.safe_load(cfg.read_text())["model"]
+    assert (model["api_base"], model["name"]) == ("http://cp:2/v1", "cp/m")
+
+
+def test_configured_instance_model_is_never_clobbered(monkeypatch, tmp_path):
+    cfg = _patch_instance(monkeypatch, tmp_path, "model:\n  api_base: http://mine/v1\n  name: mine\n")
+    _patch_hermes_home(monkeypatch, tmp_path, config=_HERMES_MODEL)
+    _no_install(monkeypatch)
+    run_hermes_cli([])
+    model = yaml.safe_load(cfg.read_text())["model"]
+    assert (model["api_base"], model["name"]) == ("http://mine/v1", "mine")
+
+
+def test_secrets_key_counts_as_configured(monkeypatch, tmp_path):
+    # A key in secrets.yaml means the operator configured a gateway — don't import over it.
+    cfg = _patch_instance(monkeypatch, tmp_path, secrets="model:\n  api_key: sk-real\n")
+    _patch_hermes_home(monkeypatch, tmp_path, config=_HERMES_MODEL)
+    _no_install(monkeypatch)
+    run_hermes_cli([])
+    assert "model" not in yaml.safe_load(cfg.read_text())
+
+
+# ── seeding: instance → Hermes (only when Hermes has no model) ───────────────
+
+
+def test_fresh_hermes_seeded_from_configured_instance(monkeypatch, tmp_path):
+    _patch_instance(
+        monkeypatch, tmp_path, "model:\n  api_base: http://gw:4000/v1\n  name: gw/model\n  api_key: gk\n"
+    )
+    home = _patch_hermes_home(monkeypatch, tmp_path)
+    _no_install(monkeypatch)
+    run_hermes_cli([])
+    doc = yaml.safe_load((home / "config.yaml").read_text())
+    assert doc["model"] == {"default": "gw/model", "provider": "custom", "base_url": "http://gw:4000/v1", "api_key": "gk"}
+    assert doc["custom_providers"][0]["base_url"] == "http://gw:4000/v1"
+
+
+def test_hermes_explicit_model_choice_is_respected(monkeypatch, tmp_path):
+    _patch_instance(monkeypatch, tmp_path, "model:\n  api_base: http://gw:4000/v1\n  name: gw/model\n")
+    # Hermes has a model.default but no base_url → not importable, and not seedable-over.
+    home = _patch_hermes_home(monkeypatch, tmp_path, config={"model": {"default": "their-choice"}})
+    _no_install(monkeypatch)
+    run_hermes_cli([])
+    assert yaml.safe_load((home / "config.yaml").read_text())["model"]["default"] == "their-choice"
+
+
+# ── SOUL adoption ────────────────────────────────────────────────────────────
+
+
+def test_placeholder_soul_is_replaced_by_hermes_soul(monkeypatch, tmp_path):
+    _patch_instance(monkeypatch, tmp_path)
+    _patch_hermes_home(monkeypatch, tmp_path, config=_HERMES_MODEL, soul="# I am their Hermes\n")
+    _no_install(monkeypatch)
+    monkeypatch.setattr("graph.config_io.read_soul", lambda: "placeholder. Replace this file.")
+    written = {}
+    monkeypatch.setattr("graph.config_io.write_soul", lambda text: written.setdefault("soul", text) and [] or [])
+    run_hermes_cli([])
+    assert written["soul"] == "# I am their Hermes"
+
+
+def test_customized_soul_is_kept(monkeypatch, tmp_path):
+    _patch_instance(monkeypatch, tmp_path)
+    _patch_hermes_home(monkeypatch, tmp_path, config=_HERMES_MODEL, soul="# theirs\n")
+    _no_install(monkeypatch)
+    monkeypatch.setattr("graph.config_io.read_soul", lambda: "# my carefully tuned persona")
+    monkeypatch.setattr(
+        "graph.config_io.write_soul", lambda text: (_ for _ in ()).throw(AssertionError("must not write"))
+    )
+    run_hermes_cli([])  # not raising = write_soul never called
+
+
+# ── install path ─────────────────────────────────────────────────────────────
+
+
+def test_missing_hermes_is_installed_via_uv(monkeypatch, tmp_path):
+    _patch_instance(monkeypatch, tmp_path)
+    _patch_hermes_home(monkeypatch, tmp_path, config=_HERMES_MODEL)
+    monkeypatch.setattr(runtime_cli.shutil, "which", lambda name: "/fake/uv" if name == "uv" else None)
+    calls = []
+    monkeypatch.setattr(
+        runtime_cli.subprocess, "run", lambda cmd, **kw: calls.append(cmd) or type("R", (), {"returncode": 0})()
+    )
+    run_hermes_cli([])
+    assert calls and calls[0] == runtime_cli._HERMES_INSTALL
+    assert "--with" in calls[0] and "mcp==1.26.0" in calls[0]  # the pin the [acp] extra misses
+
+
+def test_no_uv_prints_manual_instructions_and_continues(monkeypatch, tmp_path, capsys):
+    cfg = _patch_instance(monkeypatch, tmp_path)
+    _patch_hermes_home(monkeypatch, tmp_path, config=_HERMES_MODEL)
+    monkeypatch.setattr(runtime_cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        runtime_cli.subprocess, "run", lambda cmd, **kw: (_ for _ in ()).throw(AssertionError("no shell-out"))
+    )
+    assert run_hermes_cli([]) == 0
+    assert "uv tool install" in capsys.readouterr().err
+    assert yaml.safe_load(cfg.read_text())["agent_runtime"] == "acp:hermes"  # flip still lands


### PR DESCRIPTION
## What

Makes **Hermes Agent (NousResearch)** a first-class runtime option, with a one-command onboarding path for existing Hermes users:

```bash
protoagent hermes    # = protoagent runtime use hermes
protoagent up
```

Their Hermes — identity, memory, skills, model endpoint, all of `~/.hermes` — stays the **brain** (over its in-tree ACP adapter); protoAgent wraps it as the **shell**: console, A2A, scheduler, goals, knowledge, fleet.

## How

- **`runtime/cli.py`** (new): `protoagent runtime use <native|hermes|acp:<agent>>` + `runtime list` (mirrors `protoagent model`), plus `protoagent hermes` sugar. The Hermes preset, all best-effort and never clobbering an explicit config on either side:
  1. installs/repairs `hermes-acp` — `uv tool install 'hermes-agent[acp]' --with mcp==1.26.0`. The pin is load-bearing: the `[acp]` extra does **not** include the `mcp` SDK, and without it Hermes *silently* skips MCP registration, so protoAgent's operator tools never mount.
  2. makes the model configs agree, **Hermes wins**: imports `~/.hermes/config.yaml`'s endpoint into an unconfigured instance (aux calls need a model); seeds the reverse direction only when Hermes has no model.
  3. adopts `~/.hermes/SOUL.md` as the persona — only over the shipped placeholder, via `write_soul` (soul history).
  4. sets `agent_runtime: acp:hermes`.
- **`runtime/acp_agents.py`**: hermes catalog entry → Settings select, setup wizard, `GET /api/acp-agents` all pick it up.
- **Docs**: `guides/hermes.md` + sidebar/nav.json + CLI-guide rows.

## Validation

- Live spike: `hermes-acp` under `AcpRuntime` registered **all 58 operator MCP tools** and round-tripped `task_list` into the dev-instance store, streaming through the existing frame vocabulary.
- 17 new tests (`tests/test_runtime_cli.py`) pinning the no-clobber seeding matrix, SOUL adoption guard, install pin, and the flip-lands-even-if-bootstrap-fails contract.
- Full suite 3404 passed; ruff + lint-imports green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)