### PR TITLE
fix(runtime): harden the ACP/Hermes runtime path — /v1 switch, instance pinning, serialization, context usage

### DIFF
--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -285,6 +285,9 @@ class AcpClient:
 
         self._proc: asyncio.subprocess.Process | None = None
         self._session_id: str | None = None
+        # Latest ACP-native context pressure ({used, size} tokens) from a
+        # ``usage_update`` session update — None until the agent sends one.
+        self.last_usage: dict | None = None
         # Captured from the `initialize` response (was previously discarded).
         self._auth_methods: list[dict] = []
         self._agent_capabilities: dict = {}
@@ -564,8 +567,17 @@ class AcpClient:
                         "status": status,
                     }
                 )
+        elif kind == "usage_update":
+            # ACP-native context pressure — {used, size} in tokens (e.g. hermes-acp sends
+            # one after each response; Zed drives its context ring off it). This is NOT
+            # billable usage (the agent's own provider meters that) — recorded so the
+            # runtime's usage frame can surface context_* fields without faking cost.
+            try:
+                self.last_usage = {"used": int(update.get("used") or 0), "size": int(update.get("size") or 0)}
+            except (TypeError, ValueError):
+                logger.debug("[acp/%s] unparseable usage_update %r", self.name, update)
         elif kind:
-            # plan / current_mode_update / available_commands_update / usage_update —
+            # plan / current_mode_update / available_commands_update —
             # not surfaced yet, but logged so they're visibly dropped, not silent.
             logger.debug("[acp/%s] unhandled session update %r", self.name, kind)
 

--- a/runtime/acp_runtime.py
+++ b/runtime/acp_runtime.py
@@ -83,12 +83,31 @@ def operator_mcp_server_spec(config) -> dict:
     repo_root = str(_REPO_ROOT)
     pythonpath = repo_root + (os.pathsep + os.environ["PYTHONPATH"] if os.environ.get("PYTHONPATH") else "")
     env: list[dict] = [{"name": "PYTHONPATH", "value": pythonpath}]
+    # Pin the child to THIS instance's resolved root. The ACP agent spawns the MCP
+    # server with the spec env REPLACING the environment, so anything not listed here
+    # is lost — forwarding only PROTOAGENT_INSTANCE let a PROTOAGENT_HOME-scoped
+    # instance's child boot the DEFAULT stores and write another instance's data
+    # (found live: a smoke agent's task_create landed in the operator's prod board).
+    # The resolved instance_root wins over any env/auto-scope derivation in the child.
+    try:
+        from infra.paths import instance_paths
+
+        env.append({"name": "PROTOAGENT_HOME", "value": str(instance_paths().instance_root)})
+    except Exception:  # noqa: BLE001 — path resolution must never block the mount
+        log.warning("[acp-runtime] could not resolve instance root for the operator MCP env", exc_info=True)
+    box = os.environ.get("PROTOAGENT_BOX_ROOT")
+    if box:
+        env.append({"name": "PROTOAGENT_BOX_ROOT", "value": box})  # host-layer fidelity in the child
     inst = os.environ.get("PROTOAGENT_INSTANCE")
     if inst:
         env.append({"name": "PROTOAGENT_INSTANCE", "value": inst})  # share this instance's data
     # Pass the resolved allowlist to the child explicitly — the spawned server otherwise
     # reads operator_mcp.tools from YAML, which wouldn't carry the "*" default.
     env.append({"name": "OPERATOR_MCP_TOOLS", "value": ",".join(allow)})
+    # Frozen desktop sidecar: sys.executable IS the server entrypoint and rejects
+    # `-m server.operator_mcp` argv (#1603's class) — use the dispatch verb instead.
+    if getattr(sys, "frozen", False):
+        return {"name": "protoagent-operator", "command": sys.executable, "args": ["operator-mcp"], "env": env}
     return {
         "name": "protoagent-operator",
         "command": sys.executable,
@@ -229,6 +248,12 @@ class AcpRuntime:
         )
         self._context.after_turn(user=message, response=answer)
         return answer
+
+    def last_usage(self) -> dict | None:
+        """Latest ACP-native context pressure ({used, size} tokens) the agent reported
+        via ``usage_update`` — None when the agent hasn't sent one (most coding agents
+        don't; hermes-acp does after each response)."""
+        return getattr(self._client, "last_usage", None)
 
     async def close(self) -> None:
         if self._client is not None and hasattr(self._client, "close"):

--- a/runtime/cli.py
+++ b/runtime/cli.py
@@ -262,6 +262,27 @@ def _bootstrap_hermes() -> None:
 # ── subcommands ──────────────────────────────────────────────────────────────
 
 
+def _running_server_port() -> int | None:
+    """Port of a live server for THIS instance, else None — the `protoagent up`
+    pidfile + a port probe. Replicates server.cli's tiny check; can't import it
+    here (runtime/ must not import server/, ADR 0023 layering)."""
+    import json
+    import socket
+
+    from infra.paths import instance_paths
+
+    try:
+        rec = json.loads((instance_paths().instance_root / "server.pid").read_text(encoding="utf-8"))
+        port = int(rec.get("port") or 0)
+    except (OSError, ValueError, TypeError):
+        return None
+    if not port:
+        return None
+    with socket.socket() as s:
+        s.settimeout(0.3)
+        return port if s.connect_ex(("127.0.0.1", port)) == 0 else None
+
+
 def _known_runtimes(config=None) -> list[str]:
     from runtime.acp_agents import acp_runtime_options
 
@@ -292,7 +313,12 @@ def _cmd_use(args) -> int:
     doc["agent_runtime"] = target
     save_yaml_doc(doc)
     print(f"runtime: now {target}")
-    print("Start it with:  protoagent up   (console: http://127.0.0.1:7870)")
+    port = _running_server_port()
+    if port:
+        # The switch only applies on boot — a live server keeps the old runtime.
+        print(f"Server on :{port} is still on the previous runtime — restart:  protoagent down && protoagent up")
+    else:
+        print("Start it with:  protoagent up   (console: http://127.0.0.1:7870)")
     return 0
 
 

--- a/server/chat.py
+++ b/server/chat.py
@@ -259,20 +259,54 @@ async def _acp_drive_turn(rt, message: str):
     # Attribute the turn to the ACP agent in telemetry — gateway tokens/cost are 0 (the
     # external agent's own subscription meters its usage). The acp:<agent> model label is
     # the honest signal that this turn wasn't gateway-metered.
-    yield (
-        "usage",
-        {
-            "model": f"acp:{rt.agent}",
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cache_read_input_tokens": 0,
-            "cache_creation_input_tokens": 0,
-            "cost_usd": 0.0,
-        },
-    )
+    usage_frame = {
+        "model": f"acp:{rt.agent}",
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "cost_usd": 0.0,
+    }
+    # Context pressure is a different axis than billing: when the agent reports
+    # ACP-native usage_update ({used, size} tokens — hermes-acp does), surface it as
+    # context_* fields so the console can render a context indicator, tokens/cost
+    # stay 0 (estimates must not pollute cost telemetry).
+    ctx = rt.last_usage() if hasattr(rt, "last_usage") else None
+    if isinstance(ctx, dict) and ctx.get("size"):
+        usage_frame["context_used_tokens"] = int(ctx.get("used") or 0)
+        usage_frame["context_window_tokens"] = int(ctx.get("size") or 0)
+    yield ("usage", usage_frame)
     # The answer already streamed as text deltas; `done` finalizes (executor appends only
     # meta when text was streamed, so no duplication).
     yield ("done", answer)
+
+
+async def _acp_turn_collected(session_id: str, message: str) -> list[dict[str, Any]]:
+    """The non-streaming shape of the ACP runtime switch: drive the turn, collect the
+    frames, and return the single assistant message the non-streaming callers expect.
+    ``usage`` is translated to the OpenAI shape the /v1 handler sums (ADR 0075 D4)."""
+    tid = _resolve_thread_id(None, session_id)
+    rt = await _acp_acquire(tid)
+    answer, usage, error = "", None, None
+    try:
+        # Same serialization as the streaming switch: one prompt per ACP session.
+        async with _thread_lock(tid):
+            async for kind, payload in _acp_drive_turn(rt, message):
+                if kind == "done":
+                    answer = payload or answer
+                elif kind == "usage" and isinstance(payload, dict):
+                    _in = int(payload.get("input_tokens", 0) or 0)
+                    _out = int(payload.get("output_tokens", 0) or 0)
+                    usage = {"prompt_tokens": _in, "completion_tokens": _out, "total_tokens": _in + _out}
+                elif kind == "error":
+                    error = payload
+    finally:
+        await _acp_release(tid)
+    content = error or answer or "_(The agent ended the turn without a textual reply.)_"
+    out: dict[str, Any] = {"role": "assistant", "content": content}
+    if usage is not None:
+        out["usage"] = usage
+    return [out]
 
 
 def _setup_required_message() -> list[dict[str, Any]]:
@@ -1382,8 +1416,13 @@ async def _chat_langgraph_stream_impl(
                 # idle TTL); registry mutation is serialized by _ACP_LOCK. See _acp_acquire.
                 rt = await _acp_acquire(_acp_tid)
                 try:
-                    async for frame in _acp_drive_turn(rt, message):
-                        yield frame
+                    # One prompt at a time per ACP session — AcpClient forbids concurrent
+                    # prompts on an instance (a session is a single conversation), and the
+                    # refcount above only guards eviction. Same per-thread lock the native
+                    # turns hold, so compact/rewind on this thread are excluded too.
+                    async with _thread_lock(_acp_tid):
+                        async for frame in _acp_drive_turn(rt, message):
+                            yield frame
                 finally:
                     await _acp_release(_acp_tid)
                 return
@@ -1672,6 +1711,16 @@ async def _chat_langgraph_impl(
             parsed_skill = _parse_skill_command(message)
             if parsed_skill is not None:
                 message = _skill_directive(*parsed_skill)
+
+            # Non-native runtime (ADR 0033) — same switch as the streaming driver, same
+            # position (after the control-plane short-circuits). Without it, an acp:*
+            # config silently ran this surface (OpenAI-compat /v1, the desktop /api/chat
+            # fallback, internal self-prompts) on the native loop — which a gateway-less
+            # ACP-only setup (e.g. the Hermes preset) can't serve at all.
+            from runtime.acp_runtime import is_acp_runtime
+
+            if is_acp_runtime(STATE.graph_config):
+                return await _acp_turn_collected(session_id, message)
 
             # Same thread-id resolution as the streaming path (ADR 0069 D4): the
             # non-streaming turns used to key `chat:{session_id}` apart from the

--- a/server/cli.py
+++ b/server/cli.py
@@ -45,6 +45,10 @@ _FORWARD: dict[str, tuple[str, str]] = {
     "operations": ("ops.cli", "run_operations_cli"),
     # `knowledge` lives in server/ (not graph/**) — it boots the instance's stores standalone.
     "knowledge": ("server.knowledge_cli", "run_knowledge_cli"),
+    # Internal daemon verb: serve the operator tools over MCP stdio. The ACP runtime
+    # launches this in the frozen desktop sidecar, where `-m server.operator_mcp`
+    # isn't a valid argv (the frozen entrypoint IS `-m server` — see #1603).
+    "operator-mcp": ("server.operator_mcp", "main"),
 }
 
 _FORWARD_HELP = {
@@ -58,6 +62,7 @@ _FORWARD_HELP = {
     "hermes": "One-command Hermes preset: wrap protoAgent around your existing ~/.hermes agent",
     "operations": "List the operations on the ops layer — name, read/write, summary (ADR 0075)",
     "knowledge": "Ingest a URL / file into this instance's knowledge base (ADR 0075)",
+    "operator-mcp": "Serve the operator tools over MCP stdio (internal — mounted into ACP runtimes)",
 }
 
 _LIFECYCLE_HELP = {

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -537,3 +537,144 @@ def test_adapters_derived_from_canonical_catalog():
     assert ACP_MODEL_OPTIONS == acp_runtime_options() == [f"acp:{a['id']}" for a in acp_agent_catalog()]
     # claude maps to the current adapter (the deprecated @zed-industries one is gone).
     assert "@agentclientprotocol/claude-agent-acp" in _ACP_ADAPTERS["claude"]["args"]
+
+
+# ── hardening: non-streaming switch, usage_update, frozen spawn ────────────────
+
+
+async def test_acp_turn_collected_returns_single_message_with_usage(monkeypatch):
+    """The non-streaming ACP path folds the frame stream into the one assistant
+    message the /api/chat + OpenAI-compat callers expect, usage in OpenAI shape."""
+    chat = _chat_module()
+
+    async def fake_drive(rt, message):
+        yield ("text", "hel")
+        yield ("text", "lo")
+        yield ("usage", {"model": "acp:mock", "input_tokens": 7, "output_tokens": 3, "cost_usd": 0.0})
+        yield ("done", "hello")
+
+    rt = _MockRuntime()
+
+    async def fake_acquire(tid):
+        return rt
+
+    async def fake_release(tid):
+        return None
+
+    monkeypatch.setattr(chat, "_acp_acquire", fake_acquire)
+    monkeypatch.setattr(chat, "_acp_release", fake_release)
+    monkeypatch.setattr(chat, "_acp_drive_turn", fake_drive)
+    out = await chat._acp_turn_collected("s1", "hi")
+    assert out == [
+        {
+            "role": "assistant",
+            "content": "hello",
+            "usage": {"prompt_tokens": 7, "completion_tokens": 3, "total_tokens": 10},
+        }
+    ]
+
+
+async def test_acp_turn_collected_surfaces_error(monkeypatch):
+    chat = _chat_module()
+
+    async def fake_drive(rt, message):
+        yield ("error", "ACP runtime (mock) failed: boom")
+
+    async def fake_acquire(tid):
+        return _MockRuntime()
+
+    async def fake_release(tid):
+        return None
+
+    monkeypatch.setattr(chat, "_acp_acquire", fake_acquire)
+    monkeypatch.setattr(chat, "_acp_release", fake_release)
+    monkeypatch.setattr(chat, "_acp_drive_turn", fake_drive)
+    out = await chat._acp_turn_collected("s1", "hi")
+    assert "boom" in out[0]["content"] and "usage" not in out[0]
+
+
+async def test_nonstreaming_impl_routes_to_acp(monkeypatch):
+    """`_chat_langgraph_impl` (OpenAI-compat /v1, desktop /api/chat fallback) must honor
+    agent_runtime — it used to run the native loop under an acp:* config."""
+    import types as _types
+
+    chat = _chat_module()
+    from runtime.state import STATE
+
+    monkeypatch.setattr(
+        STATE,
+        "graph_config",
+        _types.SimpleNamespace(agent_runtime="acp:codex", operator_mcp_tools=[], acp_agents={}),
+        raising=False,
+    )
+    monkeypatch.setattr(STATE, "goal_controller", None, raising=False)
+    sentinel = [{"role": "assistant", "content": "via-acp"}]
+
+    async def fake_collected(session_id, message):
+        return sentinel
+
+    monkeypatch.setattr(chat, "_acp_turn_collected", fake_collected)
+    out = await chat._chat_langgraph_impl("plain message", "sess-x")
+    assert out is sentinel  # switched before any graph/native-path work
+
+
+async def test_acp_client_records_usage_update():
+    """ACP-native usage_update ({used, size} context pressure) is recorded, not dropped."""
+    from plugins.coding_agent.acp_client import AcpClient
+
+    client = AcpClient("noop", cwd="/tmp", name="t")
+    assert client.last_usage is None
+    await client._handle_update({"update": {"sessionUpdate": "usage_update", "used": 1234, "size": 128000}})
+    assert client.last_usage == {"used": 1234, "size": 128000}
+
+
+async def test_drive_turn_usage_frame_carries_context_pressure(monkeypatch):
+    """When the runtime reports usage_update data, the usage frame carries context_*
+    fields — tokens/cost stay 0 (estimates must not pollute cost telemetry)."""
+    chat = _chat_module()
+
+    class _Rt(_MockRuntime):
+        async def run_turn(self, message, *, progress_callback=None, tool_callback=None, text_callback=None):
+            return "done-text"
+
+        def last_usage(self):
+            return {"used": 123, "size": 1000}
+
+    frames = [f async for f in chat._acp_drive_turn(_Rt(), "m")]
+    usage = next(p for k, p in frames if k == "usage")
+    assert usage["context_used_tokens"] == 123 and usage["context_window_tokens"] == 1000
+    assert usage["input_tokens"] == 0 and usage["cost_usd"] == 0.0
+    assert ("done", "done-text") in frames
+
+
+def test_operator_mcp_spec_is_frozen_aware(monkeypatch):
+    """Frozen desktop sidecar: sys.executable IS the server entrypoint — the spec must
+    use the `operator-mcp` dispatch verb, not `-m server.operator_mcp` (#1603's class)."""
+    import sys as _sys
+    import types as _types
+
+    from runtime.acp_runtime import operator_mcp_server_spec
+
+    cfg = _types.SimpleNamespace(operator_mcp_tools=[])
+    spec = operator_mcp_server_spec(cfg)
+    assert spec["args"][:2] == ["-m", "server.operator_mcp"]  # source checkout: unchanged
+
+    monkeypatch.setattr(_sys, "frozen", True, raising=False)
+    frozen_spec = operator_mcp_server_spec(cfg)
+    assert frozen_spec["args"] == ["operator-mcp"]
+    assert frozen_spec["command"] == _sys.executable
+
+
+def test_operator_mcp_spec_pins_resolved_instance_root(monkeypatch, tmp_path):
+    """The MCP child's env REPLACES the environment (the ACP agent spawns it that way),
+    so the spec must carry the resolved instance root — forwarding only
+    PROTOAGENT_INSTANCE let a PROTOAGENT_HOME-scoped instance write DEFAULT-instance
+    data (found live: a smoke agent's task landed on the operator's prod board)."""
+    import types as _types
+
+    monkeypatch.setenv("PROTOAGENT_HOME", str(tmp_path / "scoped-home"))
+    from runtime.acp_runtime import operator_mcp_server_spec
+
+    spec = operator_mcp_server_spec(_types.SimpleNamespace(operator_mcp_tools=[]))
+    env = {e["name"]: e["value"] for e in spec["env"]}
+    assert env["PROTOAGENT_HOME"] == str(tmp_path / "scoped-home")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,3 +118,11 @@ def test_help_lists_every_command(capsys):
     out = capsys.readouterr().out
     for name in ("serve", "up", "down", "status", "setup", "plugin", "workspace", "skills", "fleet", "config"):
         assert name in out
+
+
+def test_operator_mcp_verb_is_routed():
+    # The frozen desktop sidecar launches the ACP runtime's operator MCP server as
+    # `<binary> operator-mcp` (it can't take `-m server.operator_mcp`) — the verb
+    # must stay routable and documented.
+    assert cli._FORWARD["operator-mcp"] == ("server.operator_mcp", "main")
+    assert "operator-mcp" in cli._FORWARD_HELP

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -227,3 +227,21 @@ def test_no_uv_prints_manual_instructions_and_continues(monkeypatch, tmp_path, c
     assert run_hermes_cli([]) == 0
     assert "uv tool install" in capsys.readouterr().err
     assert yaml.safe_load(cfg.read_text())["agent_runtime"] == "acp:hermes"  # flip still lands
+
+
+# ── restart hint ─────────────────────────────────────────────────────────────
+
+
+def test_use_hints_restart_when_server_running(monkeypatch, tmp_path, capsys):
+    _patch_instance(monkeypatch, tmp_path)
+    monkeypatch.setattr(runtime_cli, "_running_server_port", lambda: 7870)
+    assert run_runtime_cli(["use", "native"]) == 0
+    out = capsys.readouterr().out
+    assert "protoagent down && protoagent up" in out  # live server keeps the old runtime
+
+
+def test_use_hints_up_when_stopped(monkeypatch, tmp_path, capsys):
+    _patch_instance(monkeypatch, tmp_path)
+    monkeypatch.setattr(runtime_cli, "_running_server_port", lambda: None)
+    run_runtime_cli(["use", "native"])
+    assert "protoagent up" in capsys.readouterr().out


### PR DESCRIPTION
## What

Hardening batch on top of #1889 (`protoagent hermes` preset), all four fixes **validated against a live `acp:hermes` server** (isolated instance, gateway-less — Hermes as the only brain).

## Fixes

1. **Non-streaming turns now honor `agent_runtime`** — the OpenAI-compat `/v1` endpoint, desktop `/api/chat` fallback, and internal self-prompts silently ran the **native** loop under an `acp:*` config. A gateway-less ACP-only setup (exactly the Hermes-preset persona) can't serve that path at all. New `_acp_turn_collected` mirrors the streaming switch and folds frames into the single-message shape (+ OpenAI-shape `usage`). **Live: `/v1/chat/completions` answered on an instance with `api_key_configured: false`.**
2. **Operator MCP child pinned to the resolved instance root** — the ACP agent spawns the MCP server with a *replaced* env; only `PROTOAGENT_INSTANCE` was forwarded, so a `PROTOAGENT_HOME`-scoped instance's child booted the **default** stores. **Found live: the smoke agent's `task_create` landed on the operator's prod board.** Now carries resolved `PROTOAGENT_HOME` + `PROTOAGENT_BOX_ROOT`. (Leaked test row removed; store integrity verified.)
3. **Per-thread serialization of ACP turns** — `AcpClient` forbids concurrent prompts on one session; `_acp_acquire` refcount only guards eviction. Both switches now hold the same `_thread_lock` the native turns use (also excludes compact/rewind races).
4. **Context-pressure telemetry, honestly** — ACP-native `usage_update` (`{used, size}`; hermes-acp sends one per response — **live: `24891/256000`**) is recorded and surfaced on the usage frame as `context_used_tokens`/`context_window_tokens`. Tokens/cost stay 0: estimates must not pollute cost telemetry. Console can render a context ring off this (follow-up).
5. **Frozen sidecar spawn** — new `operator-mcp` dispatch verb; the frozen entrypoint rejects `-m server.operator_mcp` argv (#1603's class). Source checkouts unchanged.
6. **CLI polish** — `runtime use` prints `protoagent down && protoagent up` when a live server still runs the old runtime.

## Deep smoke (live, isolated instance on :7897)

| Check | Result |
|---|---|
| `scripts/live_smoke.py` | PASSED |
| Boot `acp:hermes`, headless setup (ACP-only, no gateway key) | ✓ |
| `/api/chat` non-streaming turn | ✓ 200 in 10.5s (first turn, incl. MCP registration) |
| `task_create` → instance store round-trip | ✓ (post-fix; pre-fix it leaked to the default box) |
| Multi-turn session statefulness | ✓ recalled prior turn without tools |
| A2A `SendStreamingMessage` | ✓ 9 frames, append/lastChunk, `TASK_STATE_COMPLETED` |
| Telemetry row | ✓ `model=acp:hermes`, 0 cost, `tool_calls=1` |
| `/v1/chat/completions` | ✓ (surface was broken pre-fix) |
| `usage_update` capture | ✓ `{used: 24891, size: 256000}` |

Gates: ruff ✓, import contracts 3/3 ✓, full suite **3415 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new `operator-mcp` command in the CLI.
  * Chat responses now include better usage/context information for ACP-based sessions.

* **Bug Fixes**
  * Switching runtimes now gives a clearer hint when a server is already running, helping avoid confusion.
  * ACP chat handling now works more reliably in non-streaming mode and under concurrent session activity.

* **Refactor**
  * Improved runtime environment handling so operator tools launch with the correct instance-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->