### PR TITLE
fix(tracing): make a fleet agent's trace whole when it runs in its own Langfuse project

### DIFF
--- a/graph/middleware/trace_context.py
+++ b/graph/middleware/trace_context.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 
 from langchain.agents.middleware import AgentMiddleware
 
@@ -67,8 +68,54 @@ class TraceContextMiddleware(AgentMiddleware):
             log.debug("[trace-context] could not stamp trace context", exc_info=True)
             return request
 
+    def _emit_fleet_generation(self, response, duration_ms: int) -> None:
+        """Emit a lightweight generation into the AGENT's own Langfuse project.
+
+        The gateway logs the full-detail generation into ITS project (via the
+        ``_with_trace`` metadata above). When the agent runs in a *different*
+        project — a dedicated fleet project — that generation is absent from
+        the agent's own trace, leaving a hole where its model call should be.
+        This lands a model + usage + cost node (no prompt/completion payload)
+        in the agent's project so its trace is whole. Best-effort; never raises.
+        """
+        try:
+            from observability import pricing, tracing
+
+            if not tracing.is_enabled():
+                return
+            # Per the wrap_model_call contract the return is a ModelResponse
+            # (``.result``: list[BaseMessage]) or an AIMessage directly.
+            msg = None
+            result = getattr(response, "result", None)
+            if result:
+                from langchain_core.messages import AIMessage
+
+                msg = next(
+                    (m for m in reversed(result) if isinstance(m, AIMessage)),
+                    result[-1],
+                )
+            elif hasattr(response, "usage_metadata") or hasattr(response, "response_metadata"):
+                msg = response
+            if msg is None:
+                return
+            usage = getattr(msg, "usage_metadata", None) or {}
+            model = (getattr(msg, "response_metadata", None) or {}).get("model_name", "") or ""
+            cost = pricing.cost_usd(model, usage) if usage else 0.0
+            name = f"{os.environ.get('AGENT_NAME', 'protoagent')}-turn"
+            tracing.trace_generation(
+                name=name, model=model, usage=usage, cost_usd=cost, duration_ms=duration_ms
+            )
+        except Exception:  # noqa: BLE001 — tracing must never break a model call
+            log.debug("[trace-context] could not emit fleet generation", exc_info=True)
+
     def wrap_model_call(self, request, handler):
-        return handler(self._with_trace(request))
+        t0 = time.monotonic()
+        response = handler(self._with_trace(request))
+        self._emit_fleet_generation(response, int((time.monotonic() - t0) * 1000))
+        return response
 
     async def awrap_model_call(self, request, handler):
-        return await handler(self._with_trace(request))
+        t0 = time.monotonic()
+        response = await handler(self._with_trace(request))
+        self._emit_fleet_generation(response, int((time.monotonic() - t0) * 1000))
+        return response

--- a/observability/tracing.py
+++ b/observability/tracing.py
@@ -359,6 +359,65 @@ def trace_tool_call(
         return None
 
 
+def trace_generation(
+    name: str,
+    model: str = "",
+    usage: dict | None = None,
+    cost_usd: float = 0.0,
+    duration_ms: int = 0,
+    session_id: str = "",
+) -> Any:
+    """Log a completed LLM generation as a child observation in the CURRENT trace.
+
+    Why this exists — fleet tracing across TWO Langfuse projects. The LiteLLM
+    gateway logs the FULL-fidelity generation (prompt + completion) into its
+    OWN project via its success callback; ``TraceContextMiddleware`` joins it
+    to the active ``trace_id``. That's ideal when the agent and the gateway
+    share a project. But when an agent runs in a DIFFERENT project than the
+    gateway — a dedicated fleet project — that generation lands in the
+    gateway's project, leaving the agent's own trace with a HOLE where its
+    model call should be (only the structural spans remain). This emits a
+    lightweight generation — model + token usage + cost, NO prompt/completion
+    payload — into the AGENT's project so its trace is whole. The heavy IO
+    stays in the gateway project; the two are joinable by ``trace_id``.
+
+    Mirrors ``trace_tool_call``: ``start_observation`` + ``end`` so it nests
+    under the current session span without becoming the parent. No-op /
+    swallow-all when tracing is disabled or the SDK errors — never alters the
+    turn.
+    """
+    if not _enabled or _langfuse is None:
+        return None
+    try:
+        usage_details = None
+        if usage:
+            candidates = {
+                "input": usage.get("input_tokens"),
+                "output": usage.get("output_tokens"),
+                "total": usage.get("total_tokens"),
+            }
+            usage_details = {k: int(v) for k, v in candidates.items() if v} or None
+        span = _langfuse.start_observation(
+            name=name,
+            as_type="generation",
+            model=model or None,
+            usage_details=usage_details,
+            cost_details=({"total": float(cost_usd)} if cost_usd else None),
+            metadata={
+                "session_id": session_id,
+                "trace_id": _trace_id_ctx.get(),
+                "duration_ms": duration_ms,
+                # Full prompt/completion IO is logged by the gateway's LiteLLM
+                # callback into the gateway Langfuse project (joined by trace_id).
+                "detail_in": "gateway_project",
+            },
+        )
+        span.end()
+        return span
+    except Exception:
+        return None
+
+
 def score_current_trace(name: str, value: float, comment: str = "") -> None:
     """Attach a numeric score to the currently-active trace.
 

--- a/tests/test_trace_context_middleware.py
+++ b/tests/test_trace_context_middleware.py
@@ -136,3 +136,98 @@ async def test_awrap_model_call_passes_stamped_request_to_handler(monkeypatch, m
 
     assert await mw.awrap_model_call(_FakeRequest(_FakeModel()), handler) == "resp"
     assert seen["req"].model.extra_body["metadata"]["existing_trace_id"] == _TID
+
+
+# ─── Fleet generation node (whole-trace in the agent's OWN project) ──────────
+# The gateway logs the full-detail generation into ITS project; when the agent
+# runs in a different (fleet) project, the middleware also emits a lightweight
+# model+usage+cost generation into the agent's project so its trace is whole.
+
+
+class _Resp:
+    """ModelResponse stand-in: carries .result (list[BaseMessage])."""
+
+    def __init__(self, result):
+        self.result = result
+
+
+def _ai(usage=None, model="gw/model"):
+    from langchain_core.messages import AIMessage
+
+    return AIMessage(
+        content="ok",
+        usage_metadata=usage,
+        response_metadata=({"model_name": model} if model else {}),
+    )
+
+
+def test_emit_fleet_generation_records_model_usage_cost(monkeypatch, mw):
+    monkeypatch.setattr(tracing, "is_enabled", lambda: True)
+    monkeypatch.setenv("AGENT_NAME", "vera")
+    seen = {}
+    monkeypatch.setattr(tracing, "trace_generation", lambda **kw: seen.update(kw))
+
+    mw._emit_fleet_generation(
+        _Resp([_ai(usage={"input_tokens": 100, "output_tokens": 20, "total_tokens": 120})]),
+        1234,
+    )
+
+    assert seen["name"] == "vera-turn"
+    assert seen["model"] == "gw/model"
+    assert seen["usage"]["input_tokens"] == 100
+    assert seen["duration_ms"] == 1234
+    assert seen["cost_usd"] >= 0.0
+
+
+def test_emit_handles_bare_aimessage_response(monkeypatch, mw):
+    """The contract allows the handler to return an AIMessage directly."""
+    monkeypatch.setattr(tracing, "is_enabled", lambda: True)
+    calls = []
+    monkeypatch.setattr(tracing, "trace_generation", lambda **kw: calls.append(kw))
+
+    mw._emit_fleet_generation(_ai(usage={"input_tokens": 5, "output_tokens": 5, "total_tokens": 10}), 0)
+
+    assert calls and calls[0]["model"] == "gw/model"
+
+
+def test_emit_noop_when_tracing_disabled(monkeypatch, mw):
+    monkeypatch.setattr(tracing, "is_enabled", lambda: False)
+    calls = []
+    monkeypatch.setattr(tracing, "trace_generation", lambda **kw: calls.append(kw))
+
+    mw._emit_fleet_generation(
+        _Resp([_ai(usage={"input_tokens": 1, "output_tokens": 1, "total_tokens": 2})]), 0
+    )
+
+    assert not calls
+
+
+def test_emit_never_raises_on_garbage_or_sink_blowup(monkeypatch, mw):
+    monkeypatch.setattr(tracing, "is_enabled", lambda: True)
+
+    def _boom(**kw):
+        raise RuntimeError("otel misery")
+
+    monkeypatch.setattr(tracing, "trace_generation", _boom)
+    # garbage response (no .result / no usage) → nothing to emit, no raise
+    mw._emit_fleet_generation(object(), 0)
+    # valid response but the sink throws → still swallowed
+    mw._emit_fleet_generation(
+        _Resp([_ai(usage={"input_tokens": 1, "output_tokens": 1, "total_tokens": 2})]), 0
+    )
+
+
+async def test_awrap_emits_generation_and_returns_response(monkeypatch, mw):
+    _set_ctx(monkeypatch, {"trace_id": _TID})
+    monkeypatch.setattr(tracing, "is_enabled", lambda: True)
+    calls = []
+    monkeypatch.setattr(tracing, "trace_generation", lambda **kw: calls.append(kw))
+    resp = _Resp([_ai(usage={"input_tokens": 10, "output_tokens": 2, "total_tokens": 12})])
+
+    async def handler(request):
+        return resp
+
+    out = await mw.awrap_model_call(_FakeRequest(_FakeModel()), handler)
+
+    assert out is resp  # response passes through untouched
+    assert calls and calls[0]["usage"]["output_tokens"] == 2


### PR DESCRIPTION
Closes #1892.

## Problem
When a fleet agent is pointed at a **dedicated Langfuse project** (separate from the shared LiteLLM gateway's project), a single turn's trace **fragments across two projects**:

- **SPAN**s (`a2a-stream`, `tool:*`) → the agent's project (agent's own OTLP key). ✅
- **GENERATION**s (`<agent>-turn`, the LLM call with model/tokens/cost) → the **gateway's** project — because the gateway's LiteLLM success callback logs every generation with the *gateway's* Langfuse key.

Same `trace_id`, two `project_id`s. A no-tool turn then shows in the agent's project as just an empty `a2a-stream` wrapper — the actual model call is invisible there. `TraceContextMiddleware`'s docstring even names the now-broken assumption: *"the gateway runs its Langfuse callback in the SAME project."*

## Fix
`TraceContextMiddleware.wrap_model_call` is the single seam that sees every model call. It already stamps the trace context onto the request; now it also emits — into the **agent's own** project — a lightweight generation via a new `observability.tracing.trace_generation()` helper: model + token usage + cost + duration, **no prompt/completion payload**. The full IO stays in the gateway project (unchanged), joinable by `trace_id`.

- When agent and gateway **share** a project (the common case), this is a small summary node next to the gateway's detailed one — harmless.
- When they **differ**, the agent's trace is now whole.

This deliberately keeps the heavy LLM detail in the gateway project (that's where LLM-observability for all consumers lives) while making the fleet trace stand on its own.

## Tests
`tests/test_trace_context_middleware.py` — 6 new cases: records model/usage/cost, handles both `ModelResponse.result` and bare-`AIMessage` returns, no-op when tracing disabled, never raises on garbage/sink-blowup, and `awrap_model_call` emits + passes the response through untouched. Full file green (13) + adjacent trace/subagent suites (18 total).

## Context
Homelab fleet dogfooding — jon/roxy/frank/vera moved to a dedicated `protoLabs.studio` Langfuse project (homelab-iac #185); the gateway stays on its own project for external consumers. Requires a base rebuild + fleet redeploy to activate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved tracing for model calls, including duration and usage details, so completed generations are captured more consistently.
  * Enhanced tracing to preserve visibility even when responses are returned in different shapes.

* **Bug Fixes**
  * Reduced gaps in trace records when model calls are routed through different projects.
  * Tracing now fails safely, avoiding interruptions if logging is unavailable or data is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->