### PR TITLE
fix(fleet): defer plugin-view auth to the member so proxied views stop 401ing (#1890)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exit. Everything is a no-op when Langfuse isn't configured.
 
 ### Fixed
+- **A fleet member's plugin views 401'd through a token-gated hub** (#1890). A view page is
+  auth-exempt public chrome on the instance that serves it, but through the hub it lives at
+  `/agents/<slug>/plugins/<id>/…` — a prefix the hub's public list can't know (the member may
+  run plugins the hub doesn't). The hub now defers the public decision to the MEMBER: every
+  instance serves its live auth-exempt prefix list on `/.well-known/protoagent/public-paths`,
+  the hub checks slug-prefixed plugin-namespace paths against it (TTL-cached, fail-closed),
+  and the proxy forwards such requests anonymously — never lending a stored remote bearer to
+  an unauthenticated caller. Bonus (same #1752 rule): hot-reload now re-applies plugin public
+  prefixes to the live auth gate, so a hot-enabled plugin's view no longer stays 401 until a
+  restart.
 - **A subagent hitting `max_turns` failed its whole delegation (GRAPH_RECURSION_LIMIT).** Every
   subagent prompt promises "hard stop at max_turns: return what you have," but the runner's
   `ainvoke` raised at the recursion limit and lost the run — seen live when one review-finder

--- a/a2a_impl/auth.py
+++ b/a2a_impl/auth.py
@@ -112,6 +112,34 @@ def set_public_prefixes(prefixes) -> None:
         logger.info("[a2a] %d plugin-declared auth-exempt path(s): %s", len(cleaned), ", ".join(cleaned))
 
 
+def public_prefixes() -> list[str]:
+    """The live plugin-declared auth-exempt prefixes (post-validation) — exactly what
+    ``_is_public`` enforces. Served on the public-paths well-known endpoint so a fleet
+    hub can defer its public decision to this member (#1890)."""
+    return list(_PLUGIN_PUBLIC)
+
+
+# Fleet-proxied member view pages (#1890). A member's plugin view page is public
+# *chrome* on the member itself (see ``set_public_prefixes``) — but the console
+# iframes it through the hub as ``/agents/<slug>/plugins/<id>/…``, a plain
+# navigation that cannot carry the operator bearer, and the hub's own public list
+# is built from the HUB's manifests (the member may run plugins the hub doesn't).
+# The member is the authority on what it serves anonymously, so the hub defers:
+# for a slug-prefixed path inside a plugin namespace, an injected async resolver
+# ``(slug, rest) -> bool`` answers "would the member serve this anonymously?"
+# (graph/fleet/member_public.py — fetched from the member's public-paths endpoint,
+# TTL-cached, fail-closed). Injected from the server bootstrap so this module
+# stays host-free.
+_MEMBER_PUBLIC: list = [None]
+
+_AGENTS_RE = re.compile(r"^/agents/([^/]+)(/.+)$")
+
+
+def set_member_public_resolver(fn) -> None:
+    """Install the async ``(slug, rest) -> bool`` member-public resolver (None = off)."""
+    _MEMBER_PUBLIC[0] = fn
+
+
 def _metrics_public() -> bool:
     """Whether ``/metrics`` is reachable without auth.
 
@@ -266,6 +294,26 @@ class A2AAuthMiddleware(BaseHTTPMiddleware):
         # Public allowlist — pass without auth.
         if _is_public(path):
             return await call_next(request)
+
+        # Fleet-proxied member-public paths (#1890): ``/agents/<slug>/<rest>`` where
+        # ``<rest>`` sits inside a plugin namespace defers to the MEMBER's own public
+        # list — its view pages are public chrome THERE, and the iframe navigation
+        # cannot carry a bearer. Consulted only when a credential actually gates this
+        # hub (open mode passes below anyway) and only for the plugin namespace —
+        # never ``/agents/<slug>/api/…``. ``request.state.member_public`` tells the
+        # fleet proxy NOT to lend a stored remote bearer to this request.
+        resolver = _MEMBER_PUBLIC[0]
+        if resolver is not None and (_BEARER[0] is not None or _API_KEY[0]):
+            m = _AGENTS_RE.match(path)
+            if m and _PLUGIN_NS_RE.match(m.group(2)):
+                try:
+                    member_public = await resolver(m.group(1), m.group(2))
+                except Exception:  # noqa: BLE001 — resolver trouble = fail closed to normal auth
+                    logger.exception("[a2a] member-public resolver failed for %s", path)
+                    member_public = False
+                if member_public:
+                    request.state.member_public = True
+                    return await call_next(request)
 
         # SSE endpoint: accept either a valid query-string token OR a bearer header.
         # The query token is for browser EventSource clients that cannot send headers.

--- a/docs/guides/building-react-plugin-views.md
+++ b/docs/guides/building-react-plugin-views.md
@@ -86,6 +86,12 @@ prefix); everything the page *fetches* (your data) goes through gated `/api/plug
 authed with the bearer the console hands you over the [init handshake](#the-init-handshake-bearer--theme).
 The page is public chrome; its data is not.
 
+This holds **through the fleet proxy** too (#1890): when the console views a member, the page loads
+at `/agents/<slug>/plugins/<id>/…` and a token-gated hub defers the public decision to the *member's*
+own auth-exempt list (served on `/.well-known/protoagent/public-paths`, TTL-cached). You don't have
+to do anything — your view's page path is auto-exempted from the manifest on the instance that runs
+the plugin, and the hub honors that instance's list.
+
 ## Claim the chat slot (`slot: "chat"`)
 
 The chat surface is a **slot** (ADR 0045): your view can *replace* the built-in chat panel instead of

--- a/graph/fleet/member_public.py
+++ b/graph/fleet/member_public.py
@@ -1,0 +1,78 @@
+"""Member-public deferral for the fleet proxy (#1890).
+
+A plugin view page is auth-exempt public *chrome* on the instance that serves it
+(``graph/plugins/manifest.py::_view_public_paths``): the console iframes it with
+a plain navigation that cannot carry the operator bearer. Through the hub the
+same page lives at ``/agents/<slug>/plugins/<id>/…`` — a path the HUB's public
+list knows nothing about (it is built from the hub's own manifests, and a member
+may run plugins the hub doesn't). So the hub defers the decision to the member:
+every instance serves its live public-prefix list on a ``/.well-known`` endpoint
+(public by definition — the listed paths are anonymously reachable anyway), and
+the hub checks the slug-stripped path against the MEMBER's list, cached per slug.
+
+Fail-closed: an unreachable member or a bad payload yields no prefixes, so the
+hub falls back to normal bearer auth (the pre-#1890 behavior). The auth
+middleware scopes consultation to plugin-namespace paths, entries here are
+re-validated against the same namespace shape, and the proxy never lends a
+stored remote bearer to a request admitted this way — a member can only ever
+open its own ``/plugins/<id>/…`` subtree on the hub, exactly as far as it
+already opens it to direct callers.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+
+import httpx
+
+log = logging.getLogger("protoagent.server")
+
+# Served by every instance (server bootstrap); fetched by the hub below.
+WELL_KNOWN_PATH = "/.well-known/protoagent/public-paths"
+
+# Same namespace shape the auth gate enforces on its own list (a2a_impl/auth.py).
+_PLUGIN_NS_RE = re.compile(r"^/(?:api/)?plugins/[^/]+/")
+
+_TTL = 30.0  # how long a member's fetched list is trusted
+_NEG_TTL = 5.0  # unreachable / bad member — retry soon, don't hammer
+_MAX_PREFIXES = 256  # cap a hostile/buggy member's list
+
+# slug -> (expires_at_monotonic, prefixes)
+_cache: dict[str, tuple[float, tuple[str, ...]]] = {}
+
+
+async def member_public_prefixes(slug: str) -> tuple[str, ...]:
+    """The member's live plugin public-prefix list, TTL-cached; ``()`` when unknown."""
+    now = time.monotonic()
+    hit = _cache.get(slug)
+    if hit and now < hit[0]:
+        return hit[1]
+
+    from graph.fleet import proxy
+
+    target = proxy._target_for_slug(slug)
+    prefixes: tuple[str, ...] = ()
+    ttl = _NEG_TTL
+    if target is not None:
+        base = target[0]  # never send stored credentials — the endpoint is public
+        try:
+            resp = await proxy._get_client().get(
+                f"{base}{WELL_KNOWN_PATH}", timeout=httpx.Timeout(3.0, connect=2.0)
+            )
+            if resp.status_code == 200:
+                raw = resp.json().get("public_paths")
+                if not isinstance(raw, list):
+                    raw = []
+                prefixes = tuple(s for s in (str(p) for p in raw[:_MAX_PREFIXES]) if _PLUGIN_NS_RE.match(s))
+                ttl = _TTL
+        except Exception as exc:  # noqa: BLE001 — unreachable/bad member = no prefixes (fail closed)
+            log.debug("[fleet] public-paths fetch for %r failed: %s", slug, exc)
+    _cache[slug] = (now + ttl, prefixes)
+    return prefixes
+
+
+async def is_member_public(slug: str, rest: str) -> bool:
+    """Would the member at ``slug`` serve ``rest`` anonymously? (the auth resolver, #1890)"""
+    return any(rest.startswith(p) for p in await member_public_prefixes(slug))

--- a/graph/fleet/proxy.py
+++ b/graph/fleet/proxy.py
@@ -121,6 +121,12 @@ async def forward_to(slug: str, request, path: str):
     if target is None:
         return JSONResponse({"detail": f"agent {slug!r} is not running"}, status_code=409)
     base, extra = target
+    # A request the hub admitted off the MEMBER's public list (#1890 — the auth
+    # middleware stamps ``member_public``) arrived anonymous; forward it anonymous.
+    # Attaching the stored remote bearer would lend an unauthenticated caller the
+    # remote's credential (same rule as the remote-WS refusal in forward_ws).
+    if extra and getattr(getattr(request, "state", None), "member_public", False):
+        extra = {k: v for k, v in extra.items() if k.lower() != "authorization"}
     return await _forward_to_base(base, request, path, extra)
 
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -822,6 +822,21 @@ def _main():
         federation_token=((STATE.graph_config.federation_token if STATE.graph_config else "") or None),
     )
 
+    # Member-public deferral for the fleet proxy (#1890): a member's plugin view
+    # pages are public chrome on the MEMBER, but through the hub they live at
+    # /agents/<slug>/… — a prefix the hub's own public list can't know (the member
+    # may run plugins the hub doesn't). Every instance serves its live auth-exempt
+    # list on a public /.well-known endpoint (the listed paths are anonymously
+    # reachable by definition, so the list discloses nothing new), and the hub's
+    # auth gate defers slug-prefixed plugin-namespace paths to that list.
+    from graph.fleet import member_public as _member_public
+
+    auth.set_member_public_resolver(_member_public.is_member_public)
+
+    @fastapi_app.get(_member_public.WELL_KNOWN_PATH, include_in_schema=False)
+    async def _plugin_public_paths():
+        return {"public_paths": auth.public_prefixes()}
+
     # Short-lived SSE token endpoint (Part 3 of auth inversion): the React
     # console fetches a 30s HMAC token here (bearer-gated under /api/) and
     # passes it to ``EventSource("/api/events?token=...")``. Server-to-server

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -1644,6 +1644,13 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
         # Without this a plugin update/enable that ships a new verifier leaves the watch/goal
         # controllers resolving it as "unknown" until a full restart.
         _apply_plugin_registries(new_plugins)
+        # Re-push the auth-exempt public prefixes too (#1890 — same rule as #1752: any
+        # init-time registry wiring must re-apply on reload). Without this a hot-enabled
+        # plugin's view page stays 401 under a token gate until a full restart.
+        STATE.plugin_public_paths = new_plugins.public_paths
+        from a2a_impl import auth as _a2a_auth
+
+        _a2a_auth.set_public_prefixes(new_plugins.public_paths)
 
     if new_graph is None:
         log.info("[reload] setup not complete — config reloaded, graph not compiled")

--- a/tests/test_a2a_auth.py
+++ b/tests/test_a2a_auth.py
@@ -27,11 +27,13 @@ def _reset_guard():
     auth._FEDERATION[0] = None
     auth._API_KEY[0] = ""
     auth._ALLOWED_ORIGINS[0] = None
+    auth._MEMBER_PUBLIC[0] = None
     yield
     auth._BEARER[0] = None
     auth._FEDERATION[0] = None
     auth._API_KEY[0] = ""
     auth._ALLOWED_ORIGINS[0] = None
+    auth._MEMBER_PUBLIC[0] = None
 
 
 def _client() -> TestClient:
@@ -609,3 +611,105 @@ def test_requires_operator_classification(path, operator):
 )
 def test_is_public(path, expected):
     assert auth._is_public(path) is expected
+
+
+# ── member-public deferral for fleet-proxied view pages (#1890) ───────────────
+#
+# A member's plugin view page is public chrome on the MEMBER; through the hub it
+# lives at /agents/<slug>/plugins/<id>/… — a path the hub's own public list can't
+# know. The middleware defers those to an injected resolver (the member's own
+# public list) and stamps request.state.member_public so the proxy forwards the
+# request anonymous instead of lending the stored remote bearer.
+
+
+def _member_client() -> TestClient:
+    def echo_state(r):
+        return PlainTextResponse(str(getattr(r.state, "member_public", False)))
+
+    app = Starlette(routes=[Route("/agents/{slug}/{rest:path}", echo_state, methods=["GET"])])
+    app.add_middleware(auth.A2AAuthMiddleware)
+    return TestClient(app)
+
+
+def test_member_public_view_page_passes_without_bearer():
+    auth.configure(bearer_token="hub-secret", api_key="", allowed_origins_raw="")
+    calls = []
+
+    async def resolver(slug, rest):
+        calls.append((slug, rest))
+        return True
+
+    auth.set_member_public_resolver(resolver)
+    res = _member_client().get("/agents/matt/plugins/content/view")
+    assert res.status_code == 200
+    assert res.text == "True"  # request.state.member_public stamped for the proxy
+    assert calls == [("matt", "/plugins/content/view")]
+
+
+def test_member_public_false_falls_through_to_401():
+    auth.configure(bearer_token="hub-secret", api_key="", allowed_origins_raw="")
+
+    async def resolver(slug, rest):
+        return False
+
+    auth.set_member_public_resolver(resolver)
+    res = _member_client().get("/agents/matt/plugins/content/secret")
+    assert res.status_code == 401
+
+
+def test_member_public_not_consulted_outside_plugin_namespace():
+    auth.configure(bearer_token="hub-secret", api_key="", allowed_origins_raw="")
+
+    async def resolver(slug, rest):  # pragma: no cover — must not be reached
+        raise AssertionError("resolver consulted for a non-plugin-namespace path")
+
+    auth.set_member_public_resolver(resolver)
+    c = _member_client()
+    # Operator API through the proxy stays fully gated.
+    assert c.get("/agents/matt/api/chat/sessions").status_code == 401
+    # No trailing slash after the plugin id = not inside a plugin namespace
+    # (the shape that keeps core /api/plugins/<verb> routes out of reach).
+    assert c.get("/agents/matt/api/plugins/install").status_code == 401
+
+
+def test_member_public_not_consulted_in_open_mode():
+    auth.configure(bearer_token="", api_key="", allowed_origins_raw="")
+
+    async def resolver(slug, rest):  # pragma: no cover — must not be reached
+        raise AssertionError("resolver consulted in open mode")
+
+    auth.set_member_public_resolver(resolver)
+    res = _member_client().get("/agents/matt/plugins/content/view")
+    assert res.status_code == 200  # open mode passes anyway
+    assert res.text == "False"  # and is NOT stamped member_public
+
+
+def test_member_public_resolver_error_fails_closed():
+    auth.configure(bearer_token="hub-secret", api_key="", allowed_origins_raw="")
+
+    async def resolver(slug, rest):
+        raise RuntimeError("member probe blew up")
+
+    auth.set_member_public_resolver(resolver)
+    assert _member_client().get("/agents/matt/plugins/content/view").status_code == 401
+
+
+def test_member_public_bearer_caller_still_passes_gated_paths():
+    auth.configure(bearer_token="hub-secret", api_key="", allowed_origins_raw="")
+
+    async def resolver(slug, rest):
+        return False
+
+    auth.set_member_public_resolver(resolver)
+    res = _member_client().get(
+        "/agents/matt/plugins/content/view", headers={"Authorization": "Bearer hub-secret"}
+    )
+    assert res.status_code == 200  # the console's probe (bearer attached) is unaffected
+    assert res.text == "False"
+
+
+def test_public_prefixes_getter_reflects_live_list():
+    auth.set_public_prefixes(["/plugins/content/view", "/api/plugins/content/hook/", "/api/config"])
+    assert auth.public_prefixes() == ["/plugins/content/view", "/api/plugins/content/hook/"]
+    auth.set_public_prefixes([])
+    assert auth.public_prefixes() == []

--- a/tests/test_fleet_member_public.py
+++ b/tests/test_fleet_member_public.py
@@ -1,0 +1,122 @@
+"""Member-public deferral (#1890) — graph/fleet/member_public.py.
+
+The hub answers "is this slug-prefixed path public on the MEMBER?" from the
+member's own live public-prefix list, fetched off its public /.well-known
+endpoint and TTL-cached per slug. Fail-closed: unreachable member, bad payload,
+or a non-conforming prefix all yield "not public" (normal bearer auth applies).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from graph.fleet import member_public, proxy
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    member_public._cache.clear()
+    proxy._slug_cache.clear()
+    yield
+    member_public._cache.clear()
+    proxy._slug_cache.clear()
+
+
+class FakeResp:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class FakeClient:
+    def __init__(self, resp=None, exc=None):
+        self.resp, self.exc, self.calls = resp, exc, []
+
+    async def get(self, url, timeout=None):
+        self.calls.append(url)
+        if self.exc:
+            raise self.exc
+        return self.resp
+
+
+def _wire(monkeypatch, client, target=("http://127.0.0.1:7001", {})):
+    monkeypatch.setattr(proxy, "_target_for_slug", lambda slug: target)
+    monkeypatch.setattr(proxy, "_get_client", lambda: client)
+
+
+async def test_fetches_and_matches_member_prefixes(monkeypatch):
+    client = FakeClient(resp=FakeResp(payload={"public_paths": ["/plugins/content/view"]}))
+    _wire(monkeypatch, client)
+    assert await member_public.is_member_public("matt", "/plugins/content/view") is True
+    assert await member_public.is_member_public("matt", "/plugins/content/view/assets/x.js") is True
+    assert await member_public.is_member_public("matt", "/plugins/content/secret") is False
+    assert client.calls == [f"http://127.0.0.1:7001{member_public.WELL_KNOWN_PATH}"]  # cached after 1 fetch
+
+
+async def test_non_conforming_member_prefixes_are_dropped(monkeypatch):
+    # A hostile/buggy member can't exempt anything outside a plugin namespace on the hub.
+    client = FakeClient(
+        resp=FakeResp(payload={"public_paths": ["/", "/api/config", "/api/plugins/install", 42]})
+    )
+    _wire(monkeypatch, client)
+    assert await member_public.member_public_prefixes("matt") == ()
+
+
+async def test_unreachable_member_fails_closed(monkeypatch):
+    client = FakeClient(exc=httpx.ConnectError("refused"))
+    _wire(monkeypatch, client)
+    assert await member_public.is_member_public("matt", "/plugins/content/view") is False
+    # negative-cached — no refetch inside the window
+    assert await member_public.is_member_public("matt", "/plugins/content/view") is False
+    assert len(client.calls) == 1
+
+
+async def test_non_200_fails_closed(monkeypatch):
+    client = FakeClient(resp=FakeResp(status_code=502, payload={}))
+    _wire(monkeypatch, client)
+    assert await member_public.member_public_prefixes("matt") == ()
+
+
+async def test_bad_payload_shape_fails_closed(monkeypatch):
+    client = FakeClient(resp=FakeResp(payload={"public_paths": "not-a-list"}))
+    _wire(monkeypatch, client)
+    assert await member_public.member_public_prefixes("matt") == ()
+
+
+async def test_unresolvable_slug_fails_closed(monkeypatch):
+    client = FakeClient(resp=FakeResp(payload={"public_paths": ["/plugins/x/view"]}))
+    _wire(monkeypatch, client, target=None)
+    assert await member_public.is_member_public("ghost", "/plugins/x/view") is False
+    assert client.calls == []  # never fetched — no base URL to ask
+
+
+async def test_cache_expiry_refetches(monkeypatch):
+    client = FakeClient(resp=FakeResp(payload={"public_paths": ["/plugins/content/view"]}))
+    _wire(monkeypatch, client)
+    assert await member_public.is_member_public("matt", "/plugins/content/view") is True
+    # Force the cache entry stale; the next call re-fetches.
+    exp, prefixes = member_public._cache["matt"]
+    member_public._cache["matt"] = (exp - member_public._TTL - 1, prefixes)
+    assert await member_public.is_member_public("matt", "/plugins/content/view") is True
+    assert len(client.calls) == 2
+
+
+async def test_never_sends_stored_remote_credentials(monkeypatch):
+    # The well-known endpoint is public; the stored remote bearer must not be sprayed at it.
+    seen = {}
+
+    class SpyClient(FakeClient):
+        async def get(self, url, timeout=None, headers=None):
+            seen["headers"] = headers
+            return FakeResp(payload={"public_paths": []})
+
+    client = SpyClient()
+    _wire(monkeypatch, client, target=("http://remote:7870", {"authorization": "Bearer sekrit"}))
+    await member_public.member_public_prefixes("matt")
+    assert seen["headers"] is None

--- a/tests/test_fleet_proxy.py
+++ b/tests/test_fleet_proxy.py
@@ -166,6 +166,46 @@ async def test_forward_to_delegates_to_target_when_running(monkeypatch):
     assert seen == {"base": "http://127.0.0.1:7001", "path": "api/chat", "extra": {}}
 
 
+async def test_forward_to_member_public_drops_stored_remote_bearer(monkeypatch):
+    """#1890: a request the hub admitted off the MEMBER's public list arrived anonymous —
+    forwarding it must NOT lend the remote's stored bearer to an unauthenticated caller."""
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        proxy, "_target_for_slug", lambda slug: ("http://remote:7870", {"authorization": "Bearer sekrit"})
+    )
+    seen = {}
+
+    async def fake_fwd(base, request, path, extra=None):
+        seen.update(extra=extra)
+        return "OK"
+
+    monkeypatch.setattr(proxy, "_forward_to_base", fake_fwd)
+    req = FakeRequest()
+    req.state = SimpleNamespace(member_public=True)
+    assert await proxy.forward_to("matt", req, "plugins/content/view") == "OK"
+    assert seen["extra"] == {}
+
+
+async def test_forward_to_authed_request_keeps_stored_remote_bearer(monkeypatch):
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        proxy, "_target_for_slug", lambda slug: ("http://remote:7870", {"authorization": "Bearer sekrit"})
+    )
+    seen = {}
+
+    async def fake_fwd(base, request, path, extra=None):
+        seen.update(extra=extra)
+        return "OK"
+
+    monkeypatch.setattr(proxy, "_forward_to_base", fake_fwd)
+    req = FakeRequest()
+    req.state = SimpleNamespace()  # no member_public stamp — normal authed traffic
+    assert await proxy.forward_to("matt", req, "api/chat") == "OK"
+    assert seen["extra"] == {"authorization": "Bearer sekrit"}
+
+
 # --- _forward_to_base -----------------------------------------------------
 
 

--- a/tests/test_reload_rebuild_deps.py
+++ b/tests/test_reload_rebuild_deps.py
@@ -128,6 +128,7 @@ def test_reload_refreshes_plugin_verifier_registry(tmp_path, monkeypatch):
         import a2a_impl.auth as _a2a_auth
 
         monkeypatch.setattr(_a2a_auth, "set_bearer_token", lambda *a, **k: None)
+        monkeypatch.setattr(_a2a_auth, "set_public_prefixes", lambda *a, **k: None)
     except ImportError:
         pass
 
@@ -142,8 +143,8 @@ def test_reload_refreshes_plugin_verifier_registry(tmp_path, monkeypatch):
         lambda *a, **k: SimpleNamespace(
             mcp_servers=[], tools=[], tool_plugins={}, skill_dirs=[], meta=[],
             chat_commands={}, subagents=[], middleware=[], late_tool_factories=[], routers=[],
-            goal_verifiers={"demo:brand_new": _new_verifier}, goal_hooks=[], watch_hooks=[],
-            lifecycle_hooks=[],
+            public_paths=[], goal_verifiers={"demo:brand_new": _new_verifier}, goal_hooks=[],
+            watch_hooks=[], lifecycle_hooks=[],
         ),
     )
     # Let the graph rebuild SUCCEED so the commit block (with the registry refresh) runs.


### PR DESCRIPTION
Closes #1890.

## Problem
On a token-gated **fleet hub**, viewing another member's plugin views 401s:
```json
{"detail": "Unauthorized: expected 'Authorization: Bearer <token>'"}
```
(observed on a protoContent instance — Jon viewing Matt's plugins).

A plugin view page is deliberately auth-exempt **public chrome** (`_view_public_paths`): a browser iframe navigation can't carry an `Authorization` header, so the page loads unauthenticated and then receives the bearer via the postMessage init handshake for its gated `/api/plugins/<id>/*` data calls.

Through the hub the same page loads at `/agents/<slug>/plugins/<id>/view`. The hub's `A2AAuthMiddleware._is_public` does plain `startswith` matching against prefixes like `/plugins/<id>/view` — the `/agents/<slug>` prefix defeats the match (and the hub's public list is built from the **hub's** manifests anyway; the member may run plugins the hub doesn't). The headerless navigation falls through to the bearer check → 401. It only surfaces under a bearer-gated hub (tailnet/homelab); open-mode desktop hubs pass everything.

## Fix
The **member** is the authority on what it serves anonymously, so the hub defers to it:

- Every instance serves its live auth-exempt prefix list on the public `GET /.well-known/protoagent/public-paths` (the listed paths are already anonymously reachable — this discloses nothing new).
- `A2AAuthMiddleware` checks a slug-prefixed **plugin-namespace** path against the *member's* list through an injected async resolver (`graph/fleet/member_public.py` — TTL-cached, fail-closed), and stamps `request.state.member_public`.
- `proxy.forward_to` sees that stamp and forwards the request **anonymously** — it does not attach a stored remote bearer, so an unauthenticated caller can never borrow the remote's credential (same posture as the existing remote-WS refusal in `forward_ws`).

Scoped tightly: consulted only when a credential actually gates the hub, and only inside a `/plugins/<id>/` namespace — `/agents/<slug>/api/…` (incl. `/api/plugins/install`) stays fully gated. A member can only ever open its own `/plugins/<id>/…` subtree on the hub, exactly as far as it already opens it to direct callers. Resolver error / unreachable member / bad payload all fail closed to normal bearer auth.

### Bonus fix (same class as #1752)
The hot-reload commit now re-pushes plugin public prefixes to the live auth gate (`set_public_prefixes`) — without it, a hot-enabled plugin's view page stayed 401 until a full restart. Same rule as #1752: any init-time registry wiring must re-apply on reload.

## Tests
- `tests/test_a2a_auth.py` (+8): member-public path passes without a bearer and is stamped; false → 401; not consulted outside a plugin namespace or in open mode; resolver error fails closed; the console's bearer-attached probe is unaffected; `public_prefixes()` getter.
- `tests/test_fleet_member_public.py` (new): fetch + prefix match + TTL cache; non-conforming member prefixes dropped; unreachable / non-200 / bad-shape / unresolvable-slug all fail closed; cache expiry refetch; never sends stored remote credentials to the well-known endpoint.
- `tests/test_fleet_proxy.py` (+2): `forward_to` drops the stored remote bearer for a `member_public` request, keeps it for normal authed traffic.
- `tests/test_reload_rebuild_deps.py`: fake `LoadedPlugins` gains `public_paths`; reload no-op'd for the new `set_public_prefixes` call.

Gates green in-worktree: full pytest (3437 passed / 5 skipped), ruff, lint-imports (3 contracts kept), live_smoke. Layering held — the resolver is injected from the server bootstrap so `a2a_impl`/`graph` stay host-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)