### PR TITLE
chore: release v0.96.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.96.0] - 2026-07-07
+
 ### Added
 - **Hermes is a first-class agent runtime** (#1889). `protoagent hermes` is a one-command preset
   that points the runtime at NousResearch Hermes over the ADR 0033 ACP seam; `protoagent runtime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.95.1"
+version = "0.96.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "v0.96.0",
+    "date": "2026-07-07",
+    "changes": [
+      "Hermes is a first-class agent runtime",
+      "Fleet-wide distributed Langfuse tracing.",
+      "filesystem.allow_run defaults OFF on the headless tier",
+      "A fleet member's plugin views 401'd through a token-gated hub",
+      "A subagent hitting max_turns failed its whole delegation (GRAPH_RECURSION_LIMIT).",
+      "Fleet members no longer inherit the hub's identity.",
+      "An agent tracing to its own Langfuse project now produces a whole trace",
+      "A background knowledge-ingest job now wakes the agent when it finishes",
+      "Quieter plugin hot-reload logs"
+    ]
+  },
+  {
     "version": "v0.95.1",
     "date": "2026-07-07",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.96.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.96.0 -m 'Release v0.96.0' && git push origin v0.96.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new release entry for version 0.96.0 with highlights including Hermes as a first-class agent runtime, fleet-wide distributed Langfuse tracing, and several agent, plugin, fleet, and logging updates.
* **Chores**
  * Bumped the project version to 0.96.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->