### PR TITLE
fix(console): mobile viewport correctness — kill dead canvas, dvh, safe-area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Mobile viewport correctness for the console.** On phones (the DS single-pane shell,
+  ≤767px) the active surface no longer strands a slab of dead canvas below it — the chat
+  composer was floating mid-screen because the DS `.pl-appshell__mobile-stage` lays its
+  child out in block flow, so a surface panel's `flex: 1 1 0` went inert and it sized to
+  content (a leftover `.stage-panel { height: calc(100vh - 260px) }` from the retired
+  hand-rolled layout pinned it). The mobile stage is now a flex column, so the active
+  `.stage-panel` fills it and scrolls internally, exactly like a desktop dock column.
+  Also: `.app-shell` uses `100dvh` (falling back to `100vh`) so the mobile URL bar can't
+  hide the bottom nav/composer; `index.html` gains `viewport-fit=cover` and the bottom
+  quick-bar pads clear of the iOS home indicator / Android gesture bar via
+  `env(safe-area-inset-bottom)`; and the two dead pre-DS responsive media queries
+  (`.workspace`/`.rail`/`.stage` at 900/720px) are removed, keeping only the live
+  content-grid rules and realigning them to the 767px shell breakpoint.
+
 ## [0.96.0] - 2026-07-07
 
 ### Added

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- viewport-fit=cover exposes env(safe-area-inset-*) so the bottom nav / topbar
+         can pad clear of the iOS home indicator + notch in the installed PWA. -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <meta name="color-scheme" content="dark" />
     <meta name="theme-color" content="#9b87f2" />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%protolabs-icon-outline.svg" />

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3,7 +3,9 @@
    The shared :root token bridge + resets moved to theme-base.css (loads first). */
 
 .app-shell {
-  height: 100vh;
+  height: 100vh; /* fallback for browsers without dvh */
+  height: 100dvh; /* the dynamic viewport — excludes the mobile URL bar so the bottom
+                     nav/composer never hide under browser chrome */
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -1685,89 +1687,43 @@ textarea {
 /* The app `.spin` keyframe is retired — busy spinners now come from the DS
    (`<Button loading>` and `<Spinner>`, @protolabsai/ui ≥ 0.50). */
 
-/* Below this width there isn't room for the rail + chat + side panel, so drop
-   to two columns and hide the panel (reachable again by widening / the toggle).
-   Kept under the desktop's 980px min window so the panel stays put there; this
-   mainly affects narrow browser windows. The two-column template here now
-   actually wins because .workspace no longer sets its columns inline. */
-@media (max-width: 900px) {
-  .workspace {
-    grid-template-columns: 64px minmax(0, 1fr);
-  }
+/* ── Mobile shell (≤767px — the DS AppShell single-pane breakpoint, ADR 0035) ────
+   Under 768px the DS collapses to ONE stage + a bottom quick-bar. Its
+   `.pl-appshell__mobile-stage` is a flex ITEM but lays its child out in normal
+   block flow, so a surface panel's `flex: 1 1 0` goes inert and the panel sizes to
+   content — stranding dead canvas below it (the chat composer ends up floating
+   mid-screen). Making the stage a flex column lets the active `.stage-panel` fill
+   it and scroll INTERNALLY, exactly like a desktop dock column.
 
-  .right-panel {
-    display: none;
-  }
-}
+   (The old hand-rolled `.workspace`/`.rail`/`.stage`/`.topbar`/`.right-panel` grid
+   and its `.stage-panel { height: calc(100vh - 260px) }` were removed here — those
+   classes no longer render, and that fixed height was the actual cause of the gap.
+   Kept below: only the content-grid rules whose classes are still live.)
 
-@media (max-width: 720px) {
-  .app-shell {
-    grid-template-rows: auto minmax(0, 1fr);
-  }
-
-  .topbar {
-    min-height: 56px;
-    align-items: flex-start;
+   Breakpoint note: keep this 767 in lockstep with `useIsMobile` (lib/useIsMobile.ts)
+   and the DS `mobileBreakpoint` (768 ⇒ its query is also ≤767). */
+@media (max-width: 767px) {
+  .pl-appshell__mobile-stage {
+    display: flex;
     flex-direction: column;
-    padding: 10px 12px;
   }
 
-  .topbar-status {
-    width: 100%;
-    overflow-x: auto;
-    padding-bottom: 2px;
+  /* Bottom quick-bar clears the iOS home indicator / Android gesture bar
+     (needs `viewport-fit=cover`, set in index.html). */
+  .pl-mobilenav {
+    padding-bottom: env(safe-area-inset-bottom);
   }
 
-  .workspace {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto minmax(0, 1fr);
-  }
-
-  .rail {
-    flex-direction: row;
-    border-right: 0;
-    border-bottom: 1px solid var(--border);
-  }
-
-  .rail button {
-    flex: 1 1 0;
-    min-height: 44px;
-  }
-
-  .stage {
-    border-right: 0;
-    padding: 8px;
-    overflow: auto;
-  }
-
-  .stage-panel {
-    height: calc(100vh - 260px);
-    min-height: 420px;
-  }
-
-  .composer,
+  /* Dense content grids collapse to a single column on phones. */
   .subagent-grid,
-  .batch-task-fields,
-  .issue-create,
-  .issue-create-meta,
-  .notes-meta,
   .setup-grid.two,
   .setup-grid.three,
   .setup-grid.model-row {
     grid-template-columns: 1fr;
   }
 
-  .composer textarea {
-    min-height: 76px;
-  }
-
   .metric-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .message {
-    grid-template-columns: 1fr;
-    gap: 4px;
   }
 
   .setup-overlay {


### PR DESCRIPTION
## Mobile styling, PR 1 of a series — the shell-level correctness foundation

First slice of the "get mobile sorted" polish pass. This one fixes the **real defects** in the mobile shell; the tablet band and the per-view phone sweep follow in separate PRs.

### The headline fix — dead canvas under the active surface
On phones (the DS single-pane shell, ≤767px) every surface stranded a slab of empty canvas below it — most visibly, the **chat composer floated mid-screen** with grey space beneath it.

**Root cause:** the DS `.pl-appshell__mobile-stage` is a flex *item* but lays its child out in **block flow**, so a surface panel's `flex: 1 1 0` goes inert and the panel sizes to content. A leftover `.stage-panel { height: calc(100vh - 260px) }` from the retired hand-rolled layout pinned it to ~584px in an 744px stage → ~160px dead gap.

**Fix:** make the mobile stage a flex column so the active `.stage-panel` fills it and scrolls **internally**, exactly like a desktop dock column.

| Before | After |
|---|---|
| composer floats mid-screen, ~160px grey gap below | composer docks to the bottom nav, panel fills |

### Also in this PR
- **`100dvh`** (fallback `100vh`) on `.app-shell` — the mobile URL bar can no longer hide the bottom nav / composer.
- **Safe-area** — `viewport-fit=cover` in `index.html` + `env(safe-area-inset-bottom)` on the bottom quick-bar so it clears the iOS home indicator / Android gesture bar.
- **Dead-CSS cleanup** — removed the two pre-DS responsive media queries (`.workspace`/`.rail`/`.stage`/`.topbar`/`.right-panel` at 900/720px; those classes no longer render). Kept only the live content-grid rules, realigned to the 767px shell breakpoint.

### Verification
Real build (worktree `vite preview`), iPhone-SE/Pro widths:
- ✅ chat + knowledge panels fill to the nav (gap **0**), composer docked
- ✅ no horizontal overflow at 375 / 390 / 720px
- ✅ `100dvh` resolves cleanly; no console errors
- ✅ desktop (1280px) unchanged — rail layout intact, no mobile nav

**Draft** — UI work, wants a human eye + a real notched-device pass for the safe-area padding (headless can't simulate the home indicator; the rule is correct-by-construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile layout behavior, including a cleaner single-column view on smaller screens.
  * Added better support for iOS safe areas when the app is installed as a PWA.

* **Bug Fixes**
  * Reduced viewport sizing issues on mobile by using a more reliable screen-height approach.
  * Updated spacing so key UI elements like navigation and top bars avoid notches and home indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->