### PR TITLE
fix(console): dvh on mobile overlays + drop dead pre-DS mobile shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Modals/overlays use `dvh` on mobile.** Every tall dialog height (the full-screen
+  DocumentViewer reader, the Settings overlay, the theme-quick + MCP-catalog +
+  plugin-widget dialogs, the background-jobs list, the SOUL history, the crash screen)
+  now uses the dynamic viewport (`Ndvh`, falling back to `Nvh`) so the mobile browser
+  URL bar can't clip the top/bottom of a near-full-height overlay. Also removes the last
+  of the dead pre-DS mobile shell CSS (`.workspace.mobile` / `.mobile-bar` / `.mobile-tab`
+  / `.mobile-drawer*` — ~95 lines, superseded by the DS `.pl-mobilenav` + `AppDrawer`).
 - **Mobile viewport correctness for the console.** On phones (the DS single-pane shell,
   ≤767px) the active surface no longer strands a slab of dead canvas below it — the chat
   composer was floating mid-screen because the DS `.pl-appshell__mobile-stage` lays its

--- a/apps/web/src/agent/identity.css
+++ b/apps/web/src/agent/identity.css
@@ -68,6 +68,7 @@
      but cap at most of the viewport so a long history scrolls inside the dialog rather than
      pushing it past the screen. The DS dialog itself is content-sized (max-height 100vh). */
   max-height: 68vh;
+  max-height: 68dvh;
   overflow-y: auto;
 }
 .soul-history-item {

--- a/apps/web/src/app/app-crash.css
+++ b/apps/web/src/app/app-crash.css
@@ -3,6 +3,7 @@
 
 .app-crash {
   height: 100vh;
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -150,6 +150,7 @@
   flex-direction: column;
   min-height: 0;
   height: min(60vh, 560px);
+  height: min(60dvh, 560px);
 }
 
 /* Background subagents (ADR 0050 Phase 3) — UtilityBar pill + jobs dialog. */
@@ -177,6 +178,7 @@
   flex-direction: column;
   gap: 4px;
   max-height: min(60vh, 520px);
+  max-height: min(60dvh, 520px);
   overflow-y: auto;
 }
 .bg-jobs-row {
@@ -687,6 +689,7 @@ select:disabled {
    short and leaving dead space under it. The configure step keeps its content height. */
 .mcp-catalog-dialog--browse .pl-dialog {
   height: min(82vh, calc(100vh - 2 * var(--pl-space-4, 16px)));
+  height: min(82dvh, calc(100dvh - 2 * var(--pl-space-4, 16px)));
 }
 .mcp-catalog-dialog--browse .pl-dialog__body {
   display: flex;
@@ -1903,7 +1906,7 @@ textarea {
 .plugin-view-state { display: flex; align-items: center; gap: 8px; padding: 24px; color: var(--fg-muted); font-size: 13px; }
 /* A plugin view hosted in a utility-widget DIALOG (vs the stage): give it a fixed height
    so the iframe has room to fill (the stage normally supplies that via its flex column). */
-.plugin-widget-dialog { display: flex; flex-direction: column; height: 70vh; min-height: 0; }
+.plugin-widget-dialog { display: flex; flex-direction: column; height: 70vh; height: 70dvh; min-height: 0; }
 .plugin-widget-dialog > .plugin-view { flex: 1; min-height: 0; }
 
 /* Plugins panel (ADR 0027, .plugin-install-* / .plugin-list / .plugin-row-main / -title /
@@ -1931,103 +1934,6 @@ textarea {
   font-size: 0.78rem;
   color: var(--fg-muted);
   word-break: break-word;
-}
-
-/* Mobile shell (ADR 0035 S4) — single surface + bottom quick-bar + hamburger drawer. The
-   --pl-color-overlay / --pl-color-bg-hover tokens land in @protolabsai/design 0.4.0; fallbacks
-   keep it correct until then. */
-.workspace.mobile {
-  display: flex;
-  flex-direction: column;
-  grid-template-columns: none;
-}
-.workspace.mobile .stage {
-  flex: 1;
-  min-height: 0;
-  border-right: none;
-  padding-bottom: 60px; /* clear the fixed bottom bar */
-}
-.mobile-bar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  display: flex;
-  border-top: 1px solid var(--border);
-  background: var(--bg-panel);
-  z-index: 40;
-}
-.mobile-tab {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 3px;
-  padding: 8px 4px;
-  background: transparent;
-  border: none;
-  color: var(--fg-muted);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  cursor: pointer;
-}
-.mobile-tab.active {
-  color: var(--brand-violet-light);
-}
-.mobile-drawer-overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--pl-color-overlay, rgba(0, 0, 0, 0.55));
-  z-index: 50;
-  display: flex;
-}
-.mobile-drawer {
-  width: 82%;
-  max-width: 320px;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  background: var(--bg-panel);
-  border-right: 1px solid var(--border);
-}
-.mobile-drawer-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--border);
-  font-size: 0.85rem;
-}
-.mobile-drawer-head button {
-  background: transparent;
-  border: none;
-  color: var(--fg-muted);
-  cursor: pointer;
-}
-.mobile-drawer-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 8px;
-  overflow: auto;
-}
-.mobile-drawer-list button {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 12px;
-  background: transparent;
-  border: none;
-  border-radius: var(--radius);
-  color: var(--fg);
-  cursor: pointer;
-  text-align: left;
-  font-size: 0.85rem;
-}
-.mobile-drawer-list button.active,
-.mobile-drawer-list button:hover {
-  background: var(--pl-color-bg-hover, rgba(255, 255, 255, 0.06));
 }
 
 /* Fleet manager (Settings → Agents, ADR 0042) — the .fleet-list / .fleet-row* /

--- a/apps/web/src/docviewer/docviewer.css
+++ b/apps/web/src/docviewer/docviewer.css
@@ -3,7 +3,9 @@
    full-screen read instead of a short centered modal. */
 .doc-viewer.pl-dialog {
   height: min(90vh, 1000px);
+  height: min(90dvh, 1000px); /* dvh: the reader must not spill under mobile browser chrome */
   max-height: 96vh;
+  max-height: 96dvh;
   display: flex;
   flex-direction: column;
 }

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -17,6 +17,7 @@
    element). */
 .pl-dialog.quick-setting-dialog {
   max-height: min(72vh, 620px);
+  max-height: min(72dvh, 620px);
 }
 .quick-setting-body {
   display: flex;
@@ -112,6 +113,7 @@
 .settings-overlay .pl-dialog__body {
   padding: 0;
   height: 80vh;
+  height: 80dvh; /* dvh so the overlay fits the visible viewport on mobile */
   overflow: hidden;
   /* Flex column so the shell (.settings-shell { flex: 1 }) fills the 80vh — without
      a flex parent the shell collapses to content height and the panel/rail don't
@@ -122,6 +124,7 @@
 .theme-quick-dialog .pl-dialog__body {
   padding: 0;
   max-height: 80vh;
+  max-height: 80dvh;
   min-height: 50vh;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Mobile styling, PR 2 — overlay viewport correctness

Stacked on #1899 (base = `mobile/viewport-correctness`). Extends PR1's `100dvh` fix from the shell to every **overlay**.

### dvh on tall dialogs
Tall dialog heights used `vh`, so on mobile the browser URL bar could clip the top/bottom of a near-full-height overlay. Converted to the dynamic viewport (`Ndvh`, fallback `Nvh`):

| Overlay | was |
|---|---|
| DocumentViewer full-screen reader | `90vh` / `96vh` |
| Settings overlay body | `80vh` |
| Theme-quick dialog | `80vh` |
| MCP-catalog browse dialog | `82vh` |
| Plugin-widget dialog | `70vh` |
| util-dialog-fill / background-jobs list | `60vh` |
| SOUL history | `68vh` |
| Crash screen | `100vh` |

Widths stay `vw` (the horizontal viewport is stable — no dynamic-viewport issue there).

### Dead-CSS cleanup
Removes the **last** dead pre-DS mobile shell CSS — `.workspace.mobile` / `.mobile-bar` / `.mobile-tab` / `.mobile-drawer*` (~95 lines, **0 renders**, superseded by the DS `.pl-mobilenav` + `AppDrawer`). Finishes the cleanup PR1 started.

### Verification
Real build (worktree preview): Settings overlay + dialogs render correctly on a phone, no overflow, no errors. `dvh == vh` headless so there's no regression to see there — the URL-bar benefit is device-only, and the fallback keeps old webviews correct.

### Follow-up (not this PR)
The Settings overlay's **two-column** (sidenav | content) layout is still cramped on a phone (sidenav eats ~250px of ~360px). Same "two-pane won't collapse" class as the Docs surface — I'm fixing both together in the next PR.

**Draft** — UI work, wants your eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)