### PR TITLE
fix(console): Settings collapses to one column on phones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Settings collapses to a single column on phones.** The Settings surface/overlay is a
+  200px SideNav rail + content pane; on a ~360px phone overlay that left the content pane a
+  ~130px sliver (labels wrapped a word per line, inputs clipped). On mobile the SideNav now
+  renders `responsive` so it collapses to its DS `<select>` (a full-width section dropdown on
+  top) and the shell stacks to one column, giving the content the full width. Desktop is
+  unchanged — the rail is still a vertical tablist (the `responsive` prop is gated on
+  `useIsMobile`, and the mobile shell CSS is viewport-scoped).
 - **Modals/overlays use `dvh` on mobile.** Every tall dialog height (the full-screen
   DocumentViewer reader, the Settings overlay, the theme-quick + MCP-catalog +
   plugin-widget dialogs, the background-jobs list, the SOUL history, the crash screen)

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -12,6 +12,7 @@ import { isHostConsole } from "../lib/api";
 import { PluginsSurface } from "../plugins/PluginsSurface";
 import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
+import { useIsMobile } from "../lib/useIsMobile";
 import { useUI } from "../state/uiStore";
 import { DelegatesSection } from "./DelegatesSection";
 import { FleetSurface } from "./FleetSurface";
@@ -105,6 +106,9 @@ const CONSOLE_SECTIONS: Section[] = [
 // command). The Box group is gated to the host console.
 export function SettingsSurface({ initialSection }: { only?: "host" | "workspace"; initialSection?: string } = {}) {
   const onHost = isHostConsole();
+  // On phones the two-column shell can't fit a 200px rail + readable content, so collapse
+  // the SideNav to its DS <select> (mobile only — the desktop rail is deliberately a tablist).
+  const isMobile = useIsMobile();
   const persistedSection = useUI((s) => s.settingsSection);
   const setSection = useUI((s) => s.setSettingsSection);
 
@@ -137,7 +141,7 @@ export function SettingsSurface({ initialSection }: { only?: "host" | "workspace
 
   return (
     <div className="settings-shell">
-      <SideNav ariaLabel="Settings sections" groups={groups} active={active.id} onSelect={(id) => setSection(id)} />
+      <SideNav responsive={isMobile} ariaLabel="Settings sections" groups={groups} active={active.id} onSelect={(id) => setSection(id)} />
       <div className="settings-content">
         {active.render()}
       </div>

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -94,6 +94,34 @@
   .settings-content .setting-input { max-width: none; }
 }
 
+/* Phones: the two-column shell can't fit a 200px rail + readable content in a ~360px
+   overlay, so stack it — the SideNav (rendered `responsive` on mobile, see
+   SettingsSurface) becomes a full-width <select> on top, content fills the width below.
+   The DS collapse is a 15rem container query on the rail's own width; the stacked rail is
+   full-width (> 15rem) so that query never fires — force the <select> by viewport instead. */
+@media (max-width: 767px) {
+  .settings-shell {
+    flex-direction: column;
+    gap: 10px;
+    padding-left: 0;
+  }
+  .settings-shell > .pl-sidenav-wrap {
+    flex: 0 0 auto;
+    width: 100%;
+    overflow: visible;
+    padding-right: 0;
+    padding-bottom: 10px;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+  .settings-shell > .pl-sidenav-wrap--responsive > .pl-sidenav {
+    display: none;
+  }
+  .settings-shell > .pl-sidenav-wrap--responsive > .pl-sidenav__select {
+    display: block;
+  }
+}
+
 /* Collapsible field groups (DS Accordion, 0.29). Drop the default muted panel
    tint so field labels render at full contrast, and let the dirty-count badge sit
    inline in the trigger title. */


### PR DESCRIPTION
## Mobile styling, PR 3 — Settings overlay two-pane collapse

Stacked on #1900 (base = `mobile/dialogs-dvh`).

### Problem
The Settings surface/overlay is a **200px SideNav rail + content pane**. On a ~360px phone overlay that starved the content to a **~130px sliver** — labels wrapped a word per line, inputs clipped:

| Before | After |
|---|---|
| sidenav eats 200px, content ~130px, text 2-words/line | full-width `<select>` on top, content full-width (356px) |

### Fix
On mobile the SideNav renders `responsive`, so it collapses to the DS `<select>` (a full-width section dropdown), and the shell stacks to one column.

- `responsive={isMobile}` (via the existing `useIsMobile`) so **only phones** collapse — the desktop rail stays a vertical tablist (the deliberate non-responsive default is preserved).
- The DS `<select>` collapse is a 15rem container query on the rail's *own* width; the stacked mobile rail is full-width (> 15rem) so that query never fires — a viewport-scoped media query forces the `<select>` and stacks the shell.

### Verification
Real build (worktree preview):
- ✅ Mobile: `<select>` shown full-width (356px), tablist hidden, content full-width (356px, was ~130), no overflow
- ✅ Desktop (1280px): tablist shows, no `<select>`, unchanged

**Draft.** The **Docs** surface has the same two-pane-on-mobile problem but it's a Python-rendered iframe plugin (`plugins/docs`) — fixing + testing that is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)