### PR TITLE
fix(console): 40px touch targets for icon buttons on phones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Bigger touch targets on phones.** The DS icon button is 30px (26px `--sm`) — below the
+  ~44px touch guideline, and a dense surface like Memory has ~90 of them (per-row edit/delete).
+  On ≤767px icon buttons now get a 40px min hit area (the 16px glyph stays centered, so nothing
+  looks bigger — taps just land). Verified across Chat, Knowledge, and Memory with no crowding
+  or overflow.
 - **Docs reader is a master-detail flow on phones.** The `plugins/docs` reader view kept its
   desktop two-pane (280px tree | reader) on phones, crushing the reader into a ~90px sliver
   ("Select a doc from the list." wrapped a word per line). It's now master-detail: the doc

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1739,6 +1739,15 @@ textarea {
     bottom: 0;
     background: var(--bg-panel);
   }
+
+  /* Touch ergonomics: the DS icon button is 30px (26px in --sm) — below the ~44px
+     touch guideline, and there are ~90 of them on a dense surface (Memory row
+     edit/delete). Bump the hit area to 40px on phones; the 16px glyph stays centered,
+     so nothing looks bigger than it should, taps just land. */
+  .pl-btn--icon {
+    min-width: 40px;
+    min-height: 40px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Mobile styling, PR 5 — touch targets

Stacked on #1902 (base = `mobile/docs-view`).

The DS icon button is **30px** (26px `--sm`) — below the ~44px touch guideline — and a dense surface like **Memory** has ~90 of them (per-row edit/delete). On ≤767px they now get a **40px min hit area**; the 16px glyph stays centered so nothing looks bigger, taps just land.

```css
@media (max-width: 767px) {
  .pl-btn--icon { min-width: 40px; min-height: 40px; }
}
```

### Verification
Injected on the real preview and screenshotted across Chat, Knowledge, Memory — comfortable targets, **no** toolbar crowding, no overflow. (Knowledge's 4-icon header + Memory's per-row actions were the tightest cases; both fine.)

> DS-side note: touch-target sizing is arguably a `@protolabsai/ui` concern (a `mobile`/touch density mode). This is the console-side override; worth a protoContent issue to push it upstream.

**Draft.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)