### PR TITLE
feat(observability): fleet trace export → lab (the flywheel Observe, #1897)

### DIFF
--- a/observability/trace_export.py
+++ b/observability/trace_export.py
@@ -1,0 +1,352 @@
+"""Fleet trace export — the Observe seam of the agent-fleet flywheel (#1897).
+
+The lab (protoLab) mines the ProtoAgent Fleet's real production traces to find
+where agents fail → which deterministic worlds to build → what to train. This
+module emits those traces in the shape its training pipeline eats: one
+**canonical Trajectory** JSON row per terminal A2A turn, OpenAI chat-format,
+appended to a daily JSONL dump the lab ingests via ``dataset/adapters.py::_fleet``.
+
+Schema is a three-repo contract (protoAgent = source, MythXEngine = env traces,
+protoLab = consumer), pinned on protoAgent#1897. The row shape mirrors protoLab's
+``experiments/agentic-data/dataset/schema.py``::
+
+    id, source, teacher, domain, messages[], tools[], verified, reward,
+    thinking, split, license_note, meta{...}
+
+where ``meta`` carries the OODA signal the lab asked for — ``loop_shape``
+(ReAct vs OODA, labelled by whether the goals subsystem was active) and
+``orient`` (the durable goal-plan snapshot, our scratchpad-as-world-model).
+
+Config
+──────
+Env-gated like Langfuse (``tracing.init``), off by default, graceful no-op:
+
+    PROTOAGENT_FLEET_TRACE_EXPORT  unset / "0" / "off"  → disabled
+                                   "1" / "on" / "true"  → enabled at the default
+                                                          instance path
+                                   <path>               → enabled, dumps there
+
+Everything here is **best-effort**: a failure never touches the turn. The
+terminal hook that calls ``export_turn`` already swallows exceptions, and each
+helper degrades to a no-op / partial row rather than raising.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+_enabled = False
+_base_dir: Path | None = None
+
+# Per-message content cap — a pathological turn (a giant tool dump) shouldn't
+# produce a multi-MB row. The system prompt is well under this; genuine
+# truncation is stamped into meta so the lab can filter.
+_CONTENT_CAP = 100_000
+# The goal-plan snapshot (our Orient artifact) is small by design; cap defensively.
+_ORIENT_CAP = 16_000
+
+_TRUE = {"1", "true", "yes", "on"}
+_FALSE = {"", "0", "false", "no", "off"}
+
+# OpenAI tool schemas, converted once from the graph's bound tools (static for
+# the process lifetime) and reused across rows so the hot path stays cheap.
+_tool_schema_cache: list[dict] | None = None
+
+
+def init() -> None:
+    """Enable export if ``PROTOAGENT_FLEET_TRACE_EXPORT`` is set. Idempotent."""
+    global _enabled, _base_dir
+
+    raw = os.environ.get("PROTOAGENT_FLEET_TRACE_EXPORT", "").strip()
+    if raw.lower() in _FALSE:
+        print("[trace_export] fleet trace export disabled.")
+        return
+
+    try:
+        if raw.lower() in _TRUE:
+            from infra.paths import instance_paths
+
+            _base_dir = instance_paths().store("fleet-traces")
+        else:
+            _base_dir = Path(raw).expanduser()
+        _base_dir.mkdir(parents=True, exist_ok=True)
+        _enabled = True
+        print(f"[trace_export] fleet trace export -> {_base_dir}")
+    except Exception as e:  # noqa: BLE001 — never fail boot for an export sink
+        print(f"[trace_export] init failed: {e}. Export disabled.")
+
+
+def is_enabled() -> bool:
+    return _enabled
+
+
+def _daily_path() -> Path:
+    """Today's dump file — ``fleet-traces-YYYYMMDD.jsonl`` under the base dir."""
+    assert _base_dir is not None
+    day = datetime.now(timezone.utc).strftime("%Y%m%d")
+    return _base_dir / f"fleet-traces-{day}.jsonl"
+
+
+def _text_of(content: Any) -> str:
+    """Flatten a LangChain message ``content`` to text.
+
+    Content is usually a plain string; multimodal turns carry a list of parts
+    (``{"type": "text", ...}`` / ``{"type": "image_url", ...}``). Keep the text,
+    drop image bytes to a placeholder — the lab trains on interaction *shape*,
+    not pixels."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                out.append(part)
+            elif isinstance(part, dict):
+                if part.get("type") == "text":
+                    out.append(str(part.get("text", "")))
+                elif part.get("type") in ("image_url", "image"):
+                    out.append("[image]")
+        return "\n".join(out)
+    return str(content or "")
+
+
+def _cap(text: str, limit: int) -> tuple[str, bool]:
+    if len(text) > limit:
+        return text[:limit], True
+    return text, False
+
+
+def _to_openai_messages(messages: list) -> tuple[list[dict], bool]:
+    """LangChain checkpoint messages → OpenAI chat-format rows.
+
+    Returns ``(messages, truncated)``. Roles map:
+    Human→user, AI→assistant (+``tool_calls``), Tool→tool (+``tool_call_id``),
+    System→system. ``tool_calls`` arguments are emitted as a JSON *string* to
+    match the OpenAI wire shape the lab's adapter expects.
+    """
+    out: list[dict] = []
+    truncated = False
+    for m in messages:
+        role = None
+        # Prefer the class name (langchain), fall back to a ``.type`` attr.
+        cls = type(m).__name__
+        if cls == "HumanMessage":
+            role = "user"
+        elif cls == "AIMessage":
+            role = "assistant"
+        elif cls == "ToolMessage":
+            role = "tool"
+        elif cls == "SystemMessage":
+            role = "system"
+        else:
+            mtype = getattr(m, "type", "")
+            role = {"human": "user", "ai": "assistant", "tool": "tool", "system": "system"}.get(mtype)
+        if role is None:
+            continue
+
+        content, cut = _cap(_text_of(getattr(m, "content", "")), _CONTENT_CAP)
+        truncated = truncated or cut
+        row: dict[str, Any] = {"role": role, "content": content}
+
+        if role == "assistant":
+            calls = []
+            for tc in getattr(m, "tool_calls", None) or []:
+                # langchain tool_calls: {name, args (dict), id}
+                try:
+                    args = tc.get("args", {}) if isinstance(tc, dict) else getattr(tc, "args", {})
+                    name = tc.get("name", "") if isinstance(tc, dict) else getattr(tc, "name", "")
+                    tcid = tc.get("id", "") if isinstance(tc, dict) else getattr(tc, "id", "")
+                    calls.append(
+                        {
+                            "id": tcid or "",
+                            "name": name or "",
+                            "arguments": json.dumps(args, default=str),
+                        }
+                    )
+                except Exception:  # noqa: BLE001 — skip a malformed call, keep the turn
+                    continue
+            if calls:
+                row["tool_calls"] = calls
+        elif role == "tool":
+            tcid = getattr(m, "tool_call_id", "") or ""
+            if tcid:
+                row["tool_call_id"] = tcid
+
+        out.append(row)
+    return out, truncated
+
+
+def _tool_schemas(bound_tools: Any) -> list[dict]:
+    """OpenAI tool schemas for the graph's bound tools (converted once, cached).
+
+    ``bound_tools`` is ``STATE.graph.bound_tools`` — the full set bound to the
+    lead agent. Deferred tools (progressive disclosure) narrow what's *visible*
+    per turn; this is the superset, noted as such in ``meta``.
+    """
+    global _tool_schema_cache
+    if _tool_schema_cache is not None:
+        return _tool_schema_cache
+    schemas: list[dict] = []
+    try:
+        from langchain_core.utils.function_calling import convert_to_openai_tool
+
+        for t in bound_tools or []:
+            try:
+                schemas.append(convert_to_openai_tool(t))
+            except Exception:  # noqa: BLE001 — skip a tool that won't convert
+                continue
+    except Exception:  # noqa: BLE001 — no converter → empty tool set, not a crash
+        schemas = []
+    _tool_schema_cache = schemas
+    return schemas
+
+
+def _reward(state: str) -> tuple[bool, float | None]:
+    """Verifiable outcome from the turn's terminal state (never an LLM judge).
+
+    Per the locked #1897 contract: completed → verified success (1.0), failed →
+    verified failure (0.0), anything else (canceled/unknown) → unverified/null.
+    Dense subgoal-verifier rewards (``graph/goals/verifiers.py``) are a later,
+    R3-scoped addition surfaced as ``meta.subgoal_events``.
+    """
+    if state == "completed":
+        return True, 1.0
+    if state == "failed":
+        return True, 0.0
+    return False, None
+
+
+def _thinking_mode(graph_config: Any) -> str | None:
+    """Map the configured thinking mode to the schema's on/off/null."""
+    val = str(getattr(graph_config, "thinking", "") or "").lower()
+    if val in ("enabled", "on", "true"):
+        return "on"
+    if val in ("disabled", "off", "false"):
+        return "off"
+    return None
+
+
+def export_turn(outcome: Any, *, checkpointer: Any, graph_config: Any, bound_tools: Any = None) -> None:
+    """Append one canonical Trajectory row for a terminal A2A turn.
+
+    Called from the single terminal chokepoint (``_record_a2a_telemetry``),
+    sync and best-effort — swallow everything. Reads the turn's messages from
+    the checkpoint (sync ``get_tuple`` on the ``ThreadedSqliteSaver``), shapes
+    them per the locked schema, and appends JSONL to today's dump.
+    """
+    if not _enabled or _base_dir is None:
+        return
+    try:
+        session_id = getattr(outcome, "context_id", "") or ""
+        task_id = getattr(outcome, "task_id", "") or ""
+        state = getattr(outcome, "state", "") or ""
+
+        # Messages live in the checkpoint, keyed by the resolver's thread_id.
+        # The template default is ``a2a:<session_id>`` (server/chat._resolve…);
+        # a fork with a custom resolver scopes elsewhere — v1 targets the
+        # default, which is what the dev/prod template instances use.
+        messages: list = []
+        incognito = False
+        if checkpointer is not None and session_id:
+            try:
+                tup = checkpointer.get_tuple({"configurable": {"thread_id": f"a2a:{session_id}"}})
+                channel_values = (getattr(tup, "checkpoint", None) or {}).get("channel_values", {}) if tup else {}
+                incognito = bool(channel_values.get("incognito"))
+                messages = channel_values.get("messages", []) or []
+            except Exception:  # noqa: BLE001 — no checkpoint → skip, don't crash the hook
+                messages = []
+
+        # Incognito threads (ADR 0069 D3b) leave no memory trail — honour that
+        # here too; never export a turn the user asked to be forgotten.
+        if incognito or not messages:
+            return
+
+        oai_messages, truncated = _to_openai_messages(messages)
+        if not oai_messages:
+            return
+
+        # Orient artifact: the durable goal-plan snapshot. Its presence is our
+        # ReAct-vs-OODA label (goals subsystem active ⇒ OODA/Orient turn).
+        orient = ""
+        try:
+            from graph.goals.store import GoalStore
+
+            orient = (GoalStore().read_plan(session_id) or "").strip()
+        except Exception:  # noqa: BLE001 — plan is optional
+            orient = ""
+        orient, _ = _cap(orient, _ORIENT_CAP)
+        loop_shape = "ooda" if orient else "react"
+
+        verified, reward = _reward(state)
+        models = list(getattr(outcome, "models", None) or [])
+
+        # Trace id ties this row to the distributed Langfuse trace (and to any
+        # cross-agent delegation rows that share it). Best-effort — the trace
+        # contextvar is still set inside the terminal hook's scope.
+        trace_id = ""
+        try:
+            from observability import tracing
+
+            trace_id = tracing.current_trace_id() or ""
+        except Exception:  # noqa: BLE001
+            trace_id = ""
+        row_id = f"fleet__{trace_id or task_id}"
+
+        row = {
+            "id": row_id,
+            "source": "protoagent-fleet",
+            "teacher": os.environ.get("AGENT_NAME", "protoagent"),
+            "domain": "unknown",  # skill/domain inference is a follow-up
+            "messages": oai_messages,
+            "tools": _tool_schemas(bound_tools),
+            "verified": verified,
+            "reward": reward,
+            "thinking": _thinking_mode(graph_config),
+            "split": "train",  # fleet reality is always train-split
+            "license_note": None,
+            "meta": {
+                "trace_id": trace_id,
+                "session_id": session_id,
+                "task_id": task_id,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "model": models[0] if models else "",
+                "models": models,
+                "origin": getattr(outcome, "origin", "") or "",
+                "trigger": getattr(outcome, "trigger", "") or "",
+                "priority": getattr(outcome, "priority", "") or "",
+                "loop_shape": loop_shape,
+                "orient": orient,
+                "outcome_state": state,
+                "cost_usd": float(getattr(outcome, "cost_usd", 0.0) or 0.0),
+                "duration_ms": int(getattr(outcome, "duration_ms", 0) or 0),
+                "llm_calls": int(getattr(outcome, "llm_calls", 0) or 0),
+                "tool_calls": int(getattr(outcome, "tool_calls", 0) or 0),
+                # v1 caveats for the lab's adapter:
+                "delegation": None,  # in-process task() subagents are embedded in messages;
+                                     # cross-agent A2A delegations link via shared trace_id
+                "tools_note": "bound superset; deferred-tool visibility narrows per turn",
+                "reward_semantics": "terminal-state verifier (completed=1.0, failed=0.0); "
+                                    "dense subgoal-verifier events are R3 follow-up",
+                "content_truncated": truncated,
+            },
+        }
+
+        with _daily_path().open("a", encoding="utf-8") as f:
+            f.write(json.dumps(row, ensure_ascii=False, default=str) + "\n")
+    except Exception:  # noqa: BLE001 — export must never affect a turn
+        log.exception("[trace_export] failed to export turn %s", getattr(outcome, "task_id", "?"))
+
+
+def _reset_for_test() -> None:
+    """Test hook — clear module state between cases."""
+    global _enabled, _base_dir, _tool_schema_cache
+    _enabled = False
+    _base_dir = None
+    _tool_schema_cache = None

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -411,9 +411,11 @@ def _main():
     # Initialize observability
     from observability import tracing
     from observability import metrics
+    from observability import trace_export
 
     tracing.init()
     metrics.init()
+    trace_export.init()  # fleet trace export → lab (the flywheel Observe, #1897)
 
     _init_langgraph_agent(headless_setup=headless_setup)
 

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -547,6 +547,21 @@ def _record_a2a_telemetry(outcome) -> None:
     except Exception:  # noqa: BLE001 — telemetry is best-effort
         log.exception("[telemetry] failed to record turn %s", outcome.task_id)
 
+    # Fleet trace export → lab (the flywheel Observe, #1897). Off unless
+    # PROTOAGENT_FLEET_TRACE_EXPORT is set; best-effort, never touches the turn.
+    try:
+        from observability import trace_export
+
+        if trace_export.is_enabled():
+            trace_export.export_turn(
+                outcome,
+                checkpointer=STATE.checkpointer,
+                graph_config=STATE.graph_config,
+                bound_tools=getattr(STATE.graph, "bound_tools", None),
+            )
+    except Exception:  # noqa: BLE001 — export is best-effort
+        log.exception("[trace_export] failed to export turn %s", outcome.task_id)
+
 
 def _a2a_progress(context_id: str, task_id: str, frame: dict) -> None:
     """Per-frame progress hook (ADR 0051). Only background turns get a bus push — live

--- a/tests/test_trace_export.py
+++ b/tests/test_trace_export.py
@@ -1,0 +1,178 @@
+"""Tests for observability/trace_export.py — the fleet Observe seam (#1897).
+
+Freezes the canonical Trajectory row shape the lab's ``dataset/adapters.py::_fleet``
+consumes: OpenAI chat-format messages, verifiable reward from terminal state,
+the OODA ``loop_shape``/``orient`` signal, incognito skip, and disabled no-op.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+from observability import trace_export
+
+
+@dataclass
+class _Outcome:
+    context_id: str = "sess-1"
+    task_id: str = "task-1"
+    state: str = "completed"
+    models: list = field(default_factory=lambda: ["claude-opus-4-8"])
+    origin: str = "scheduler"
+    trigger: str = "job-9"
+    priority: str = ""
+    cost_usd: float = 0.02
+    duration_ms: int = 1500
+    llm_calls: int = 2
+    tool_calls: int = 1
+
+
+class _Checkpointer:
+    """Minimal sync checkpointer stub mirroring ThreadedSqliteSaver.get_tuple."""
+
+    def __init__(self, messages, incognito=False):
+        self._messages = messages
+        self._incognito = incognito
+
+    def get_tuple(self, config):
+        assert config["configurable"]["thread_id"] == "a2a:sess-1"
+
+        class _Tup:
+            checkpoint = {"channel_values": {"messages": self._messages, "incognito": self._incognito}}
+
+        return _Tup()
+
+
+@dataclass
+class _Cfg:
+    thinking: str = "enabled"
+
+
+_MESSAGES = [
+    SystemMessage(content="You are a helpful agent."),
+    HumanMessage(content="What's the weather?"),
+    AIMessage(
+        content="Let me check.",
+        tool_calls=[{"name": "get_weather", "args": {"city": "SF"}, "id": "call_1"}],
+    ),
+    ToolMessage(content="72F and sunny", tool_call_id="call_1"),
+    AIMessage(content="It's 72F and sunny in SF."),
+]
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    trace_export._reset_for_test()
+    yield
+    trace_export._reset_for_test()
+
+
+def _enable(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_FLEET_TRACE_EXPORT", str(tmp_path))
+    trace_export.init()
+    assert trace_export.is_enabled()
+
+
+def _read_rows(tmp_path):
+    files = list(tmp_path.glob("fleet-traces-*.jsonl"))
+    assert len(files) == 1, f"expected one daily dump, got {files}"
+    return [json.loads(line) for line in files[0].read_text().splitlines()]
+
+
+def test_disabled_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_FLEET_TRACE_EXPORT", "off")
+    trace_export.init()
+    assert not trace_export.is_enabled()
+    trace_export.export_turn(_Outcome(), checkpointer=_Checkpointer(_MESSAGES), graph_config=_Cfg())
+    assert not list(tmp_path.glob("*.jsonl"))
+
+
+def test_completed_turn_row_shape(tmp_path, monkeypatch):
+    _enable(tmp_path, monkeypatch)
+    trace_export.export_turn(_Outcome(), checkpointer=_Checkpointer(_MESSAGES), graph_config=_Cfg())
+
+    (row,) = _read_rows(tmp_path)
+    assert row["id"] == "fleet__task-1"  # no trace id in test → falls back to task id
+    assert row["source"] == "protoagent-fleet"
+    assert row["split"] == "train"
+    assert row["verified"] is True
+    assert row["reward"] == 1.0
+    assert row["thinking"] == "on"
+
+    roles = [m["role"] for m in row["messages"]]
+    assert roles == ["system", "user", "assistant", "tool", "assistant"]
+
+    # assistant tool_call → OpenAI shape, arguments as a JSON string
+    call = row["messages"][2]["tool_calls"][0]
+    assert call["name"] == "get_weather"
+    assert call["id"] == "call_1"
+    assert json.loads(call["arguments"]) == {"city": "SF"}
+    # tool result carries the linking id
+    assert row["messages"][3]["tool_call_id"] == "call_1"
+
+    meta = row["meta"]
+    assert meta["session_id"] == "sess-1"
+    assert meta["origin"] == "scheduler"
+    assert meta["loop_shape"] == "react"  # no goal plan on disk
+    assert meta["outcome_state"] == "completed"
+
+
+@pytest.mark.parametrize(
+    "state,verified,reward",
+    [("completed", True, 1.0), ("failed", True, 0.0), ("canceled", False, None)],
+)
+def test_reward_mapping(tmp_path, monkeypatch, state, verified, reward):
+    _enable(tmp_path, monkeypatch)
+    trace_export.export_turn(
+        _Outcome(state=state), checkpointer=_Checkpointer(_MESSAGES), graph_config=_Cfg()
+    )
+    (row,) = _read_rows(tmp_path)
+    assert row["verified"] is verified
+    assert row["reward"] == reward
+
+
+def test_incognito_thread_skipped(tmp_path, monkeypatch):
+    _enable(tmp_path, monkeypatch)
+    trace_export.export_turn(
+        _Outcome(), checkpointer=_Checkpointer(_MESSAGES, incognito=True), graph_config=_Cfg()
+    )
+    assert not list(tmp_path.glob("*.jsonl"))
+
+
+def test_empty_transcript_skipped(tmp_path, monkeypatch):
+    _enable(tmp_path, monkeypatch)
+    trace_export.export_turn(_Outcome(), checkpointer=_Checkpointer([]), graph_config=_Cfg())
+    assert not list(tmp_path.glob("*.jsonl"))
+
+
+def test_ooda_label_from_goal_plan(tmp_path, monkeypatch):
+    _enable(tmp_path, monkeypatch)
+
+    class _Plan:
+        def read_plan(self, sid):
+            return "## Goal\n- [ ] step one\n- [x] step two"
+
+    import graph.goals.store as store_mod
+
+    monkeypatch.setattr(store_mod, "GoalStore", lambda *a, **k: _Plan())
+    trace_export.export_turn(_Outcome(), checkpointer=_Checkpointer(_MESSAGES), graph_config=_Cfg())
+
+    (row,) = _read_rows(tmp_path)
+    assert row["meta"]["loop_shape"] == "ooda"
+    assert "step one" in row["meta"]["orient"]
+
+
+def test_export_never_raises_on_bad_checkpointer(tmp_path, monkeypatch):
+    _enable(tmp_path, monkeypatch)
+
+    class _Boom:
+        def get_tuple(self, config):
+            raise RuntimeError("db gone")
+
+    # Must not propagate — export is best-effort.
+    trace_export.export_turn(_Outcome(), checkpointer=_Boom(), graph_config=_Cfg())
+    assert not list(tmp_path.glob("*.jsonl"))


### PR DESCRIPTION
Wires **protoAgent's side of the agent-fleet flywheel** — the *Observe* seam (#1897). The lab (protoLab) mines the fleet's real production traces to decide which deterministic worlds to build and what to train; this lands the export that feeds them.

## What it does
One canonical **Trajectory** JSON row per terminal A2A turn, OpenAI chat-format, appended to a daily JSONL dump — matching the three-repo schema contract pinned on #1897 and protoLab `experiments/agentic-data/dataset/schema.py`.

- **`observability/trace_export.py`** (new) — reads the turn's messages from the checkpoint (sync `get_tuple` on `ThreadedSqliteSaver`), shapes them to OpenAI chat-format (`role` + `tool_calls` + `tool_call_id`), attaches the graph's bound-tool schemas, a **verifiable reward** from the terminal state (`completed`=1.0, `failed`=0.0, else `null` — **never an LLM judge**), and the **OODA signal** the lab asked for:
  - `meta.loop_shape` — `react` vs `ooda`, labelled by whether the goals subsystem was active
  - `meta.orient` — the durable goal-plan snapshot (`GoalStore` → `{session}.plan.md`), our scratchpad-as-world-model
- **Env-gated like Langfuse** (`PROTOAGENT_FLEET_TRACE_EXPORT`), **off by default**, graceful no-op.
- **Best-effort at the single terminal chokepoint** (`_record_a2a_telemetry`) — never touches the turn. Honours the **incognito** privacy gate (ADR 0069 D3b).

## Sequencing (per the locked contract)
Dev-first — no prod PII on the critical path. Enable on the dev instance → daily dev-dump → protoLab runs `dataset/adapters.py::_fleet` against it → promote to prod after the redaction bar. v1 caveats (delegation, bound-tool superset, terminal-state reward semantics) are documented inline in `meta`.

## Verification
- New unit suite `tests/test_trace_export.py` (9 tests) — OpenAI conversion, row schema, reward mapping, incognito/empty skip, OODA-label-from-plan, best-effort-never-raises.
- Gates green locally: `ruff check`, `lint-imports` (3 contracts kept — no layering violation), `pytest` (observability/tracing suites: 64 passed).
- Sample dump generated through the real exporter + real `GoalStore` (3 rows: ReAct/OODA/failed) validates against the schema — posted to #1897 for the lab's adapter.

Governed by **ADR 0006** (the local flywheel this extends outward to the fleet lab). Companion issues: protoLab#15, mythxengine-sdk#324/#325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)