### PR TITLE
feat(observability): daily rsync of fleet trace dumps → lab dataset dir (#1897)

### DIFF
--- a/scripts/redact_fleet_traces.py
+++ b/scripts/redact_fleet_traces.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Redact PII/secrets from fleet trace dumps before they enter the training corpus.
+
+The exporter (observability/trace_export.py) writes RAW dumps on-box; this batch
+redactor runs at the SINK (invoked by sync_fleet_traces.sh) and only its REDACTED
+output reaches the shared dataset dir. Hybrid, per the #1897 contract:
+
+  1. Deterministic regex — API keys / tokens / JWTs / private keys / emails /
+     phones. Exact, zero-infra, catches novel secret formats a model misses.
+  2. openai/privacy-filter — free-form PII (names, addresses, account numbers,
+     private dates/urls) regex can't catch. 1.5B sparse-MoE (50M active params),
+     Apache-2.0, ~96% F1 on PII-Masking-300k, runs on CPU.
+
+Irreversible masking to placeholders — the lab wants interaction *shape*, not
+recoverable values, so there is deliberately NO reversible mapping. Applied to
+message content, tool-call arguments, and meta.orient; never to structural
+fields (roles, tool names, ids, tool schemas), which carry no PII.
+
+FAIL-CLOSED: if the model can't load, this errors out rather than shipping
+regex-only (under-redacted) data to the shared corpus — unless you explicitly
+opt into regex-only with FLEET_REDACT_MODEL=none.
+
+Usage:  redact_fleet_traces.py <in.jsonl> <out.jsonl>
+Env:    FLEET_REDACT_MODEL   model id (default openai/privacy-filter; "none" =
+                             regex-only, explicit opt-out of the ML layer)
+        FLEET_REDACT_MIN_SCORE  span score threshold (default 0.5)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+# ── Layer 1: deterministic secret/token patterns (high precision) ──────────────
+_SECRET_PATTERNS: list[tuple[re.Pattern, str]] = [
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.DOTALL), "[PRIVATE_KEY]"),
+    (re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"), "[JWT]"),
+    (re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{30,}\b"), "[TOKEN]"),
+    (re.compile(r"\bgithub_pat_[A-Za-z0-9_]{40,}\b"), "[TOKEN]"),
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"), "[API_KEY]"),
+    (re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"), "[TOKEN]"),
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "[AWS_KEY]"),
+    (re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/-]{16,}=*"), "Bearer [TOKEN]"),
+    # Deterministic backstops for the two PII types the model also covers.
+    (re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"), "[EMAIL]"),
+    (re.compile(r"\b(?:\+?1[-.\s])?\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}\b"), "[PHONE]"),
+]
+
+# ── Layer 2: openai/privacy-filter entity → placeholder ───────────────────────
+_ENTITY_PLACEHOLDER = {
+    "account_number": "[ACCOUNT]",
+    "private_address": "[ADDRESS]",
+    "private_email": "[EMAIL]",
+    "private_person": "[NAME]",
+    "private_phone": "[PHONE]",
+    "private_url": "[URL]",
+    "private_date": "[DATE]",
+    "secret": "[SECRET]",
+}
+
+_MODEL_NAME = os.environ.get("FLEET_REDACT_MODEL", "openai/privacy-filter").strip()
+_MIN_SCORE = float(os.environ.get("FLEET_REDACT_MIN_SCORE", "0.5"))
+_pipe = None
+_cache: dict[str, str] = {}
+
+
+def _load_model():
+    """Load the token-classification pipeline. Returns None only for the explicit
+    regex-only opt-out; any OTHER failure raises (fail-closed)."""
+    if _MODEL_NAME.lower() in ("none", "off", ""):
+        print("[redact] FLEET_REDACT_MODEL=none — regex-only (ML layer disabled)", file=sys.stderr)
+        return None
+    from transformers import pipeline  # heavy import — deferred to actual use
+
+    return pipeline(
+        "token-classification",
+        model=_MODEL_NAME,
+        aggregation_strategy="simple",
+    )
+
+
+def _model_redact(text: str) -> str:
+    """Mask model-detected PII spans, replacing right-to-left to keep offsets valid."""
+    if _pipe is None or not text.strip():
+        return text
+    spans = [s for s in _pipe(text) if s.get("score", 1.0) >= _MIN_SCORE]
+    for s in sorted(spans, key=lambda x: x["start"], reverse=True):
+        placeholder = _ENTITY_PLACEHOLDER.get(s.get("entity_group", ""), "[PII]")
+        # Model spans often include leading whitespace — preserve it so
+        # "You are Jon" masks to "You are [NAME]", not "You are[NAME]".
+        start = s["start"]
+        while start < s["end"] and text[start].isspace():
+            start += 1
+        text = text[:start] + placeholder + text[s["end"] :]
+    return text
+
+
+def redact(text: str) -> str:
+    """Full hybrid pass: deterministic secrets/PII regex, then the model for
+    free-form PII. Memoized — the (identical) system prompt recurs every row."""
+    if not text:
+        return text
+    hit = _cache.get(text)
+    if hit is not None:
+        return hit
+    out = text
+    for pat, repl in _SECRET_PATTERNS:
+        out = pat.sub(repl, out)
+    out = _model_redact(out)
+    _cache[text] = out
+    return out
+
+
+def redact_row(row: dict) -> dict:
+    """Redact the free-text surfaces of one Trajectory row in place."""
+    for m in row.get("messages", []) or []:
+        if isinstance(m.get("content"), str):
+            m["content"] = redact(m["content"])
+        for tc in m.get("tool_calls", []) or []:
+            if isinstance(tc.get("arguments"), str):
+                tc["arguments"] = redact(tc["arguments"])
+    meta = row.setdefault("meta", {})
+    if isinstance(meta.get("orient"), str) and meta["orient"]:
+        meta["orient"] = redact(meta["orient"])
+    meta["redacted"] = True
+    meta["redaction"] = {"regex": True, "model": (_MODEL_NAME if _pipe is not None else None)}
+    return row
+
+
+def main(argv: list[str]) -> int:
+    global _pipe
+    if len(argv) != 3:
+        print(__doc__)
+        return 2
+    src, dst = argv[1], argv[2]
+    _pipe = _load_model()
+
+    n_in = n_out = n_err = 0
+    tmp = dst + ".tmp"
+    with open(src, encoding="utf-8") as fin, open(tmp, "w", encoding="utf-8") as fout:
+        for line in fin:
+            line = line.strip()
+            if not line:
+                continue
+            n_in += 1
+            try:
+                row = redact_row(json.loads(line))
+                fout.write(json.dumps(row, ensure_ascii=False, default=str) + "\n")
+                n_out += 1
+            except Exception as e:  # noqa: BLE001 — skip a bad line, never emit it raw
+                n_err += 1
+                print(f"[redact] skipped malformed row {n_in}: {e}", file=sys.stderr)
+    os.replace(tmp, dst)
+    print(f"[redact] {src} -> {dst}: {n_out} redacted, {n_err} skipped (model={_MODEL_NAME if _pipe else 'none'})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/sync_fleet_traces.sh
+++ b/scripts/sync_fleet_traces.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Sync fleet trace-export dumps → the lab's dataset dir (the flywheel Observe, #1897).
+#
+# The trace exporter (observability/trace_export.py, gated by
+# PROTOAGENT_FLEET_TRACE_EXPORT) writes one daily JSONL per instance at
+#   $PROTOAGENT_HOME/<instance>/fleet-traces/fleet-traces-YYYYMMDD.jsonl
+# This ships those dumps to a shared dataset dir protoLab ingests via
+# dataset/adapters.py::_fleet. Meant to run daily from cron.
+#
+# Every fleet member emits an identically-named daily file, so dest filenames are
+# namespaced by instance (`<instance>__fleet-traces-YYYYMMDD.jsonl`) — flat dir,
+# collision-free, provenance in the name (each row also carries `teacher`).
+#
+#   FLEET_TRACES_DEST            dest dir (default /mnt/data/datasets/fleet-traces)
+#   PROTOAGENT_HOME             box root to scan (default ~/.protoagent)
+#   FLEET_TRACES_EXTRA_SOURCES  extra ':'-separated fleet-traces dirs (e.g. host
+#                               mount points for the containerized prod fleet)
+#
+# Dumps are append-only + daily-partitioned: past days are immutable, only today's
+# file grows, so a plain re-copy each run is idempotent and safe.
+set -euo pipefail
+
+DEST="${FLEET_TRACES_DEST:-/mnt/data/datasets/fleet-traces}"
+BOX_ROOT="${PROTOAGENT_HOME:-$HOME/.protoagent}"
+
+mkdir -p "$DEST"
+
+# Collect candidate fleet-traces source dirs: every instance root under the box,
+# plus any explicit extras (container volume mounts).
+sources=()
+for src in "$BOX_ROOT"/*/fleet-traces; do
+  [ -d "$src" ] && sources+=("$src")
+done
+if [ -n "${FLEET_TRACES_EXTRA_SOURCES:-}" ]; then
+  IFS=':' read -ra extra <<<"$FLEET_TRACES_EXTRA_SOURCES"
+  for src in "${extra[@]}"; do
+    [ -d "$src" ] && sources+=("$src")
+  done
+fi
+
+synced=0
+for src in "${sources[@]}"; do
+  inst="$(basename "$(dirname "$src")")"
+  for f in "$src"/fleet-traces-*.jsonl; do
+    [ -e "$f" ] || continue
+    rsync -a "$f" "$DEST/${inst}__$(basename "$f")"
+    synced=$((synced + 1))
+  done
+done
+
+echo "$(date -Iseconds) [sync_fleet_traces] synced $synced dump(s) from ${#sources[@]} source(s) -> $DEST"

--- a/scripts/sync_fleet_traces.sh
+++ b/scripts/sync_fleet_traces.sh
@@ -5,8 +5,14 @@
 # The trace exporter (observability/trace_export.py, gated by
 # PROTOAGENT_FLEET_TRACE_EXPORT) writes one daily JSONL per instance at
 #   $PROTOAGENT_HOME/<instance>/fleet-traces/fleet-traces-YYYYMMDD.jsonl
-# This ships those dumps to a shared dataset dir protoLab ingests via
-# dataset/adapters.py::_fleet. Meant to run daily from cron.
+# Raw dumps stay on-box; this REDACTS them (scripts/redact_fleet_traces.py:
+# regex secrets + openai/privacy-filter PII) and ships only the redacted rows to
+# the shared dataset dir protoLab ingests via dataset/adapters.py::_fleet. Meant
+# to run daily from cron.
+#
+# FAIL-CLOSED: if the redactor is unavailable, a source is SKIPPED rather than
+# shipping raw PII to the shared corpus. Set FLEET_REDACT=0 to copy raw (only for
+# a PII-free / high-trust source, e.g. the dev instance).
 #
 # Every fleet member emits an identically-named daily file, so dest filenames are
 # namespaced by instance (`<instance>__fleet-traces-YYYYMMDD.jsonl`) — flat dir,
@@ -16,15 +22,32 @@
 #   PROTOAGENT_HOME             box root to scan (default ~/.protoagent)
 #   FLEET_TRACES_EXTRA_SOURCES  extra ':'-separated fleet-traces dirs (e.g. host
 #                               mount points for the containerized prod fleet)
+#   FLEET_REDACT                "0" copies raw (no redaction); default redacts
+#   FLEET_REDACT_PY             redactor venv python (default
+#                               ~/.fleet-trace-redactor/venv/bin/python)
+#   FLEET_REDACT_SCRIPT         path to redact_fleet_traces.py (default: alongside)
 #
 # Dumps are append-only + daily-partitioned: past days are immutable, only today's
-# file grows, so a plain re-copy each run is idempotent and safe.
+# file grows, so re-processing each run is idempotent.
 set -euo pipefail
 
 DEST="${FLEET_TRACES_DEST:-/mnt/data/datasets/fleet-traces}"
 BOX_ROOT="${PROTOAGENT_HOME:-$HOME/.protoagent}"
+REDACT="${FLEET_REDACT:-1}"
+REDACT_PY="${FLEET_REDACT_PY:-$HOME/.fleet-trace-redactor/venv/bin/python}"
+REDACT_SCRIPT="${FLEET_REDACT_SCRIPT:-$(dirname "$(readlink -f "$0")")/redact_fleet_traces.py}"
+# Pin the HF cache so cron (which doesn't inherit the shell's HF_HOME) reuses the
+# already-downloaded privacy-filter weights instead of re-fetching ~3GB.
+export HF_HOME="${FLEET_REDACT_HF_HOME:-${HF_HOME:-/mnt/data/huggingface/misc}}"
 
 mkdir -p "$DEST"
+
+# Fail-closed guard: unless raw copy is explicitly requested, the redactor MUST be
+# present — otherwise we'd ship unredacted prod PII to the shared training corpus.
+if [ "$REDACT" != "0" ] && { [ ! -x "$REDACT_PY" ] || [ ! -f "$REDACT_SCRIPT" ]; }; then
+  echo "$(date -Iseconds) [sync_fleet_traces] FATAL: redactor unavailable (PY=$REDACT_PY SCRIPT=$REDACT_SCRIPT) — refusing to ship raw PII. Set FLEET_REDACT=0 to override for a PII-free source." >&2
+  exit 1
+fi
 
 # Collect candidate fleet-traces source dirs: every instance root under the box,
 # plus any explicit extras (container volume mounts).
@@ -44,9 +67,14 @@ for src in "${sources[@]}"; do
   inst="$(basename "$(dirname "$src")")"
   for f in "$src"/fleet-traces-*.jsonl; do
     [ -e "$f" ] || continue
-    rsync -a "$f" "$DEST/${inst}__$(basename "$f")"
+    dest="$DEST/${inst}__$(basename "$f")"
+    if [ "$REDACT" = "0" ]; then
+      rsync -a "$f" "$dest"                      # raw copy — PII-free/high-trust source only
+    else
+      "$REDACT_PY" "$REDACT_SCRIPT" "$f" "$dest" # redact on the way to the shared corpus
+    fi
     synced=$((synced + 1))
   done
 done
 
-echo "$(date -Iseconds) [sync_fleet_traces] synced $synced dump(s) from ${#sources[@]} source(s) -> $DEST"
+echo "$(date -Iseconds) [sync_fleet_traces] synced $synced dump(s) from ${#sources[@]} source(s) -> $DEST (redact=$([ "$REDACT" = 0 ] && echo off || echo on))"


### PR DESCRIPTION
Push side of the flywheel **Observe** seam (#1897), following #1904 (the exporter). Ships the trace-export dumps to the shared dataset dir protoLab ingests via `dataset/adapters.py::_fleet`.

## What
`scripts/sync_fleet_traces.sh` — rsyncs each instance's `fleet-traces/fleet-traces-YYYYMMDD.jsonl` → `FLEET_TRACES_DEST` (default `/mnt/data/datasets/fleet-traces`).

- **Collision-safe**: every fleet member emits an identically-named daily file, so dest filenames are namespaced by instance (`<instance>__fleet-traces-YYYYMMDD.jsonl`) — flat dir, provenance in the name (each row also carries `teacher`).
- **Config**: `FLEET_TRACES_DEST` / `PROTOAGENT_HOME` / `FLEET_TRACES_EXTRA_SOURCES` (the last for host-mounted container volumes once the prod-fleet flag lands).
- **Idempotent**: dumps are append-only + daily-partitioned (past days immutable, only today grows), so a plain re-copy each run is safe.

## Deployment (this box)
Cron installed (host state, not in repo): `15 3 * * * scripts/sync_fleet_traces.sh`. Verified under a minimal cron env (`HOME` + `PATH=/usr/bin:/bin`). First real dump already landed at `/mnt/data/datasets/fleet-traces/dev__fleet-traces-20260708.jsonl` (2 live rows) for the lab's `_fleet` adapter.

For the **containerized prod fleet** (jon/roxy/frank/vera): mount each member's `fleet-traces/` to a host path and add it via `FLEET_TRACES_EXTRA_SOURCES`, or land it under `$PROTOAGENT_HOME/<name>/fleet-traces` so the glob picks it up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a daily sync utility to consolidate fleet trace exports into a shared dataset location.
  * Supports additional source directories and preserves each instance’s traces with clear instance-based filenames.
  * Prints a summary after each run showing how many files were synced and how many sources were checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->