### PR TITLE
chore: release v0.97.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.97.0] - 2026-07-08
+
 ### Added
 - **Fleet trace export → the agent-fleet flywheel (the "Observe" seam, #1897).** Agents can
   now emit one per-turn **trajectory** row (OpenAI chat format — messages incl. `tool_calls`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.96.0"
+version = "0.97.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "v0.97.0",
+    "date": "2026-07-08",
+    "changes": [
+      "Fleet trace export → the agent-fleet flywheel (the \"Observe\" seam, #1897).",
+      "Fleet-trace sink + PII redaction (scripts/sync_fleet_traces.sh, scripts/redact_fleet_traces.py).",
+      "Portable per-rig setup (scripts/setup_fleet_tracing.sh).",
+      "Bigger touch targets on phones.",
+      "Docs reader is a master-detail flow on phones.",
+      "Settings collapses to a single column on phones.",
+      "Modals/overlays use dvh on mobile.",
+      "Mobile viewport correctness for the console."
+    ]
+  },
+  {
     "version": "v0.96.0",
     "date": "2026-07-07",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.97.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.97.0 -m 'Release v0.97.0' && git push origin v0.97.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).