### PR TITLE
docs(observability): document fleet trace export + redaction + per-rig setup (#1897)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Fleet trace export → the agent-fleet flywheel (the "Observe" seam, #1897).** Agents can
+  now emit one per-turn **trajectory** row (OpenAI chat format — messages incl. `tool_calls`,
+  the in-context `tools`, a verifiable `reward` from the terminal state, and the OODA signal:
+  `loop_shape` + the durable goal-plan `orient` snapshot) to `<instance>/fleet-traces/` for
+  downstream training-data collection. **Off by default**; enable per instance via the
+  **Settings ▸ Telemetry ▸ "Fleet trace export"** toggle or the `PROTOAGENT_FLEET_TRACE_EXPORT`
+  env var (which overrides the toggle in both directions and can point at an explicit path).
+  Best-effort at the single terminal chokepoint — never affects a turn — and honors the
+  incognito gate. Governed by ADR 0006.
+- **Fleet-trace sink + PII redaction (`scripts/sync_fleet_traces.sh`, `scripts/redact_fleet_traces.py`).**
+  A daily sync ships dumps to a shared dataset dir, **redacting first** — hybrid regex
+  (keys/tokens/JWTs/emails/phones) + the `openai/privacy-filter` model (names/addresses) —
+  so raw content never enters the corpus. Fail-closed; irreversible masking; stamps
+  `meta.redacted`.
+- **Portable per-rig setup (`scripts/setup_fleet_tracing.sh`).** One command wires a dev
+  laptop or desktop rig to ship its trace dumps to the lab box over the tailnet (launchd on
+  macOS, cron on Linux), with the redaction boundary kept on the receiving box.
+
 ### Fixed
 - **Bigger touch targets on phones.** The DS icon button is 30px (26px `--sm`) — below the
   ~44px touch guideline, and a dense surface like Memory has ~90 of them (per-row edit/delete).

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -110,6 +110,57 @@ curl localhost:7870/api/telemetry/insights
 Named numeric series a plugin records (`sdk.record_metric` — treasury, net worth, fleet size, #1632) live in their own always-on per-instance `metrics.db`, **not** in this turn-rollup store: they're functional plugin state (history-dependent watch verifiers read them), so the `telemetry.enabled` toggle never affects them. See [Plugins ▸ consumption SDK](/guides/plugins#consumption-sdk).
 :::
 
+## Fleet trace export (the flywheel Observe)
+
+The local stores above answer *"what did this agent cost?"*. **Fleet trace export** answers a different question — *"what does the agent actually do, turn by turn?"* — by writing one **trajectory** row per terminal turn in OpenAI chat format, so a fleet's real production traces can drive downstream training-data collection (the "Observe" step of the self-improving flywheel, ADR 0006 / #1897).
+
+**Off by default.** Turn it on per instance either way:
+
+```yaml
+telemetry:
+  fleet_trace_export: true    # Settings ▸ Telemetry ▸ "Fleet trace export"
+```
+
+```bash
+# Env var — overrides the config toggle in BOTH directions:
+PROTOAGENT_FLEET_TRACE_EXPORT=1              # on, default path
+PROTOAGENT_FLEET_TRACE_EXPORT=0              # off (even if the toggle is on)
+PROTOAGENT_FLEET_TRACE_EXPORT=/data/traces   # on, explicit path
+```
+
+On the desktop app, use the **Settings ▸ Telemetry** toggle — a GUI app doesn't inherit shell env, so the config toggle is the reachable path.
+
+Each row lands in `<instance>/fleet-traces/fleet-traces-YYYYMMDD.jsonl` (append-only, daily-partitioned, instance-scoped) and carries:
+
+```jsonc
+{
+  "id": "fleet__<trace_id>", "source": "protoagent-fleet", "teacher": "<AGENT_NAME>",
+  "messages": [ /* OpenAI chat format, incl. tool_calls + tool results */ ],
+  "tools":    [ /* the in-context OpenAI tool schemas */ ],
+  "verified": true, "reward": 1.0,          // deterministic terminal-state outcome — never an LLM judge
+  "meta": {
+    "loop_shape": "ooda",                   // "ooda" when the goals subsystem was active, else "react"
+    "orient": "<goal-plan snapshot>",       // the durable world-model artifact, when present
+    "trace_id": "…", "session_id": "…", "model": "…", "cost_usd": 0.01, "duration_ms": 1500
+  }
+}
+```
+
+Writing is best-effort (never affects a turn) and honors the incognito gate — an incognito thread is never exported.
+
+### Shipping to a shared dataset (redaction)
+
+Raw dumps stay **on the machine**. To collect them centrally, `scripts/sync_fleet_traces.sh` redacts and forwards on a daily cron:
+
+- **Hybrid redaction before the corpus** — deterministic regex (API keys / tokens / JWTs / emails / phones) **+** the `openai/privacy-filter` model (names, addresses, account numbers). Irreversible masking; structural fields (roles, tool names, ids, schemas) are untouched; `meta.redacted` is stamped. **Fail-closed** — it won't ship raw if the redactor is unavailable.
+- Dest filenames are namespaced `<instance>__…` so many fleet members can't collide.
+
+For a **laptop or desktop rig** off the collection box, `scripts/setup_fleet_tracing.sh` wires a once-daily rsync of that rig's raw dumps to the collection box over your private network (launchd on macOS, cron on Linux); the redaction boundary stays on the receiving box, so the rig needs no model or venv.
+
+::: warning A personal rig's traffic is real data
+Export is per-rig opt-in for a reason: a personal agent's turns contain real content. The redactor masks PII, but decide per rig whether it should contribute at all — the fleet containers are a clear yes; your personal desktop may be a no.
+:::
+
 ## Audit log
 
 Every tool call is written to `/sandbox/audit/audit.jsonl`. One line per call:

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -128,8 +128,9 @@ The bundled scheduler is enabled by default. See [Schedule future work](/guides/
 | `LANGFUSE_PUBLIC_KEY` | Langfuse project public key |
 | `LANGFUSE_SECRET_KEY` | Langfuse project secret key |
 | `LANGFUSE_HOST` | Langfuse host URL (e.g. `https://langfuse.company.com`). Falls back to `LANGFUSE_URL`, then `http://host.docker.internal:3001`. |
+| `PROTOAGENT_FLEET_TRACE_EXPORT` | Fleet trace export (the flywheel Observe, #1897). Unset → off (or the `telemetry.fleet_trace_export` config toggle decides). `1`/`on` → on at `<instance>/fleet-traces/`; a path → on there; `0`/`off` → hard-off, overriding the config toggle. See [Observability ▸ Fleet trace export](/guides/observability#fleet-trace-export-the-flywheel-observe). |
 
-If both keys are unset, tracing is disabled and every helper in `tracing.py` becomes a no-op.
+If both Langfuse keys are unset, distributed tracing is disabled and every helper in `tracing.py` becomes a no-op. Fleet trace export is independent — it needs no Langfuse.
 
 ## Logging
 


### PR DESCRIPTION
Docs for the fleet-tracing feature shipped in v0.97.0: config toggle vs env precedence, the trajectory row shape, the redacting sink, and the per-rig setup script. Adds `PROTOAGENT_FLEET_TRACE_EXPORT` to the env-var reference.