### PR TITLE
fix(goals): kick + inject the goal on turn 1, and make goal turns headless-safe (#1910, #1911)

### DIFF
--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -29,6 +29,10 @@ log = logging.getLogger(__name__)
 
 CLEAR_ALIASES = {"clear", "stop", "off", "reset", "none", "cancel"}
 
+# The exact prefix a successful ``/goal`` SET replies with. The chat runners match on it
+# to decide whether to KICK an initial goal-driven turn (#1910) — see ``is_set_ack``.
+SET_ACK_PREFIX = "Goal set. "
+
 
 def _coerce_str_list(value) -> list[str]:
     """Normalize a contract list field (``constraints``/``boundaries``) to ``list[str]``.
@@ -124,7 +128,48 @@ class GoalController:
             stop_when=contract.get("stop_when", ""),
         )
         self._store.set(state)
-        return f"Goal set. {state.status_line()}"
+        return f"{SET_ACK_PREFIX}{state.status_line()}"
+
+    @staticmethod
+    def is_set_ack(reply: str | None) -> bool:
+        """True when a ``parse_control`` reply is the ack for a *successful* goal SET
+        (as opposed to a status / clear / parse-error reply). The chat runners use this to
+        decide whether to KICK an initial goal-driven turn (#1910): a SET should drive the
+        agent immediately, whereas /goal status or /goal clear just reply and stop."""
+        return isinstance(reply, str) and reply.startswith(SET_ACK_PREFIX)
+
+    def kickoff_prompt(self, state: GoalState, user_message: str = "") -> str:
+        """The initial goal-driven turn's prompt (#1910). The re-invoke iterations receive
+        the goal via ``_continuation``; the *first* turn had nothing — it fell through to a
+        bare user message, so the agent never learned its own active goal and asked
+        "what goal?", parking at INPUT_REQUIRED before the drive loop could run. This
+        injects the goal condition (and completion contract, if any) so the agent BEGINS on
+        turn 1. Mirrors the continuation framing for iteration 0 (no verifier result yet)."""
+        if state.fresh_context:
+            lead = (
+                f"[goal kickoff — 0/{state.max_iterations}, fresh context]\n"
+                f"Goal: {state.condition}\n\n"
+                "Take ONE concrete step toward the goal now. Record your running plan by "
+                "calling the `update_goal_plan` tool (it is persisted for the next "
+                "iteration). If you determine the goal is impossible or out of scope, call "
+                "the `abandon_goal` tool with a reason and stop."
+            )
+        else:
+            lead = (
+                f"[goal kickoff — 0/{state.max_iterations}]\n"
+                f"You have an active goal for this session: {state.condition}\n\n"
+                "Begin working toward it now — take concrete action; do not ask which goal "
+                "it is. If it is impossible or out of scope, call the `abandon_goal` tool "
+                "with a reason and stop."
+            )
+        contract = self._contract_prompt(state)
+        body = f"{lead}\n\n{contract}" if contract else lead
+        # A plain inbound message that arrived alongside an already-active goal (not a
+        # /goal command) is folded in so the operator's words aren't lost.
+        extra = (user_message or "").strip()
+        if extra and not extra.lower().startswith("/goal"):
+            body = f"{body}\n\nThe operator also said: {extra}"
+        return body
 
     @staticmethod
     def _chat_verifier_allowed(verifier: dict) -> bool:

--- a/server/chat.py
+++ b/server/chat.py
@@ -934,9 +934,26 @@ _AUTONOMOUS_HITL_SENTINEL = (
 _MAX_AUTONOMOUS_AUTOANSWERS = 3
 
 
+def _truthy(value) -> bool:
+    """Coerce a metadata value to bool. JSON-RPC callers may send the flag as a real bool,
+    a string ("true"/"1"), or an int — bare bool("false") is a footgun, so treat strings
+    by their content."""
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
 def _is_autonomous(request_metadata: dict | None) -> bool:
-    """Whether this turn runs with no operator watching (see _AUTONOMOUS_ORIGINS)."""
-    return ((request_metadata or {}).get("origin") or "").strip().lower() in _AUTONOMOUS_ORIGINS
+    """Whether this turn runs with no operator watching (see _AUTONOMOUS_ORIGINS).
+
+    Headless-first (#1911): a fleet-to-fleet A2A caller with no human in the loop can also
+    DECLARE the turn unattended by setting ``unattended: true`` in the request metadata,
+    which takes the same no-deadlock path as the internal autonomous origins. Undeclared
+    plain A2A stays operator-attended (an approval interrupt still parks for a human)."""
+    md = request_metadata or {}
+    if _truthy(md.get("unattended")):
+        return True
+    return ((md.get("origin") or "").strip().lower()) in _AUTONOMOUS_ORIGINS
 
 
 def _is_hitl_resume(request_metadata: dict | None) -> bool:
@@ -1015,7 +1032,14 @@ async def _run_native_turn(message, session_id, config, *, request_metadata=None
         _fence = None
     # When a goal is already active, the whole turn is goal-driven (suppress cross-session
     # prior_sessions on the initial turn + kicker, matching the continuation turns).
-    goal_active = STATE.goal_controller is not None and STATE.goal_controller.active_goal(session_id) is not None
+    _goal_state = STATE.goal_controller.active_goal(session_id) if STATE.goal_controller is not None else None
+    goal_active = _goal_state is not None
+    # Kickoff injection (#1910): on the FIRST goal-driven turn (iteration 0, not a HITL resume)
+    # rewrite the message to carry the goal condition, so the agent begins on the goal instead
+    # of asking "what goal?" — the raw user text is folded into the kickoff prompt. Re-invoke
+    # iterations already get the goal via the continuation prompt, so gate on iteration 0.
+    if goal_active and not resume and _goal_state.iteration == 0:
+        message = STATE.goal_controller.kickoff_prompt(_goal_state, user_message=message)
 
     # One graph turn (model tokens accumulated silently; A2A consumers get progress from
     # tool_start/tool_end). Final text is extracted once via extract_output().
@@ -1025,7 +1049,11 @@ async def _run_native_turn(message, session_id, config, *, request_metadata=None
     # An autonomous turn (no operator watching) must never deadlock on a HITL pause: when one
     # of these turns hits input_required we resume the graph with a "no operator" sentinel and
     # run another pass, up to a cap, instead of parking the task forever (see _AUTONOMOUS_*).
-    _autonomous = _is_autonomous(request_metadata)
+    # A goal-driven turn is autonomous BY DEFINITION (#1911): a goal is an explicit opt-in to
+    # self-drive, so it must take the no-deadlock path and never park on a HITL interrupt even
+    # over plain (undeclared) A2A — otherwise the first "what goal?" ask parks the task and the
+    # drive loop below never runs (the #1910 deadlock). Non-goal turns are unchanged.
+    _autonomous = _is_autonomous(request_metadata) or goal_active
     _resume_value = (message if resume else None)
     _auto_answers = 0
     with goal_turn(goal_active):
@@ -1301,8 +1329,17 @@ async def _chat_langgraph_stream_impl(
             if STATE.goal_controller is not None:
                 reply = await STATE.goal_controller.parse_control(message, session_id, trusted=False)
                 if reply is not None:
-                    yield ("done", reply)
-                    return
+                    gs = STATE.goal_controller.active_goal(session_id)
+                    if STATE.goal_controller.is_set_ack(reply) and gs is not None:
+                        # /goal SET kicks the drive immediately (#1910): surface the ack as a
+                        # status frame, then fall through into a goal-driven turn instead of
+                        # short-circuiting here and waiting for a separate inbound message. The
+                        # goal condition is injected at the kickoff below (iteration 0), which
+                        # also covers a plain message arriving on an already-active goal.
+                        yield ("tool_start", f"🎯 {reply}")
+                    else:
+                        yield ("done", reply)
+                        return
 
             # Core /lifecycle command (ADR 0074) — read-only listing of the lifecycle
             # events + configured reactions + registered hooks. Reserved like /goal.
@@ -1675,10 +1712,16 @@ async def _chat_langgraph_impl(
         metadata={"message_preview": message[:100], "soul_rev": soul_revision()},
     ):
         try:
-            # Goal control messages short-circuit (set / status / clear).
+            # Goal control messages short-circuit (status / clear) — but a /goal SET kicks the
+            # drive immediately (#1910) rather than returning just the ack: fall through into a
+            # goal-driven turn (the condition is injected at the kickoff below). The ack is
+            # folded into the turn's terminal goal note, so the caller still sees it.
             if STATE.goal_controller is not None:
                 reply = await STATE.goal_controller.parse_control(message, session_id, trusted=False)
-                if reply is not None:
+                if reply is not None and not (
+                    STATE.goal_controller.is_set_ack(reply)
+                    and STATE.goal_controller.active_goal(session_id) is not None
+                ):
                     return [{"role": "assistant", "content": reply}]
 
             # Core /lifecycle command (ADR 0074) — read-only listing. Reserved like /goal.
@@ -1747,9 +1790,10 @@ async def _chat_langgraph_impl(
 
             # When a goal is already active, the whole turn is goal-driven —
             # suppress cross-session prior_sessions on the initial turn too.
-            goal_active = (
-                STATE.goal_controller is not None and STATE.goal_controller.active_goal(session_id) is not None
+            _goal_state = (
+                STATE.goal_controller.active_goal(session_id) if STATE.goal_controller is not None else None
             )
+            goal_active = _goal_state is not None
             # Sharing the streaming thread means sharing its serialization contract:
             # every other writer to `a2a:{sid}` (the streaming turn driver,
             # compact_session, rewind_session) holds the per-thread lock — an
@@ -1780,13 +1824,38 @@ async def _chat_langgraph_impl(
 
                     graph_input = Command(resume=await _resume_payload(config, message))
                 else:
+                    _msg = message
+                    # Kickoff injection (#1910), same as the streaming path: the first
+                    # goal-driven turn (iteration 0) carries the goal condition so the agent
+                    # begins on the goal instead of asking "what goal?".
+                    if goal_active and _goal_state.iteration == 0:
+                        _msg = STATE.goal_controller.kickoff_prompt(_goal_state, user_message=message)
                     graph_input = {
-                        "messages": [HumanMessage(content=message)],
+                        "messages": [HumanMessage(content=_msg)],
                         "session_id": session_id,
                         **_state_extra,
                     }
                 with goal_turn(goal_active):
                     result = await STATE.graph.ainvoke(graph_input, config=config)
+                    # Headless-first parity (#1911): a goal-driven turn is autonomous, so if it
+                    # parks on a HITL interrupt there's no operator here to answer — resume with
+                    # the no-operator sentinel and re-run (bounded) instead of echoing the ask
+                    # and stalling the drive. Non-goal turns are untouched (they still echo).
+                    if goal_active:
+                        from langgraph.types import Command
+
+                        _auto = 0
+                        while _auto < _MAX_AUTONOMOUS_AUTOANSWERS:
+                            if await _pending_interrupt_value(config) is None:
+                                break
+                            _auto += 1
+                            result = await STATE.graph.ainvoke(
+                                Command(resume=_AUTONOMOUS_HITL_SENTINEL), config=config
+                            )
+                        if await _pending_interrupt_value(config) is not None:
+                            # Budget spent, still parked → clear the dangling interrupt so the
+                            # checkpoint isn't stranded; the drive loop below continues on the text.
+                            await _clear_pending_interrupt(config)
             raw = _last_ai(result)
             response = extract_output(raw)
 

--- a/tests/test_goal_kickoff.py
+++ b/tests/test_goal_kickoff.py
@@ -1,0 +1,111 @@
+"""Goal kickoff + headless-first wiring (#1910 / #1911).
+
+Freezes the two seams the live A2A path fell through:
+
+  #1910 — the FIRST goal-driven turn now injects the goal condition (``kickoff_prompt``)
+          so the agent begins on the goal instead of asking "what goal?", and a ``/goal``
+          SET is distinguishable from status/clear (``is_set_ack``) so the runner knows to
+          kick a drive turn rather than short-circuiting.
+  #1911 — a plain A2A caller can DECLARE itself unattended (``_is_autonomous`` honors the
+          ``unattended`` metadata flag), and a goal-driven turn is autonomous by definition.
+
+Pure + hermetic: the controller helpers take deterministic inputs; ``_is_autonomous`` is a
+plain function. No model, no graph, no network.
+"""
+
+from __future__ import annotations
+
+from graph.config import LangGraphConfig
+from graph.goals.controller import GoalController, SET_ACK_PREFIX
+from graph.goals.store import GoalStore
+
+
+def _ctrl(tmp_path, **overrides) -> GoalController:
+    return GoalController(LangGraphConfig(**overrides), GoalStore(tmp_path))
+
+
+# ── #1910: is_set_ack distinguishes a SET from status/clear ────────────────
+def test_is_set_ack_only_true_for_successful_set(tmp_path):
+    c = _ctrl(tmp_path)
+    assert c.is_set_ack(f"{SET_ACK_PREFIX}goal [active] via llm: 'x' (iteration 0/8)")
+    # status / clear / parse-error replies must NOT kick a drive turn
+    assert not c.is_set_ack("No active goal for this session.")
+    assert not c.is_set_ack("Goal cleared.")
+    assert not c.is_set_ack("Could not parse goal. Use `/goal <text>` ...")
+    assert not c.is_set_ack(None)
+    assert not c.is_set_ack("")
+
+
+async def test_parse_control_set_reply_is_a_set_ack(tmp_path):
+    """The reply a real /goal SET produces must be recognized as a set-ack (round-trip)."""
+    c = _ctrl(tmp_path)
+    reply = await c.parse_control("/goal ship the thing", "s1", trusted=False)
+    assert c.is_set_ack(reply)
+    assert c.active_goal("s1") is not None
+    # a status query on the same session is NOT a set-ack
+    status = await c.parse_control("/goal", "s1", trusted=False)
+    assert not c.is_set_ack(status)
+
+
+# ── #1910: kickoff_prompt injects the goal condition ───────────────────────
+def test_kickoff_prompt_carries_the_condition(tmp_path):
+    c = _ctrl(tmp_path)
+    ok, _ = c.set_goal_operator("s1", "make the tests pass", {"type": "llm"})
+    assert ok
+    prompt = c.kickoff_prompt(c.active_goal("s1"))
+    assert "make the tests pass" in prompt
+    assert "kickoff" in prompt.lower()
+    # it must tell the agent to BEGIN, not to ask which goal
+    assert "abandon_goal" in prompt
+
+
+def test_kickoff_prompt_folds_in_user_message_but_not_a_goal_command(tmp_path):
+    c = _ctrl(tmp_path)
+    c.set_goal_operator("s1", "cond", {"type": "llm"})
+    gs = c.active_goal("s1")
+    # a plain inbound message rides along
+    with_msg = c.kickoff_prompt(gs, user_message="also check the logs")
+    assert "also check the logs" in with_msg
+    # the raw /goal command must NOT be echoed back into the prompt
+    cmd = c.kickoff_prompt(gs, user_message="/goal cond")
+    assert "/goal cond" not in cmd
+
+
+def test_kickoff_prompt_includes_contract_when_present(tmp_path):
+    c = _ctrl(tmp_path)
+    c.set_goal_operator(
+        "s1", "cond", {"type": "command", "command": "pytest -q"},
+        outcome="green CI", constraints=["do not touch prod"],
+    )
+    prompt = c.kickoff_prompt(c.active_goal("s1"))
+    assert "green CI" in prompt
+    assert "do not touch prod" in prompt
+
+
+def test_kickoff_prompt_fresh_context_variant(tmp_path):
+    c = _ctrl(tmp_path)
+    c.set_goal_operator("s1", "cond", {"type": "llm"})
+    gs = c.active_goal("s1")
+    gs.fresh_context = True
+    prompt = c.kickoff_prompt(gs)
+    assert "fresh context" in prompt
+    assert "update_goal_plan" in prompt
+
+
+# ── #1911: declared-unattended + goal-autonomy in _is_autonomous ───────────
+def test_is_autonomous_honors_unattended_and_origins():
+    from server.chat import _is_autonomous
+
+    # internal autonomous origins (unchanged)
+    assert _is_autonomous({"origin": "scheduler"})
+    assert _is_autonomous({"origin": "background-resume"})
+    # declared unattended — bool AND string forms (JSON-RPC may send either)
+    assert _is_autonomous({"unattended": True})
+    assert _is_autonomous({"unattended": "true"})
+    assert _is_autonomous({"unattended": "1"})
+    # NOT autonomous: plain operator-attended A2A, falsey/absent flags
+    assert not _is_autonomous({"origin": "user"})
+    assert not _is_autonomous({"unattended": "false"})
+    assert not _is_autonomous({"unattended": False})
+    assert not _is_autonomous({})
+    assert not _is_autonomous(None)

--- a/tests/test_goal_kickoff_live.py
+++ b/tests/test_goal_kickoff_live.py
@@ -1,0 +1,159 @@
+"""Goal kickoff + headless-first, driven through the REAL streaming turn runner (#1910/#1911).
+
+This is the end-to-end path the issues said had never run: a real ``/goal`` over the A2A
+streaming entry (``server.chat._chat_langgraph_stream``), with a real ``GoalController``
+wired into ``STATE``, a real ``create_agent_graph`` (fake chat model), and the real
+checkpointer — asserting:
+
+  #1910 — a ``/goal <text>`` SET KICKS a drive turn (not just an ack), and the graph's
+          first HumanMessage carries the injected goal condition (kickoff), so the agent
+          begins on the goal instead of asking "what goal?".
+  #1911 — a goal-driven turn that hits a HITL form does NOT park at input_required; it
+          auto-answers (no operator) and completes the drive.
+
+Reuses the fake-model + graph harness shape from ``test_hitl_hold.py``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from unittest.mock import patch
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.outputs import ChatGenerationChunk
+
+from runtime.state import STATE
+
+chat_mod = importlib.import_module("server.chat")
+
+
+class _ToolFake(GenericFakeChatModel):
+    """Fake chat model that supports bind_tools and emits tool calls (see test_hitl_hold)."""
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+    async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+        from langchain_core.messages import AIMessageChunk
+
+        message = next(self.messages)
+        tool_call_chunks = [
+            {"name": tc["name"], "args": json.dumps(tc["args"]), "id": tc["id"], "index": i, "type": "tool_call_chunk"}
+            for i, tc in enumerate(getattr(message, "tool_calls", []) or [])
+        ]
+        yield ChatGenerationChunk(
+            message=AIMessageChunk(content=message.content or "", tool_call_chunks=tool_call_chunks)
+        )
+
+
+class _FakeJudge:
+    """Goal-eval model stand-in — returns the llm verifier's judge JSON."""
+
+    def __init__(self, met: bool) -> None:
+        self._met = met
+
+    async def ainvoke(self, _messages, config=None):  # noqa: ARG002 — signature parity
+        return type("R", (), {"content": json.dumps({"met": self._met, "reason": "faked"})})()
+
+
+def _form_call(call_id: str = "c1") -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "request_user_input",
+                "args": {"title": "Pick env", "steps": [{"schema": {"type": "object", "properties": {}}}]},
+                "id": call_id,
+                "type": "tool_call",
+            }
+        ],
+    )
+
+
+def _install(monkeypatch, model_messages, *, judge_met: bool, max_iters: int = 1):
+    import runtime.state as rs
+    from graph.config import LangGraphConfig
+    from graph.goals.controller import GoalController
+    from graph.goals.store import GoalStore
+    from langgraph.checkpoint.memory import MemorySaver
+
+    cfg = LangGraphConfig(goal_max_iterations=max_iters)
+    fake = _ToolFake(messages=iter(model_messages))
+    with patch("graph.agent.create_llm", lambda *a, **k: fake):
+        from graph.agent import create_agent_graph
+
+        g = create_agent_graph(cfg, include_subagents=False, checkpointer=MemorySaver())
+    monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", cfg, raising=False)
+    monkeypatch.setattr(rs.STATE, "goal_controller", GoalController(cfg, GoalStore(str(_tmp()))), raising=False)
+    # The goal's llm verifier reaches out via graph.llm.create_llm — fake its verdict.
+    monkeypatch.setattr("graph.llm.create_llm", lambda *a, **k: _FakeJudge(judge_met))
+
+
+def _tmp():
+    import tempfile
+
+    return tempfile.mkdtemp()
+
+
+async def _frames(message, session_id, *, request_metadata=None):
+    return [
+        frame
+        async for frame in chat_mod._chat_langgraph_stream(message, session_id, request_metadata=request_metadata)
+    ]
+
+
+async def _history(session_id):
+    snap = await STATE.graph.aget_state({"configurable": {"thread_id": f"a2a:{session_id}"}})
+    return list(snap.values.get("messages", []))
+
+
+@pytest.mark.asyncio
+async def test_goal_set_kicks_and_injects_condition(monkeypatch):
+    """#1910: /goal SET kicks a turn whose graph input carries the goal condition."""
+    _install(monkeypatch, [AIMessage(content="On it — starting now.")], judge_met=True)
+
+    frames = await _frames("/goal ship the release notes", "g1")
+
+    kinds = [k for k, _ in frames]
+    # Kicked a real turn (not a bare ack short-circuit): a terminal done frame exists.
+    assert "done" in kinds
+    # The ack was surfaced as a status frame before the drive.
+    assert any(k == "tool_start" and "Goal set." in str(p) for k, p in frames)
+
+    # The graph's first user message is the KICKOFF, carrying the goal condition — the agent
+    # was told its goal instead of receiving a bare "/goal ..." it can't act on.
+    history = await _history("g1")
+    first_human = next(m for m in history if isinstance(m, HumanMessage))
+    assert "ship the release notes" in str(first_human.content)
+    assert "kickoff" in str(first_human.content).lower()
+    assert "/goal ship the release notes" not in str(first_human.content)
+
+    # Terminal goal outcome rode out on the final answer (drive actually ran + verified).
+    done_text = next(p for k, p in frames if k == "done")
+    assert "goal" in str(done_text).lower()
+
+
+@pytest.mark.asyncio
+async def test_goal_turn_does_not_park_on_hitl(monkeypatch):
+    """#1911: a goal-driven turn hitting a HITL form auto-answers instead of parking."""
+    # First model step opens a form (parks the graph); autonomous goal turn resumes past it
+    # with the no-operator sentinel, then the second step completes the turn.
+    _install(
+        monkeypatch,
+        [_form_call(), AIMessage(content="Done — release notes shipped.")],
+        judge_met=True,
+        max_iters=2,
+    )
+
+    frames = await _frames("/goal ship the release notes", "g2")
+    kinds = [k for k, _ in frames]
+
+    # Headless-first invariant: the turn must NOT end parked at input_required.
+    assert kinds[-1] != "input_required"
+    assert "done" in kinds
+    # And the form interrupt must not be left dangling on the thread.
+    assert await chat_mod._pending_interrupt_value({"configurable": {"thread_id": "a2a:g2"}}) is None


### PR DESCRIPTION
Closes #1910. Closes #1911.

First two dogfooding finds from **protoResearcher-as-fleet-member** — goal mode was dead over A2A (the canonical fleet surface), which starves the OODA half of the flywheel trace-supply. Both root causes were confirmed line-for-line against `server/chat.py`.

## The failure (two seams, compounding)
1. **No kickoff.** `/goal set` short-circuited with `yield ("done", ack)` and never ran a turn (`chat.py`).
2. **No injection.** The first goal-driven turn carried only the raw user message — `goal_turn(True)` merely *suppresses* prior-sessions, it doesn't *inject* the goal. The agent never learned its own goal and asked "what goal?".
3. **Deadlock.** That ask hit HITL → parked, because a plain A2A turn isn't in `_AUTONOMOUS_ORIGINS` → returned *before* the goal-continuation loop → iteration stuck at `0/N`.

## The fix
- **`GoalController`**: `kickoff_prompt(state, user_message)` injects the goal condition (+ completion contract) for iteration 0; `is_set_ack()` distinguishes a SET from status/clear so the runner knows to **kick** a drive turn; `SET_ACK_PREFIX` shared with `parse_control`.
- **Both runners** inject the kickoff on the first goal-driven turn (iteration 0) — covering both `/goal set` *and* a plain message on an already-active goal.
- **Goal turns are autonomous by definition** → they take the no-deadlock auto-answer path and never park, even over undeclared A2A. Non-goal traffic is unchanged.
- **Headless-first (declared-unattended)**: `_is_autonomous` also honors an `unattended: true` metadata flag so fleet-to-fleet A2A can opt into the no-deadlock path explicitly; an **undeclared** plain-A2A approval interrupt still parks for a human (approval safety preserved).
- **Non-streaming parity**: the autonomous auto-answer is lifted onto `_chat_langgraph_impl` for goal turns too (#1911 fix 2).

### Headless scope decision
Chose **declared-unattended** over "all A2A autonomous": goal turns + callers that set `unattended`/fleet `origin` self-drive; undeclared plain A2A still parks. Keeps approval interrupts safe by default.

## Tests
- **Pure**: `kickoff_prompt`, `is_set_ack`, `_is_autonomous` (unattended + origins).
- **Live end-to-end** (`test_goal_kickoff_live.py`) — the path the issues said *had never run*: drives `/goal` through the real streaming runner + real `create_agent_graph` (fake model) + real checkpointer, asserting the graph's first message carries the injected condition (#1910), and a goal turn hitting a HITL form auto-answers instead of parking (#1911).
- 72 passed across goal + HITL + chat-route suites; ruff + import contracts clean.

Unblocks the first live OODA/goal-shaped traces for the fleet flywheel (Observe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Goal-driven turns now start immediately with the requested goal context, making `/goal` flows more seamless.
  * Headless/unattended requests can now continue automatically through goal-driven interactions without waiting for operator confirmation.

* **Bug Fixes**
  * Improved handling of successful goal setup so active goals continue into execution instead of stopping after acknowledgment.
  * Reduced cases where goal-driven runs would remain stuck waiting for human input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->