### PR TITLE
feat: autonomous operating model — goals · tasks · scheduling · watches into one OODA loop (ADR 0079)

### DIFF
--- a/docs/adr/0079-autonomous-operating-model.md
+++ b/docs/adr/0079-autonomous-operating-model.md
@@ -117,3 +117,13 @@ The agent runs an **OODA loop** over that state:
 - **Rollout:** staged P0→P4 (plan-store unification → Observe injection → doctrine → composition →
   trace verification), each independently tested, one PR, gates green, dev-validated before any
   fleet roll.
+
+### Deferred (safe follow-up)
+
+- **Durable task→goal attribution** (a `session_id`/`goal_id` column on the task board) is
+  deferred to its own change. The task board is instance-global and holds live prod data, so its
+  schema migration is verified separately rather than folded into this PR. The composition itself
+  is already delivered behaviorally: `<working_state>` surfaces the goal and the open tasks
+  together every turn, and the doctrine + goal-drive tactic instruct the agent to decompose the
+  goal into `task_create` items — so goals and tasks compose in the loop today; only the durable
+  back-reference (for console filtering/attribution) waits.

--- a/docs/adr/0079-autonomous-operating-model.md
+++ b/docs/adr/0079-autonomous-operating-model.md
@@ -1,0 +1,119 @@
+# 0079 — Autonomous operating model (goals · tasks · scheduling · watches → one OODA loop)
+
+- Status: Accepted
+- Date: 2026-07-08
+- Builds on: ADR 0028 (plugin goal verifiers), ADR 0030 (monitor goals — superseded by 0067),
+  ADR 0053 (`wait`/`run_in_session` resume), ADR 0067 (standalone watch primitive), ADR 0073
+  (goal completion contracts), ADR 0074 (system lifecycle events).
+- Supersedes the loose ends of: the plan-storage half of the goal subsystem, and the
+  "primitives compose" intent gestured at across 0030/0067/0073 but never wired.
+
+## Context
+
+An agent has four primitives for acting over time — **goals** (`graph/goals/`), **tasks**
+(the `task_*` board), **scheduling** (`scheduler/`), and **watches** (`graph/watches/`).
+Together they are, in principle, everything an agent needs to run itself: hold an objective,
+break it into work, manage timing and external conditions, and self-correct. In practice they
+are **four disconnected silos with no shared operating model**, and the agent is never told
+they compose. A due-diligence pass across all four subsystems (and a live fleet dogfood) found:
+
+1. **No operating doctrine exists.** The system prompt is persona (`SOUL.md`) plus six tactical
+   bullets (`graph/prompts.py`). The only long-horizon primitive it names is `wait()`. The five
+   primitives are documented *only* in isolated tool docstrings; nothing tells the agent to hold
+   a goal, decompose it into tasks, or schedule/watch for timing. The operating-model block in
+   `prompts.py` is a `# OVERRIDE THIS in your fork` placeholder that was never filled in.
+
+2. **The agent cannot observe its own commitments.** No middleware injects the active goal, open
+   tasks, live watches, or pending schedules into context. The agent sees them only if it
+   remembers to poll `task_list`/`list_watches`/`list_schedules` — which nothing prompts. The
+   "Observe" step of OODA has nothing to observe about the agent's *own* state.
+
+3. **The primitives have no agent-facing bridge.** The only composition primitive,
+   `run_in_session`, is plugin/SDK-only. The agent has no way to make a goal schedule a
+   follow-up, a watch advance a goal, or a task become a trigger. The task board is inert —
+   nothing polls it.
+
+4. **The goal "plan" is split-brained.** `record_plan` writes `state.checklist` for a default
+   (same-session) goal but the durable `.plan.md` artifact only for `fresh_context` goals. The
+   continuation loop-back and the trace-export "orient"/`loop_shape` signal read only `.plan.md`.
+   So a default goal maintains a plan that `read_plan()` never sees → the turn is always labelled
+   `react`. **Live proof:** a fleet PM agent drove a goal for 11.8 min maintaining a 542-char
+   plan and every one of its 11 trace rows was `react`, `orient_len=0`. The fleet emits **0%**
+   of the OODA signal the lab keys off (`observability/trace_export.py`).
+
+5. **A long, delegated goal cannot span time.** The goal drive is a bounded, *synchronous*
+   re-invoke loop. The same dogfood agent delegated an async multi-agent build, then burned its
+   8-iteration budget waiting and gave up (`exhausted`, no deliverable) — because it had no way
+   to hand the async work off to a watch/schedule and resume. The primitives that would have let
+   it self-manage across time exist; it was never told they compose and cannot reach them as a
+   loop.
+
+The through-line: **"OODA" is only a post-hoc trace label, never a prompted behavior.** We
+measure a loop we never taught the agent to run.
+
+## Decision
+
+Define a single **autonomous operating model** and make it real in the prompt and the wiring.
+
+### The model
+
+The agent's **durable working-state** is:
+
+> **{ active goal + its plan (orient) · open tasks · live watches · pending schedules }**
+
+The agent runs an **OODA loop** over that state:
+
+- **Observe** — every turn, the agent is *shown* its working-state (injected, not polled) plus
+  why it is awake (a scheduled fire / a watch trip / an operator turn).
+- **Orient** — it maintains a durable plan and decomposes the goal into tracked tasks; the plan
+  is the world-model, the task board is the backlog.
+- **Decide** — it picks the next concrete step, and decides whether to act now, schedule a
+  follow-up, or set a watch on an external condition.
+- **Act** — it does the work (directly or by delegation) and, for anything async, **hands off to
+  a schedule/watch and yields** instead of spinning; when the trigger fires it resumes with
+  context. The deterministic verifier remains the sole arbiter of DONE (ADR 0073).
+
+### Five moves
+
+1. **Unify the plan store.** `record_plan` always writes the durable `.plan.md`; `state.checklist`
+   is removed (no back-compat). `read_plan()` — and therefore the continuation loop-back and the
+   `orient`/`loop_shape` signal — works for **every** goal. The non-`fresh_context` kickoff prompt
+   asks for a plan too (it was silent). Root fix for the 0% OODA finding, at the source rather
+   than by patching the exporter.
+
+2. **Observe: inject `<working_state>`** each turn (active goal + plan, open tasks, live watches,
+   pending schedules), bounded and empty-safe, via the `# Context` injection point
+   (`graph/middleware/knowledge.py`). Injected on goal turns too.
+
+3. **Write the doctrine** into the system prompt (`graph/prompts.py`): the OODA loop over
+   working-state and how the five primitives compose. Extend the goal kickoff/continuation
+   prompts to point at `task_create`/`schedule_task`/`create_watch`, not just `update_goal_plan`.
+   `SOUL.md` stays pure persona.
+
+4. **Compose + async handoff.** Agent-facing bridges: tasks carry a goal/session reference; the
+   goal drive can yield to a schedule/watch and resume; scheduled/watch fires carry "why am I
+   awake" (a distinct watch origin + the originating goal/condition/evidence) so the agent
+   orients on wake instead of receiving a bare prompt.
+
+5. **Trace alignment.** With move 1 the label is truthful; verify real OODA rows flow to the lab.
+
+### Non-goals / invariants
+
+- **No LLM judge in the reward path.** Reward stays deterministic terminal-state; the verifier
+  stays the sole DONE arbiter (ADR 0073). The operating model shapes *behavior*, never *reward*.
+- **No back-compat / migration.** `state.checklist` and the `fresh_context` plan-storage fork are
+  deleted outright (`fresh_context` keeps its *thread-isolation* behavior — only the plan-storage
+  fork goes). Existing on-disk goals re-plan on their next turn; acceptable.
+- **Prod safety.** Changes land in `protoAgent` behind the full gate suite and are validated on the
+  dev sandbox; the running fleet only picks them up on a deliberate image rebuild.
+
+## Consequences
+
+- **Good:** goals emit real OODA traces; the agent can see and drive its own commitments; long,
+  delegated goals self-manage across time instead of exhausting; the four primitives become one
+  coherent loop; the trace label measures a behavior we actually taught.
+- **Cost:** a larger, always-on `# Context` block (bounded); a real system-prompt doctrine to
+  maintain; the goal drive gains a yield/resume path (more states to test).
+- **Rollout:** staged P0→P4 (plan-store unification → Observe injection → doctrine → composition →
+  trace verification), each independently tested, one PR, gates green, dev-validated before any
+  fleet roll.

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -33,6 +33,16 @@ CLEAR_ALIASES = {"clear", "stop", "off", "reset", "none", "cancel"}
 # to decide whether to KICK an initial goal-driven turn (#1910) — see ``is_set_ack``.
 SET_ACK_PREFIX = "Goal set. "
 
+# Appended to every kickoff + continuation prompt (ADR 0079): point the drive loop at the full
+# toolkit so it composes goals with tasks/watches/scheduling instead of spinning. The system
+# prompt carries the full operating model; this is the goal-loop-specific reminder.
+_DRIVE_TACTIC = (
+    "Decompose this into `task_create` items and drive them down. If your next step waits on "
+    "async or delegated work (a build, a peer agent, CI, a review), set a `create_watch` on that "
+    "condition (or a `schedule_task`) and END the turn — you'll be resumed when it's ready. Don't "
+    "spin polling to the iteration cap."
+)
+
 
 def _coerce_str_list(value) -> list[str]:
     """Normalize a contract list field (``constraints``/``boundaries``) to ``list[str]``.
@@ -165,6 +175,7 @@ class GoalController:
             )
         contract = self._contract_prompt(state)
         body = f"{lead}\n\n{contract}" if contract else lead
+        body = f"{body}\n\n{_DRIVE_TACTIC}"
         # A plain inbound message that arrived alongside an already-active goal (not a
         # /goal command) is folded in so the operator's words aren't lost.
         extra = (user_message or "").strip()
@@ -456,7 +467,8 @@ class GoalController:
         # unchanged from before contracts existed (backward-compat).
         base = self._continuation_base(state, result)
         contract = self._contract_prompt(state)
-        return f"{base}\n\n{contract}" if contract else base
+        body = f"{base}\n\n{contract}" if contract else base
+        return f"{body}\n\n{_DRIVE_TACTIC}"
 
     @staticmethod
     def _verifier_summary(verifier: dict) -> str:

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -159,8 +159,9 @@ class GoalController:
                 f"[goal kickoff — 0/{state.max_iterations}]\n"
                 f"You have an active goal for this session: {state.condition}\n\n"
                 "Begin working toward it now — take concrete action; do not ask which goal "
-                "it is. If it is impossible or out of scope, call the `abandon_goal` tool "
-                "with a reason and stop."
+                "it is. Record your running plan by calling the `update_goal_plan` tool (it "
+                "is persisted and fed back to you each iteration). If it is impossible or out "
+                "of scope, call the `abandon_goal` tool with a reason and stop."
             )
         contract = self._contract_prompt(state)
         body = f"{lead}\n\n{contract}" if contract else lead
@@ -279,21 +280,18 @@ class GoalController:
     # --- agent goal-loop tools (retired the <goal_plan>/<goal_unachievable> XML) ---
 
     def record_plan(self, session_id: str, plan: str) -> tuple[bool, str]:
-        """Persist the agent's running plan for its active goal — called by the
-        ``update_goal_plan`` tool DURING a turn (replaces the old ``<goal_plan>`` tag).
-        Fresh-context goals write the durable plan artifact; same-session goals carry it
-        on the goal state. The next continuation prompt feeds it back. Returns (ok, msg)."""
+        """Persist the agent's running plan (its "orient" world-model) for the active goal —
+        called by the ``update_goal_plan`` tool DURING a turn. Writes the durable ``GoalStore``
+        plan artifact for EVERY goal (ADR 0079 — no fresh-context fork), so the next continuation
+        prompt feeds it back and the trace ``orient``/``loop_shape`` signal sees it uniformly.
+        Returns (ok, msg)."""
         state = self.active_goal(session_id)
         if state is None:
             return (False, "no active goal for this session.")
         plan = (plan or "").strip()
         if not plan:
             return (False, "a plan is required.")
-        if state.fresh_context:
-            self._store.write_plan(state.session_id, plan)
-        else:
-            state.checklist = plan
-            self._store.set(state)
+        self._store.write_plan(state.session_id, plan)
         return (True, "plan recorded.")
 
     def request_abandon(self, session_id: str, reason: str) -> tuple[bool, str]:
@@ -536,7 +534,7 @@ class GoalController:
             )
         evidence = (result.evidence or "").strip()
         evidence_block = f"\nEvidence:\n{evidence}\n" if evidence else "\n"
-        plan_block = state.checklist.strip() or "(no plan yet — create one)"
+        plan_block = self._store.read_plan(state.session_id).strip() or "(no plan yet — create one)"
         vtype = state.verifier.get("type", "llm")
         return (
             f"[goal continuation {state.iteration}/{state.max_iterations}]\n"

--- a/graph/goals/types.py
+++ b/graph/goals/types.py
@@ -41,8 +41,12 @@ class GoalState:
     ``verifier`` is a free-form spec dict whose ``type`` selects an entry in
     ``graph/goals/verifiers.VERIFIERS`` and whose other keys are that verifier's
     parameters (e.g. ``{"type": "command", "command": "pytest -q"}``).
-    ``checklist`` holds the running plan the agent records with the
-    ``update_goal_plan`` tool, carried forward across iterations.
+
+    The running plan (the "orient" world-model the agent records with the
+    ``update_goal_plan`` tool) is NOT a field here — it lives in the durable
+    ``GoalStore`` plan artifact (``read_plan``/``write_plan``) for EVERY goal, so
+    the continuation loop-back and the trace ``orient``/``loop_shape`` signal see
+    it uniformly (ADR 0079).
     """
 
     session_id: str
@@ -70,7 +74,6 @@ class GoalState:
     # transcript from prior iterations. Durable state (plan artifact) lives
     # on disk. Opt-in only; short goals benefit from transcript continuity.
     fresh_context: bool = False
-    checklist: str = ""
     # Set by the agent's ``abandon_goal`` tool mid-turn; ``evaluate`` finishes the goal
     # ``unachievable`` after the verifier runs (retired the ``<goal_unachievable/>`` tag).
     abandon_reason: str = ""

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -31,6 +31,14 @@ log = logging.getLogger(__name__)
 # per-turn disk I/O.
 _PRIOR_SESSIONS_TTL_S = 60.0
 
+# <working_state> caps (ADR 0079) — the agent's own live commitments injected every turn so
+# it OBSERVES its durable state without polling. Bounded so a big plan / long board can't blow
+# the context budget.
+_WS_PLAN_CAP = 1500
+_WS_TASK_CAP = 12
+_WS_WATCH_CAP = 10
+_WS_SCHED_CAP = 10
+
 # Untrusted-reference framing for every auto-injected memory part (ADR 0069
 # D2): the prior-sessions digest, hot memory, and RAG hits can be stale or
 # carry third-party/ingested text (OWASP ASI06 memory poisoning), so the model
@@ -185,6 +193,87 @@ class KnowledgeMiddleware(AgentMiddleware):
     # Middleware hooks
     # ---------------------------------------------------------------------------
 
+    def _working_state_block(self, state) -> str:
+        """The agent's own live commitments — active goal + plan(orient), open tasks, active
+        watches, pending schedules — rendered as one compact ``<working_state>`` block so the
+        agent OBSERVES its durable state every turn instead of having to poll for it (ADR 0079,
+        the "Observe" step). This is the agent's OWN operational state (trusted — unlike recalled
+        memory), so it sits OUTSIDE the ``<injected_memory>`` envelope. Best-effort: every read is
+        guarded so a store hiccup skips its section and never breaks the turn."""
+        from runtime.state import STATE
+
+        session_id = state.get("session_id", "") or ""
+        if not session_id:
+            try:
+                from observability import tracing
+
+                session_id = tracing.current_session_id() or ""
+            except Exception:  # noqa: BLE001
+                session_id = ""
+
+        sections: list[str] = []
+
+        # Active goal + its plan (the durable orient world-model).
+        try:
+            gc = STATE.goal_controller
+            goal = gc.active_goal(session_id) if (gc is not None and session_id) else None
+            if goal is not None:
+                head = f"GOAL [{goal.status}] (iteration {goal.iteration}/{goal.max_iterations}): {goal.condition}"
+                plan = (gc._store.read_plan(session_id) or "").strip()
+                if plan:
+                    if len(plan) > _WS_PLAN_CAP:
+                        plan = plan[:_WS_PLAN_CAP] + " …[truncated]"
+                    head += f"\nPlan (your orient — keep it current with update_goal_plan):\n{plan}"
+                else:
+                    head += "\n(no plan recorded yet — record one with update_goal_plan)"
+                sections.append(head)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("[working_state] goal read failed: %s", exc)
+
+        # Open tasks — the goal's backlog / multi-step decomposition.
+        try:
+            ts = STATE.tasks_store
+            if ts is not None:
+                items = list(ts.list(include_closed=False))[:_WS_TASK_CAP]
+                if items:
+                    lines = "\n".join(
+                        f"- [{i['status']}] {i['id']} (p{i['priority']}) {i['title']}" for i in items
+                    )
+                    sections.append(f"OPEN TASKS:\n{lines}")
+        except Exception as exc:  # noqa: BLE001
+            log.debug("[working_state] task read failed: %s", exc)
+
+        # Active watches — external conditions you're supervising out-of-band.
+        try:
+            wc = STATE.watch_controller
+            if wc is not None:
+                watches = [w for w in wc.list_watches() if getattr(w, "status", "") == "active"][:_WS_WATCH_CAP]
+                if watches:
+                    sections.append("ACTIVE WATCHES:\n" + "\n".join(f"- {w.status_line()}" for w in watches))
+        except Exception as exc:  # noqa: BLE001
+            log.debug("[working_state] watch read failed: %s", exc)
+
+        # Pending schedules — future turns you've queued.
+        try:
+            sched = STATE.scheduler
+            if sched is not None:
+                jobs = list(sched.list_jobs())[:_WS_SCHED_CAP]
+                if jobs:
+                    lines = "\n".join(
+                        f"- {j.id} next={j.next_fire or '?'}: {(j.prompt or '')[:60]}" for j in jobs
+                    )
+                    sections.append(f"PENDING SCHEDULES:\n{lines}")
+        except Exception as exc:  # noqa: BLE001
+            log.debug("[working_state] schedule read failed: %s", exc)
+
+        if not sections:
+            return ""
+        return (
+            "<working_state>\n"
+            "Your live commitments — OBSERVE these before acting, and keep them current as you work "
+            "(this is your own state, not recalled memory).\n\n" + "\n\n".join(sections) + "\n</working_state>"
+        )
+
     def before_model(self, state, runtime) -> dict | None:
         """Query knowledge store with last user message, inject context.
 
@@ -282,6 +371,14 @@ class KnowledgeMiddleware(AgentMiddleware):
             self._record_injection(state, memory_parts, digest_ids, hot_ids, rag_ids)
         if skill_block:
             parts.append(skill_block)
+
+        # The agent's own live commitments (ADR 0079 — the "Observe" step). Always injected,
+        # even on goal turns and incognito threads: this is operational state the agent must
+        # see to self-manage, not recalled memory, so the goal_turn/incognito suppressions above
+        # don't apply. Empty-safe (returns "" when nothing is active).
+        working_state = self._working_state_block(state)
+        if working_state:
+            parts.append(working_state)
 
         if not parts:
             return None

--- a/graph/prompts.py
+++ b/graph/prompts.py
@@ -27,6 +27,52 @@ from pathlib import Path
 from graph.subagents.config import SUBAGENT_REGISTRY
 
 
+# The autonomous operating model (ADR 0079). You are not just a request/response bot — you are a
+# long-horizon operator that manages its own work over time. Your four durable primitives compose
+# into ONE loop; this section is what turns "five separate tools" into "a system that runs itself".
+_OPERATING_MODEL = """
+# Operating model
+
+You operate as a long-horizon autonomous agent, not a one-shot responder. You hold objectives
+across turns and drive them to done — observing your own state, planning, acting, and correcting.
+
+Your durable working-state is shown to you each turn in a `<working_state>` block:
+your **active goal + its plan**, your **open tasks**, your **active watches**, and your
+**pending schedules**. Read it first — it is what you are responsible for.
+
+Run this loop:
+
+- **Observe** — read `<working_state>` and why you are awake (an operator asked, a schedule
+  fired, or a watch tripped — stated at the top of the turn). Take in what changed.
+- **Orient** — keep your **plan** current with `update_goal_plan` (it is your world-model:
+  what's done, what's next, what failed — persisted and fed back to you every turn). Break the
+  goal into concrete **tasks** with `task_create`; the task board is the goal's backlog.
+- **Decide** — pick the next concrete step. Decide whether to do it now, or, if it depends on
+  something that isn't ready, to hand it off (below).
+- **Act** — do the step (directly or by delegating with `task`). Update/close tasks as you go.
+
+Compose your primitives — they are one system, not four:
+
+- **Goal** (`set_goal`) — your standing objective. A deterministic verifier decides DONE, never
+  your own say-so; keep working until it passes, or call `abandon_goal` if it's truly out of scope.
+- **Tasks** (`task_create`/`task_update`/`task_close`) — the goal's backlog. Decompose the goal
+  into tasks and drive them down; this is your board (NOT any built-in todo tool).
+- **Schedule** (`schedule_task`) — do something *later* or on a cadence (a follow-up, a recurring
+  sweep). The prompt you schedule must be self-contained.
+- **Watch** (`create_watch`) — supervise an external *condition* (a deploy, CI, a metric, a peer's
+  PR); when it trips you're brought back to react. Hold as many as you need, in parallel.
+
+**Do not spin waiting on async work.** When your next step depends on something in flight — a
+build, a delegated peer agent, CI, a review — do NOT burn turns polling it. Set a **watch** on
+the condition (or a **schedule** for a known time, or `wait` for a short countdown) and END the
+turn. You'll be resumed with context when it's actually ready. Persisting means yielding and
+coming back, not looping.
+
+**Self-correct.** If your plan isn't producing progress, change the approach and say so in the
+plan. If you're blocked, record what's blocking you. Don't repeat an action that already failed.
+""".strip()
+
+
 def _read_file(path: str | Path) -> str:
     """Read a file if it exists, return empty string otherwise."""
     p = Path(path)
@@ -101,6 +147,11 @@ def build_system_prompt(
     # 3. Dynamic context (typically from KnowledgeMiddleware)
     if context:
         parts.append(f"\n# Context\n\n{context}")
+
+    # 3.5 Operating model — the autonomous doctrine (ADR 0079). Core, always shipped: it
+    # teaches the agent to compose its four durable primitives (goal · tasks · schedule ·
+    # watch) into ONE self-managing OODA loop, instead of treating each as an isolated tool.
+    parts.append(_OPERATING_MODEL)
 
     # 4. Operator guidelines — OVERRIDE THIS in your fork
     parts.append("""

--- a/graph/watches/controller.py
+++ b/graph/watches/controller.py
@@ -261,7 +261,14 @@ class WatchController:
             try:
                 from graph.sdk import run_in_session
 
-                run_in_session(watch.run_session, watch.run_prompt, job_id=f"watch-{watch.id}")
+                # Carry WHAT tripped into the reaction (ADR 0079): prefix the creator's run_prompt
+                # with the watch condition + the verifier's evidence so the agent orients on wake
+                # instead of receiving a bare instruction with no context.
+                context = f"Watch `{watch.id}` tripped: {watch.condition}."
+                if (watch.last_evidence or "").strip():
+                    context += f"\nEvidence: {watch.last_evidence.strip()}"
+                reaction_prompt = f"{context}\n\n{watch.run_prompt}"
+                run_in_session(watch.run_session, reaction_prompt, job_id=f"watch-{watch.id}")
             except Exception:  # noqa: BLE001 — a reaction failure must not break the tick
                 log.exception("[watch] run_in_session reaction failed for %s", watch.id)
 

--- a/plugins/docs/nav.json
+++ b/plugins/docs/nav.json
@@ -677,6 +677,10 @@
           "title": "0078 — Fleet PR review as a protoAgent tier: harvest Quinn, keep the panel"
         },
         {
+          "path": "adr/0079-autonomous-operating-model.md",
+          "title": "0079 — Autonomous operating model (goals · tasks · scheduling · watches → one OODA loop)"
+        },
+        {
           "path": "adr/index.md",
           "title": "Architecture Decision Records"
         }

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -661,6 +661,22 @@ class LocalScheduler:
         origin = job.id if job.id.startswith("watch-") else "scheduler"
         self._publish_turn("turn.started", session_id=session_id, origin=origin, trigger=job.id)
 
+        # Wake-framing (ADR 0079): a scheduled/watch fire delivered a bare prompt, so the agent
+        # had no idea WHY it was awake (a cron sweep? a watch trip? a wait resume?). Prepend a
+        # one-line "why you're awake" header and point it at <working_state> so it orients before
+        # acting, and set a distinct `watch` origin so a watch reaction is no longer masquerading
+        # as an ordinary scheduler fire (server._AUTONOMOUS_ORIGINS recognizes both).
+        is_watch = job.id.startswith("watch-")
+        is_wait = job.id.startswith("wait:")
+        fire_origin = "watch" if is_watch else "scheduler"
+        if is_watch:
+            wake_header = "[Autonomous wake — a watch you set has tripped. Orient from <working_state>, then:]"
+        elif is_wait:
+            wake_header = "[Autonomous wake — a wait you scheduled has elapsed. Continue:]"
+        else:
+            wake_header = "[Autonomous wake — scheduled run. Orient from <working_state>, then:]"
+        wake_prompt = f"{wake_header}\n\n{job.prompt}"
+
         message_id = str(uuid.uuid4())
         body = {
             "jsonrpc": "2.0",
@@ -669,7 +685,7 @@ class LocalScheduler:
             "params": {
                 "message": {
                     "role": "ROLE_USER",
-                    "parts": [{"text": job.prompt}],
+                    "parts": [{"text": wake_prompt}],
                     "messageId": message_id,
                     # Fire into the job's own context when set (ADR 0053 — the
                     # `wait` tool stamps the originating chat session so a resume
@@ -678,11 +694,12 @@ class LocalScheduler:
                     # somewhere visible/continuable instead of a throwaway context.
                     "contextId": session_id,
                     # Scheduler bookkeeping for this fire (origin + job id) —
-                    # informational; the handler doesn't require these keys.
+                    # informational; the handler doesn't require these keys. `origin`
+                    # is `watch` for a watch reaction, else `scheduler` (ADR 0079).
                     "metadata": {
                         "scheduler_job_id": job.id,
                         "scheduler_kind": "local",
-                        "origin": "scheduler",
+                        "origin": fire_origin,
                     },
                 },
             },

--- a/server/chat.py
+++ b/server/chat.py
@@ -920,7 +920,7 @@ def _thread_lock(thread_id: str) -> asyncio.Lock:
 # "background-resume" is the ADR 0070 push-resume nudge — server-fired like the rest
 # (the manager discards the A2A response), so a briefing turn that asks a question
 # must auto-answer, not park.
-_AUTONOMOUS_ORIGINS = frozenset({"scheduler", "inbox", "webhook", "background", "background-resume"})
+_AUTONOMOUS_ORIGINS = frozenset({"scheduler", "watch", "inbox", "webhook", "background", "background-resume"})
 
 # What we resume an autonomous turn's HITL interrupt with, so the agent stops waiting and
 # finishes the turn instead of deadlocking. Bounded by the cap below so a model that keeps

--- a/server/chat.py
+++ b/server/chat.py
@@ -956,6 +956,33 @@ def _is_autonomous(request_metadata: dict | None) -> bool:
     return ((md.get("origin") or "").strip().lower()) in _AUTONOMOUS_ORIGINS
 
 
+def _awaiting_self_resume(session_id: str) -> bool:
+    """Async handoff (ADR 0079): True when the agent has queued a trigger that will resume THIS
+    session later — an active watch whose reaction fires here, or a pending scheduled/wait job
+    targeting this context. The goal drive loop PAUSES (leaves the goal active, ends the turn)
+    when one exists instead of spinning its continuation loop to the iteration cap; the trigger's
+    eventual fire re-enters the session and — the goal still being active — resumes the drive.
+    Best-effort: any read failure just means "not awaiting" (fall through to the normal loop)."""
+    if not session_id:
+        return False
+    try:
+        wc = STATE.watch_controller
+        if wc is not None and any(
+            getattr(w, "status", "") == "active" and getattr(w, "run_session", "") == session_id
+            for w in wc.list_watches()
+        ):
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        sched = STATE.scheduler
+        if sched is not None and any(getattr(j, "context_id", None) == session_id for j in sched.list_jobs()):
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    return False
+
+
 def _is_hitl_resume(request_metadata: dict | None) -> bool:
     """Whether this message IS the operator's answer to the pending HITL pause.
 
@@ -1129,6 +1156,12 @@ async def _run_native_turn(message, session_id, config, *, request_metadata=None
             note = decision.note
             yield ("tool_start", f"🎯 {decision.note}")
             if decision.action == "done":
+                break
+            if _awaiting_self_resume(session_id):
+                # The agent handed off to a watch/schedule that resumes this session — pause the
+                # drive (goal stays active) rather than spinning; the trigger's fire continues it.
+                note = "⏸ goal paused — handed off to a watch/schedule; will resume when it fires."
+                yield ("tool_start", f"🎯 {note}")
                 break
             # Fresh-context goals get a scoped per-iteration thread; same-session reuse
             # `config`. Shared helper keeps the streaming + non-streaming loops in lockstep.
@@ -1897,6 +1930,12 @@ async def _chat_langgraph_impl(
                         break
                     note = decision.note
                     if decision.action == "done":
+                        break
+                    if _awaiting_self_resume(session_id):
+                        # Async handoff (ADR 0079) — mirror the streaming path: the agent queued a
+                        # watch/schedule that resumes this session, so pause the drive instead of
+                        # spinning; the trigger's fire continues the goal.
+                        note = "⏸ goal paused — handed off to a watch/schedule; will resume when it fires."
                         break
                     # Fresh-context goals get a scoped per-iteration thread; same-session
                     # reuse `config`. Same shared helper as the streaming path (no drift).

--- a/tests/test_goal_async_handoff.py
+++ b/tests/test_goal_async_handoff.py
@@ -1,0 +1,109 @@
+"""Async handoff — a goal drive PAUSES on a self-resume trigger instead of spinning (ADR 0079).
+
+The failure this fixes: a long, delegated goal (roxy's marketing spike) burned its whole
+iteration budget synchronously and gave up (`exhausted`) because it couldn't hand the async
+work off and yield. Now, when the agent has queued a watch/schedule that resumes this session,
+the drive loop pauses (goal stays active) and the trigger's fire continues it later.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, AIMessageChunk
+from langchain_core.outputs import ChatGenerationChunk
+
+import runtime.state as rs
+
+chat_mod = importlib.import_module("server.chat")
+
+
+# ── unit: _awaiting_self_resume ────────────────────────────────────────────
+@pytest.fixture
+def clear_triggers(monkeypatch):
+    monkeypatch.setattr(rs.STATE, "watch_controller", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "scheduler", None, raising=False)
+    yield
+
+
+def test_awaiting_false_when_nothing_queued(clear_triggers):
+    assert chat_mod._awaiting_self_resume("s") is False
+    assert chat_mod._awaiting_self_resume("") is False
+
+
+def test_awaiting_true_for_active_watch_on_this_session(clear_triggers, monkeypatch):
+    w = SimpleNamespace(status="active", run_session="s")
+    monkeypatch.setattr(rs.STATE, "watch_controller", SimpleNamespace(list_watches=lambda: [w]), raising=False)
+    assert chat_mod._awaiting_self_resume("s") is True
+    # ...but not for a watch targeting a different session, or a finished watch
+    other = SimpleNamespace(status="active", run_session="other")
+    met = SimpleNamespace(status="met", run_session="s")
+    monkeypatch.setattr(rs.STATE, "watch_controller", SimpleNamespace(list_watches=lambda: [other, met]), raising=False)
+    assert chat_mod._awaiting_self_resume("s") is False
+
+
+def test_awaiting_true_for_pending_schedule_on_this_session(clear_triggers, monkeypatch):
+    job = SimpleNamespace(context_id="s")
+    monkeypatch.setattr(rs.STATE, "scheduler", SimpleNamespace(list_jobs=lambda: [job]), raising=False)
+    assert chat_mod._awaiting_self_resume("s") is True
+    monkeypatch.setattr(
+        rs.STATE, "scheduler", SimpleNamespace(list_jobs=lambda: [SimpleNamespace(context_id="elsewhere")]),
+        raising=False,
+    )
+    assert chat_mod._awaiting_self_resume("s") is False
+
+
+# ── live: the drive loop pauses instead of exhausting ──────────────────────
+class _ToolFake(GenericFakeChatModel):
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+    async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+        message = next(self.messages)
+        yield ChatGenerationChunk(message=AIMessageChunk(content=message.content or ""))
+
+
+class _FakeJudge:
+    async def ainvoke(self, _messages, config=None):  # noqa: ARG002
+        return type("R", (), {"content": json.dumps({"met": False, "reason": "still working"})})()
+
+
+@pytest.mark.asyncio
+async def test_goal_drive_pauses_on_handoff_instead_of_exhausting(monkeypatch):
+    from graph.config import LangGraphConfig
+    from graph.goals.controller import GoalController
+    from graph.goals.store import GoalStore
+    from langgraph.checkpoint.memory import MemorySaver
+
+    cfg = LangGraphConfig(goal_max_iterations=8)
+    # Only ONE model message is consumed: the kickoff turn. If the drive DIDN'T pause it would
+    # loop for continuations and exhaust the iterator — so reaching a clean 'done' proves the pause.
+    fake = _ToolFake(messages=iter([AIMessage(content="Delegated the build; set a watch on its PR.")]))
+    with patch("graph.agent.create_llm", lambda *a, **k: fake):
+        from graph.agent import create_agent_graph
+
+        g = create_agent_graph(cfg, include_subagents=False, checkpointer=MemorySaver())
+    monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", cfg, raising=False)
+    import tempfile
+
+    ctrl = GoalController(cfg, GoalStore(tempfile.mkdtemp()))
+    monkeypatch.setattr(rs.STATE, "goal_controller", ctrl, raising=False)
+    monkeypatch.setattr("graph.llm.create_llm", lambda *a, **k: _FakeJudge())
+    # The verifier never passes; the ONLY way this ends cleanly is the async-handoff pause.
+    monkeypatch.setattr(chat_mod, "_awaiting_self_resume", lambda sid: True)
+
+    frames = [f async for f in chat_mod._chat_langgraph_stream("/goal ship the redesign", "h1")]
+    kinds = [k for k, _ in frames]
+
+    assert "done" in kinds
+    assert any(k == "tool_start" and "paused" in str(p).lower() for k, p in frames)
+    # The goal is PAUSED (still active), not exhausted — it will resume when the trigger fires.
+    goal = ctrl.active_goal("h1")
+    assert goal is not None and goal.status == "active"
+    assert goal.iteration < goal.max_iterations  # did not spin to the cap

--- a/tests/test_goal_controller.py
+++ b/tests/test_goal_controller.py
@@ -139,14 +139,15 @@ async def test_verifier_overrides_giveup(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_checklist_recorded_and_carried(tmp_path):
+async def test_plan_recorded_and_carried(tmp_path):
     # The plan is recorded mid-turn via the update_goal_plan tool (→ record_plan),
-    # persisted, and fed back into the next continuation prompt.
+    # persisted to the durable plan artifact (ADR 0079 — for EVERY goal, not just
+    # fresh-context), and fed back into the next continuation prompt.
     c = _ctrl(tmp_path)
     await c.parse_control('/goal {"condition": "done", "verifier": {"type": "command", "command": "exit 1"}}', "s")
     c.record_plan("s", "1. do A\n2. do B")
     decision = await c.evaluate("s", last_text="progress")
-    assert "do A" in c.active_goal("s").checklist
+    assert "do A" in c._store.read_plan("s")  # durable plan artifact, unified store
     assert "do A" in decision.message
 
 

--- a/tests/test_goal_fresh_context.py
+++ b/tests/test_goal_fresh_context.py
@@ -29,6 +29,26 @@ def test_plan_round_trip(tmp_path):
     assert store.read_plan("s1") == "- [x] step one\n- [ ] step two"
 
 
+@pytest.mark.parametrize("fresh", [False, True])
+def test_record_plan_persists_durable_artifact_for_every_goal(tmp_path, fresh):
+    """ADR 0079 root fix: record_plan writes the durable .plan.md for BOTH default
+    (same-session) and fresh-context goals — so read_plan (and therefore the trace
+    ``orient``/``loop_shape`` OODA signal) is populated for the DEFAULT goal, which was
+    previously always empty → mislabelled ``react``."""
+    c = _ctrl(tmp_path)
+    ok, _ = c.set_goal_operator("sess", "make it green", {"type": "llm"})
+    assert ok
+    gs = c.active_goal("sess")
+    gs.fresh_context = fresh
+    c._store.set(gs)
+
+    assert c._store.read_plan("sess") == ""  # no plan yet → would label react
+    ok, _ = c.record_plan("sess", "- [ ] step 1\n- [ ] step 2")
+    assert ok
+    # The durable artifact the exporter's `orient` reads is now populated → ooda.
+    assert "step 1" in c._store.read_plan("sess")
+
+
 def test_read_plan_absent_returns_empty(tmp_path):
     assert GoalStore(tmp_path).read_plan("never-written") == ""
 
@@ -116,12 +136,14 @@ def test_default_continuation_stays_same_session(tmp_path):
     state = GoalState(
         session_id="s",
         condition="make it green",
-        checklist="- [ ] do the work",
         iteration=1,
         max_iterations=8,
     )
+    c._store.set(state)
+    # Plan lives in the unified durable artifact for default goals too (ADR 0079).
+    c._store.write_plan("s", "- [ ] do the work")
     result = VerifyResult(met=False, reason="nope", evidence="")
     prompt = c._continuation(state, result)
     assert "fresh context" not in prompt  # default path: same-session continuity
     assert "Current plan" in prompt  # the existing template
-    assert "do the work" in prompt  # seeded from in-memory checklist, not disk
+    assert "do the work" in prompt  # read back from the durable plan artifact

--- a/tests/test_goal_kickoff.py
+++ b/tests/test_goal_kickoff.py
@@ -109,3 +109,20 @@ def test_is_autonomous_honors_unattended_and_origins():
     assert not _is_autonomous({"unattended": False})
     assert not _is_autonomous({})
     assert not _is_autonomous(None)
+
+
+# --- ADR 0079: goal drive references tasks/watches/scheduling ---------------
+def test_kickoff_and_continuation_reference_composition(tmp_path):
+    from graph.goals.controller import GoalController
+    from graph.goals.store import GoalStore
+    from graph.goals.types import VerifyResult
+
+    c = GoalController(LangGraphConfig(), GoalStore(tmp_path))
+    c.set_goal_operator("s", "ship it", {"type": "llm"})
+    gs = c.active_goal("s")
+    kick = c.kickoff_prompt(gs)
+    cont = c._continuation(gs, VerifyResult(met=False, reason="not yet", evidence=""))
+    for prompt in (kick, cont):
+        assert "task_create" in prompt
+        assert "create_watch" in prompt or "schedule_task" in prompt
+        assert "END the turn" in prompt  # the async-handoff / don't-spin directive

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -46,3 +46,27 @@ def test_falls_back_to_workspace_soul_when_no_instance_soul(monkeypatch, tmp_pat
     prompt = build_system_prompt(workspace=str(hub), include_subagents=False)
 
     assert "Legacy runtime persona." in prompt
+
+
+# --- Operating model doctrine (ADR 0079) -----------------------------------
+
+
+def test_operating_model_doctrine_is_always_present():
+    """The autonomous operating model ships in every system prompt (core, not fork-gated):
+    the OODA framing + all four composable primitives + the async-handoff rule."""
+    prompt = build_system_prompt(include_subagents=False)
+    assert "# Operating model" in prompt
+    # the loop
+    for step in ("Observe", "Orient", "Decide", "Act"):
+        assert step in prompt
+    # the four primitives composed (not just listed as isolated tools)
+    for tool in ("set_goal", "task_create", "schedule_task", "create_watch", "update_goal_plan"):
+        assert tool in prompt
+    # the async-handoff rule (the roxy-exhausted fix) + working_state observe
+    assert "Do not spin" in prompt
+    assert "<working_state>" in prompt
+
+
+def test_working_state_block_is_referenced_for_observe():
+    prompt = build_system_prompt(include_subagents=False)
+    assert "working-state" in prompt.lower() or "<working_state>" in prompt

--- a/tests/test_scheduler_local.py
+++ b/tests/test_scheduler_local.py
@@ -707,7 +707,11 @@ async def test_fire_emits_a2a_1_0_wire_shape(tmp_path, monkeypatch):
     assert "contextId" not in body["params"]  # moved onto the message
     msg = body["params"]["message"]
     assert msg["role"] == "ROLE_USER"  # not "user"
-    assert msg["parts"] == [{"text": "do the thing"}]  # not [{"kind":"text",...}]
+    # A2A 1.0 part shape ({text}, not {kind:text}); the prompt now carries a wake-framing
+    # header (ADR 0079) so the agent orients on why it's awake, then the original prompt.
+    assert len(msg["parts"]) == 1 and set(msg["parts"][0]) == {"text"}
+    assert msg["parts"][0]["text"].endswith("do the thing")
+    assert "Autonomous wake — scheduled run" in msg["parts"][0]["text"]
     assert msg["contextId"] == ACTIVITY_CONTEXT
     assert msg["metadata"]["scheduler_job_id"] == job.id
     assert msg["metadata"]["origin"] == "scheduler"

--- a/tests/test_watch_controller.py
+++ b/tests/test_watch_controller.py
@@ -164,7 +164,10 @@ async def test_met_enqueues_followup_turn_in_session(tmp_path, monkeypatch):
     )
     assert await c.evaluate(w.id) == "met"
     assert added and added[0]["context_id"] == "sess-7"  # follow-up turn fired into the target session
-    assert added[0]["prompt"] == "Run the smoke test."
+    # The reaction carries the creator's run_prompt AND what tripped (condition), so the agent
+    # orients on wake instead of getting a bare instruction (ADR 0079 wake-framing).
+    assert "Run the smoke test." in added[0]["prompt"]
+    assert "deploy done" in added[0]["prompt"]
 
 
 def test_clear(tmp_path):

--- a/tests/test_working_state.py
+++ b/tests/test_working_state.py
@@ -1,0 +1,128 @@
+"""<working_state> injection — the "Observe" step of the autonomous operating model (ADR 0079).
+
+KnowledgeMiddleware injects the agent's OWN live commitments (active goal + plan, open tasks,
+active watches, pending schedules) every turn, so the agent observes its durable state instead
+of polling for it. These tests exercise the assembly directly with fake STATE surfaces.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import runtime.state as rs
+from graph.middleware.knowledge import KnowledgeMiddleware
+
+
+def _mw() -> KnowledgeMiddleware:
+    return KnowledgeMiddleware(knowledge_store=None)
+
+
+class _GoalCtrl:
+    def __init__(self, goal, plan=""):
+        self._goal = goal
+        self._store = SimpleNamespace(read_plan=lambda sid: plan)
+
+    def active_goal(self, session_id):
+        return self._goal
+
+
+class _Tasks:
+    def __init__(self, items):
+        self._items = items
+
+    def list(self, *, include_closed=False):
+        return self._items
+
+
+class _Watches:
+    def __init__(self, watches):
+        self._watches = watches
+
+    def list_watches(self):
+        return self._watches
+
+
+class _Sched:
+    def __init__(self, jobs):
+        self._jobs = jobs
+
+    def list_jobs(self):
+        return self._jobs
+
+
+@pytest.fixture
+def clear_state(monkeypatch):
+    for attr in ("goal_controller", "tasks_store", "watch_controller", "scheduler"):
+        monkeypatch.setattr(rs.STATE, attr, None, raising=False)
+    yield
+
+
+def test_empty_when_nothing_active(clear_state):
+    assert _mw()._working_state_block({"session_id": "s"}) == ""
+
+
+def test_full_block_assembles_all_sections(clear_state, monkeypatch):
+    goal = SimpleNamespace(status="active", iteration=2, max_iterations=8, condition="ship the redesign")
+    monkeypatch.setattr(rs.STATE, "goal_controller", _GoalCtrl(goal, plan="- [x] scope\n- [ ] build"), raising=False)
+    monkeypatch.setattr(
+        rs.STATE, "tasks_store",
+        _Tasks([{"status": "open", "id": "task-1", "priority": 1, "issue_type": "task", "title": "wire the hero"}]),
+        raising=False,
+    )
+    watch = SimpleNamespace(status="active", status_line=lambda: "watch [active] (w1) via plugin: 'ci green'")
+    monkeypatch.setattr(rs.STATE, "watch_controller", _Watches([watch]), raising=False)
+    job = SimpleNamespace(id="job-9", next_fire="2026-07-09T09:00:00", prompt="follow up on the build")
+    monkeypatch.setattr(rs.STATE, "scheduler", _Sched([job]), raising=False)
+
+    block = _mw()._working_state_block({"session_id": "s"})
+
+    assert block.startswith("<working_state>") and block.endswith("</working_state>")
+    assert "GOAL [active] (iteration 2/8): ship the redesign" in block
+    assert "- [ ] build" in block  # plan (orient)
+    assert "task-1" in block and "wire the hero" in block
+    assert "watch [active]" in block
+    assert "job-9" in block and "follow up on the build" in block
+
+
+def test_goal_without_plan_nudges_to_record_one(clear_state, monkeypatch):
+    goal = SimpleNamespace(status="active", iteration=0, max_iterations=5, condition="do the thing")
+    monkeypatch.setattr(rs.STATE, "goal_controller", _GoalCtrl(goal, plan=""), raising=False)
+    block = _mw()._working_state_block({"session_id": "s"})
+    assert "no plan recorded yet" in block
+    assert "update_goal_plan" in block
+
+
+def test_plan_is_capped(clear_state, monkeypatch):
+    from graph.middleware.knowledge import _WS_PLAN_CAP
+
+    goal = SimpleNamespace(status="active", iteration=1, max_iterations=8, condition="c")
+    monkeypatch.setattr(rs.STATE, "goal_controller", _GoalCtrl(goal, plan="x" * (_WS_PLAN_CAP + 500)), raising=False)
+    block = _mw()._working_state_block({"session_id": "s"})
+    assert "[truncated]" in block
+    assert len(block) < _WS_PLAN_CAP + 800  # bounded, not the full 2000 chars
+
+
+def test_only_active_watches_shown(clear_state, monkeypatch):
+    active = SimpleNamespace(status="active", status_line=lambda: "watch [active] (w1)")
+    met = SimpleNamespace(status="met", status_line=lambda: "watch [met] (w2)")
+    monkeypatch.setattr(rs.STATE, "watch_controller", _Watches([active, met]), raising=False)
+    block = _mw()._working_state_block({"session_id": "s"})
+    assert "w1" in block and "w2" not in block
+
+
+def test_read_failure_is_skipped_not_raised(clear_state, monkeypatch):
+    class _Boom:
+        def active_goal(self, sid):
+            raise RuntimeError("db gone")
+
+    monkeypatch.setattr(rs.STATE, "goal_controller", _Boom(), raising=False)
+    # A task still renders — the goal section is skipped, nothing propagates.
+    monkeypatch.setattr(
+        rs.STATE, "tasks_store",
+        _Tasks([{"status": "open", "id": "task-2", "priority": 2, "issue_type": "task", "title": "t"}]),
+        raising=False,
+    )
+    block = _mw()._working_state_block({"session_id": "s"})
+    assert "task-2" in block and "GOAL" not in block


### PR DESCRIPTION
Implements **ADR 0079**. Turns four disconnected primitives (goals, tasks, scheduling, watches) into one self-managing operating model — and fixes the root cause of **0% OODA trace supply** to the lab.

## Why
Due diligence across all four subsystems (+ a live fleet dogfood) found they're silos with no shared operating model, and the agent is never told they compose:
- **No operating doctrine** — the system prompt was persona + 6 tactical bullets; the five primitives lived only in isolated tool docstrings.
- **The agent couldn't observe its own commitments** — nothing injected the active goal/tasks/watches/schedules.
- **Split-brain goal plan** — `record_plan` wrote `state.checklist` for default goals but the durable `.plan.md` only for fresh-context; the OODA/`orient` signal reads only `.plan.md`. **Live proof:** a fleet PM drove a goal 11.8 min with a 542-char plan and all 11 trace rows were `react`/`orient_len=0`.
- **A long delegated goal couldn't span time** — the same agent burned its 8-iteration budget waiting on async work and gave up (`exhausted`, no PR).

## What (staged, one phase per commit)
- **P0 — unify the plan store.** `record_plan` always writes the durable artifact; `state.checklist` deleted (no back-compat; `from_dict` drops stale keys, so live goals load clean). Non-fresh kickoff now asks for a plan. → **`orient`/`loop_shape=ooda` works for every goal.**
- **P1 — `<working_state>` injection (Observe).** `KnowledgeMiddleware` injects the agent's own goal+plan / open tasks / active watches / pending schedules every turn, bounded and empty-safe.
- **P2 — the operating doctrine.** A core `# Operating model` section: the OODA loop over working-state + how the four primitives compose + "don't spin on async work — set a watch/schedule and yield." Goal kickoff/continuation now point at `task_create`/`create_watch`/`schedule_task`. SOUL stays pure persona.
- **P3a — wake-framing.** Scheduled/watch fires carry a "why you're awake" header (pointing at `<working_state>`), a distinct `watch` origin, and the tripping condition + evidence — so the agent orients on wake instead of getting a bare prompt.
- **P3b — pause-on-handoff.** When the agent queues a self-resume trigger (active watch or pending schedule targeting this session), the goal drive **pauses (stays active) instead of spinning to the cap**; the trigger's fire resumes it. **This is the roxy-exhausted failure fixed at the mechanism level.**

## Tests
New: `test_working_state.py`, `test_goal_async_handoff.py` (incl. a live drive proving the goal **pauses instead of exhausting**), plus P0/P2 coverage across goal + prompt + trace-export suites. Updated scheduler/watch tests for the wake-framed shape. **Full suite: 3477 passed**, ruff + import-contracts clean.

## Deferred (called out in the ADR)
Durable task→goal attribution (a `session_id` column on the **shared, instance-global** task board) is deferred to its own verified change — the behavioral composition already ships via `<working_state>` + the doctrine. Kept out of this PR to honor prod-safety on live board data.

## Prod safety
Merging to main does **not** touch the running fleet (no build fanout — agents only update on a deliberate image rebuild). Gates (A2A live smoke + Fleet integration) are the e2e. No fleet roll until explicitly requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)