### PR TITLE
feat(tasks): durable task→goal attribution (ADR 0079 P3c)

### DIFF
--- a/docs/adr/0079-autonomous-operating-model.md
+++ b/docs/adr/0079-autonomous-operating-model.md
@@ -118,12 +118,11 @@ The agent runs an **OODA loop** over that state:
   trace verification), each independently tested, one PR, gates green, dev-validated before any
   fleet roll.
 
-### Deferred (safe follow-up)
+### Durable task→goal attribution (P3c — included)
 
-- **Durable task→goal attribution** (a `session_id`/`goal_id` column on the task board) is
-  deferred to its own change. The task board is instance-global and holds live prod data, so its
-  schema migration is verified separately rather than folded into this PR. The composition itself
-  is already delivered behaviorally: `<working_state>` surfaces the goal and the open tasks
-  together every turn, and the doctrine + goal-drive tactic instruct the agent to decompose the
-  goal into `task_create` items — so goals and tasks compose in the loop today; only the durable
-  back-reference (for console filtering/attribution) waits.
+Tasks carry a `session_id` stamping the goal/session that motivated them. The board is
+instance-global and holds live prod data, so the migration is a **guarded, non-destructive
+`ALTER TABLE ADD COLUMN`** — existing rows backfill to `''` and live boards upgrade on first
+open (covered by a legacy-board migration test). `task_create` stamps the session from injected
+graph state; `list(session_id=…)` scopes to a goal's backlog; `<working_state>` marks a goal's
+own tasks with "← this goal".

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -237,7 +237,9 @@ class KnowledgeMiddleware(AgentMiddleware):
                 items = list(ts.list(include_closed=False))[:_WS_TASK_CAP]
                 if items:
                     lines = "\n".join(
-                        f"- [{i['status']}] {i['id']} (p{i['priority']}) {i['title']}" for i in items
+                        f"- [{i['status']}] {i['id']} (p{i['priority']}) {i['title']}"
+                        + (" ← this goal" if session_id and i.get("session_id") == session_id else "")
+                        for i in items
                     )
                     sections.append(f"OPEN TASKS:\n{lines}")
         except Exception as exc:  # noqa: BLE001

--- a/tasks/store.py
+++ b/tasks/store.py
@@ -81,10 +81,18 @@ class TaskStore:
                     created_at   TEXT NOT NULL,
                     updated_at   TEXT NOT NULL,
                     closed_at    TEXT,
-                    close_reason TEXT
+                    close_reason TEXT,
+                    session_id   TEXT NOT NULL DEFAULT ''
                 )
                 """
             )
+            # Attribution to the goal/session that motivated a task (ADR 0079). Guarded
+            # migration for boards created before the column existed — ADD COLUMN is
+            # non-destructive (existing rows get the '' default), so live prod boards
+            # upgrade cleanly on first open.
+            cols = {r["name"] for r in self._conn.execute("PRAGMA table_info(issues)").fetchall()}
+            if "session_id" not in cols:
+                self._conn.execute("ALTER TABLE issues ADD COLUMN session_id TEXT NOT NULL DEFAULT ''")
             self._conn.commit()
 
     # ── helpers ───────────────────────────────────────────────────────────────
@@ -121,6 +129,7 @@ class TaskStore:
         priority: int = 2,
         issue_type: str = "task",
         assignee: str = "",
+        session_id: str = "",
     ) -> dict[str, Any]:
         title = (title or "").strip()
         if not title:
@@ -130,7 +139,7 @@ class TaskStore:
             issue_id = self._next_id()
             self._conn.execute(
                 "INSERT INTO issues (id, title, description, status, priority, issue_type, "
-                "assignee, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?)",
+                "assignee, created_at, updated_at, session_id) VALUES (?,?,?,?,?,?,?,?,?,?)",
                 (
                     issue_id,
                     title,
@@ -141,17 +150,24 @@ class TaskStore:
                     assignee or "",
                     now,
                     now,
+                    session_id or "",
                 ),
             )
             self._conn.commit()
             _publish("task.changed", {"id": issue_id, "action": "created"})
             return dict(self._row(issue_id))
 
-    def list(self, *, include_closed: bool = True) -> list[dict[str, Any]]:
-        if include_closed:
-            rows = self._conn.execute("SELECT * FROM issues ORDER BY created_at").fetchall()
-        else:
-            rows = self._conn.execute("SELECT * FROM issues WHERE status != 'closed' ORDER BY created_at").fetchall()
+    def list(self, *, include_closed: bool = True, session_id: str | None = None) -> list[dict[str, Any]]:
+        where: list[str] = []
+        params: list[Any] = []
+        if not include_closed:
+            where.append("status != 'closed'")
+        if session_id is not None:
+            # Scope to the goal/session that motivated the task (ADR 0079).
+            where.append("session_id = ?")
+            params.append(session_id)
+        clause = f" WHERE {' AND '.join(where)}" if where else ""
+        rows = self._conn.execute(f"SELECT * FROM issues{clause} ORDER BY created_at", params).fetchall()
         return [dict(r) for r in rows]
 
     def get(self, issue_id: str) -> dict[str, Any] | None:

--- a/tests/test_tasks_store.py
+++ b/tests/test_tasks_store.py
@@ -141,3 +141,51 @@ def test_delete_missing_does_not_publish(store, monkeypatch):
     monkeypatch.setattr(host.HOST, "publish", lambda topic, data: events.append((topic, data)))
     assert store.delete("bd-404") is False
     assert events == []  # nothing deleted → no event
+
+
+# --- ADR 0079: task→goal/session attribution -------------------------------
+
+
+def test_create_stamps_session_id_and_defaults_empty(store):
+    a = store.create("no session")
+    b = store.create("goal task", session_id="sess-7")
+    assert a["session_id"] == ""
+    assert b["session_id"] == "sess-7"
+
+
+def test_list_filters_by_session(store):
+    store.create("global one")
+    store.create("goal A", session_id="A")
+    store.create("goal A two", session_id="A")
+    store.create("goal B", session_id="B")
+    a_tasks = store.list(session_id="A")
+    assert {t["title"] for t in a_tasks} == {"goal A", "goal A two"}
+    assert len(store.list(session_id="B")) == 1
+    assert len(store.list()) == 4  # unfiltered still returns all
+
+
+def test_session_id_column_migrates_onto_a_legacy_board(tmp_path):
+    """A board created WITHOUT session_id (pre-ADR-0079) gains the column on next open,
+    non-destructively — the guarded ALTER keeps live prod boards loading clean."""
+    import sqlite3
+
+    db = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE issues (id TEXT PRIMARY KEY, title TEXT NOT NULL, description TEXT DEFAULT '', "
+        "status TEXT DEFAULT 'open', priority INTEGER DEFAULT 2, issue_type TEXT DEFAULT 'task', "
+        "assignee TEXT DEFAULT '', created_at TEXT NOT NULL, updated_at TEXT NOT NULL, "
+        "closed_at TEXT, close_reason TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO issues (id, title, created_at, updated_at) VALUES ('task-1','old one','t','t')"
+    )
+    conn.commit()
+    conn.close()
+
+    store = TaskStore(db_path=db)  # opens + migrates
+    rows = store.list()
+    assert rows and rows[0]["id"] == "task-1"
+    assert rows[0]["session_id"] == ""  # existing row backfilled to the default
+    # and new session-attributed creates work on the migrated board
+    assert store.create("new", session_id="s9")["session_id"] == "s9"

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -1135,12 +1135,24 @@ def _build_task_tools(tasks_store) -> list:
     in-process planning/task surface. Returns a list."""
 
     @tool
-    def task_create(title: str, description: str = "", priority: int = 2, issue_type: str = "task") -> str:
+    def task_create(
+        title: str,
+        description: str = "",
+        priority: int = 2,
+        issue_type: str = "task",
+        state: Annotated[Any, InjectedState] = None,
+    ) -> str:
         """Track a task/issue on your tasks board — your planning surface for
         multi-step work. ``priority`` 0=highest…3=low; ``issue_type`` is one of
         task|bug|feature|chore|epic. Returns the new issue id."""
+        # Attribute the task to the session/goal that motivated it (ADR 0079) so a goal's
+        # backlog is queryable; from injected graph state (current_session_id() is empty in a
+        # tool body). Empty when there's no session context — an instance-global task, as before.
+        session_id = _session_id_from(state) or ""
         try:
-            i = tasks_store.create(title, description=description, priority=priority, issue_type=issue_type)
+            i = tasks_store.create(
+                title, description=description, priority=priority, issue_type=issue_type, session_id=session_id
+            )
         except ValueError as exc:
             return f"Error: {exc}"
         return f"Created {i['id']}: {i['title']} ({i['issue_type']}, p{i['priority']})"


### PR DESCRIPTION
Completes **ADR 0079** — the one piece that landed after #1915 auto-merged. Tasks now carry the goal/session that motivated them, so a goal's backlog is queryable and `<working_state>` marks which open tasks belong to the active goal.

- **tasks/store.py** — `session_id` column + a **guarded, non-destructive `ALTER TABLE ADD COLUMN`** migration (existing rows backfill to `''`; live prod boards upgrade on first open — covered by a legacy-board migration test). `create()` stamps it; `list(session_id=…)` scopes to a goal's backlog.
- **tools/lg_tools.py** — `task_create` stamps the session from injected graph state (`current_session_id()` is empty in a tool body); empty ⇒ an instance-global task, as before.
- **graph/middleware/knowledge.py** — `<working_state>` tags a goal's own tasks with "← this goal".
- ADR 0079 updated: this is now included, not deferred (prod-data concern cleared).

Tests: task store session stamping + filter + legacy-board migration; full task/working_state/operator suites green. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)