### PR TITLE
docs: align goal/watch guides + ADR 0079 with the shipped operating model

### DIFF
--- a/docs/adr/0079-autonomous-operating-model.md
+++ b/docs/adr/0079-autonomous-operating-model.md
@@ -126,3 +126,28 @@ instance-global and holds live prod data, so the migration is a **guarded, non-d
 open (covered by a legacy-board migration test). `task_create` stamps the session from injected
 graph state; `list(session_id=…)` scopes to a goal's backlog; `<working_state>` marks a goal's
 own tasks with "← this goal".
+
+### Validation (prod, 2026-07-08)
+
+Shipped in two PRs (`#1915` P0–P3b + nav; `#1917` P3c) and rolled to the four-agent fleet, then
+validated live over real A2A `/goal` drives:
+
+- **frank** — a `data`-verifier goal produced the first-ever `loop_shape=ooda` fleet trace row,
+  confirming Move 1 fixed the 0% OODA-supply finding at the source (the plan is now durable for
+  every goal, so `read_plan()` / the exporter's `orient` sees it).
+- **jon** — the full compose-and-yield path end to end: the agent recorded a plan (orient),
+  `task_create`'d a session-linked task (P3c), **yielded** on an active watch instead of spinning
+  (P3b: `⏸ goal paused — handed off to a watch/schedule`), **woke** on the watch trip with the
+  ADR 0079 framing (`[Autonomous wake …]` + condition + `Evidence:`), acted, and the deterministic
+  verifier flipped the goal to `achieved`. A single verified OODA row (`verified=True`, `reward=1.0`,
+  `reward_semantics="terminal-state verifier"`) spans **both** the kickoff `user` turn and the wake
+  `user` turn — one whole trace.
+
+Two operational notes surfaced and are documented in the guides: (1) for an agent-completed goal
+set over untrusted `/goal`, `data`-verifier `path`s must sit under the agent's writable workspace
+(`/sandbox/workspace/…`), since the agent's file tools are workspace-rooted and its shell fallback
+is declined without an operator — see [Goal mode ▸ Security](/guides/goal-mode#security); (2) the
+watch met-reaction is wake-framed and its `Evidence:` is load-bearing — see
+[Watches ▸ Reacting](/guides/watches#reacting). The verifier-as-sole-arbiter invariant held: an
+agent's optimistic "done" self-report against a mispathed artifact correctly left the goal
+unverified.

--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -29,6 +29,8 @@ It's modelled on protocli's goal system but deliberately more rigorous for a lon
 
 The loop wraps graph invocation in `server/chat.py` (both the A2A streaming path and the non-streaming chat path); the graph itself is unchanged.
 
+**Yield instead of spin (ADR 0079).** If the agent's next step waits on async or delegated work — a build, a peer agent, CI, a review — it doesn't have to burn iterations polling. It hands off to a [watch](/guides/watches) or a [schedule](/guides/scheduler) and ends the turn; the drive **pauses** (the goal stays `active`, iterations untouched) and **resumes automatically** when the trigger fires (`⏸ goal paused — handed off to a watch/schedule`). This is what lets a long, delegated goal span time instead of exhausting its budget waiting. Goals, tasks, watches, and schedules compose into one OODA loop over the agent's durable working-state — see [ADR 0079](/adr/0079-autonomous-operating-model).
+
 ## Setting a goal
 
 Send a control message through any channel (A2A, the React console chat, OpenAI-compat):
@@ -131,7 +133,7 @@ Examples:
 
 ## The running plan (`update_goal_plan`)
 
-Continuation prompts ask the agent to keep a running plan and record it each turn by calling the **`update_goal_plan`** tool. The controller persists that plan with the goal state (fresh-context goals write it to a durable plan artifact) and feeds it back into the next continuation — so the agent maintains a coherent plan across iterations instead of re-planning from scratch. To stop early when the goal is impossible or out of scope, the agent calls **`abandon_goal`** with a reason (honoured only after the verifier runs, so a goal the world already satisfies still finishes `achieved`). Both tools are bound whenever goal mode is on and are harmless no-ops outside a goal.
+Continuation prompts ask the agent to keep a running plan and record it each turn by calling the **`update_goal_plan`** tool. The controller persists that plan to a durable plan artifact for **every** goal and feeds it back into the next continuation — so the agent maintains a coherent plan across iterations instead of re-planning from scratch. (ADR 0079 unified this: the plan used to be written durably only for `fresh_context` goals, so a default same-session goal maintained a plan that `read_plan()` never saw.) The plan is injected back each turn as part of the agent's `<working_state>` block, and it doubles as the **`orient`** signal in the [fleet trace export](/adr/0079-autonomous-operating-model): a goal that maintains a real plan emits `loop_shape=ooda` training rows; a goal with no plan is labelled `react`. To stop early when the goal is impossible or out of scope, the agent calls **`abandon_goal`** with a reason (honoured only after the verifier runs, so a goal the world already satisfies still finishes `achieved`). Both tools are bound whenever goal mode is on and are harmless no-ops outside a goal.
 
 ## Configuration
 
@@ -140,3 +142,5 @@ See the [`goal` config block](/reference/configuration#goal). Defaults: machiner
 ## Security
 
 `command` / `test` / `ci` verifiers execute on the server host with the agent's privileges. **Setting a goal is an operator action** — only accept goal specs from trusted callers. If you expose `/goal` to untrusted input, restrict it to `data` / `llm` verifiers or gate goal-setting behind auth.
+
+> **`data`-verifier path must sit inside the agent's writable workspace when the goal is agent-completed over untrusted `/goal`.** The agent's `read_file`/`write_file` tools are rooted at its `workspace` project (`/sandbox/workspace/`) and **cannot reach the parent** — `../x` → *"path escapes project 'workspace'"* — and the shell fallback that could write elsewhere is **declined** for an untrusted caller (no operator present to approve it). So a verifier pointed at `/sandbox/report.md` will never flip: the agent writes to `/sandbox/workspace/report.md` and the verifier reads a path it can't produce. Point the `path` at `/sandbox/workspace/…`. (This is by design — the deterministic verifier, not the agent's own "done" self-report, is the sole arbiter, so a mispathed artifact correctly leaves the goal unverified.)

--- a/docs/guides/watches.md
+++ b/docs/guides/watches.md
@@ -54,6 +54,18 @@ N consecutive **unchanged**-evidence checks fire `on_stalled` once per stall epi
 ending the watch. The console **Watches** panel lists every watch with its status, and toasts on
 met/expired.
 
+**Wake-framing (ADR 0079).** The reaction turn doesn't arrive as a bare `run_prompt`. The
+scheduler prepends a *why-you're-awake* header (`[Autonomous wake — a watch you set has tripped.
+Orient from <working_state>, then:]`) and the watch controller prefixes the tripping
+**condition** and the verifier's **evidence** — so the agent orients on wake instead of acting
+blind. The evidence is load-bearing: an agent that can't re-read the source can still act on the
+value the watch surfaced (e.g. a release tag carried in `Evidence:`).
+
+**Yield-and-resume with a goal (ADR 0079).** A watch is how an [active goal](/guides/goal-mode)
+hands off async work: the goal drive **pauses** while a watch on the goal's `run_session` is
+live, and the watch's met-reaction **resumes** that same session — the goal's verifier re-runs on
+the resumed turn, so the loop closes without the agent spinning.
+
 ## Watch vs goal — which?
 
 | | Goal (drive) | Watch |


### PR DESCRIPTION
The `goal-mode`/`watches` guides predated ADR 0079 and still described goals·tasks·watches·scheduling as isolated silos — one of them literally documenting the split-brain plan-storage bug that P0 deleted. This brings the docs in line with what shipped (#1915 / #1917) and was validated live on the fleet this session.

## Changes (docs-only, 42 insertions / 1 deletion)

**`docs/guides/goal-mode.md`**
- **Fix:** removed the stale line claiming only `fresh_context` goals persist a durable plan. P0 unified this — *every* goal now writes the durable plan artifact, which is also the `orient` / `loop_shape=ooda` signal in the fleet trace export. (This is the one deletion — it documented the bug.)
- **Add:** "yield instead of spin" — pause-on-handoff to a watch/schedule so a long delegated goal spans time instead of exhausting its budget.
- **Add:** Security note — `data`-verifier `path`s must sit under the agent's writable workspace (`/sandbox/workspace/…`) for a goal completed over untrusted `/goal`, since the agent's file tools are workspace-rooted and its shell fallback is declined without an operator.

**`docs/guides/watches.md`**
- **Add:** wake-framing — the met-reaction carries the tripping condition + `Evidence:` so the agent orients on wake (the evidence proved load-bearing live).
- **Add:** yield-and-resume-with-a-goal composition (a watch is how an active goal hands off async work and resumes).

**`docs/adr/0079-autonomous-operating-model.md`**
- **Add:** "Validation (prod, 2026-07-08)" — frank's first OODA row, jon's full pause→wake→resume→verify (one whole trace, `verified=True`, `reward=1.0`), the two operational findings, and confirmation the verifier-as-sole-arbiter invariant held.

## Validation
Docs-only; no code paths touched. All internal links (`/adr/0079-…`, `/guides/watches#reacting`, `/guides/goal-mode#security`) resolve to real files and match repo link conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)