### PR TITLE
fix(console): auth dialog is a blocking modal; dialog scroll verified

### DIFF
--- a/apps/web/e2e/auth-gate.spec.ts
+++ b/apps/web/e2e/auth-gate.spec.ts
@@ -38,8 +38,14 @@ test("a 401 opens the token prompt; saving recovers in place and persists", asyn
   expect(stored).toBe(TOKEN);
 });
 
-test("'Not now' dismisses; the next 401 re-prompts", async ({ page }) => {
+test("the auth gate is a blocking modal — no bail-out, backdrop/Escape don't dismiss", async ({ page }) => {
+  // Blocking modal (#1921): while a 401 stands, every panel behind the gate is
+  // dead, so the gate must not be bypassable — no "Not now" bail-out, and clicking
+  // away / Escape must NOT dismiss it. The only exit is authenticating. (The route
+  // lets the correct bearer through, like test 1, so we can prove that exit works.)
   await page.route("**/api/**", async (route) => {
+    const auth = route.request().headers()["authorization"] || "";
+    if (auth === `Bearer ${TOKEN}`) return route.fallback(); // through to the mock
     await route.fulfill({
       status: 401,
       contentType: "application/json",
@@ -50,12 +56,21 @@ test("'Not now' dismisses; the next 401 re-prompts", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   const dialog = page.getByRole("dialog", { name: "Authentication required" });
   await expect(dialog).toBeVisible({ timeout: 10_000 });
-  await dialog.getByRole("button", { name: "Not now", exact: true }).click();
-  await expect(dialog).not.toBeVisible();
 
-  // Dismissing doesn't loop the prompt: the 401-aware boot probe stops retrying,
-  // and the BootGate reappears in its failed state. Its Retry fires a fresh
-  // request → 401 → the prompt returns.
-  await page.locator(".pl-bootgate").getByRole("button", { name: "Retry", exact: true }).click();
-  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  // No bail-out button.
+  await expect(dialog.getByRole("button", { name: "Not now" })).toHaveCount(0);
+
+  // A backdrop click (on the scrim, in the corner outside the centered dialog)
+  // does not dismiss it.
+  await page.locator(".pl-overlay").click({ position: { x: 5, y: 5 } });
+  await expect(dialog).toBeVisible();
+
+  // Escape does not dismiss it.
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeVisible();
+
+  // The only recovery is authenticating: a valid token + Connect closes the gate.
+  await dialog.getByLabel("Operator token").fill(TOKEN);
+  await dialog.getByRole("button", { name: "Connect", exact: true }).click();
+  await expect(dialog).not.toBeVisible();
 });

--- a/apps/web/src/app/AuthGate.test.ts
+++ b/apps/web/src/app/AuthGate.test.ts
@@ -1,0 +1,111 @@
+// AuthGate is a BLOCKING modal (#1921): while a 401 stands, the app behind it is
+// dead, so the gate must not be dismissible — no backdrop click, no Escape, no `×`,
+// no "Not now". The blocking behavior rides the DS Dialog's contract (omit `onClose`),
+// so this file pins both halves: (1) the DS contract itself — a Dialog WITH `onClose`
+// stays dismissible (normal settings dialogs must still close), a Dialog WITHOUT it
+// does not; and (2) AuthGate wires itself as the non-dismissible variant.
+//
+// jsdom + react-dom/client (the console has no @testing-library; the unit harness is
+// `.test.ts` only, so we build elements with React.createElement rather than JSX).
+import { createElement as h } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Dialog } from "@protolabsai/ui/overlays";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuthGate } from "./AuthGate";
+import { authRequired, clearAuthRequired, notifyAuthRequired } from "../lib/auth";
+
+// Tell React we're inside an act-capable environment so effect flushing is clean.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLElement;
+let root: Root;
+
+function mount(node: Parameters<Root["render"]>[0]) {
+  act(() => {
+    root.render(node);
+  });
+}
+
+function pressEscape() {
+  act(() => {
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  });
+}
+
+function clickBackdrop() {
+  const overlay = container.querySelector<HTMLElement>(".pl-overlay");
+  if (!overlay) throw new Error("no .pl-overlay rendered");
+  act(() => {
+    overlay.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  });
+}
+
+function buttonByText(text: string) {
+  return [...container.querySelectorAll("button")].find((b) => b.textContent?.trim() === text);
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("DS Dialog dismissal contract", () => {
+  it("a Dialog WITH onClose stays dismissible (× button, Escape + backdrop close)", () => {
+    const onClose = vi.fn();
+    mount(h(Dialog, { open: true, title: "Settings", onClose }, "body"));
+
+    // The × close affordance renders only when a dialog is dismissible.
+    expect(container.querySelector(".pl-dialog__close")).not.toBeNull();
+
+    pressEscape();
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    clickBackdrop();
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("a Dialog WITHOUT onClose is non-dismissible (no × button, Escape + backdrop are inert)", () => {
+    mount(h(Dialog, { open: true, title: "Blocking" }, "body"));
+
+    // No dismiss affordance, and the dialog stays mounted through Escape + backdrop.
+    expect(container.querySelector(".pl-dialog__close")).toBeNull();
+    pressEscape();
+    clickBackdrop();
+    expect(container.querySelector(".pl-dialog")).not.toBeNull();
+  });
+});
+
+describe("AuthGate — blocking auth modal (#1921)", () => {
+  beforeEach(() => notifyAuthRequired());
+  afterEach(() => clearAuthRequired());
+
+  function mountGate() {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mount(h(QueryClientProvider, { client: qc }, h(AuthGate)));
+  }
+
+  it("renders no dismiss affordances — no × close, no 'Not now', only Connect", () => {
+    mountGate();
+    expect(container.querySelector(".pl-dialog")).not.toBeNull();
+    expect(container.querySelector(".pl-dialog__close")).toBeNull();
+    expect(buttonByText("Not now")).toBeUndefined();
+    expect(buttonByText("Connect")).toBeDefined();
+  });
+
+  it("does not close on Escape or backdrop click — the auth state persists", () => {
+    mountGate();
+    pressEscape();
+    clickBackdrop();
+    expect(container.querySelector(".pl-dialog")).not.toBeNull();
+    expect(authRequired()).toBe(true); // still gated — the only exit is authenticating
+  });
+});

--- a/apps/web/src/app/AuthGate.tsx
+++ b/apps/web/src/app/AuthGate.tsx
@@ -4,15 +4,26 @@ import { Dialog } from "@protolabsai/ui/overlays";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState, useSyncExternalStore } from "react";
 
-import { authRequired, clearAuthRequired, saveAuthToken, subscribeAuth } from "../lib/auth";
+import { authRequired, saveAuthToken, subscribeAuth } from "../lib/auth";
 
 // Token prompt for token-gated deployments (#873): any 401 (panel query, boot
 // probe, chat turn) trips the auth store and this dialog appears — previously the
 // only signal was per-panel "401 Unauthorized" cards, and writing
 // `protoagent.authToken` required devtools. Saving invalidates every query so the
-// app recovers in place, no reload. "Not now" dismisses; the next 401 re-prompts.
+// app recovers in place, no reload.
 // (localStorage as the token home is the standing posture — the httpOnly-cookie
 // move is #869's call, not this gate's.)
+//
+// Blocking modal (#1921): a standing 401 leaves every panel dead, so this gate must
+// NOT be bypassable — while it's up, the app behind it is unusable. We render it
+// WITHOUT an `onClose`, which is the DS Dialog's non-dismissible contract: no
+// backdrop-click close, no Escape close, no `×` button, and no "Not now" bail-out.
+// It's paired with an opaque `.auth-dialog` scrim (see `.pl-overlay:has(.auth-dialog)`
+// in theme.css) that fully obscures the dead UI behind it. The only exit is
+// authenticating (or a background retry succeeding once the server stops 401ing,
+// which clears the store via saveAuthToken → clearAuthRequired). This blocking
+// posture is scoped to THIS dialog only — normal settings dialogs keep their onClose
+// and stay Escape/backdrop-dismissible.
 
 export function AuthGate() {
   const needed = useSyncExternalStore(subscribeAuth, authRequired);
@@ -32,17 +43,12 @@ export function AuthGate() {
     <Dialog
       open
       title="Authentication required"
-      onClose={clearAuthRequired}
       width={420}
+      className="auth-dialog"
       footer={
-        <>
-          <Button type="button" variant="ghost" onClick={clearAuthRequired}>
-            Not now
-          </Button>
-          <Button type="button" disabled={!token.trim()} onClick={connect}>
-            Connect
-          </Button>
-        </>
+        <Button type="button" disabled={!token.trim()} onClick={connect}>
+          Connect
+        </Button>
       }
     >
       <form

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -679,6 +679,19 @@ select:disabled {
   padding: var(--pl-space-6, 24px);
 }
 
+/* Auth gate scrim (#1921) — the AuthGate is a BLOCKING modal (no onClose; see
+   AuthGate.tsx). While a 401 stands, everything behind it is dead, so the scrim must
+   fully obscure that dead UI rather than let it peek through. The shared DS
+   `--pl-color-overlay` is a light, translucent wash (~0.35 alpha in dark) that suits
+   normal dismissible dialogs — darkening it globally would harm those, so we scope a
+   near-opaque black to the auth dialog only. `className="auth-dialog"` lands on the
+   inner `.pl-dialog`; `:has()` selects the scrim that wraps it (the DS uses the same
+   `:has()` pattern for drawer alignment). Fully opaque near-black (not a high-alpha
+   wash) so even bright content behind it can't bleed through. */
+.pl-overlay:has(.auth-dialog) {
+  background: rgb(8, 8, 12);
+}
+
 /* Toast top-right anchoring now comes from the DS prop (`<ToastProvider position="top-right">`,
    @protolabsai/ui ≥ 0.49) — the `.pl-toast-stack` override that used to live here is retired. */
 


### PR DESCRIPTION
## Summary

Two console dialog issues, investigated together. **#1921 was real and is fixed here.** **#1922 could NOT be reproduced** — the shared dialog already does exactly what the issue asks; details and evidence below.

---

## #1921 — "Authentication required" dialog is bypassable ✅ fixed

The gate was bypassable in two ways, and it must block: while a 401 stands, every panel behind it is dead, so the app is unusable until you authenticate.

**Before**
- Dismissed on backdrop click, Escape, the `×` close button, **and** a "Not now" button — any of these dropped you back onto the dead, 401'd UI.
- Scrim was the shared translucent overlay (`--pl-color-overlay`, ~0.35 alpha in dark), so the underlying UI peeked through.

**After**
- Rendered **without `onClose`**, which is the DS `Dialog`'s existing non-dismissible contract: no backdrop-click close, no Escape close, no `×` button. The "Not now" bail-out is removed. The only exit is authenticating (or a background retry clearing the store once the server stops 401ing).
- An **opaque near-black scrim** scoped to this dialog only via `.pl-overlay:has(.auth-dialog)` — it fully obscures the content behind it (verified: bright content no longer bleeds through).

**Scoping (important):** the non-dismissible behavior and the opaque scrim are scoped to the auth dialog *only*. Non-dismissibility rides the per-usage `onClose` omission (no shared component change), and the opaque backdrop is a `:has(.auth-dialog)` variant. **Normal settings dialogs keep their `onClose` and stay Escape/backdrop-dismissible** — this is asserted by the new test.

---

## #1922 — settings/config dialogs don't scroll ⚠️ already handled by the shared DS `Dialog`; no change made

The fix #1922 requests — *"constrain to viewport height + scroll the body internally with header/footer pinned"* — is **already implemented in the shared dialog component** (`@protolabsai/ui`, pinned at `0.54.1`, which is what this repo ships). The DS `.pl-dialog` already sets `max-height: calc(100vh - 2 * var(--pl-space-4))` and `.pl-dialog__body` already has `overflow-y: auto`, with the header/footer rendered outside the scroll region.

I verified this empirically (headless Chrome, exact DS CSS + the app's only global override): the dialog caps at the viewport, the header stays pinned, and the body scrolls internally.

I checked the **delegate settings dialog** specifically (`settings/DelegatesSection.tsx` → DS `Dialog`, `className="delegate-dialog"`): no app CSS disables the DS cap or body scroll for it, so it already scrolls. The app's only global `.pl-dialog__body` override (`theme.css`) changes *padding*, not overflow. Other settings dialogs (`.quick-setting-dialog`, `.settings-overlay`, `.theme-quick-dialog`) already carry their own deliberate, working scroll caps.

So there is no scroll bug to fix at the shared level in the pinned DS version. Rather than invent a no-op change, I'm reporting this. If the report was filed against an older DS build (pre-cap), the DS upgrade already resolved it. **Reopen if you can still reproduce off `main` + a fresh `npm ci` and I'll dig in.**

Closes #1921
Closes #1922

---

## Files changed
- `apps/web/src/app/AuthGate.tsx` — drop `onClose` + "Not now" (blocking modal); add `className="auth-dialog"`.
- `apps/web/src/app/theme.css` — opaque scrim scoped via `.pl-overlay:has(.auth-dialog)`.
- `apps/web/src/app/AuthGate.test.ts` — new; covers the DS dismissal contract + AuthGate's non-dismissible wiring.

## Test gate

`npm run test:unit --workspace @protoagent/web`

```
 Test Files  45 passed (45)
      Tests  456 passed (456)
   Duration  3.84s
```

Also: `tsc -p tsconfig.json --noEmit` → clean; `node scripts/check-css-comments.mjs` → OK. (No `lint` script exists in the web workspace.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
