### PR TITLE
fix(delegation): remove task_output; bias fleet delegation to fire-and-forget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **`task_output` background-job tool (ADR 0050/0051 correction).** The pull/blocking-wait
+  tool proved to be an attractive nuisance that defeated fire-and-forget delegation — agents
+  polled it to sit on a background delegation (or fleet `delegate_to` fan-out) instead of
+  ending their turn, which raced the push path and produced duplicate, out-of-order delivery
+  (delegate reports arriving *after* the agent had already synthesized). Push (`drain_pending`)
+  is now the **sole**, exactly-once, in-order delivery path; `stop_task` is retained for
+  cancellation.
+
+### Changed
+- **Fleet delegation biases to fire-and-forget.** The `delegate_to` tool and the shared
+  background-delegation prompt now strongly steer toward `background=True` (goal fan-outs,
+  reaching multiple delegates, anything more than a quick consult), tell the agent to END its
+  turn after backgrounding rather than wait/poll, and — on a fan-out — to hold synthesis until
+  ALL delegate replies are back.
+
 ## [0.97.0] - 2026-07-08
 
 ### Added

--- a/docs/adr/0050-background-subagents-reactive-notifications.md
+++ b/docs/adr/0050-background-subagents-reactive-notifications.md
@@ -177,6 +177,13 @@ the thing to check first when it lands.)
   long synchronous delegation transparently detaches and becomes killable — the direct cure for
   the audited incident.
 
+  > **Correction (later):** `task_output` was **removed**. Its only real capability was
+  > blocking-to-wait, which proved to be an attractive nuisance that defeated fire-and-forget:
+  > agents polled it to sit on a background delegation instead of ending their turn, causing
+  > duplicate, out-of-order delivery (a pull path racing the push path). The push path
+  > (`drain_pending`) is now the **sole**, exactly-once, in-order delivery mechanism; only
+  > `stop_task` (cancellation) is retained as a control tool.
+
 ### Follow-up — background batch + concurrency cap (shipped)
 - **`task_batch(run_in_background=True)`** fans a whole batch out detached: every spec spawns as
   its own background job and the call returns immediately with the job ids, instead of blocking

--- a/docs/adr/0051-a2a-realtime-streaming-and-component-rendering.md
+++ b/docs/adr/0051-a2a-realtime-streaming-and-component-rendering.md
@@ -59,6 +59,10 @@ Expose the realtime stream of any turn through a small **executor progress/lifec
 3. **`stop_task(job_id)`** — looks up the recorded A2A task_id and self-POSTs a real
    `CancelTask`; marks the job `canceled`. **`task_output(job_id, block, timeout)`** — reads
    the durable registry, optionally awaiting a terminal state (the cc-2.18 ergonomic).
+   > **Correction (later):** `task_output` was **removed** — its blocking-to-wait behavior was
+   > an attractive nuisance that defeated fire-and-forget (agents polled it instead of yielding,
+   > racing the push path into duplicate/out-of-order delivery). Push (`drain_pending`) is now
+   > the sole delivery path; `stop_task` is retained for cancellation. See ADR 0050.
 4. **Foreground→auto-background.** A synchronous `task` delegation that exceeds a time budget
    transparently detaches to the background (returns a job id), so a long inline subagent run
    stops freezing the turn — the direct cure for the audited melt-down.

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -825,38 +825,14 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
 
     # Background-job control tools (ADR 0051) — only when a background manager exists
     # (so a no-background build doesn't advertise dead controls).
+    #
+    # There is deliberately NO pull/wait tool here (the former ``task_output`` was
+    # removed): its only real capability was blocking-to-wait, which is the exact
+    # anti-pattern to fire-and-forget delegation — agents polled it instead of ending
+    # their turn, producing duplicate, out-of-order delivery. Push (``drain_pending``)
+    # is the sole, exactly-once, in-order delivery path; only cancellation is a tool.
     bg_tools: list[BaseTool] = []
     if background_mgr is not None:
-
-        @tool
-        async def task_output(job_id: str, block: bool = True, timeout: float = 30.0) -> str:
-            """Check a background job's status and result (the ``bg-…`` id from
-            ``task(run_in_background=True)``).
-
-            You normally do NOT need this — you're notified automatically when a job
-            finishes. Use it only when you deliberately want to wait for or inspect a
-            specific job now.
-
-            Args:
-                job_id: the ``bg-…`` job id.
-                block: if True (default), wait until the job finishes or ``timeout``
-                    elapses; if False, return the current state immediately.
-                timeout: max seconds to wait when ``block`` is True (capped at 600).
-            """
-            job = background_mgr.store.get(job_id)
-            if job is None:
-                return f"No background job {job_id}."
-            if block and job.status == "running":
-                cap = max(1.0, min(float(timeout or 0), 600.0))
-                waited = 0.0
-                while job.status == "running" and waited < cap:
-                    await asyncio.sleep(1.0)
-                    waited += 1.0
-                    job = background_mgr.store.get(job_id) or job
-            head = f"Job {job_id} ({job.subagent_type}: {job.description}) — {job.status}"
-            if job.status == "running":
-                return head + " (still running)."
-            return f"{head}.\n\n{job.result or '(no output)'}"
 
         @tool
         async def stop_task(job_id: str) -> str:
@@ -866,7 +842,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
             res = await background_mgr.cancel(job_id)
             return res.get("detail", "Done.")
 
-        bg_tools = [task_output, stop_task]
+        bg_tools = [stop_task]
 
     # Declarative multi-step workflows (ADR 0002) are now an opt-in plugin
     # (plugins/workflows) — its run_workflow/save_workflow tools come in via the

--- a/graph/prompts.py
+++ b/graph/prompts.py
@@ -242,8 +242,11 @@ def _build_subagent_section() -> str:
             "immediately with a job id and the result is delivered back to you automatically on a",
             "later turn, so the conversation stays live instead of freezing on a multi-minute",
             "delegation. Use foreground (the default) only when you need the result to finish your",
-            "current reply. Once you background a task, do NOT poll it or spawn a duplicate — you",
-            "will be notified when it completes.",
+            "current reply. This is a general discipline for ANY background delegation (the",
+            "`task` subagent tool AND, e.g., a fleet `delegate_to`): once you background the",
+            "work, END your turn — do NOT try to wait/poll for it or spawn a duplicate. Each",
+            "result is delivered back to you automatically on a later turn; synthesize the",
+            "replies when they arrive (on a fan-out, wait for ALL of them first).",
         ]
     )
 

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -151,7 +151,6 @@ _TOOL_CATEGORY = {
     # Delegation (subagents)
     "task": "Delegation",
     "task_batch": "Delegation",
-    "task_output": "Delegation",
     "stop_task": "Delegation",
     # Workflows
     "run_workflow": "Workflows",

--- a/plugins/delegates/__init__.py
+++ b/plugins/delegates/__init__.py
@@ -43,14 +43,21 @@ def _build_delegate_to(registry: DelegateRegistry):
         another **model endpoint**, or hand a repo-scoped coding job to a **coding
         agent**. Pick the delegate whose description best fits the task.
 
-        By default this WAITS for the delegate's reply (fine for a quick consult).
-        For a LONG delegation — a coding agent building a PR, a deep-research run —
-        set ``background=True``: the delegation runs detached, you get a job handle
-        back immediately, and the delegate's reply is delivered to you when it
-        finishes (you don't hold your turn open waiting). In-flight background jobs
-        are tracked in the background panel (``GET /api/background``). Prefer
-        ``background=True`` whenever the delegate might take minutes, or when you
-        want to fan out several delegations without blocking on each.
+        **Strongly prefer ``background=True``** for a goal-driven fan-out, for
+        reaching multiple delegates, or for any delegation that may take more than a
+        couple of seconds. Foreground (the default) is only for a single quick consult
+        whose answer you need to finish the current reply. A background delegation runs
+        detached: you get a job handle back immediately, and the delegate's reply is
+        delivered to you automatically on a later turn (you don't hold your turn open
+        waiting). In-flight background jobs are tracked in the background panel
+        (``GET /api/background``).
+
+        **After you start a background delegation, END YOUR TURN.** Do NOT try to wait
+        or poll for it, and do NOT re-delegate the same work — each delegate's reply
+        comes back to you automatically on a later turn; synthesize once the replies
+        arrive. **When you fan out to several delegates, wait until you have received
+        ALL of their replies before you synthesize — don't synthesize on the first one
+        back.**
 
         Args:
             target: the delegate name (see the available list in this tool's
@@ -134,8 +141,10 @@ async def _spawn_background_delegation(
     )
     return (
         f"Started a background delegation to {target!r} (job `{job_id}`). It runs detached — "
-        f"its reply comes back to me when it finishes, so I don't need to wait. In-flight "
-        f"background jobs are listed in the background panel (GET /api/background)."
+        f"its reply comes back to me automatically on a later turn, so I should END my turn "
+        f"now and NOT wait or re-delegate this. If I fanned out to several delegates, I'll "
+        f"hold off synthesizing until ALL their replies are back. In-flight background jobs "
+        f"are listed in the background panel (GET /api/background)."
     )
 
 


### PR DESCRIPTION
## Problem

An org-head agent (Ava) ran a goal, delegated to 4 fleet leads via `delegate_to(..., background=True)`, then **polled to wait** for each reply, synthesized a digest, and reported. Then all 4 full delegate reports got re-injected as `<task-notification>` cards on the next (goal-continuation) turn — **after** the synthesis, redundant and out of order.

Two causes, one root:
- **Behavioral:** nothing told the agent that after a background `delegate_to` it should END ITS TURN and not wait — the discipline existed only for the `task` subagent tool.
- **Mechanical:** `task_output` handed a terminal job's result to the model via a *pull* path; the *push* path (`drain_pending`) then re-delivered the same terminal job. A pull tool racing the push path is the whole bug.

## Fix (remove the pull tool; bias to fire-and-forget)

Rather than harden `task_output`, we **remove it entirely** (keeping `stop_task` for cancellation). Its only real capability was blocking-to-wait — the exact anti-pattern — and nothing depended on it (no tests, no internal callers). With no pull path, **push (`drain_pending`) becomes the sole delivery mechanism**, which is already exactly-once and in-order — so no dedupe safety net is needed.

**Behavioral guidance (kept/strengthened):**
- `delegate_to` docstring + the `Started a background delegation…` return message now: strongly prefer `background=True`; after backgrounding **END your turn** (don't wait/poll, don't re-delegate); and **on a fan-out, wait for ALL replies before synthesizing**.
- `graph/prompts.py` generalizes the fire-and-forget rule to ANY background delegation (the `task` subagent tool AND, e.g., a fleet `delegate_to`).

**Mechanical:**
- `graph/agent.py`: delete the `task_output` tool; `bg_tools = [stop_task]`.
- `operator_api/console_handlers.py`: drop the `task_output` console label.

**Docs:** ADR 0050 (§ Phase 4) and ADR 0051 get a correction note that `task_output` was removed as an attractive nuisance; CHANGELOG `[Unreleased]` records the removal + the delegation bias change.

## Gates (from repo root, `uv run`)

```
$ ruff check .
All checks passed!

$ lint-imports
Contracts: 3 kept, 0 broken.

$ python -m pytest tests/ -q
3481 passed, 5 skipped, 199 warnings in 254.78s
```

(The one benign teardown warning is a pre-existing `RuntimeError: Event loop is closed` during GC of an async fixture, not a failure.)

`grep -rn task_output` over code/tests/prompts/TS console is clean — the only remaining hits are documentation (ADR/CHANGELOG historical + correction notes) and one explanatory comment in `graph/agent.py` noting the deliberate absence of a pull tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background delegation behavior to avoid duplicate or out-of-order results.
  * Background tasks now use a single completion delivery path, and cancellation is handled separately.
  * Updated background task guidance so agents end turns promptly and wait for replies before combining results.

* **Documentation**
  * Clarified guidance for background and fan-out delegation workflows.
  * Updated developer-facing notes to reflect the current control and completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->